### PR TITLE
[Schema support for Postgres] Supporting TS w/o TZ for Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,17 +119,24 @@ Note: Keys here are formatted in dot notation for readability purposes, please e
 
 
 ## Limitations
+_Note: If any of these limitations are blocking you from using Transfer. Feel free to contribute or file a bug and we'll get this prioritized!</br>
+The long term goal for Artie Transfer is to be able to extend the service to have as little of these limitations as possible.
+
 **Postgres Debezium wal2json** <br/>
 * `decimal.handling.mode` only works for `double` or `string`.<br/>
 The default value is `precise` which will cast the value in `java.math.BigDecimal` and Transfer does not know how to decode that yet.
 For further information on how to set this to be `string` or `double`, please [click here](https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-debezium.html#connector-details)
-* `key.converter.schemas.enable` and `value.converter.schemas.enable` both need to be set to `false`
+* `value.converter.schemas.enable` must be set to `true`
+* `key.converter.schemas.enable` must be set to `false`
 * `value.converter` must be set to `org.apache.kafka.connect.json.JsonConverter`
+* Transfer only supports `time.precision.mode=adaptive` which is the default value.
 
 
 **MongoDB Debezium** <br/>
-* `key.converter.schemas.enable` and `value.converter.schemas.enable` both need to be set to `false`
 * `value.converter` must be set to `org.apache.kafka.connect.json.JsonConverter`
+* `key.converter.schemas.enable` and `value.converter.schemas.enable` both need to be set to `false`
+_Supporting `value.converter.schemas.enable` is currently in our backlog_ 
+
 
 ## Telemetry
 Click [here](https://github.com/artie-labs/transfer/blob/master/lib/telemetry/README.md) to read more about Transfer's telemetry feature.

--- a/examples/postgres/connect/connect-distributed.properties
+++ b/examples/postgres/connect/connect-distributed.properties
@@ -11,7 +11,7 @@ key.converter=org.apache.kafka.connect.storage.StringConverter
 value.converter=org.apache.kafka.connect.json.JsonConverter
 
 key.converter.schemas.enable=false
-value.converter.schemas.enable=false
+value.converter.schemas.enable=true
 
 offset.storage.topic=connect-offsets
 offset.storage.replication.factor=1

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -42,6 +42,7 @@ func Empty(list []string) bool {
 	return false
 }
 
+// StringContains iterates over a list, if any `item` from the list matches `element`, it returns true.
 func StringContains(list []string, element string) bool {
 	for _, v := range list {
 		if element == v {
@@ -50,5 +51,4 @@ func StringContains(list []string, element string) bool {
 	}
 
 	return false
-
 }

--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -18,3 +18,15 @@ type Event interface {
 	GetExecutionTime() time.Time
 	GetData(pkName string, pkVal interface{}, config *kafkalib.TopicConfig) map[string]interface{}
 }
+
+// FieldLabelKind is used when the schema is turned on. Each schema object will be labelled.
+type FieldLabelKind string
+
+const (
+	Before      FieldLabelKind = "before"
+	After       FieldLabelKind = "after"
+	Source      FieldLabelKind = "source"
+	Op          FieldLabelKind = "op"
+	TsMs        FieldLabelKind = "ts_ms"
+	Transaction FieldLabelKind = "transaction"
+)

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -37,7 +37,7 @@ func (p *PostgresTestSuite) TestSource_GetExecutionTime() {
 		TsMs:      1665458364942, // Tue Oct 11 2022 03:19:24
 	}
 
-	event := &Event{Source: source}
+	event := &payload{Source: source}
 	assert.Equal(p.T(), time.Date(2022, time.October,
 		11, 3, 19, 24, 942000000, time.UTC), event.GetExecutionTime())
 }
@@ -52,7 +52,7 @@ func (p *PostgresTestSuite) TestGetDataTestInsert() {
 
 	var tc kafkalib.TopicConfig
 
-	evt := Event{
+	evt := payload{
 		Before:    nil,
 		After:     after,
 		Operation: "c",
@@ -75,7 +75,7 @@ func (p *PostgresTestSuite) TestGetDataTestDelete() {
 	}
 
 	now := time.Now().UTC()
-	evt := Event{
+	evt := payload{
 		Before:    nil,
 		After:     nil,
 		Operation: "c",
@@ -117,7 +117,7 @@ func (p *PostgresTestSuite) TestGetDataTestUpdate() {
 	}
 
 	var tc kafkalib.TopicConfig
-	evt := Event{
+	evt := payload{
 		Before:    before,
 		After:     after,
 		Operation: "c",

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -284,7 +284,11 @@ func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 	evtData := evt.GetData("id", 1001, &kafkalib.TopicConfig{})
 	assert.Equal(p.T(), evtData["id"], float64(1001))
 	assert.Equal(p.T(), evtData["email"], "sally.thomas@acme.com")
-	assert.Equal(p.T(), evtData["ts_no_tz1"], "2023-02-02T09:51:35-08:00")
+
+	// assert.Equal(p.T(), time.Date(2022, time.November,
+	//		18, 6, 35, 21, 0, time.UTC), event.GetExecutionTime())
+	td := time.Date(2023, time.February, 2, 17, 51, 35, 0, time.UTC)
+	assert.Equal(p.T(), evtData["ts_no_tz1"], td.Format(time.RFC3339))
 	assert.Equal(p.T(), evt.Table(), "customers")
 }
 

--- a/lib/cdc/postgres/event.go
+++ b/lib/cdc/postgres/event.go
@@ -1,0 +1,60 @@
+package postgres
+
+import (
+	"github.com/artie-labs/transfer/lib/cdc"
+)
+
+// SchemaEventPayload is our struct for an event with schema enabled. For reference, this is an example payload https://gist.github.com/Tang8330/3b9989ed8c659771958fe481f248397a
+type SchemaEventPayload struct {
+	Schema  schema  `json:"schema"`
+	Payload payload `json:"payload"`
+}
+
+type schema struct {
+	SchemaType   string         `json:"type"`
+	FieldsObject []fieldsObject `json:"fields"`
+}
+
+func (s *schema) GetSchemaFromLabel(kind cdc.FieldLabelKind) *fieldsObject {
+	for _, fieldObject := range s.FieldsObject {
+		if fieldObject.FieldLabel == kind {
+			return &fieldObject
+		}
+	}
+
+	return nil
+}
+
+type fieldsObject struct {
+	// What the type is for the block of field, e.g. STRUCT, or STRING.
+	FieldObjectType string `json:"type"`
+
+	// The actual schema object.
+	Fields []Field `json:"fields"`
+
+	// Whether this block for "after", "before", exists
+	Optional   bool               `json:"optional"`
+	FieldLabel cdc.FieldLabelKind `json:"field"`
+}
+
+type Field struct {
+	Optional     bool        `json:"optional"`
+	Default      interface{} `json:"default"`
+	FieldName    string      `json:"field"`
+	DebeziumType string      `json:"name"`
+}
+
+type payload struct {
+	Before    map[string]interface{} `json:"before"`
+	After     map[string]interface{} `json:"after"`
+	Source    Source                 `json:"source"`
+	Operation string                 `json:"op"`
+}
+
+type Source struct {
+	Connector string `json:"connector"`
+	TsMs      int64  `json:"ts_ms"`
+	Database  string `json:"db"`
+	Schema    string `json:"schema"`
+	Table     string `json:"table"`
+}

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -23,7 +23,8 @@ func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) time
 	// https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-temporal-types
 	switch supportedType {
 	case MicroTimestamp:
-		return time.UnixMicro(val)
+		// Cast the TZ in UTC. By default, it would be in local (machine) TZ.
+		return time.UnixMicro(val).In(time.UTC)
 
 	}
 

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -25,7 +25,6 @@ func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) time
 	case MicroTimestamp:
 		// Cast the TZ in UTC. By default, it would be in local (machine) TZ.
 		return time.UnixMicro(val).In(time.UTC)
-
 	}
 
 	return time.Time{}

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -1,0 +1,31 @@
+package debezium
+
+import "time"
+
+type SupportedDebeziumType string
+
+const (
+	Invalid        SupportedDebeziumType = "invalid"
+	MicroTimestamp SupportedDebeziumType = "io.debezium.time.MicroTimestamp"
+)
+
+func RequiresSpecialTypeCasting(typeLabel string) (bool, SupportedDebeziumType) {
+	for _, supportedType := range []SupportedDebeziumType{MicroTimestamp} {
+		if typeLabel == string(supportedType) {
+			return true, supportedType
+		}
+	}
+
+	return false, Invalid
+}
+
+func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) time.Time {
+	// https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-temporal-types
+	switch supportedType {
+	case MicroTimestamp:
+		return time.UnixMicro(val)
+
+	}
+
+	return time.Time{}
+}

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -1,0 +1,7 @@
+package debezium
+
+import "testing"
+
+func TestMicroTimestamp(t *testing.T) {
+
+}

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -1,7 +1,0 @@
-package debezium
-
-import "testing"
-
-func TestMicroTimestamp(t *testing.T) {
-
-}

--- a/processes/kafka/consumer.go
+++ b/processes/kafka/consumer.go
@@ -102,7 +102,7 @@ func StartConsumer(ctx context.Context, flushChan chan bool) {
 
 				shouldFlush, processErr := processMessage(ctx, msg, topicToConfigFmtMap, kafkaConsumer.Config().GroupID)
 				if processErr != nil {
-					log.WithError(err).WithFields(logFields).Warn("skipping message...")
+					log.WithError(processErr).WithFields(logFields).Warn("skipping message...")
 				}
 
 				if shouldFlush {


### PR DESCRIPTION
With this PR, we are now requiring schemas to be turned on. The decision to turn this on has been a few factors.
1) When Debezium runs (and if others in this case) - it is reasonable to expect that they have their own interim data types.
2) Without schema support and understanding of interim data types, we will be passing the library complexity down to our users.

The issue here arose when I was testing the `TIMESTAMP WITHOUT TIME ZONE` data type in Postgres. Researching more, as you can see from the [Debezium documentation](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-temporal-types)

![image](https://user-images.githubusercontent.com/4412200/216413191-760a165c-12e7-42ff-88d6-c885ce09d5b3.png)

Steps required prior to merge:
- [x] Documentation
- [x] Fix tests
- [x] Fix the examples
- [x] Publish a new image