### PR TITLE
[Snowflake] Fixing all inactive sessions

### DIFF
--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -13,7 +13,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
-func merge(tableData *optimization.TableData) (string, error) {
+func getMergeStatement(tableData *optimization.TableData) (string, error) {
 	var tableValues []string
 	var cols []string
 	var sflkCols []string

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -26,8 +26,8 @@ func (s *SnowflakeTestSuite) TestMergeNoDeleteFlag() {
 		LatestCDCTs:     time.Time{},
 	}
 
-	_, err := merge(tableData)
-	assert.Error(s.T(), err, "merge failed")
+	_, err := getMergeStatement(tableData)
+	assert.Error(s.T(), err, "getMergeStatement failed")
 
 }
 
@@ -62,8 +62,8 @@ func (s *SnowflakeTestSuite) TestMerge() {
 		LatestCDCTs:     time.Time{},
 	}
 
-	mergeSQL, err := merge(tableData)
-	assert.NoError(s.T(), err, "merge failed")
+	mergeSQL, err := getMergeStatement(tableData)
+	assert.NoError(s.T(), err, "getMergeStatement failed")
 	assert.Contains(s.T(), mergeSQL, "robin")
 	assert.Contains(s.T(), mergeSQL, "false")
 	assert.Contains(s.T(), mergeSQL, "1")
@@ -79,8 +79,8 @@ func (s *SnowflakeTestSuite) TestMerge() {
 			}
 
 			assert.True(s.T(), strings.Contains(mergeSQL, fmt.Sprint(val)), map[string]interface{}{
-				"merge": mergeSQL,
-				"val":   val,
+				"getMergeStatement": mergeSQL,
+				"val":               val,
 			})
 		}
 	}
@@ -114,8 +114,8 @@ func (s *SnowflakeTestSuite) TestMergeWithSingleQuote() {
 		LatestCDCTs:     time.Time{},
 	}
 
-	mergeSQL, err := merge(tableData)
-	assert.NoError(s.T(), err, "merge failed")
+	mergeSQL, err := getMergeStatement(tableData)
+	assert.NoError(s.T(), err, "getMergeStatement failed")
 	assert.Contains(s.T(), mergeSQL, `I can\'t fail`)
 }
 
@@ -147,7 +147,7 @@ func (s *SnowflakeTestSuite) TestMergeJson() {
 		LatestCDCTs:     time.Time{},
 	}
 
-	mergeSQL, err := merge(tableData)
-	assert.NoError(s.T(), err, "merge failed")
+	mergeSQL, err := getMergeStatement(tableData)
+	assert.NoError(s.T(), err, "getMergeStatement failed")
 	assert.Contains(s.T(), mergeSQL, `"label": "2\\" pipe"`)
 }

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -79,8 +79,8 @@ func (s *SnowflakeTestSuite) TestMerge() {
 			}
 
 			assert.True(s.T(), strings.Contains(mergeSQL, fmt.Sprint(val)), map[string]interface{}{
-				"getMergeStatement": mergeSQL,
-				"val":               val,
+				"merge": mergeSQL,
+				"val":   val,
 			})
 		}
 	}

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -16,6 +16,7 @@ import (
 
 type Store struct {
 	db.Store
+	testDB    bool // Used for testing
 	configMap *types.DwhToTablesConfigMap
 }
 
@@ -110,6 +111,11 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 }
 
 func (s *Store) ReestablishConnection(ctx context.Context) {
+	if s.testDB {
+		// Don't actually re-establish for tests.
+		return
+	}
+
 	cfg := &gosnowflake.Config{
 		Account:   config.GetSettings().Config.Snowflake.AccountID,
 		User:      config.GetSettings().Config.Snowflake.Username,
@@ -137,6 +143,7 @@ func LoadSnowflake(ctx context.Context, _store *db.Store) *Store {
 	if _store != nil {
 		// Used for tests.
 		return &Store{
+			testDB:    true,
 			Store:     *_store,
 			configMap: &types.DwhToTablesConfigMap{},
 		}

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -20,7 +20,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	// Say the column first_name already exists in Snowflake as "STRING"
 	// I want to delete the value, so I update Postgres and set the cell to be null
 	// TableData will think the column is invalid and tableConfig will think column = string
-	// Before we call getMergeStatement, it should reconcile it.
+	// Before we call merge, it should reconcile it.
 	columns := map[string]typing.KindDetails{
 		"first_name":                 typing.String,
 		"invalid_column":             typing.Invalid,
@@ -96,10 +96,10 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 	err := s.store.Merge(context.Background(), tableData)
 	assert.Nil(s.T(), err)
 	s.fakeStore.ExecReturns(nil, nil)
-	assert.Equal(s.T(), s.fakeStore.ExecCallCount(), 1, "called getMergeStatement")
+	assert.Equal(s.T(), s.fakeStore.ExecCallCount(), 1, "called merge")
 }
 
-// TestExecuteMergeDeletionFlagRemoval is going to run execute getMergeStatement twice.
+// TestExecuteMergeDeletionFlagRemoval is going to run execute merge twice.
 // First time, we will try to delete a column
 // Second time, we'll simulate the data catching up (column exists) and it should now
 // Remove it from the in-memory store.
@@ -150,7 +150,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	err := s.store.Merge(context.Background(), tableData)
 	assert.Nil(s.T(), err)
 	s.fakeStore.ExecReturns(nil, nil)
-	assert.Equal(s.T(), s.fakeStore.ExecCallCount(), 1, "called getMergeStatement")
+	assert.Equal(s.T(), s.fakeStore.ExecCallCount(), 1, "called merge")
 
 	// Check the temp deletion table now.
 	assert.Equal(s.T(), len(s.store.configMap.TableConfig(topicConfig.ToFqName(constants.Snowflake)).ColumnsToDelete()), 1,
@@ -159,7 +159,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	_, isOk := s.store.configMap.TableConfig(topicConfig.ToFqName(constants.Snowflake)).ColumnsToDelete()["new"]
 	assert.True(s.T(), isOk)
 
-	// Now try to execute getMergeStatement where 1 of the rows have the column now
+	// Now try to execute merge where 1 of the rows have the column now
 	for _, pkMap := range tableData.RowsData {
 		pkMap["new"] = "123"
 		tableData.InMemoryColumns = sflkColumns
@@ -172,7 +172,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	err = s.store.Merge(context.Background(), tableData)
 	assert.NoError(s.T(), err)
 	s.fakeStore.ExecReturns(nil, nil)
-	assert.Equal(s.T(), s.fakeStore.ExecCallCount(), 2, "called getMergeStatement again")
+	assert.Equal(s.T(), s.fakeStore.ExecCallCount(), 2, "called merge again")
 
 	// Caught up now, so columns should be 0.
 	assert.Equal(s.T(), len(s.store.configMap.TableConfig(topicConfig.ToFqName(constants.Snowflake)).ColumnsToDelete()), 0,


### PR DESCRIPTION
With the previous PR: https://github.com/artie-labs/transfer/pull/57, we made it so that we would re-establish a session upon a failed execute.

However, other queries can fail. So we are now wrapping the whole merge function and will re-establish a connection upon any idle errors as a result of execution or query.