### PR TITLE
BigQuery <> MongoDB equality fix

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -151,8 +151,6 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		return err
 	}
 
-	fmt.Println("query", query)
-
 	log.WithField("query", query).Debug("executing...")
 	_, err = s.Exec(query)
 	return err

--- a/clients/bigquery/merge_test.go
+++ b/clients/bigquery/merge_test.go
@@ -64,6 +64,64 @@ func (b *BigQueryTestSuite) TestMerge() {
 	assert.NoError(b.T(), err, "merge failed")
 	// Check if MERGE INTO FQ Table exists.
 	assert.True(b.T(), strings.Contains(mergeSQL, "MERGE INTO shop.customer c"), mergeSQL)
+	// Check for equality merge
+	assert.True(b.T(), strings.Contains(mergeSQL, fmt.Sprintf("c.%s = cc.%s", tableData.PrimaryKey, tableData.PrimaryKey)))
+	for _, rowData := range tableData.RowsData {
+		for col, val := range rowData {
+			switch cols[col] {
+			case typing.String, typing.Array, typing.Struct:
+				val = fmt.Sprintf("'%v'", val)
+			}
+
+			assert.True(b.T(), strings.Contains(mergeSQL, fmt.Sprint(val)), map[string]interface{}{
+				"merge": mergeSQL,
+				"val":   val,
+			})
+		}
+	}
+}
+
+func (b *BigQueryTestSuite) TestMergeJSONKey() {
+	cols := map[string]typing.KindDetails{
+		"id":                         typing.Struct,
+		"name":                       typing.String,
+		constants.DeleteColumnMarker: typing.Boolean,
+	}
+
+	rowData := make(map[string]map[string]interface{})
+	for idx, name := range []string{"robin", "jacqueline", "dusty"} {
+		pkVal := fmt.Sprint(map[string]interface{}{
+			"$oid": fmt.Sprintf("640127e4beeb1ccfc821c25c++%v", idx),
+		})
+
+		rowData[pkVal] = map[string]interface{}{
+			"id":                         pkVal,
+			"name":                       name,
+			constants.DeleteColumnMarker: false,
+		}
+	}
+
+	topicConfig := kafkalib.TopicConfig{
+		Database:  "shop",
+		TableName: "customer",
+		Schema:    "public",
+	}
+
+	tableData := &optimization.TableData{
+		InMemoryColumns: cols,
+		RowsData:        rowData,
+		PrimaryKey:      "id",
+		TopicConfig:     topicConfig,
+		LatestCDCTs:     time.Time{},
+	}
+
+	mergeSQL, err := merge(tableData)
+
+	assert.NoError(b.T(), err, "merge failed")
+	// Check if MERGE INTO FQ Table exists.
+	assert.True(b.T(), strings.Contains(mergeSQL, "MERGE INTO shop.customer c"), mergeSQL)
+	// Check for equality merge
+	assert.True(b.T(), strings.Contains(mergeSQL, fmt.Sprintf("TO_JSON_STRING(c.%s) = TO_JSON_STRING(cc.%s)", tableData.PrimaryKey, tableData.PrimaryKey)))
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
 			switch cols[col] {

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -82,5 +82,5 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 		strings.Join(tableValues, ","), tableData.TopicConfig.TableName, strings.Join(cols, ","))
 
 	return dml.MergeStatement(tableData.ToFqName(constants.Snowflake), subQuery,
-		tableData.PrimaryKey, tableData.IdempotentKey, cols, tableData.SoftDelete)
+		tableData.PrimaryKey, tableData.IdempotentKey, cols, tableData.SoftDelete, false)
 }

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -71,6 +71,7 @@ func (s *SnowflakeTestSuite) TestMerge() {
 
 	// Check if MERGE INTO FQ Table exists.
 	assert.True(s.T(), strings.Contains(mergeSQL, "MERGE INTO shop.public.customer c"))
+	assert.True(s.T(), strings.Contains(mergeSQL, fmt.Sprintf("c.%s = cc.%s", tableData.PrimaryKey, tableData.PrimaryKey)))
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
 			switch cols[col] {

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -30,7 +30,7 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
 	for _, idempotentKey := range []string{"", "updated_at"} {
-		mergeSQL, err := MergeStatement(fqTable, subQuery, "id", idempotentKey, cols, true)
+		mergeSQL, err := MergeStatement(fqTable, subQuery, "id", idempotentKey, cols, true, false)
 		assert.NoError(t, err)
 		assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
 		// Soft deletion flag being passed.
@@ -61,7 +61,7 @@ func TestMergeStatement(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
-	mergeSQL, err := MergeStatement(fqTable, subQuery, "id", "", cols, false)
+	mergeSQL, err := MergeStatement(fqTable, subQuery, "id", "", cols, false, false)
 	assert.NoError(t, err)
 	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
 	assert.False(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
@@ -86,7 +86,7 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
-	mergeSQL, err := MergeStatement(fqTable, subQuery, "id", "updated_at", cols, false)
+	mergeSQL, err := MergeStatement(fqTable, subQuery, "id", "updated_at", cols, false, false)
 	assert.NoError(t, err)
 	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
 	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))


### PR DESCRIPTION
BigQuery cannot compare equality of two objects without having some typecasting to a STRING.

Transfer only does equality comparisons with primary keys which should not be JSON structs with the exception to MongoDB which may use `objectID`.