### PR TITLE
Bug around column typing

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -197,6 +197,14 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		}
 	}
 
+	// We are swapping the order and iterating over InMemoryColumns instead, as the columns are case-sensitive.
+	for inMemCol := range tableData.InMemoryColumns {
+		tcKind, isOk := tableConfig.Columns()[strings.ToLower(inMemCol)]
+		if isOk {
+			tableData.InMemoryColumns[inMemCol] = tcKind
+		}
+	}
+
 	query, err := merge(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -198,7 +198,15 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	// We are swapping the order and iterating over InMemoryColumns instead, as the columns are case-sensitive.
-	for inMemCol := range tableData.InMemoryColumns {
+	for inMemCol, inMemoryKind := range tableData.InMemoryColumns {
+		if inMemoryKind == typing.Invalid {
+			// Don't copy this over.
+			// The being that the rows within tableData probably have the wrong colVal
+			// So it's better to skip even attempting to create this column from memory values.
+			// Whenever we get the first value that's a not-nil or invalid, this column type will be updated.
+			continue
+		}
+
 		tcKind, isOk := tableConfig.Columns()[strings.ToLower(inMemCol)]
 		if isOk {
 			tableData.InMemoryColumns[inMemCol] = tcKind

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -250,13 +250,14 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	// TableData will think the column is invalid and tableConfig will think column = string
 	// Before we call merge, it should reconcile it.
 	columns := map[string]typing.Kind{
-		"first_name":                 typing.Invalid,
+		"first_name":                 typing.String,
+		"invalid_column":             typing.Invalid,
 		constants.DeleteColumnMarker: typing.Boolean,
 	}
 
 	rowsData := map[string]map[string]interface{}{
 		"pk-1": {
-			"first_name": nil,
+			"first_name": "bob",
 		},
 	}
 


### PR DESCRIPTION
We were not swapping `tableConfig.Columns()[strings.ToLower(inMemCol)]` with `tableData.InMemoryColumns` if exists.

The data from `tableConfig` is considered SOT.

