### PR TITLE
Fix HTML code in string column and double quote in JSON data

### DIFF
--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -14,7 +14,7 @@ import (
 
 func stringWrapping(colVal interface{}) string {
 	// Escape line breaks, JSON_PARSE does not like it.
-	colVal = strings.ReplaceAll(fmt.Sprint(colVal), `\n`, `\\n`)
+	colVal = strings.ReplaceAll(fmt.Sprint(colVal), `\`, `\\`)
 	// The normal string escape is to do for O'Reilly is O\\'Reilly, but Snowflake escapes via \'
 	return fmt.Sprintf("'%s'", strings.ReplaceAll(fmt.Sprint(colVal), "'", `\'`))
 }


### PR DESCRIPTION
Opening this pull request to fix some issues I run into while setting up sync between PostgreSQL 12.11 and Snowflake.

Apologies if the tests look weird, I'm not familiar with Golang, so I just followed the pattern I saw in the existing test file.

Basically I saw 2 scenarios when the generated SQL code contained syntax errors:
1. When a text column in the database table contains HTML code that contains escaped javascript code (ie. data got in the DB during penetration testing for XSS attacks)
2. When a JSON column in the database table contains a string value that contains a `"` symbol