### PR TITLE
[Bug] Fix casing

### DIFF
--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -2,6 +2,7 @@ package snowflake
 
 import (
 	"context"
+	"fmt"
 	"github.com/snowflakedb/gosnowflake"
 
 	"github.com/artie-labs/transfer/lib/config"
@@ -89,6 +90,8 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	tableData.UpdateInMemoryColumns(tableConfig.Columns())
 	query, err := merge(tableData)
+	fmt.Println("query", query)
+
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")
 		return err

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -2,7 +2,6 @@ package snowflake
 
 import (
 	"context"
-	"fmt"
 	"github.com/snowflakedb/gosnowflake"
 
 	"github.com/artie-labs/transfer/lib/config"
@@ -90,8 +89,6 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	tableData.UpdateInMemoryColumns(tableConfig.Columns())
 	query, err := merge(tableData)
-	fmt.Println("query", query)
-
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")
 		return err

--- a/models/memory.go
+++ b/models/memory.go
@@ -9,6 +9,7 @@ import (
 	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/segmentio/kafka-go"
+	"strings"
 	"sync"
 )
 
@@ -68,15 +69,17 @@ func (e *Event) Save(topicConfig *kafkalib.TopicConfig, message kafka.Message) (
 
 	// Update col if necessary
 	for col, val := range e.Data {
+		// columns need to all be normalized and lower cased.
+		col = strings.ToLower(col)
+
 		// Columns here could contain spaces. Every destination treats spaces in a column differently.
 		// So far, Snowflake accepts them when escaped properly, however BigQuery does not accept it.
 		// Instead of making this more complicated for future destinations, we will escape the spaces by having double underscore `__`
 		// So, if customers want to retrieve spaces again, they can replace `__`.
-
 		var containsSpace bool
 		containsSpace, col = stringutil.EscapeSpaces(col)
 		if containsSpace {
-			// Write the message back if the column has changed.
+			// Write the new message
 			e.Data[col] = val
 		}
 

--- a/models/memory.go
+++ b/models/memory.go
@@ -79,7 +79,7 @@ func (e *Event) Save(topicConfig *kafkalib.TopicConfig, message kafka.Message) (
 		var containsSpace bool
 		containsSpace, col = stringutil.EscapeSpaces(col)
 		if containsSpace {
-			// Write the new message
+			// Write the message back if the column has changed.
 			e.Data[col] = val
 		}
 


### PR DESCRIPTION
As a follow up to https://github.com/artie-labs/transfer/pull/31, right now if the source has the following object:
```json
{
"Item Name": "Foo",
"Item name": "Foo"
}
```

Transfer will treat these as distinct columns and try to update the destination. However, the destination will error out since it normalizes all columns and ignores casing.

As a result, we'll now normalize the columns we receive so we don't get errors around duplicate columns.