### PR TITLE
[Bug] Fix typecasing problem.

### DIFF
--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -20,7 +20,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 	var sflkCols []string
 
 	// Given all the columns, diff this against SFLK.
-	for col, kind := range tableData.Columns {
+	for col, kind := range tableData.InMemoryColumns {
 		if kind == typing.Invalid {
 			// Don't update Snowflake
 			continue
@@ -45,7 +45,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 				artieDeleteMetadataIdx = ptr.ToInt(idx)
 			}
 
-			colKind := tableData.Columns[col]
+			colKind := tableData.InMemoryColumns[col]
 			colVal := value[col]
 			if colVal != nil {
 				switch colKind {

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -34,7 +34,7 @@ func (s *SnowflakeTestSuite) TestMergeNoDeleteFlag() {
 func (s *SnowflakeTestSuite) TestMerge() {
 	cols := map[string]typing.Kind{
 		"id":                      typing.Integer,
-		"name":                    typing.String,
+		"NAME":                    typing.String,
 		config.DeleteColumnMarker: typing.Boolean,
 	}
 
@@ -43,7 +43,7 @@ func (s *SnowflakeTestSuite) TestMerge() {
 		pk := fmt.Sprint(idx + 1)
 		rowData[pk] = map[string]interface{}{
 			"id":                      pk,
-			"name":                    name,
+			"NAME":                    name,
 			config.DeleteColumnMarker: false,
 		}
 	}
@@ -64,6 +64,10 @@ func (s *SnowflakeTestSuite) TestMerge() {
 
 	mergeSQL, err := merge(tableData)
 	assert.NoError(s.T(), err, "merge failed")
+	assert.Contains(s.T(), mergeSQL, "robin")
+	assert.Contains(s.T(), mergeSQL, "false")
+	assert.Contains(s.T(), mergeSQL, "1")
+	assert.Contains(s.T(), mergeSQL, "NAME")
 
 	// Check if MERGE INTO FQ Table exists.
 	assert.True(s.T(), strings.Contains(mergeSQL, "MERGE INTO shop.public.customer c"))

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -19,11 +19,11 @@ func (s *SnowflakeTestSuite) TestMergeNoDeleteFlag() {
 	}
 
 	tableData := &optimization.TableData{
-		Columns:     cols,
-		RowsData:    nil,
-		PrimaryKey:  "id",
-		TopicConfig: kafkalib.TopicConfig{},
-		LatestCDCTs: time.Time{},
+		InMemoryColumns: cols,
+		RowsData:        nil,
+		PrimaryKey:      "id",
+		TopicConfig:     kafkalib.TopicConfig{},
+		LatestCDCTs:     time.Time{},
 	}
 
 	_, err := merge(tableData)
@@ -55,11 +55,11 @@ func (s *SnowflakeTestSuite) TestMerge() {
 	}
 
 	tableData := &optimization.TableData{
-		Columns:     cols,
-		RowsData:    rowData,
-		PrimaryKey:  "id",
-		TopicConfig: topicConfig,
-		LatestCDCTs: time.Time{},
+		InMemoryColumns: cols,
+		RowsData:        rowData,
+		PrimaryKey:      "id",
+		TopicConfig:     topicConfig,
+		LatestCDCTs:     time.Time{},
 	}
 
 	mergeSQL, err := merge(tableData)

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -134,7 +134,7 @@ func ExecuteMerge(ctx context.Context, tableData *optimization.TableData) error 
 			tableData.InMemoryColumns[inMemCol] = tcKind
 		}
 	}
-	
+
 	query, err := merge(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -90,7 +90,7 @@ func ExecuteMerge(ctx context.Context, tableData *optimization.TableData) error 
 
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.Columns, tableConfig.Columns)
+	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, tableConfig.Columns)
 
 	// Keys that exist in CDC stream, but not in Snowflake
 	err = alterTable(fqName, tableConfig.CreateTable, Add, tableData.LatestCDCTs, targetKeysMissing...)
@@ -127,9 +127,14 @@ func ExecuteMerge(ctx context.Context, tableData *optimization.TableData) error 
 
 	// We now need to merge the two columns from tableData (which is constructed in-memory) and tableConfig (coming from the describe statement)
 	// Cannot do a full swap because tableData is a super-set of tableConfig (it contains the temp deletion flag and other columns with the __artie prefix).
-	for tcCol, tcKind := range tableConfig.Columns {
-		tableData.Columns[tcCol] = tcKind
+	// We are swapping the order and iterating over InMemoryColumns instead, as the columns are case-sensitive.
+	for inMemCol := range tableData.InMemoryColumns {
+		tcKind, isOk := tableConfig.Columns[strings.ToLower(inMemCol)]
+		if isOk {
+			tableData.InMemoryColumns[inMemCol] = tcKind
+		}
 	}
+	
 	query, err := merge(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -281,11 +281,11 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	}
 
 	tableData := &optimization.TableData{
-		Columns:     columns,
-		RowsData:    rowsData,
-		TopicConfig: topicConfig,
-		PrimaryKey:  "id",
-		Rows:        1,
+		InMemoryColumns: columns,
+		RowsData:        rowsData,
+		TopicConfig:     topicConfig,
+		PrimaryKey:      "id",
+		Rows:            1,
 	}
 
 	mdConfig.snowflakeTableToConfig[topicConfig.ToFqName()] = &snowflakeTableConfig{
@@ -296,7 +296,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	}
 
 	ExecuteMerge(context.Background(), tableData)
-	assert.Equal(s.T(), tableData.Columns["first_name"], typing.String)
+	assert.Equal(s.T(), tableData.InMemoryColumns["first_name"], typing.String)
 }
 
 func (s *SnowflakeTestSuite) TestExecuteMerge() {
@@ -324,11 +324,11 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 	}
 
 	tableData := &optimization.TableData{
-		Columns:     columns,
-		RowsData:    rowsData,
-		TopicConfig: topicConfig,
-		PrimaryKey:  "id",
-		Rows:        1,
+		InMemoryColumns: columns,
+		RowsData:        rowsData,
+		TopicConfig:     topicConfig,
+		PrimaryKey:      "id",
+		Rows:            1,
 	}
 
 	mdConfig.snowflakeTableToConfig[topicConfig.ToFqName()] = &snowflakeTableConfig{
@@ -370,11 +370,11 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	}
 
 	tableData := &optimization.TableData{
-		Columns:     columns,
-		RowsData:    rowsData,
-		TopicConfig: topicConfig,
-		PrimaryKey:  "id",
-		Rows:        1,
+		InMemoryColumns: columns,
+		RowsData:        rowsData,
+		TopicConfig:     topicConfig,
+		PrimaryKey:      "id",
+		Rows:            1,
 	}
 
 	sflkColumns := map[string]typing.Kind{
@@ -405,7 +405,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	// Now try to execute merge where 1 of the rows have the column now
 	for _, pkMap := range tableData.RowsData {
 		pkMap["new"] = "123"
-		tableData.Columns = sflkColumns
+		tableData.InMemoryColumns = sflkColumns
 		break
 	}
 
@@ -421,7 +421,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 func (s *SnowflakeTestSuite) TestExecuteMergeExitEarly() {
 	err := ExecuteMerge(context.Background(), &optimization.TableData{
-		Columns:                 nil,
+		InMemoryColumns:         nil,
 		RowsData:                nil,
 		PrimaryKey:              "",
 		TopicConfig:             kafkalib.TopicConfig{},

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -10,9 +10,9 @@ import (
 )
 
 type TableData struct {
-	Columns    map[string]typing.Kind            // list of columns
-	RowsData   map[string]map[string]interface{} // pk -> { col -> val }
-	PrimaryKey string
+	InMemoryColumns map[string]typing.Kind            // list of columns
+	RowsData        map[string]map[string]interface{} // pk -> { col -> val }
+	PrimaryKey      string
 
 	kafkalib.TopicConfig
 	// Partition to the latest offset.

--- a/lib/typing/diff.go
+++ b/lib/typing/diff.go
@@ -57,7 +57,7 @@ func Diff(source map[string]Kind, target map[string]Kind) (srcKeyMissing []Colum
 func CopyColMap(source map[string]Kind) map[string]Kind {
 	retVal := make(map[string]Kind)
 	for k, v := range source {
-		retVal[k] = v
+		retVal[strings.ToLower(k)] = v
 	}
 
 	return retVal

--- a/lib/typing/diff_test.go
+++ b/lib/typing/diff_test.go
@@ -54,17 +54,22 @@ func TestDiffDelta2(t *testing.T) {
 		"b":  Boolean,
 		"c":  Struct,
 		"d":  String,
+		"CC": String,
+		"cC": String,
+		"Cc": String,
 	}
 
 	target := map[string]Kind{
 		"aa": String,
 		"b":  Boolean,
 		"cc": String,
+		"CC": String,
+		"dd": String,
 	}
 
 	srcKeyMissing, targKeyMissing := Diff(source, target)
-	assert.Equal(t, len(srcKeyMissing), 1)  // Missing cc
-	assert.Equal(t, len(targKeyMissing), 3) // Missing a, c, d
+	assert.Equal(t, len(srcKeyMissing), 1, srcKeyMissing)   // Missing dd
+	assert.Equal(t, len(targKeyMissing), 3, targKeyMissing) // Missing a, c, d
 }
 
 func TestCopyColMap(t *testing.T) {

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -36,7 +36,7 @@ func (m *ModelsTestSuite) SaveEvent() {
 	optimization := GetMemoryDB().TableData["foo"]
 	// Check the in-memory DB columns.
 	var found int
-	for col := range optimization.Columns {
+	for col := range optimization.InMemoryColumns {
 		if col == expectedLowerCol || col == anotherLowerCol {
 			found += 1
 		}
@@ -46,5 +46,5 @@ func (m *ModelsTestSuite) SaveEvent() {
 		}
 	}
 
-	assert.Equal(m.T(), 2, found, optimization.Columns)
+	assert.Equal(m.T(), 2, found, optimization.InMemoryColumns)
 }


### PR DESCRIPTION
There's a type casing problem between downstreams apps and JSON.

Imagine the following scenario:
1) `name`
2) `NAME`
3) `NAmE`
4) `NamE`

JSON will treat these as **four** distinct values.
DWH will normalize this (Snowflake will UPPERCASE and BigQuery will LOWERCASE) into `name`, thus 1 value.

Fix here is to remove redundant lowercasing AND be more cognizant around case sensitive operations.