### PR TITLE
[DDL] Edge case around typing

### DIFF
--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -125,6 +125,11 @@ func ExecuteMerge(ctx context.Context, tableData *optimization.TableData) error 
 		}
 	}
 
+	// We now need to merge the two columns from tableData (which is constructed in-memory) and tableConfig (coming from the describe statement)
+	// Cannot do a full swap because tableData is a super-set of tableConfig (it contains the temp deletion flag and other columns with the __artie prefix).
+	for tcCol, tcKind := range tableConfig.Columns {
+		tableData.Columns[tcCol] = tcKind
+	}
 	query, err := merge(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")


### PR DESCRIPTION
## Context

Within Transfer, we have 2 table structures.

One is created as we consume events. This is used so that we can overlay DDL support on top of consuming CDC messages (this is called `tableData`).

The other one comes from DWH, where we can query and find out what the current table structure looks like (this is called `tableConfig`)

Whenever `tableData` and `tableConfig` disagree, we will try to rectify this by updating DWH.

Scenarios:
1) Adding a new column (supported)
2) Deleting a column (supported with the 2 phase check)
3) Modifying a column type (this is considered a breaking change and **NOT** supported)

## Problem

When we invoke `MERGE`, we have a safety check to not merge columns where the type is `Invalid`. This is fine, but we're passing `tableData` as a column to `MERGE`. Normally, this is fine - but imagine this scenario.

* There's a column `first_name` in SFLK, type = `string` and it's `NULLABLE`
* We delete the value by marking the column value to `nil`.

If that is the only event being consumed by Transfer, the `tableData` will think that `first_name` is `invalid` and skip during merge.

## Fix

Upon merge, we reconcile the two data structures `tableData` and `tableConfig`. Note - we iterate over `tableConfig` to update `tableData` for two primary reasons.

1) SoT is `tableConfig`
2) `tableConfig` is a super-set of `tableData` which as the comment indicates - contains other columns with the prefix `__artie`