### PR TITLE
Swap where we source table name from

### DIFF
--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -14,7 +14,6 @@ type Format interface {
 }
 
 type Event interface {
-	Table() string
 	GetExecutionTime() time.Time
 	GetData(ctx context.Context, pkName string, pkVal interface{}, config *kafkalib.TopicConfig) map[string]interface{}
 }

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -81,11 +81,6 @@ func (s *SchemaEventPayload) GetExecutionTime() time.Time {
 	return time.UnixMilli(s.Payload.Source.TsMs).UTC()
 }
 
-func (s *SchemaEventPayload) Table() string {
-	// MongoDB calls a table a collection.
-	return s.Payload.Source.Collection
-}
-
 func (s *SchemaEventPayload) GetData(ctx context.Context, pkName string, pkVal interface{}, tc *kafkalib.TopicConfig) map[string]interface{} {
 	retMap := make(map[string]interface{})
 	if len(s.Payload.AfterMap) == 0 {

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -87,7 +87,10 @@ func (p *MongoTestSuite) TestMongoDBEventOrder() {
 
 	evt, err := p.Debezium.GetEventFromBytes(ctx, []byte(payload))
 	assert.NoError(p.T(), err)
-	assert.Equal(p.T(), evt.Table(), "orders")
+
+	schemaEvt, isOk := evt.(*SchemaEventPayload)
+	assert.True(p.T(), isOk)
+	assert.Equal(p.T(), time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC), schemaEvt.GetExecutionTime())
 }
 
 func (p *MongoTestSuite) TestMongoDBEventCustomer() {
@@ -138,8 +141,6 @@ func (p *MongoTestSuite) TestMongoDBEventCustomer() {
 
 	assert.Equal(p.T(), nestedData["object"], "foo")
 	assert.Equal(p.T(), evtData[constants.DeleteColumnMarker], false)
-
-	assert.Equal(p.T(), evt.Table(), "customers")
 	assert.Equal(p.T(), evt.GetExecutionTime(),
 		time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC))
 }
@@ -182,8 +183,6 @@ func (p *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 
 	assert.Equal(p.T(), evtData["_id"], 1003)
 	assert.Equal(p.T(), evtData[constants.DeleteColumnMarker], true)
-
-	assert.Equal(p.T(), evt.Table(), "customers123")
 	assert.Equal(p.T(), evt.GetExecutionTime(),
 		time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC))
 }

--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -48,10 +48,6 @@ func (s *SchemaEventPayload) GetExecutionTime() time.Time {
 	return time.UnixMilli(s.Payload.Source.TsMs).UTC()
 }
 
-func (s *SchemaEventPayload) Table() string {
-	return s.Payload.Source.Table
-}
-
 func (s *SchemaEventPayload) GetData(ctx context.Context, pkName string, pkVal interface{}, tc *kafkalib.TopicConfig) map[string]interface{} {
 	retMap := make(map[string]interface{})
 	if len(s.Payload.After) == 0 {

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -193,8 +193,8 @@ func (p *PostgresTestSuite) TestPostgresEvent() {
 
 	assert.Equal(p.T(), evtData["item"], "Barings Participation Investors")
 	assert.Equal(p.T(), evtData["nested"], map[string]interface{}{"object": "foo"})
-
-	assert.Equal(p.T(), evt.Table(), "orders")
+	assert.Equal(p.T(), time.Date(2022, time.November, 16,
+		4, 1, 53, 308000000, time.UTC), evt.GetExecutionTime())
 }
 
 func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
@@ -307,5 +307,7 @@ func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 			Format: time.RFC3339Nano,
 		},
 	})
-	assert.Equal(p.T(), evt.Table(), "customers")
+
+	assert.Equal(p.T(), time.Date(2023, time.February, 2,
+		17, 54, 11, 451000000, time.UTC), evt.GetExecutionTime())
 }

--- a/models/event.go
+++ b/models/event.go
@@ -20,7 +20,7 @@ type Event struct {
 
 func ToMemoryEvent(ctx context.Context, event cdc.Event, pkName string, pkValue interface{}, tc *kafkalib.TopicConfig) Event {
 	return Event{
-		Table:           event.Table(),
+		Table:           tc.TableName,
 		PrimaryKeyName:  pkName,
 		PrimaryKeyValue: pkValue,
 		ExecutionTime:   event.GetExecutionTime(),

--- a/models/event_test.go
+++ b/models/event_test.go
@@ -37,7 +37,6 @@ func (m *ModelsTestSuite) TestEvent_IsValid() {
 }
 
 func (m *ModelsTestSuite) TestEvent_TableName() {
-	//var evt postgres.SchemaEventPayload
 	var f fakeEvent
 	evt := ToMemoryEvent(context.Background(), f, "id", "123", &kafkalib.TopicConfig{
 		TableName: "orders",


### PR DESCRIPTION
# Context

Previously, we were fetching the table name from within the message payload itself. Now, we are fetching it directly from the config file.

# Why

We are doing this so that we can support Kafka tombstones (the message will be null, so we will not be able to derive the name from there).

This should be a relatively minor change - however, the in-memory database will now store the table with the table name derived from the destination vs. src.

Scenario #1 - My source table is called `orders` and the table in Snowflake is called `PREFIX_orders`. Our in-memory DB will be saving data against `PREFIX_orders`.

Scenario #2 - Both table names are the same, no changes.