### PR TITLE
Fixing Dockerfile to account for M1 chip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS builder
+FROM --platform=linux/amd64 golang:1.19-alpine AS builder
 
 WORKDIR /app
 
@@ -9,6 +9,6 @@ COPY . .
 
 RUN go build -o transfer .
 
-FROM alpine:3.16 AS runner
+FROM --platform=linux/amd64 alpine:3.16 AS runner
 
 COPY --from=builder /app/transfer /


### PR DESCRIPTION
We'll need this line so that we can publish the images correctly.

Following this guide: https://cloudaffaire.com/faq/docker-buildx-with-node-app-on-apple-m1-silicon-standard_init_linux-go211-exec-user-process-caused-exec-format-error/

Tested before and after within the Kubernetes cluster.