### PR TITLE
Adding optional schemas to our typing library + fixes array parsing bug

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -67,7 +67,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 						return "", err
 					}
 
-					colVal = fmt.Sprintf("%s", strings.ReplaceAll(string(colValBytes), "'", `\'`))
+					colVal = stringutil.Wrap(string(colValBytes))
 				}
 			} else {
 				colVal = "null"

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -66,7 +66,7 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 						return "", err
 					}
 
-					colVal = fmt.Sprintf("'%s'", strings.ReplaceAll(string(colValBytes), "'", `\'`))
+					colVal = stringutil.Wrap(string(colValBytes))
 				}
 			} else {
 				colVal = "null"

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -65,7 +65,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
-		"created_at": typing.ParseValue(time.Now().Format(time.RFC3339Nano)),
+		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
 	rowsData := make(map[string]map[string]interface{})
@@ -111,7 +111,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
-		"created_at": typing.ParseValue(time.Now().Format(time.RFC3339Nano)),
+		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
 	rowsData := make(map[string]map[string]interface{})
@@ -172,7 +172,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
-		"created_at": typing.ParseValue(time.Now().Format(time.RFC3339Nano)),
+		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
 	tableData := &optimization.TableData{
@@ -212,7 +212,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		tableData.InMemoryColumns = sflkColumns
 
 		// Since sflkColumns overwrote the format, let's set it correctly again.
-		tableData.InMemoryColumns["created_at"] = typing.ParseValue(time.Now().Format(time.RFC3339Nano))
+		tableData.InMemoryColumns["created_at"] = typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano))
 		break
 	}
 

