### PR TITLE
Supporting additional Debezium time precision

### DIFF
--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -13,7 +13,6 @@ import (
 type Debezium string
 
 func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Event, error) {
-	fmt.Println("string", string(bytes))
 	var event util.SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.

--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -13,6 +13,7 @@ import (
 type Debezium string
 
 func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Event, error) {
+	fmt.Println("string", string(bytes))
 	var event util.SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -15,6 +15,10 @@ const (
 	Date           SupportedDebeziumType = "io.debezium.time.Date"
 	Time           SupportedDebeziumType = "io.debezium.time.Time"
 	TimeMicro      SupportedDebeziumType = "io.debezium.time.MicroTime"
+
+	DateKafkaConnect     SupportedDebeziumType = "org.apache.kafka.connect.data.Date"
+	TimeKafkaConnect     SupportedDebeziumType = "org.apache.kafka.connect.data.Time"
+	DateTimeKafkaConnect SupportedDebeziumType = "org.apache.kafka.connect.data.Timestamp"
 )
 
 var supportedTypes = []SupportedDebeziumType{
@@ -23,6 +27,9 @@ var supportedTypes = []SupportedDebeziumType{
 	Date,
 	Time,
 	TimeMicro,
+	DateKafkaConnect,
+	TimeKafkaConnect,
+	DateTimeKafkaConnect,
 }
 
 func RequiresSpecialTypeCasting(typeLabel string) (bool, SupportedDebeziumType) {
@@ -38,21 +45,23 @@ func RequiresSpecialTypeCasting(typeLabel string) (bool, SupportedDebeziumType) 
 func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ext.ExtendedTime, error) {
 	// https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-temporal-types
 	switch supportedType {
-	case Timestamp:
+	case Timestamp, DateTimeKafkaConnect:
 		// Represents the number of milliseconds since the epoch, and does not include timezone information.
 		return ext.NewExtendedTime(time.UnixMilli(val).In(time.UTC), ext.DateTimeKindType, time.RFC3339Nano)
 	case MicroTimestamp:
 		// Represents the number of microseconds since the epoch, and does not include timezone information.
 		return ext.NewExtendedTime(time.UnixMicro(val).In(time.UTC), ext.DateTimeKindType, time.RFC3339Nano)
-	case Date:
+	case Date, DateKafkaConnect:
+		unix := time.UnixMilli(0).In(time.UTC) // 1970-01-01
 		// Represents the number of days since the epoch.
-		return ext.NewExtendedTime(time.UnixMicro(0).AddDate(0, 0, int(val)).In(time.UTC), ext.DateKindType, "")
-	case Time:
+		return ext.NewExtendedTime(unix.AddDate(0, 0, int(val)), ext.DateKindType, "")
+	case Time, TimeKafkaConnect:
 		// Represents the number of milliseconds past midnight, and does not include timezone information.
 		return ext.NewExtendedTime(time.UnixMilli(val).In(time.UTC), ext.TimeKindType, "")
 	case TimeMicro:
 		// Represents the number of microseconds past midnight, and does not include timezone information.
 		return ext.NewExtendedTime(time.UnixMicro(val).In(time.UTC), ext.TimeKindType, "")
+
 	}
 
 	return nil, fmt.Errorf("supportedType: %s, val: %v failed to be matched", supportedType, val)

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -3,10 +3,28 @@ package debezium
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestFromDebeziumTypeToTime(t *testing.T) {
 	dt, err := FromDebeziumTypeToTime(Date, int64(19401))
 	assert.Equal(t, "2023-02-13", dt.String(""))
 	assert.NoError(t, err)
+}
+
+func TestFromDebeziumTypeTimePrecisionConnect(t *testing.T) {
+	// Timestamp
+	extendedTimestamp, err := FromDebeziumTypeToTime(DateTimeKafkaConnect, 1678901050700)
+	assert.NoError(t, err)
+	assert.Equal(t, time.Date(2023, 03, 15, 17, 24, 10, 700000000, time.UTC), extendedTimestamp.Time)
+
+	// Time
+	extendedTime, timeErr := FromDebeziumTypeToTime(TimeKafkaConnect, 54720000)
+	assert.NoError(t, timeErr)
+	assert.Equal(t, "15:12:00+00", extendedTime.String(""))
+
+	// Date
+	extendedDate, dateErr := FromDebeziumTypeToTime(DateKafkaConnect, 19429)
+	assert.NoError(t, dateErr)
+	assert.Equal(t, "2023-03-13", extendedDate.String(""))
 }


### PR DESCRIPTION
Debezium has different modes for handling time precisions, 

[Source](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-temporal-types)
* Adaptive (default)
* Adaptive microseconds (PostgreSQL only)
* Connect

We already supported adaptive, this PR will enable us to support the other two types to make it easier.

## time.precision.mode=adaptive  

Database Type | Value | Notes |
-- | -- | --
DATE | INT32 | io.debezium.time.Date<br />Represents the number of days since the epoch.
TIME(1), TIME(2), TIME(3) | INT32 | io.debezium.time.Time<br />Represents the number of milliseconds past midnight, and does not include timezone information.
TIME(4), TIME(5), TIME(6) | INT64 | io.debezium.time.MicroTime<br />Represents the number of microseconds past midnight, and does not include timezone information.
TIMESTAMP(1), TIMESTAMP(2), TIMESTAMP(3) | INT64 | io.debezium.time.Timestamp<br />Represents the number of milliseconds since the epoch, and does not include timezone information.
TIMESTAMP(4), TIMESTAMP(5), TIMESTAMP(6), TIMESTAMP | INT64 | io.debezium.time.MicroTimestamp<br />Represents the number of microseconds since the epoch, and does not include timezone information.


## time.precision.mode=adaptive_time_microseconds

Database Type | Value | Notes |
-- | -- | --
DATE | INT32 | io.debezium.time.Date<br />Represents the number of days since the epoch.
TIME([P]) | INT64 | io.debezium.time.MicroTime<br />Represents the time value in microseconds and does not include timezone information. PostgreSQL allows precision P to be in the range 0-6 to store up to microsecond precision.
TIMESTAMP(1) , TIMESTAMP(2), TIMESTAMP(3) | INT64 | io.debezium.time.Timestamp<br />Represents the number of milliseconds past the epoch, and does not include timezone information.
TIMESTAMP(4) , TIMESTAMP(5), TIMESTAMP(6), TIMESTAMP | INT64 | io.debezium.time.MicroTimestamp<br />Represents the number of microseconds past the epoch, and does not include timezone information.


## time.precision.mode=connect

Database Type | Value | Notes |
-- | -- | --
DATE | INT32 | org.apache.kafka.connect.data.Date<br />Represents the number of days since the epoch.
TIME([P]) | INT64 | org.apache.kafka.connect.data.Time<br />Represents the number of milliseconds since midnight, and does not include timezone information. PostgreSQL allows P to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when P is greater than 3.
TIMESTAMP([P]) | INT64 | org.apache.kafka.connect.data.Timestamp<br />Represents the number of milliseconds since the epoch, and does not include timezone information. PostgreSQL allows P to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when P is greater than 3.



