### PR TITLE
Clean up and remove wal2json limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Transfer is aiming to provide coverage across all OLTPs and OLAPs databases. Cur
     - BigQuery
 - OLTPs:
     - MongoDB (Debezium)
-    - Postgres (Debezium w/ wal2json)
+    - Postgres (w/ Debezium), we support the following replication slot plug-ins: `pgoutput`, `decoderbufs` and `wal2json`
 
 _If the database you are using is not on the list, feel free to file for a [feature request](https://github.com/artie-labs/transfer/issues/new)._
 
@@ -102,7 +102,7 @@ Note: Keys here are formatted in dot notation for readability purposes, please e
 | kafka.topicConfigs[0].schema | String | Varies by destination | Name of the schema in Snowflake (required).<br/>Not needed for BigQuery |
 | kafka.topicConfigs[0].topic | String | N | Name of the Kafka topic |
 | kafka.topicConfigs[0].idempotentKey | String | Y | Name of the column that is used for idempotency. This field is highly recommended. <br/> For example: `updated_at` or another timestamp column. |
-| kafka.topicConfigs[0].cdcFormat | String | N | Name of the CDC connector (thus format) we should be expecting to parse against. <br/> Currently, the supported values are: `debezium.postgres.wal2json`, `debezium.mongodb` |
+| kafka.topicConfigs[0].cdcFormat | String | N | Name of the CDC connector (thus format) we should be expecting to parse against. <br/> Currently, the supported values are: `debezium.postgres`, `debezium.postgres.wal2json`, `debezium.mongodb` |
 | kafka.topicConfigs[0].cdcKeyFormat | String | Y | Format for what Kafka Connect will the key to be. This is called `key.converter` in the Kafka Connect properties file. <br/> The supported values are: `org.apache.kafka.connect.storage.StringConverter`, `org.apache.kafka.connect.json.JsonConverter` <br/> If not provided, the default value will be `org.apache.kafka.connect.storage.StringConverter`|
 | bigquery | Object | N<br/>`if outputSource == 'bigquery'` | This is the parent object, please see below |
 | bigquery.pathToCredentials | String | Y<br/>You can directly inject `GOOGLE_APPLICATION_CREDENTIALS` ENV VAR, else Transfer will set it for you based on this value. | Path to the credentials file for Google |
@@ -129,7 +129,7 @@ Note: Keys here are formatted in dot notation for readability purposes, please e
 _Note: If any of these limitations are blocking you from using Transfer. Feel free to contribute or file a bug and we'll get this prioritized!</br>
 The long term goal for Artie Transfer is to be able to extend the service to have as little of these limitations as possible._
 
-**Postgres Debezium wal2json** <br/>
+**Postgres Debezium** <br/>
 * `decimal.handling.mode` only works for `double` or `string`.<br/>
 The default value is `precise` which will cast the value in `java.math.BigDecimal` and Transfer does not know how to decode that yet.
 For further information on how to set this to be `string` or `double`, please [click here](https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-debezium.html#connector-details)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Transfer is aiming to provide coverage across all OLTPs and OLAPs databases. Cur
     - Snowflake
     - BigQuery
 - OLTPs:
-    - MongoDB (Debezium)
+    - MongoDB (w/ Debezium)
     - Postgres (w/ Debezium), we support the following replication slot plug-ins: `pgoutput`, `decoderbufs` and `wal2json`
 
 _If the database you are using is not on the list, feel free to file for a [feature request](https://github.com/artie-labs/transfer/issues/new)._

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -197,22 +197,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		}
 	}
 
-	// We are swapping the order and iterating over InMemoryColumns instead, as the columns are case-sensitive.
-	for inMemCol, inMemoryKind := range tableData.InMemoryColumns {
-		if inMemoryKind == typing.Invalid {
-			// Don't copy this over.
-			// The being that the rows within tableData probably have the wrong colVal
-			// So it's better to skip even attempting to create this column from memory values.
-			// Whenever we get the first value that's a not-nil or invalid, this column type will be updated.
-			continue
-		}
-
-		tcKind, isOk := tableConfig.Columns()[strings.ToLower(inMemCol)]
-		if isOk {
-			tableData.InMemoryColumns[inMemCol] = tcKind
-		}
-	}
-
+	tableData.UpdateInMemoryColumns(tableConfig.Columns())
 	query, err := merge(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -3,7 +3,6 @@ package snowflake
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/snowflakedb/gosnowflake"
@@ -128,25 +127,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		}
 	}
 
