### PR TITLE
[Enhancement] Improving typing for PostgreSQL

### DIFF
--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -386,6 +386,7 @@ func (p *MongoTestSuite) TestMongoDBEventWithSchema() {
 		Optional:     false,
 		FieldName:    "version",
 		DebeziumType: "",
+		Type:         "string",
 	})
 
 }

--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -76,6 +76,15 @@ func (s *SchemaEventPayload) GetData(pkName string, pkVal interface{}, tc *kafka
 	afterSchemaObject := s.Schema.GetSchemaFromLabel(cdc.After)
 	if afterSchemaObject != nil {
 		for _, field := range afterSchemaObject.Fields {
+			// Check if the field is an integer and requires us to cast it as such.
+			if field.IsInteger() {
+				valFloat, isOk := retMap[field.FieldName].(float64)
+				if isOk {
+					retMap[field.FieldName] = int(valFloat)
+					continue
+				}
+			}
+
 			if valid, supportedType := debezium.RequiresSpecialTypeCasting(field.DebeziumType); valid {
 				val, isOk := retMap[field.FieldName]
 				if isOk {

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/typing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -208,6 +209,11 @@ func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 				"default": 0,
 				"field": "id"
 			}, {
+				"type": "int32",
+				"optional": false,
+				"default": 0,
+				"field": "another_id"
+			}, {
 				"type": "string",
 				"optional": false,
 				"field": "first_name"
@@ -250,6 +256,7 @@ func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 		"before": {},
 		"after": {
 			"id": 1001,
+			"another_id": 333,
 			"first_name": "Sally",
 			"last_name": "Thomas",
 			"email": "sally.thomas@acme.com",
@@ -282,7 +289,12 @@ func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 	assert.Nil(p.T(), err)
 
 	evtData := evt.GetData("id", 1001, &kafkalib.TopicConfig{})
-	assert.Equal(p.T(), evtData["id"], float64(1001))
+
+	// Testing typing.
+	assert.Equal(p.T(), evtData["id"], 1001)
+	assert.Equal(p.T(), evtData["another_id"], 333)
+	assert.Equal(p.T(), typing.ParseValue(evtData["another_id"]), typing.Integer)
+
 	assert.Equal(p.T(), evtData["email"], "sally.thomas@acme.com")
 
 	td := time.Date(2023, time.February, 2, 17, 51, 35, 0, time.UTC)

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -1,6 +1,8 @@
 package debezium
 
-import "github.com/artie-labs/transfer/lib/cdc"
+import (
+	"github.com/artie-labs/transfer/lib/cdc"
+)
 
 type Schema struct {
 	SchemaType   string         `json:"type"`
@@ -30,8 +32,20 @@ type FieldsObject struct {
 }
 
 type Field struct {
+	Type         string      `json:"type"`
 	Optional     bool        `json:"optional"`
 	Default      interface{} `json:"default"`
 	FieldName    string      `json:"field"`
 	DebeziumType string      `json:"name"`
+}
+
+// IsInteger inspects the field object within the schema object, a field is classified as an int
+// When the "type" is int32 or int64. It also should not have a name (as that's where DBZ specify the data types)
+func (f *Field) IsInteger() (valid bool) {
+	if f == nil {
+		return
+	}
+
+	validIntegerType := f.Type == "int32" || f.Type == "int64"
+	return validIntegerType && f.DebeziumType == ""
 }

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -1,0 +1,59 @@
+package debezium
+
+import (
+	"encoding/json"
+	"github.com/artie-labs/transfer/lib/cdc"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestField_IsInteger(t *testing.T) {
+	payload := `
+{
+	"type": "struct",
+	"fields": [{
+		"type": "struct",
+		"fields": [{
+			"type": "int32",
+			"optional": false,
+			"default": 0,
+			"field": "id"
+		}, {
+			"type": "string",
+			"optional": false,
+			"field": "first_name"
+		}, {
+			"type": "string",
+			"optional": false,
+			"field": "last_name"
+		}, {
+			"type": "string",
+			"optional": false,
+			"field": "email"
+		}],
+		"optional": true,
+		"name": "dbserver1.inventory.customers.Value",
+		"field": "after"
+	}],
+	"optional": false,
+	"name": "dbserver1.inventory.customers.Envelope",
+	"version": 1
+}
+`
+
+	var schema Schema
+	err := json.Unmarshal([]byte(payload), &schema)
+	assert.NoError(t, err)
+
+	var checked bool
+	for _, field := range schema.GetSchemaFromLabel(cdc.After).Fields {
+		if field.FieldName == "id" {
+			assert.True(t, field.IsInteger())
+			checked = true
+		} else {
+			assert.False(t, field.IsInteger())
+		}
+	}
+
+	assert.True(t, checked)
+}

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -78,7 +78,9 @@ func ParseValue(val interface{}) Kind {
 		return Integer
 	case float32, float64:
 		// Integers will be parsed as Floats if they come from JSON
-		// This is a limitation with JSON, https://github.com/golang/go/issues/56719
+		// This is a limitation with JSON - https://github.com/golang/go/issues/56719
+		// UNLESS Transfer is provided with a schema object, and we deliberately typecast the value to an integer
+		// before calling ParseValue().
 		return Float
 	case bool:
 		return Boolean


### PR DESCRIPTION
We were previously only relying on the `JSON` library for parsing Kafka messages to determine typing. As you can see from https://github.com/golang/go/issues/56719

[RFC 8259](https://www.rfc-editor.org/rfc/rfc8259#section-3):
> A JSON value MUST be an object, array, number, or string, or one of the following three literal names:
> * false
> * null
> * true
> There is only number, but not int or float in JSON.

Previous PR added schema support within the message and this PR builds on top of this for PostgreSQL by being able to detect if the specified field is an integer. 

If so, it will typecast within `GetData(...)` and ensure that Transfer's typing library correctly labels the said value as an integer.