### PR TITLE
Escape strings correctly for BQ

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/artie-labs/transfer/lib/stringutil"
 	"strings"
 	"time"
 
@@ -53,10 +54,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 					}
 				// All the other types do not need string wrapping.
 				case typing.String.Kind, typing.Struct.Kind:
-					// Escape line breaks, JSON_PARSE does not like it.
-					colVal = strings.ReplaceAll(fmt.Sprint(colVal), `\n`, `\\n`)
-					// The normal string escape is to do for O'Reilly is O\\'Reilly, but Snowflake escapes via \'
-					colVal = fmt.Sprintf("'%s'", strings.ReplaceAll(fmt.Sprint(colVal), "'", `\'`))
+					colVal = stringutil.Wrap(colVal)
 					if colKind == typing.Struct {
 						// This is how you cast string -> JSON
 						colVal = fmt.Sprintf("JSON %s", colVal)

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -8,16 +8,10 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/dwh/dml"
 	"github.com/artie-labs/transfer/lib/optimization"
+	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
-
-func stringWrapping(colVal interface{}) string {
-	// Escape line breaks, JSON_PARSE does not like it.
-	colVal = strings.ReplaceAll(fmt.Sprint(colVal), `\`, `\\`)
-	// The normal string escape is to do for O'Reilly is O\\'Reilly, but Snowflake escapes via \'
-	return fmt.Sprintf("'%s'", strings.ReplaceAll(fmt.Sprint(colVal), "'", `\'`))
-}
 
 func merge(tableData *optimization.TableData) (string, error) {
 	var tableValues []string
@@ -57,13 +51,13 @@ func merge(tableData *optimization.TableData) (string, error) {
 
 					switch extTime.NestedKind.Type {
 					case ext.TimeKindType:
-						colVal = stringWrapping(extTime.String(ext.PostgresTimeFormatNoTZ))
+						colVal = stringutil.Wrap(extTime.String(ext.PostgresTimeFormatNoTZ))
 					default:
-						colVal = stringWrapping(extTime.String(""))
+						colVal = stringutil.Wrap(extTime.String(""))
 					}
 
 				case typing.String.Kind, typing.Struct.Kind:
-					colVal = stringWrapping(colVal)
+					colVal = stringutil.Wrap(colVal)
 				case typing.Array.Kind:
 					// We need to marshall, so we can escape the strings.
 					// https://go.dev/play/p/BcCwUSCeTmT

--- a/lib/stringutil/strings.go
+++ b/lib/stringutil/strings.go
@@ -1,5 +1,10 @@
 package stringutil
 
+import (
+	"fmt"
+	"strings"
+)
+
 func Reverse(val string) string {
 	var reverseParts []rune
 	valRune := []rune(val)
@@ -8,4 +13,11 @@ func Reverse(val string) string {
 	}
 
 	return string(reverseParts)
+}
+
+func Wrap(colVal interface{}) string {
+	// Escape line breaks, JSON_PARSE does not like it.
+	colVal = strings.ReplaceAll(fmt.Sprint(colVal), `\`, `\\`)
+	// The normal string escape is to do for O'Reilly is O\\'Reilly, but Snowflake escapes via \'
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(fmt.Sprint(colVal), "'", `\'`))
 }


### PR DESCRIPTION
Follows up from https://github.com/artie-labs/transfer/pull/49, to fix BQ.

Also pulled this into a separate utility function