### PR TITLE
Handling Kafka Tombstones

### DIFF
--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -2,7 +2,6 @@ package snowflake
 
 import (
 	"context"
-
 	"github.com/snowflakedb/gosnowflake"
 
 	"github.com/artie-labs/transfer/lib/config"
@@ -51,6 +50,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	log := logger.FromContext(ctx)
+
 	// Check if all the columns exist in Snowflake
 	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, tableConfig.Columns(), tableData.SoftDelete)
 

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -18,6 +18,11 @@ type Debezium string
 
 func (d *Debezium) GetEventFromBytes(_ context.Context, bytes []byte) (cdc.Event, error) {
 	var schemaEventPayload SchemaEventPayload
+	if len(bytes) == 0 {
+		// This is a Kafka Tombstone event.
+		return &schemaEventPayload, nil
+	}
+
 	err := json.Unmarshal(bytes, &schemaEventPayload)
 	if err != nil {
 		return nil, err

--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -19,6 +19,11 @@ type Debezium string
 
 func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Event, error) {
 	var event SchemaEventPayload
+	if len(bytes) == 0 {
+		// This is a Kafka Tombstone event.
+		return &event, nil
+	}
+
 	err := json.Unmarshal(bytes, &event)
 	if err != nil {
 		return nil, err

--- a/models/memory.go
+++ b/models/memory.go
@@ -73,6 +73,11 @@ func (e *Event) Save(topicConfig *kafkalib.TopicConfig, message kafka.Message) (
 			// DBZ has stubbed it out by providing this value, so we will skip it when we see it.
 			// See: https://issues.redhat.com/browse/DBZ-4276
 			delete(e.Data, col)
+
+			// We are directly adding this column to our in-memory database
+			// This ensures that this column exists, we just have an invalid value (so we will not replicate over).
+			// However, this will ensure that we do not drop the column within the destination
+			inMemoryDB.TableData[e.Table].InMemoryColumns[col] = typing.Invalid
 			continue
 		}
 

--- a/processes/kafka/process_test.go
+++ b/processes/kafka/process_test.go
@@ -109,7 +109,6 @@ func TestProcessMessageFailures(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Check that there are corresponding row(s) in the memory DB
-		fmt.Println("memoryDB.TableData[table].RowsData", memoryDB.TableData[table].RowsData)
 		assert.Equal(t, len(memoryDB.TableData[table].RowsData), idx)
 	}
 


### PR DESCRIPTION
In this PR, we are adding support for Kafka tombstones.

This allows users to leverage Kafka tombstone + compaction to optimize performance even further.

Motivation and considerations linked [here](https://docs.google.com/document/d/1ApCs6EewoIlUUHkJGDAJLOs7f13AyB2AhuAAk020FJM/edit?usp=sharing)