### PR TITLE
Minor improvement - removing manual row counter

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -100,7 +100,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 }
 
 func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
-	if tableData.Rows == 0 {
+	if tableData.Rows() == 0 {
 		// There's no rows. Let's skip.
 		return nil
 	}

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -49,7 +49,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 }
 
 func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) error {
-	if tableData.Rows == 0 {
+	if tableData.Rows() == 0 {
 		// There's no rows. Let's skip.
 		return nil
 	}

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -44,7 +44,6 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		RowsData:        rowsData,
 		TopicConfig:     topicConfig,
 		PrimaryKeys:     []string{"id"},
-		Rows:            1,
 	}
 
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake), types.NewDwhTableConfig(
@@ -89,7 +88,6 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		RowsData:        rowsData,
 		TopicConfig:     topicConfig,
 		PrimaryKeys:     []string{"id"},
-		Rows:            1,
 	}
 
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake),
@@ -135,7 +133,6 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 		RowsData:        rowsData,
 		TopicConfig:     topicConfig,
 		PrimaryKeys:     []string{"id"},
-		Rows:            1,
 	}
 
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake),
@@ -180,7 +177,6 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		RowsData:        rowsData,
 		TopicConfig:     topicConfig,
 		PrimaryKeys:     []string{"id"},
-		Rows:            1,
 	}
 
 	sflkColumns := map[string]typing.KindDetails{
@@ -233,7 +229,6 @@ func (s *SnowflakeTestSuite) TestExecuteMergeExitEarly() {
 		TopicConfig:             kafkalib.TopicConfig{},
 		PartitionsToLastMessage: nil,
 		LatestCDCTs:             time.Time{},
-		Rows:                    0,
 	})
 
 	assert.Nil(s.T(), err)

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -23,8 +23,14 @@ type TableData struct {
 
 	// This is used for the automatic schema detection
 	LatestCDCTs time.Time
+}
 
-	Rows uint
+func (t *TableData) Rows() uint {
+	if t == nil {
+		return 0
+	}
+
+	return uint(len(t.RowsData))
 }
 
 // UpdateInMemoryColumns - When running Transfer, we will have 2 column types.

--- a/lib/typing/typing_bench_test.go
+++ b/lib/typing/typing_bench_test.go
@@ -17,6 +17,23 @@ func BenchmarkLargeMapLengthQuery(b *testing.B) {
 	}
 }
 
+func BenchmarkLargeMapLengthQuery_WithMassiveValues(b *testing.B) {
+	retMap := make(map[string]interface{})
+	for i := 0; i < 15000; i++ {
+		retMap[fmt.Sprintf("key-%v", i)] = map[string]interface{}{
+			"foo":   "bar",
+			"hello": "world",
+			"true":  true,
+			"false": false,
+			"array": []string{"abc", "def"},
+		}
+	}
+
+	for n := 0; n < b.N; n++ {
+		_ = uint(len(retMap))
+	}
+}
+
 func BenchmarkParseValueIntegerArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		ParseValue("", nil, 45456312)

--- a/lib/typing/typing_bench_test.go
+++ b/lib/typing/typing_bench_test.go
@@ -1,13 +1,25 @@
 package typing
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
 
+func BenchmarkLargeMapLengthQuery(b *testing.B) {
+	retMap := make(map[string]interface{})
+	for i := 0; i < 15000; i++ {
+		retMap[fmt.Sprintf("key-%v", i)] = true
+	}
+
+	for n := 0; n < b.N; n++ {
+		_ = uint(len(retMap))
+	}
+}
+
 func BenchmarkParseValueIntegerArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ParseValue("", nil,45456312)
+		ParseValue("", nil, 45456312)
 	}
 }
 

--- a/models/memory.go
+++ b/models/memory.go
@@ -121,11 +121,8 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 
 	inMemoryDB.TableData[e.Table].LatestCDCTs = e.ExecutionTime
 
-	// Increment row count
-	inMemoryDB.TableData[e.Table].Rows += 1
-
 	settings := config.FromContext(ctx)
-	return inMemoryDB.TableData[e.Table].Rows > settings.Config.BufferRows, nil
+	return inMemoryDB.TableData[e.Table].Rows() > settings.Config.BufferRows, nil
 }
 
 func LoadMemoryDB() {


### PR DESCRIPTION
We were previously using a manual counter to see how many rows were in the in-memory database. However, this is unnecessary and error prone. Instead, let's do a `LEN()` on the in-memory database to figure out the length.

I tested this against a map of 15k rows and observed 0.9ns for each `LEN()` call