### PR TITLE
[Enhancement] Adding the ability to toggle soft deletion

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -88,7 +88,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 
 	subQuery := strings.Join(rowValues, " UNION ALL ")
 	return dml.MergeStatement(tableData.ToFqName(constants.BigQuery), subQuery,
-		tableData.PrimaryKey, tableData.IdempotentKey, cols)
+		tableData.PrimaryKey, tableData.IdempotentKey, cols, tableData.SoftDelete)
 }
 
 func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
@@ -104,7 +104,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, tableConfig.Columns())
+	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, tableConfig.Columns(), tableData.SoftDelete)
 
 	// Keys that exist in CDC stream, but not in Snowflake
 	err = ddl.AlterTable(ctx, s, tableConfig, tableData.ToFqName(constants.BigQuery), tableConfig.CreateTable, constants.Add, tableData.LatestCDCTs, targetKeysMissing...)

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -88,5 +88,5 @@ func merge(tableData *optimization.TableData) (string, error) {
 		strings.Join(tableValues, ","), tableData.TopicConfig.TableName, strings.Join(cols, ","))
 
 	return dml.MergeStatement(tableData.ToFqName(constants.Snowflake), subQuery,
-		tableData.PrimaryKey, tableData.IdempotentKey, cols)
+		tableData.PrimaryKey, tableData.IdempotentKey, cols, tableData.SoftDelete)
 }

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -52,7 +52,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, tableConfig.Columns())
+	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, tableConfig.Columns(), tableData.SoftDelete)
 
 	// Keys that exist in CDC stream, but not in Snowflake
 	err = ddl.AlterTable(ctx, s, tableConfig, fqName, tableConfig.CreateTable, constants.Add, tableData.LatestCDCTs, targetKeysMissing...)

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -24,7 +24,7 @@ func ColumnsUpdateQuery(columns []string, tablePrefix string) string {
 
 	for _, column := range columns {
 		// This is to make it look like: objCol = cc.objCol::variant
-		_columns = append(_columns, fmt.Sprintf("%s = %s.%s", column, tablePrefix, column))
+		_columns = append(_columns, fmt.Sprintf("%s=%s.%s", column, tablePrefix, column))
 	}
 
 	return strings.Join(_columns, ",")

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -170,7 +170,8 @@ kafka:
  password: bar
  topicConfigs:
   - { db: customer, tableName: orders, schema: public, topic: orders, cdcFormat: debezium.mongodb, dropDeletedColumns: true}
-  - { db: customer, tableName: customer, schema: public, topic: customer, cdcFormat: debezium.mongodb}
+  - { db: customer, tableName: customer, schema: public, topic: customer, cdcFormat: debezium.mongodb, softDelete: true}
+  - { db: customer, tableName: customer55, schema: public, topic: customer55, cdcFormat: debezium.mongodb, dropDeletedColumns: false, softDelete: true}
 `)
 
 	assert.Nil(t, err)
@@ -185,8 +186,10 @@ kafka:
 	for _, tc := range config.Kafka.TopicConfigs {
 		if tc.TableName == "orders" {
 			assert.Equal(t, tc.DropDeletedColumns, true)
+			assert.Equal(t, tc.SoftDelete, false)
 		} else {
 			assert.Equal(t, tc.DropDeletedColumns, false)
+			assert.Equal(t, tc.SoftDelete, true)
 		}
 	}
 

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -9,7 +9,7 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 )
 
-func MergeStatement(fqTableName, subQuery, pk, idempotentKey string, cols []string) (string, error) {
+func MergeStatement(fqTableName, subQuery, pk, idempotentKey string, cols []string, softDelete bool) (string, error) {
 	// We should not need idempotency key for DELETE
 	// This is based on the assumption that the primary key would be atomically increasing or UUID based
 	// With AI, the sequence will increment (never decrement). And UUID is there to prevent universal hash collision

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -9,6 +9,38 @@ import (
 	"time"
 )
 
+func TestMergeStatementSoftDelete(t *testing.T) {
+	// No idempotent key
+	fqTable := "database.schema.table"
+	cols := []string{
+		"id",
+		"bar",
+		"updated_at",
+		constants.DeleteColumnMarker,
+	}
+
+	tableValues := []string{
+		fmt.Sprintf("('%s', '%s', '%v', false)", "1", "456", time.Now().Round(0).Format(time.RFC3339)),
+		fmt.Sprintf("('%s', '%s', '%v', true)", "2", "bb", time.Now().Round(0).Format(time.RFC3339)), // Delete row 2.
+		fmt.Sprintf("('%s', '%s', '%v', false)", "3", "dd", time.Now().Round(0).Format(time.RFC3339)),
+	}
+
+	// select cc.foo, cc.bar from (values (12, 34), (44, 55)) as cc(foo, bar);
+	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
+		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
+
+	for _, idempotentKey := range []string{"", "updated_at"} {
+		mergeSQL, err := MergeStatement(fqTable, subQuery, "id", idempotentKey, cols, true)
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
+		// Soft deletion flag being passed.
+		assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("%s=cc.%s", constants.DeleteColumnMarker, constants.DeleteColumnMarker)), mergeSQL)
+
+		assert.Equal(t, len(idempotentKey) > 0, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")))
+	}
+
+}
+
 func TestMergeStatement(t *testing.T) {
 	// No idempotent key
 	fqTable := "database.schema.table"
@@ -36,7 +68,6 @@ func TestMergeStatement(t *testing.T) {
 }
 
 func TestMergeStatementIdempotentKey(t *testing.T) {
-	// No idempotent key
 	fqTable := "database.schema.table"
 	cols := []string{
 		"id",

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -29,7 +29,7 @@ func TestMergeStatement(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
-	mergeSQL, err := MergeStatement(fqTable, subQuery, "id", "", cols)
+	mergeSQL, err := MergeStatement(fqTable, subQuery, "id", "", cols, false)
 	assert.NoError(t, err)
 	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
 	assert.False(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
@@ -55,7 +55,7 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
-	mergeSQL, err := MergeStatement(fqTable, subQuery, "id", "updated_at", cols)
+	mergeSQL, err := MergeStatement(fqTable, subQuery, "id", "updated_at", cols, false)
 	assert.NoError(t, err)
 	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
 	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -15,8 +15,7 @@ type TopicConfig struct {
 	CDCFormat          string `yaml:"cdcFormat"`
 	CDCKeyFormat       string `yaml:"cdcKeyFormat"`
 	DropDeletedColumns bool   `yaml:"dropDeletedColumns"`
-	// TODO - test
-	SoftDelete bool `yaml:"softDelete"`
+	SoftDelete         bool   `yaml:"softDelete"`
 }
 
 const (

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -15,6 +15,8 @@ type TopicConfig struct {
 	CDCFormat          string `yaml:"cdcFormat"`
 	CDCKeyFormat       string `yaml:"cdcKeyFormat"`
 	DropDeletedColumns bool   `yaml:"dropDeletedColumns"`
+	// TODO - test
+	SoftDelete bool `yaml:"softDelete"`
 }
 
 const (

--- a/models/flush/flush.go
+++ b/models/flush/flush.go
@@ -38,7 +38,6 @@ func Flush(ctx context.Context) error {
 		if err != nil {
 			tags["what"] = "merge_fail"
 			log.WithError(err).WithFields(logFields).Warn("Failed to execute merge...not going to flush memory")
-
 		} else {
 			log.WithFields(logFields).Info("Merge success, clearing memory...")
 			commitErr := kafka.CommitOffset(ctx, tableData.Topic, tableData.PartitionsToLastMessage)


### PR DESCRIPTION
Right now, Transfer's handling of DML is that it will delete the rows in the destination if the rows have been deleted in the source.

This PR adds an ability to soft delete the row by adding a column: `__artie_delete` (bool).
* If someone turns on soft deletion (off by default), it will add the column above.
* If the row is deleted and soft deletion is turned on, it will set `__artie_delete = true`