### PR TITLE
[Telemetry] Allowing env vars to override config

### DIFF
--- a/lib/stringutil/strings.go
+++ b/lib/stringutil/strings.go
@@ -21,3 +21,13 @@ func Wrap(colVal interface{}) string {
 	// The normal string escape is to do for O'Reilly is O\\'Reilly, but Snowflake escapes via \'
 	return fmt.Sprintf("'%s'", strings.ReplaceAll(fmt.Sprint(colVal), "'", `\'`))
 }
+
+func Empty(vals ...string) bool {
+	for _, val := range vals {
+		if val == "" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/lib/stringutil/strings_test.go
+++ b/lib/stringutil/strings_test.go
@@ -18,3 +18,11 @@ func TestReverseComplex(t *testing.T) {
 	assert.Equal(t, Reverse(val), Reverse(Reverse(Reverse(val))))
 	assert.Equal(t, val, Reverse(Reverse(val)))
 }
+
+func TestEmpty(t *testing.T) {
+	assert.False(t, Empty("hi", "there", "artie", "transfer"))
+	assert.False(t, Empty("dusty"))
+
+	assert.True(t, Empty("robin", "jacqueline", "charlie", ""))
+	assert.True(t, Empty(""))
+}


### PR DESCRIPTION
This is needed because to send metrics within Kubernetes, we need to inject `status.HostIP` as an env var.

Transfer currently expects the address to be set within `config.yaml` which is being inserted as a `configMap` which is pod agnostic.

This PR allows us to override the Telemetry address by passing both variables: `TELEMETRY_HOST` & `TELEMETRY_PORT`.



![image](https://user-images.githubusercontent.com/4412200/222518856-f27c8923-ccc4-4331-bb7b-3b1166a4522c.png)
