### PR TITLE
Adding .goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# GoReleaser
+dist/*
+
 *.mock.go
 .envrc-personal
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,12 +30,19 @@ dockers:
 
   # Path to the Dockerfile (from the project root).
   # Defaults to `Dockerfile`.
-  dockerfile: Dockerfile
+  dockerfile: goreleaser.dockefile
 
   # Set the "backend" for the Docker pipe.
   # Valid options are: docker, buildx, podman.
   # Defaults to docker.
   use: docker
+  build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--platform=linux/amd64"
 
 
 archives:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,67 @@
+project_name: artie-transfer
+
+# .goreleaser.yaml
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+dockers:
+- # You can have multiple Docker images.
+  # GOOS of the built binaries/packages that should be used.
+  # Default: `linux`.
+  goos: linux
+
+  # GOARCH of the built binaries/packages that should be used.
+  # Default: `amd64`.
+  goarch: amd64
+
+  # Skips the docker push.
+  skip_push: false
+
+  # Path to the Dockerfile (from the project root).
+  # Defaults to `Dockerfile`.
+  dockerfile: Dockerfile
+
+  # Set the "backend" for the Docker pipe.
+  # Valid options are: docker, buildx, podman.
+  # Defaults to docker.
+  use: docker
+
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
 
 dockers:
@@ -46,10 +45,6 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-    # use zip for windows archives
-    format_overrides:
-    - goos: windows
-      format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,10 @@ builds:
       - darwin
 
 dockers:
-- # You can have multiple Docker images.
+- image_templates:
+    - "artie-labs/transfer:latest"
+    - "artie-labs/transfer:{{ .Tag }}"
+  # You can have multiple Docker images.
   # GOOS of the built binaries/packages that should be used.
   # Default: `linux`.
   goos: linux

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,8 +15,8 @@ builds:
 
 dockers:
 - image_templates:
-    - "artie-labs/transfer:latest"
-    - "artie-labs/transfer:{{ .Tag }}"
+    - "artielabs/transfer:latest"
+    - "artielabs/transfer:{{ .Tag }}"
   # You can have multiple Docker images.
   # GOOS of the built binaries/packages that should be used.
   # Default: `linux`.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,8 @@ before:
     # You may remove this if you don't use go modules.
     - go mod tidy
 builds:
-  - env:
+  - binary: transfer
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -30,7 +31,7 @@ dockers:
 
   # Path to the Dockerfile (from the project root).
   # Defaults to `Dockerfile`.
-  dockerfile: goreleaser.dockefile
+  dockerfile: goreleaser.dockerfile
 
   # Set the "backend" for the Docker pipe.
   # Valid options are: docker, buildx, podman.

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,10 @@ clean:
 generate:
 	go generate ./...
 
+.PHONY: build
+build:
+	goreleaser build --clean
+
+.PHONY: release
+release:
+	goreleaser release

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ build:
 
 .PHONY: release
 release:
-	goreleaser release
+	goreleaser release --clean

--- a/README.md
+++ b/README.md
@@ -83,12 +83,7 @@ make test
 
 ## Release
 
-```sh
-docker build .
-docker tag IMAGE_ID artielabs/transfer:0.1
-docker push artielabs/transfer:0.1
-```
-
+Artie Transfer is released through [GoReleaser](https://goreleaser.com/), and we use it to cross-compile our binaries on the [releases](https://github.com/artie-labs/transfer/releases) as well as our Dockerhub. If your operating system or architecture is not supported, please file a feature request!
 
 ## License
 

--- a/goreleaser.dockefile
+++ b/goreleaser.dockefile
@@ -1,0 +1,3 @@
+FROM scratch
+COPY app /app
+ENTRYPOINT [ "/app" ]

--- a/goreleaser.dockefile
+++ b/goreleaser.dockefile
@@ -1,3 +1,0 @@
-FROM scratch
-COPY app /app
-ENTRYPOINT [ "/app" ]

--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -1,0 +1,2 @@
+FROM --platform=linux/amd64 alpine:3.16
+COPY transfer /transfer


### PR DESCRIPTION
Integrating with `.goreleaser` so we can have a streamline way to release builds.