### PR TITLE
[Snowflake] Turning on session keep alive

### DIFF
--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -109,11 +109,12 @@ func LoadSnowflake(ctx context.Context, _store *db.Store) *Store {
 	}
 
 	dsn, err := gosnowflake.DSN(&gosnowflake.Config{
-		Account:   config.GetSettings().Config.Snowflake.AccountID,
-		User:      config.GetSettings().Config.Snowflake.Username,
-		Password:  config.GetSettings().Config.Snowflake.Password,
-		Warehouse: config.GetSettings().Config.Snowflake.Warehouse,
-		Region:    config.GetSettings().Config.Snowflake.Region,
+		Account:          config.GetSettings().Config.Snowflake.AccountID,
+		User:             config.GetSettings().Config.Snowflake.Username,
+		Password:         config.GetSettings().Config.Snowflake.Password,
+		Warehouse:        config.GetSettings().Config.Snowflake.Warehouse,
+		Region:           config.GetSettings().Config.Snowflake.Region,
+		KeepSessionAlive: true,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This defaults to `false` and after about a period of inactivity (about 4 hours), Snowflake will request you to restart your client.

Docs: https://docs.snowflake.com/en/sql-reference/parameters#client-session-keep-alive
You can enable it at the Snowflake session level as per [blog post](https://community.streamsets.com/share-your-best-practices-6/snowflake-file-uploader-is-failing-with-authentication-token-has-expired-the-user-must-authenticate-again-error-when-pipeline-is-idle-for-long-time-1226), but that requires additional configuration from our customers.

Instead, we will re-issue a new request upon an inactive session.
