### PR TITLE
[Bug] Fix spacing

### DIFF
--- a/lib/stringutil/strings.go
+++ b/lib/stringutil/strings.go
@@ -31,3 +31,8 @@ func Empty(vals ...string) bool {
 
 	return false
 }
+
+func EscapeSpaces(col string) (escaped bool, newString string) {
+	subStr := " "
+	return strings.Contains(col, subStr), strings.ReplaceAll(col, subStr, "__")
+}

--- a/lib/stringutil/strings_test.go
+++ b/lib/stringutil/strings_test.go
@@ -26,3 +26,17 @@ func TestEmpty(t *testing.T) {
 	assert.True(t, Empty("robin", "jacqueline", "charlie", ""))
 	assert.True(t, Empty(""))
 }
+
+func TestEscapeSpaces(t *testing.T) {
+	colsToExpectation := map[string]map[string]interface{}{
+		"columnA":  {"escaped": "columnA", "space": false},
+		"column_a": {"escaped": "column_a", "space": false},
+		"column a": {"escaped": "column__a", "space": true},
+	}
+
+	for col, expected := range colsToExpectation {
+		containsSpace, escapedString := EscapeSpaces(col)
+		assert.Equal(t, expected["escaped"], escapedString)
+		assert.Equal(t, expected["space"], containsSpace)
+	}
+}


### PR DESCRIPTION
As mentioned in the comments, certain destinations do not handle spacing well (or at all).

Snowflake handles it, if we escape it correctly. However, BigQuery does not accept any spaces within column names.

In order to provide an easy-to-use interface, we will escape all spaces within a column name by adding `__` (double underscores).

This way, columns that have been escaped do not get mistaken with genuine columns that have underscore e.g. `column_a` vs `column a`. This also provides a way for customers downstream to replace double underscores with space.

Depending on feedback, we can also provide this as a configurable option. 