-	// We now need to merge the two columns from tableData (which is constructed in-memory) and tableConfig (coming from the describe statement)
-	// Cannot do a full swap because tableData is a super-set of tableConfig (it contains the temp deletion flag and other columns with the __artie prefix).
-
-	// We are swapping the order and iterating over InMemoryColumns instead, as the columns are case-sensitive.
-	for inMemCol, inMemoryKind := range tableData.InMemoryColumns {
-		if inMemoryKind == typing.Invalid {
-			// Don't copy this over.
-			// The being that the rows within tableData probably have the wrong colVal
-			// So it's better to skip even attempting to create this column from memory values.
-			// Whenever we get the first value that's a not-nil or invalid, this column type will be updated.
-			continue
-		}
-
-		tcKind, isOk := tableConfig.Columns()[strings.ToLower(inMemCol)]
-		if isOk {
-			tableData.InMemoryColumns[inMemCol] = tcKind
-		}
-	}
-
+	tableData.UpdateInMemoryColumns(tableConfig.Columns())
 	query, err := merge(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")

--- a/examples/postgres/config.yaml
+++ b/examples/postgres/config.yaml
@@ -8,7 +8,7 @@ kafka:
       tableName: customers
       schema: public
       topic: "dbserver1.inventory.customers"
-      cdcFormat: debezium.postgres.wal2json
+      cdcFormat: debezium.postgres
       # cdcKeyFormat: org.apache.kafka.connect.json.JsonConverter
       # If you turn this on, make sure to check connect-distributed.properties for key.converter
       cdcKeyFormat: org.apache.kafka.connect.storage.StringConverter

--- a/examples/postgres/config.yaml
+++ b/examples/postgres/config.yaml
@@ -8,7 +8,7 @@ kafka:
       tableName: customers
       schema: public
       topic: "dbserver1.inventory.customers"
-      cdcFormat: debezium.postgres
+      cdcFormat: debezium.postgres.wal2json
       # cdcKeyFormat: org.apache.kafka.connect.json.JsonConverter
       # If you turn this on, make sure to check connect-distributed.properties for key.converter
       cdcKeyFormat: org.apache.kafka.connect.storage.StringConverter

--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Format interface {
-	Labels() []string
+	Labels() []string // Labels() to return a list of strings to maintain backward compatibility.
 	GetPrimaryKey(ctx context.Context, key []byte, tc *kafkalib.TopicConfig) (string, interface{}, error)
 	GetEventFromBytes(ctx context.Context, bytes []byte) (Event, error)
 }

--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Format interface {
-	Label() string
+	Labels() []string
 	GetPrimaryKey(ctx context.Context, key []byte, tc *kafkalib.TopicConfig) (string, interface{}, error)
 	GetEventFromBytes(ctx context.Context, bytes []byte) (Event, error)
 }

--- a/lib/cdc/format/format.go
+++ b/lib/cdc/format/format.go
@@ -20,9 +20,11 @@ func GetFormatParser(ctx context.Context, label string) cdc.Format {
 	}
 
 	for _, validFormat := range validFormats {
-		if validFormat.Label() == label {
-			logger.FromContext(ctx).WithField("label", validFormat.Label()).Info("Loaded CDC Format parser...")
-			return validFormat
+		for _, fmtLabel := range validFormat.Labels() {
+			if fmtLabel == label {
+				logger.FromContext(ctx).WithField("label", fmtLabel).Info("Loaded CDC Format parser...")
+				return validFormat
+			}
 		}
 	}
 

--- a/lib/cdc/format/format_test.go
+++ b/lib/cdc/format/format_test.go
@@ -2,11 +2,13 @@ package format
 
 import (
 	"context"
-	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
 )
 
 func TestGetFormatParser(t *testing.T) {

--- a/lib/cdc/format/format_test.go
+++ b/lib/cdc/format/format_test.go
@@ -1,0 +1,41 @@
+package format
+
+import (
+	"context"
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestGetFormatParser(t *testing.T) {
+	ctx := context.Background()
+	validFormats := []string{constants.DBZPostgresAltFormat, constants.DBZPostgresFormat, constants.DBZMongoFormat}
+	for _, validFormat := range validFormats {
+		assert.NotNil(t, GetFormatParser(ctx, validFormat))
+	}
+}
+
+func testOsExit(t *testing.T, testFunc func(*testing.T)) {
+	if os.Getenv(t.Name()) == "1" {
+		testFunc(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
+	cmd.Env = append(os.Environ(), t.Name()+"=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		return
+	}
+
+	t.Fatal("subprocess ran successfully, want non-zero exit status")
+}
+
+func TestGetFormatParserFatal(t *testing.T) {
+	// This test cannot be iterated because it forks a separate process to do `go test -test.run=...`
+	testOsExit(t, func(t *testing.T) {
+		GetFormatParser(context.Background(), "foo")
+	})
+}

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -58,8 +58,8 @@ func (d *Debezium) GetEventFromBytes(_ context.Context, bytes []byte) (cdc.Event
 	return &schemaEventPayload, nil
 }
 
-func (d *Debezium) Label() string {
-	return constants.DBZMongoFormat
+func (d *Debezium) Labels() []string {
+	return []string{constants.DBZMongoFormat}
 }
 
 // GetPrimaryKey - Will read from the Kafka message's partition key to get the primary key for the row.

--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -26,8 +26,8 @@ func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Eve
 	return &event, nil
 }
 
-func (d *Debezium) Label() string {
-	return constants.DBZPostgresFormat
+func (d *Debezium) Labels() []string {
+	return []string{constants.DBZPostgresFormat, constants.DBZPostgresAltFormat}
 }
 
 func (d *Debezium) GetPrimaryKey(ctx context.Context, key []byte, tc *kafkalib.TopicConfig) (pkName string, pkValue interface{}, err error) {

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -12,8 +12,9 @@ const (
 	SnowflakeArraySize = 15000
 
 	// DBZPostgresFormat is the only supported CDC format right now
-	DBZPostgresFormat = "debezium.postgres.wal2json"
-	DBZMongoFormat    = "debezium.mongodb"
+	DBZPostgresFormat    = "debezium.postgres"
+	DBZPostgresAltFormat = "debezium.postgres.wal2json"
+	DBZMongoFormat       = "debezium.mongodb"
 )
 
 // ExporterKind is used for the Telemetry package

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -1,6 +1,7 @@
 package optimization
 
 import (
+	"strings"
 	"time"
 
 	"github.com/segmentio/kafka-go"
@@ -22,4 +23,36 @@ type TableData struct {
 	LatestCDCTs time.Time
 
 	Rows uint
+}
+
+// UpdateInMemoryColumns - When running Transfer, we will have 2 column types.
+// 1) TableData (constructed in-memory)
+// 2) TableConfig (coming from the SQL DESCRIBE or equivalent statement) from the destination
+// Prior to merging, we will need to treat `tableConfig` as the source-of-truth and whenever there's discrepancies
+// We will prioritize using the values coming from (2) TableConfig. We also cannot simply do a replacement, as we have in-memory columns
+// That carry metadata for Artie Transfer. They are prefixed with __artie.
+func (t *TableData) UpdateInMemoryColumns(cols map[string]typing.Kind) {
+	if t == nil {
+		return
+	}
+
+	for inMemCol, inMemKind := range t.InMemoryColumns {
+		if inMemKind == typing.Invalid {
+			// Don't copy this over.
+			// The being that the rows within tableData probably have the wrong colVal
+			// So it's better to skip even attempting to create this column from memory values.
+			// Whenever we get the first value that's a not-nil or invalid, this column type will be updated.
+			continue
+		}
+
+		// strings.ToLower() is used because certain destinations do not follow JSON standards.
+		// Snowflake and BigQuery consider: NaMe, NAME, name as the same value. Whereas JSON considers these as 3 distinct values.
+		tcKind, isOk := cols[strings.ToLower(inMemCol)]
+		if isOk {
+			// Update in-memory column type with whatever is specified by the destination.
+			t.InMemoryColumns[inMemCol] = tcKind
+		}
+	}
+
+	return
 }

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -1,0 +1,37 @@
+package optimization
+
+import (
+	"testing"
+	
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTableData_UpdateInMemoryColumns(t *testing.T) {
+	tableData := &TableData{
+		InMemoryColumns: map[string]typing.Kind{
+			"FOO":       typing.String,
+			"bar":       typing.Invalid,
+			"CHANGE_me": typing.String,
+		},
+	}
+
+	tableData.UpdateInMemoryColumns(map[string]typing.Kind{
+		"foo":       typing.String,
+		"change_me": typing.DateTime,
+		"bar":       typing.Boolean,
+	})
+
+	// It's saved back in the original format.
+	_, isOk := tableData.InMemoryColumns["foo"]
+	assert.False(t, isOk)
+
+	_, isOk = tableData.InMemoryColumns["FOO"]
+	assert.True(t, isOk)
+
+	colType, _ := tableData.InMemoryColumns["CHANGE_me"]
+	assert.Equal(t, typing.DateTime, colType)
+
+	colType, _ = tableData.InMemoryColumns["bar"]
+	assert.Equal(t, typing.Invalid, colType)
+}

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -2,7 +2,7 @@ package optimization
 
 import (
 	"testing"
-	
+
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/stretchr/testify/assert"
 )

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -78,8 +78,7 @@ func ParseValue(val interface{}) Kind {
 		return Integer
 	case float32, float64:
 		// Integers will be parsed as Floats if they come from JSON
-		// This is a limitation with wal2json and JSON in general
-		// See: https://github.com/golang/go/issues/56719
+		// This is a limitation with JSON, https://github.com/golang/go/issues/56719
 		return Float
 	case bool:
 		return Boolean


### PR DESCRIPTION
In this PR, we will be doing the following:

1) Remove `wal2json` as a limitation for PostgreSQL replication slot plug-in. We've tested `pgoutput` and `decoderbufs` in addition to `wal2json`. All of which are supported.

2) Adding additional test coverage around BQ merge