--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -2,6 +2,7 @@ package cdc
 
 import (
 	"context"
+	"github.com/artie-labs/transfer/lib/typing"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -16,6 +17,7 @@ type Format interface {
 type Event interface {
 	GetExecutionTime() time.Time
 	GetData(ctx context.Context, pkMap map[string]interface{}, config *kafkalib.TopicConfig) map[string]interface{}
+	GetOptionalSchema(ctx  context.Context) map[string]typing.KindDetails
 }
 
 // FieldLabelKind is used when the schema is turned on. Each schema object will be labelled.

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -46,7 +46,7 @@ func (d *Debezium) GetEventFromBytes(_ context.Context, bytes []byte) (cdc.Event
 		// Now, we need to iterate over each key and if the value is JSON
 		// We need to parse the JSON into a string format
 		for key, value := range after {
-			if typing.ParseValue(value) == typing.Struct {
+			if typing.ParseValue(key, nil, value) == typing.Struct {
 				valBytes, err := json.Marshal(value)
 				if err != nil {
 					return nil, err
@@ -72,6 +72,11 @@ func (d *Debezium) GetPrimaryKey(ctx context.Context, key []byte, tc *kafkalib.T
 
 func (s *SchemaEventPayload) GetExecutionTime() time.Time {
 	return time.UnixMilli(s.Payload.Source.TsMs).UTC()
+}
+
+func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails {
+	// MongoDB does not have a schema at the database level.
+	return nil
 }
 
 func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]interface{}, tc *kafkalib.TopicConfig) map[string]interface{} {

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -184,7 +184,7 @@ func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 	// Testing typing.
 	assert.Equal(p.T(), evtData["id"], 1001)
 	assert.Equal(p.T(), evtData["another_id"], 333)
-	assert.Equal(p.T(), typing.ParseValue(evtData["another_id"]), typing.Integer)
+	assert.Equal(p.T(), typing.ParseValue("another_id", evt.GetOptionalSchema(p.ctx), evtData["another_id"]), typing.Integer)
 
 	assert.Equal(p.T(), evtData["email"], "sally.thomas@acme.com")
 

--- a/lib/cdc/postgres/postgres_suite_test.go
+++ b/lib/cdc/postgres/postgres_suite_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"github.com/stretchr/testify/suite"
 	"testing"
 )
@@ -8,11 +9,13 @@ import (
 type PostgresTestSuite struct {
 	suite.Suite
 	*Debezium
+	ctx context.Context
 }
 
 func (p *PostgresTestSuite) SetupTest() {
 	var debezium Debezium
 	p.Debezium = &debezium
+	p.ctx = context.Background()
 }
 
 func TestPostgresTestSuite(t *testing.T) {

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -48,8 +48,7 @@ func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]t
 		// (b) All the ZonedTimestamps where the actual casting is from a string will be handled by our typing library
 		// We are explicitly adding this for string types where the value may be of time/date kind but
 		// the actual column type in the source database is STRING.
-		switch field.Type {
-		case "string":
+		if field.Type == "string" && field.DebeziumType == "" {
 			schema[field.FieldName] = typing.String
 		}
 	}

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -80,7 +80,6 @@ func IsJSON(str string) bool {
 }
 
 func ParseValue(key string, optionalSchema map[string]KindDetails, val interface{}) KindDetails {
-	// TODO test nil schema
 	if len(optionalSchema) > 0 {
 		// If the column exists in the schema, let's early exit.
 		kindDetail, isOk := optionalSchema[key]

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -79,7 +79,17 @@ func IsJSON(str string) bool {
 	return false
 }
 
-func ParseValue(val interface{}) KindDetails {
+func ParseValue(key string, optionalSchema map[string]KindDetails, val interface{}) KindDetails {
+	// TODO test nil schema
+	if len(optionalSchema) > 0 {
+		// If the column exists in the schema, let's early exit.
+		kindDetail, isOk := optionalSchema[key]
+		if isOk {
+			// If the schema exists, use it as sot.
+			return kindDetail
+		}
+	}
+
 	// Check if it's a number first.
 	switch val.(type) {
 	case nil:

--- a/lib/typing/typing_bench_test.go
+++ b/lib/typing/typing_bench_test.go
@@ -7,7 +7,7 @@ import (
 
 func BenchmarkParseValueIntegerArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ParseValue(45456312)
+		ParseValue("", nil,45456312)
 	}
 }
 
@@ -19,7 +19,7 @@ func BenchmarkParseValueIntegerGo(b *testing.B) {
 
 func BenchmarkParseValueBooleanArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ParseValue(true)
+		ParseValue("", nil, true)
 	}
 }
 
@@ -31,7 +31,7 @@ func BenchmarkParseValueBooleanGo(b *testing.B) {
 
 func BenchmarkParseValueFloatArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ParseValue(7.44)
+		ParseValue("", nil, 7.44)
 	}
 }
 

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -33,29 +33,29 @@ func TestJSONString(t *testing.T) {
 
 func TestParseValueBasic(t *testing.T) {
 	// Floats
-	assert.Equal(t, ParseValue(7.5), Float)
-	assert.Equal(t, ParseValue(-7.4999999), Float)
-	assert.Equal(t, ParseValue(7.0), Float)
+	assert.Equal(t, ParseValue("", nil,7.5), Float)
+	assert.Equal(t, ParseValue("", nil, -7.4999999), Float)
+	assert.Equal(t, ParseValue("", nil,7.0), Float)
 
 	// Integers
-	assert.Equal(t, ParseValue(9), Integer)
-	assert.Equal(t, ParseValue(math.MaxInt), Integer)
-	assert.Equal(t, ParseValue(-1*math.MaxInt), Integer)
+	assert.Equal(t, ParseValue("", nil, 9), Integer)
+	assert.Equal(t, ParseValue("", nil, math.MaxInt), Integer)
+	assert.Equal(t, ParseValue("", nil, -1*math.MaxInt), Integer)
 
 	// Invalid
-	assert.Equal(t, ParseValue(nil), Invalid)
-	assert.Equal(t, ParseValue(errors.New("hello")), Invalid)
+	assert.Equal(t, ParseValue("", nil, nil), Invalid)
+	assert.Equal(t, ParseValue("", nil, errors.New("hello")), Invalid)
 
 	// Boolean
-	assert.Equal(t, ParseValue(true), Boolean)
-	assert.Equal(t, ParseValue(false), Boolean)
+	assert.Equal(t, ParseValue("", nil, true), Boolean)
+	assert.Equal(t, ParseValue("", nil, false), Boolean)
 }
 
 func TestParseValueArrays(t *testing.T) {
-	assert.Equal(t, ParseValue([]string{"a", "b", "c"}), Array)
-	assert.Equal(t, ParseValue([]interface{}{"a", 123, "c"}), Array)
-	assert.Equal(t, ParseValue([]int64{1}), Array)
-	assert.Equal(t, ParseValue([]bool{false}), Array)
+	assert.Equal(t, ParseValue("", nil, []string{"a", "b", "c"}), Array)
+	assert.Equal(t, ParseValue("", nil, []interface{}{"a", 123, "c"}), Array)
+	assert.Equal(t, ParseValue("", nil, []int64{1}), Array)
+	assert.Equal(t, ParseValue("", nil, []bool{false}), Array)
 }
 
 func TestParseValueMaps(t *testing.T) {
@@ -84,7 +84,7 @@ func TestParseValueMaps(t *testing.T) {
 	}
 
 	for _, randomMap := range randomMaps {
-		assert.Equal(t, ParseValue(randomMap), Struct, fmt.Sprintf("Failed message is: %v", randomMap))
+		assert.Equal(t, ParseValue("", nil, randomMap), Struct, fmt.Sprintf("Failed message is: %v", randomMap))
 	}
 }
 
@@ -104,7 +104,7 @@ func TestDateTime(t *testing.T) {
 	}
 
 	for _, possibleDate := range possibleDates {
-		assert.Equal(t, ParseValue(possibleDate).ExtendedTimeDetails.Type, ext.DateTime.Type, fmt.Sprintf("Failed format, value is: %v", possibleDate))
+		assert.Equal(t, ParseValue("", nil, possibleDate).ExtendedTimeDetails.Type, ext.DateTime.Type, fmt.Sprintf("Failed format, value is: %v", possibleDate))
 
 		// Test the parseDT function as well.
 		ts, err := ext.ParseExtendedDateTime(fmt.Sprint(possibleDate))
@@ -118,7 +118,7 @@ func TestDateTime(t *testing.T) {
 }
 
 func TestTime(t *testing.T) {
-	kindDetails := ParseValue("00:18:11.13116+00")
+	kindDetails := ParseValue("", nil, "00:18:11.13116+00")
 	// 00:42:26.693631Z
 	assert.Equal(t, ETime.Kind, kindDetails.Kind)
 	assert.Equal(t, ext.TimeKindType, kindDetails.ExtendedTimeDetails.Type)
@@ -132,6 +132,6 @@ func TestString(t *testing.T) {
 	}
 
 	for _, possibleString := range possibleStrings {
-		assert.Equal(t, ParseValue(possibleString), String)
+		assert.Equal(t, ParseValue("", nil, possibleString), String)
 	}
 }

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -135,3 +135,25 @@ func TestString(t *testing.T) {
 		assert.Equal(t, ParseValue("", nil, possibleString), String)
 	}
 }
+
+func TestOptionalSchema(t *testing.T) {
+	kd := ParseValue("", nil, true)
+	assert.Equal(t, kd, Boolean)
+
+	// Key in a nil-schema
+	kd = ParseValue("key", nil, true)
+	assert.Equal(t, kd, Boolean)
+
+	// Non-existent key in the schema.
+	optionalSchema := map[string]KindDetails{
+		"created_at": String,
+	}
+
+	// Parse it as a date since it doesn't exist in the optional schema.
+	kd = ParseValue("updated_at", optionalSchema, "2023-01-01")
+	assert.Equal(t, ext.Date.Type, kd.ExtendedTimeDetails.Type)
+
+	// Respecting the optional schema
+	kd = ParseValue("created_at", optionalSchema, "2023-01-01")
+	assert.Equal(t, String, kd)
+}

--- a/models/event.go
+++ b/models/event.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/typing"
 	"sort"
 	"time"
 
@@ -16,6 +17,7 @@ type Event struct {
 	Table         string
 	PrimaryKeyMap map[string]interface{}
 	Data          map[string]interface{} // json serialized column data
+	OptiomalSchema map[string]typing.KindDetails
 	ExecutionTime time.Time              // When the SQL command was executed
 }
 
@@ -24,6 +26,7 @@ func ToMemoryEvent(ctx context.Context, event cdc.Event, pkMap map[string]interf
 		Table:         tc.TableName,
 		PrimaryKeyMap: pkMap,
 		ExecutionTime: event.GetExecutionTime(),
+		OptiomalSchema: event.GetOptionalSchema(ctx),
 		Data:          event.GetData(ctx, pkMap, tc),
 	}
 }

--- a/models/event_test.go
+++ b/models/event_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/stretchr/testify/assert"
 	"time"
 )
@@ -16,6 +17,10 @@ var idMap = map[string]interface{}{
 
 func (f fakeEvent) GetExecutionTime() time.Time {
 	return time.Now()
+}
+
+func (f fakeEvent) GetOptionalSchema(ctx  context.Context) map[string]typing.KindDetails {
+	return nil
 }
 
 func (f fakeEvent) GetData(ctx context.Context, pkMap map[string]interface{}, config *kafkalib.TopicConfig) map[string]interface{} {

--- a/models/memory.go
+++ b/models/memory.go
@@ -62,6 +62,8 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 	// Update col if necessary
 	sanitizedData := make(map[string]interface{})
 	for _col, val := range e.Data {
+		// TODO test _col case sensitive operation.
+
 		// columns need to all be normalized and lower cased.
 		newColName := strings.ToLower(_col)
 
@@ -90,14 +92,14 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 
 		colTypeDetails, isOk := inMemoryDB.TableData[e.Table].InMemoryColumns[newColName]
 		if !isOk {
-			inMemoryDB.TableData[e.Table].InMemoryColumns[newColName] = typing.ParseValue(val)
+			inMemoryDB.TableData[e.Table].InMemoryColumns[newColName] = typing.ParseValue(_col, e.OptiomalSchema, val)
 		} else {
 			if colTypeDetails.Kind == typing.Invalid.Kind {
 				// If colType is Invalid, let's see if we can update it to a better type
 				// If everything is nil, we don't need to add a column
 				// However, it's important to create a column even if it's nil.
 				// This is because we don't want to think that it's okay to drop a column in DWH
-				if kindDetails := typing.ParseValue(val); kindDetails.Kind != typing.Invalid.Kind {
+				if kindDetails := typing.ParseValue(_col, e.OptiomalSchema, val); kindDetails.Kind != typing.Invalid.Kind {
 					inMemoryDB.TableData[e.Table].InMemoryColumns[newColName] = kindDetails
 				}
 			}

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -114,10 +114,13 @@ func (m *ModelsTestSuite) TestEventSaveOptionalSchema() {
 			"anotherCOL":                 13.37,
 			"created_at_date_string": "2023-01-01",
 			"created_at_date_no_schema": "2023-01-01",
+			"json_object_string": `{"foo": "bar"}`,
+			"json_object_no_schema": `{"foo": "bar"}`,
 		},
 		OptiomalSchema: map[string]typing.KindDetails{
 			// Explicitly casting this as a string.
 			"created_at_date_string": typing.String,
+			"json_object_string": typing.String,
 		},
 	}
 
@@ -132,4 +135,12 @@ func (m *ModelsTestSuite) TestEventSaveOptionalSchema() {
 	kind, isOk = inMemoryDB.TableData["foo"].InMemoryColumns["created_at_date_no_schema"]
 	assert.True(m.T(), isOk)
 	assert.Equal(m.T(), kind.ExtendedTimeDetails.Type, ext.Date.Type)
+
+	kind, isOk = inMemoryDB.TableData["foo"].InMemoryColumns["json_object_string"]
+	assert.True(m.T(), isOk)
+	assert.Equal(m.T(), kind, typing.String)
+
+	kind, isOk = inMemoryDB.TableData["foo"].InMemoryColumns["json_object_no_schema"]
+	assert.True(m.T(), isOk)
+	assert.Equal(m.T(), kind, typing.Struct)
 }

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -91,7 +92,7 @@ func (m *ModelsTestSuite) TestEvent_SaveCasing() {
 
 	kafkaMsg := kafka.Message{}
 	_, err := event.Save(m.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
-
+	assert.Nil(m.T(), err)
 	rowData := inMemoryDB.TableData["foo"].RowsData[event.PrimaryKeyValue()]
 	expectedColumns := []string{"randomcol", "anothercol"}
 	for _, expectedColumn := range expectedColumns {
@@ -99,5 +100,36 @@ func (m *ModelsTestSuite) TestEvent_SaveCasing() {
 		assert.True(m.T(), isOk, fmt.Sprintf("expected col: %s, rowsData: %v", expectedColumn, rowData))
 	}
 
+}
+
+func (m *ModelsTestSuite) TestEventSaveOptionalSchema() {
+	event := Event{
+		Table: "foo",
+		PrimaryKeyMap: map[string]interface{}{
+			"id": "123",
+		},
+		Data: map[string]interface{}{
+			constants.DeleteColumnMarker: true,
+			"randomCol":                  "dusty",
+			"anotherCOL":                 13.37,
+			"created_at_date_string": "2023-01-01",
+			"created_at_date_no_schema": "2023-01-01",
+		},
+		OptiomalSchema: map[string]typing.KindDetails{
+			// Explicitly casting this as a string.
+			"created_at_date_string": typing.String,
+		},
+	}
+
+	kafkaMsg := kafka.Message{}
+	_, err := event.Save(m.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(m.T(), err)
+
+	kind, isOk := inMemoryDB.TableData["foo"].InMemoryColumns["created_at_date_string"]
+	assert.True(m.T(), isOk)
+	assert.Equal(m.T(), kind, typing.String)
+
+	kind, isOk = inMemoryDB.TableData["foo"].InMemoryColumns["created_at_date_no_schema"]
+	assert.True(m.T(), isOk)
+	assert.Equal(m.T(), kind.ExtendedTimeDetails.Type, ext.Date.Type)
 }


### PR DESCRIPTION
# Context
In this PR, we are modifying our typing library to be treat strings with more sophistication.

Today, our library will attempt to cast and support various date time string formats for a given value. if it correctly parses, we were previously casting it as a `extendedTime` object and storing that within our in-memory database.

However, there's an edge case where if the column type in the source database is a `STRING` type, but the actual value parses to a date time...we were **previously** incorrectly storing that as date time.

# Changes
1. We now introduced an `optionalSchema` where we are inferring this directly from the Debezium Kafka message.
2. If the suspected column exists in the `optionalSchema`, we will not attempt to parse it.
3. Also applied the fix from https://github.com/artie-labs/transfer/pull/49 towards arrays that require double quote escape


This only impacts potential JSON objects (that were saved as JSON.stringify()` or date times that were stored as `time.Time.String()`. 