### PR TITLE
Ensuring column order preservation

### DIFF
--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -51,7 +51,7 @@ func (s *Store) getTableConfig(_ context.Context, tableData *optimization.TableD
 // parseSchemaQuery is to parse out the results from this query: https://cloud.google.com/bigquery/docs/information-schema-tables#example_1
 func parseSchemaQuery(row string, createTable, dropDeletedColumns bool) (*types.DwhTableConfig, error) {
 	if createTable {
-		return types.NewDwhTableConfig(nil, nil, createTable, dropDeletedColumns), nil
+		return types.NewDwhTableConfig(typing.Columns{}, nil, createTable, dropDeletedColumns), nil
 	}
 
 	// TrimSpace only does the L + R side.
@@ -87,7 +87,7 @@ func parseSchemaQuery(row string, createTable, dropDeletedColumns bool) (*types.
 		return nil, fmt.Errorf("malformed DDL string: missing (, %s", ddlString)
 	}
 
-	tableToColumnTypes := make(map[string]typing.KindDetails)
+	var bigQueryColumns typing.Columns
 	ddlString = ddlString[:endOfStatement]
 	columnsToTypes := strings.Split(ddlString, ",")
 	for _, colType := range columnsToTypes {
@@ -104,8 +104,11 @@ func parseSchemaQuery(row string, createTable, dropDeletedColumns bool) (*types.
 			return nil, fmt.Errorf("unexpected colType, colType: %s, parts: %v", colType, parts)
 		}
 
-		tableToColumnTypes[parts[0]] = typing.BigQueryTypeToKind(strings.Join(parts[1:], " "))
+		bigQueryColumns.AddColumn(typing.Column{
+			Name:        parts[0],
+			KindDetails: typing.BigQueryTypeToKind(strings.Join(parts[1:], " ")),
+		})
 	}
 
-	return types.NewDwhTableConfig(tableToColumnTypes, nil, createTable, dropDeletedColumns), nil
+	return types.NewDwhTableConfig(bigQueryColumns, nil, createTable, dropDeletedColumns), nil
 }

--- a/clients/bigquery/ddl_test.go
+++ b/clients/bigquery/ddl_test.go
@@ -20,9 +20,9 @@ func (b *BigQueryTestSuite) TestParseSchemaQuery() {
 		assert.NoError(b.T(), err, err)
 
 		assert.Equal(b.T(), true, tableConfig.DropDeletedColumns())
-		assert.Equal(b.T(), len(tableConfig.Columns()), 2, tableConfig.Columns)
-		for col, kind := range tableConfig.Columns() {
-			assert.Equal(b.T(), kind, typing.String, fmt.Sprintf("col: %s, kind: %v incorrect", col, kind))
+		assert.Equal(b.T(), len(tableConfig.Columns().GetColumns()), 2, tableConfig.Columns)
+		for _, col := range tableConfig.Columns().GetColumns() {
+			assert.Equal(b.T(), col.KindDetails, typing.String, fmt.Sprintf("col: %s, kind: %v incorrect", col.Name, col.KindDetails))
 		}
 	}
 }
@@ -34,7 +34,7 @@ func (b *BigQueryTestSuite) TestParseSchemaQueryComplex() {
 
 	assert.NoError(b.T(), err, err)
 	assert.Equal(b.T(), false, tableConfig.DropDeletedColumns())
-	assert.Equal(b.T(), len(tableConfig.Columns()), 15, tableConfig.Columns)
+	assert.Equal(b.T(), len(tableConfig.Columns().GetColumns()), 15, tableConfig.Columns)
 
 	anticipatedColumns := map[string]typing.KindDetails{
 		"string_field_0": typing.String,
@@ -55,13 +55,13 @@ func (b *BigQueryTestSuite) TestParseSchemaQueryComplex() {
 	}
 
 	for anticipatedCol, anticipatedKind := range anticipatedColumns {
-		kindDetails, isOk := tableConfig.Columns()[anticipatedCol]
-		assert.True(b.T(), isOk)
-		assert.Equal(b.T(), kindDetails.Kind, anticipatedKind.Kind, fmt.Sprintf("expected kind: %v, got: col: %s, kind: %v mismatched.", kindDetails.Kind,
+		col := tableConfig.Columns().GetColumn(anticipatedCol)
+		assert.NotNil(b.T(), col)
+		assert.Equal(b.T(), col.KindDetails.Kind, anticipatedKind.Kind, fmt.Sprintf("expected kind: %v, got: col: %s, kind: %v mismatched.", col.KindDetails.Kind,
 			anticipatedCol, anticipatedKind))
 
-		if kindDetails.Kind == typing.ETime.Kind {
-			assert.Equal(b.T(), kindDetails.ExtendedTimeDetails.Type, anticipatedKind.ExtendedTimeDetails.Type)
+		if col.KindDetails.Kind == typing.ETime.Kind {
+			assert.Equal(b.T(), col.KindDetails.ExtendedTimeDetails.Type, anticipatedKind.ExtendedTimeDetails.Type)
 		}
 
 	}

--- a/clients/bigquery/ddl_test.go
+++ b/clients/bigquery/ddl_test.go
@@ -55,8 +55,8 @@ func (b *BigQueryTestSuite) TestParseSchemaQueryComplex() {
 	}
 
 	for anticipatedCol, anticipatedKind := range anticipatedColumns {
-		col := tableConfig.Columns().GetColumn(anticipatedCol)
-		assert.NotNil(b.T(), col)
+		col, isOk := tableConfig.Columns().GetColumn(anticipatedCol)
+		assert.True(b.T(), isOk)
 		assert.Equal(b.T(), col.KindDetails.Kind, anticipatedKind.Kind, fmt.Sprintf("expected kind: %v, got: col: %s, kind: %v mismatched.", col.KindDetails.Kind,
 			anticipatedCol, anticipatedKind))
 

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -70,7 +70,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 					colVal = stringutil.Wrap(string(colValBytes))
 				}
 			} else {
-				if colKind == typing.String {
+				if colKind.KindDetails == typing.String {
 					// BigQuery does not like null as a string for CTEs.
 					// It throws this error: Value of type INT64 cannot be assigned to column name, which has type STRING
 					colVal = "''"

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -87,13 +87,13 @@ func merge(tableData *optimization.TableData) (string, error) {
 	subQuery := strings.Join(rowValues, " UNION ALL ")
 
 	return dml.MergeStatement(dml.MergeArgument{
-		FqTableName:   tableData.ToFqName(constants.BigQuery),
-		SubQuery:      subQuery,
-		IdempotentKey: tableData.IdempotentKey,
-		PrimaryKeys:   tableData.PrimaryKeys,
-		Columns:       cols,
-		ColumnToType:  *tableData.InMemoryColumns,
-		SoftDelete:    tableData.SoftDelete,
+		FqTableName:    tableData.ToFqName(constants.BigQuery),
+		SubQuery:       subQuery,
+		IdempotentKey:  tableData.IdempotentKey,
+		PrimaryKeys:    tableData.PrimaryKeys,
+		Columns:        cols,
+		ColumnsToTypes: *tableData.InMemoryColumns,
+		SoftDelete:     tableData.SoftDelete,
 		// BigQuery specifically needs it.
 		SpecialCastingRequired: true,
 	})

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -152,7 +152,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		}
 	}
 
-	tableData.UpdateInMemoryColumns(tableConfig.Columns().GetColumns()...)
+	tableData.UpdateInMemoryColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 	query, err := merge(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -34,7 +34,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 	for _, value := range tableData.RowsData {
 		var colVals []string
 		for _, col := range cols {
-			colKind := tableData.InMemoryColumns.GetColumn(col)
+			colKind, _ := tableData.InMemoryColumns.GetColumn(col)
 			colVal := value[col]
 			if colVal != nil {
 				switch colKind.KindDetails.Kind {

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -110,9 +110,14 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		return err
 	}
 
+	var targetColumns typing.Columns
+	if tableConfig.Columns() != nil {
+		targetColumns = *tableConfig.Columns()
+	}
+
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, tableConfig.Columns(), tableData.SoftDelete)
+	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, targetColumns, tableData.SoftDelete)
 
 	// Keys that exist in CDC stream, but not in Snowflake
 	err = ddl.AlterTable(ctx, s, tableConfig, tableData.ToFqName(constants.BigQuery), tableConfig.CreateTable, constants.Add, tableData.LatestCDCTs, targetKeysMissing...)

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -134,7 +134,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	// If not, then we should assume the column is good and then remove it from our in-mem store.
 	for colToDelete := range tableConfig.ColumnsToDelete() {
 		var found bool
-		for _, col := range srcKeysMissing.GetColumns() {
+		for _, col := range srcKeysMissing {
 			if found = col.Name == colToDelete; found {
 				// Found it.
 				break
@@ -147,7 +147,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		}
 	}
 
-	tableData.UpdateInMemoryColumns(tableConfig.Columns()....)
+	tableData.UpdateInMemoryColumns(tableConfig.Columns().GetColumns()...)
 	query, err := merge(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")

--- a/clients/bigquery/merge_test.go
+++ b/clients/bigquery/merge_test.go
@@ -12,12 +12,14 @@ import (
 )
 
 func (b *BigQueryTestSuite) TestMergeNoDeleteFlag() {
-	cols := map[string]typing.KindDetails{
-		"id": typing.Integer,
-	}
+	var cols typing.Columns
+	cols.AddColumn(typing.Column{
+		Name:        "id",
+		KindDetails: typing.Integer,
+	})
 
 	tableData := &optimization.TableData{
-		InMemoryColumns: cols,
+		InMemoryColumns: &cols,
 		RowsData:        nil,
 		PrimaryKeys:     []string{"id"},
 		TopicConfig:     kafkalib.TopicConfig{},
@@ -31,10 +33,16 @@ func (b *BigQueryTestSuite) TestMergeNoDeleteFlag() {
 func (b *BigQueryTestSuite) TestMerge() {
 	primaryKeys := []string{"id"}
 
-	cols := map[string]typing.KindDetails{
+	var cols typing.Columns
+	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
+	} {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -54,7 +62,7 @@ func (b *BigQueryTestSuite) TestMerge() {
 	}
 
 	tableData := &optimization.TableData{
-		InMemoryColumns: cols,
+		InMemoryColumns: &cols,
 		RowsData:        rowData,
 		PrimaryKeys:     primaryKeys,
 		TopicConfig:     topicConfig,
@@ -74,7 +82,7 @@ func (b *BigQueryTestSuite) TestMerge() {
 
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
-			switch cols[col] {
+			switch cols.GetColumn(col).KindDetails {
 			case typing.String, typing.Array, typing.Struct:
 				val = fmt.Sprintf("'%v'", val)
 			}
@@ -88,10 +96,16 @@ func (b *BigQueryTestSuite) TestMerge() {
 }
 
 func (b *BigQueryTestSuite) TestMergeJSONKey() {
-	cols := map[string]typing.KindDetails{
+	var cols typing.Columns
+	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.Struct,
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
+	} {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -116,7 +130,7 @@ func (b *BigQueryTestSuite) TestMergeJSONKey() {
 	primaryKeys := []string{"id"}
 
 	tableData := &optimization.TableData{
-		InMemoryColumns: cols,
+		InMemoryColumns: &cols,
 		RowsData:        rowData,
 		PrimaryKeys:     primaryKeys,
 		TopicConfig:     topicConfig,
@@ -136,7 +150,7 @@ func (b *BigQueryTestSuite) TestMergeJSONKey() {
 
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
-			switch cols[col] {
+			switch cols.GetColumn(col).KindDetails {
 			case typing.String, typing.Array, typing.Struct:
 				val = fmt.Sprintf("'%v'", val)
 			}
@@ -150,11 +164,17 @@ func (b *BigQueryTestSuite) TestMergeJSONKey() {
 }
 
 func (b *BigQueryTestSuite) TestMergeSimpleCompositeKey() {
-	cols := map[string]typing.KindDetails{
+	var cols typing.Columns
+	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.String,
 		"idA":                        typing.String,
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
+	} {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -178,7 +198,7 @@ func (b *BigQueryTestSuite) TestMergeSimpleCompositeKey() {
 
 	primaryKeys := []string{"id", "idA"}
 	tableData := &optimization.TableData{
-		InMemoryColumns: cols,
+		InMemoryColumns: &cols,
 		RowsData:        rowData,
 		PrimaryKeys:     primaryKeys,
 		TopicConfig:     topicConfig,
@@ -198,7 +218,7 @@ func (b *BigQueryTestSuite) TestMergeSimpleCompositeKey() {
 	assert.True(b.T(), strings.Contains(mergeSQL, fmt.Sprintf("c.%s = cc.%s and c.%s = cc.%s", "id", "id", "idA", "idA")), mergeSQL)
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
-			switch cols[col] {
+			switch cols.GetColumn(col).KindDetails {
 			case typing.String, typing.Array, typing.Struct:
 				val = fmt.Sprintf("'%v'", val)
 			}
@@ -212,13 +232,20 @@ func (b *BigQueryTestSuite) TestMergeSimpleCompositeKey() {
 }
 
 func (b *BigQueryTestSuite) TestMergeJSONKeyAndCompositeHybrid() {
-	cols := map[string]typing.KindDetails{
+	var cols typing.Columns
+
+	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.Struct,
 		"idA":                        typing.String,
 		"idB":                        typing.String,
 		"idC":                        typing.Struct,
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
+	} {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -243,7 +270,7 @@ func (b *BigQueryTestSuite) TestMergeJSONKeyAndCompositeHybrid() {
 	primaryKeys := []string{"id", "idA", "idB", "idC"}
 
 	tableData := &optimization.TableData{
-		InMemoryColumns: cols,
+		InMemoryColumns: &cols,
 		RowsData:        rowData,
 		PrimaryKeys:     primaryKeys,
 		TopicConfig:     topicConfig,
@@ -266,7 +293,7 @@ func (b *BigQueryTestSuite) TestMergeJSONKeyAndCompositeHybrid() {
 
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
-			switch cols[col] {
+			switch cols.GetColumn(col).KindDetails {
 			case typing.String, typing.Array, typing.Struct:
 				val = fmt.Sprintf("'%v'", val)
 			}

--- a/clients/bigquery/merge_test.go
+++ b/clients/bigquery/merge_test.go
@@ -82,7 +82,7 @@ func (b *BigQueryTestSuite) TestMerge() {
 
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
-			switch cols.GetColumn(col).KindDetails {
+			switch _col, _ := cols.GetColumn(col); _col.KindDetails {
 			case typing.String, typing.Array, typing.Struct:
 				val = fmt.Sprintf("'%v'", val)
 			}
@@ -150,7 +150,7 @@ func (b *BigQueryTestSuite) TestMergeJSONKey() {
 
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
-			switch cols.GetColumn(col).KindDetails {
+			switch _col, _ := cols.GetColumn(col); _col.KindDetails {
 			case typing.String, typing.Array, typing.Struct:
 				val = fmt.Sprintf("'%v'", val)
 			}
@@ -218,7 +218,7 @@ func (b *BigQueryTestSuite) TestMergeSimpleCompositeKey() {
 	assert.True(b.T(), strings.Contains(mergeSQL, fmt.Sprintf("c.%s = cc.%s and c.%s = cc.%s", "id", "id", "idA", "idA")), mergeSQL)
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
-			switch cols.GetColumn(col).KindDetails {
+			switch _col, _ := cols.GetColumn(col); _col.KindDetails {
 			case typing.String, typing.Array, typing.Struct:
 				val = fmt.Sprintf("'%v'", val)
 			}
@@ -293,7 +293,7 @@ func (b *BigQueryTestSuite) TestMergeJSONKeyAndCompositeHybrid() {
 
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
-			switch cols.GetColumn(col).KindDetails {
+			switch _col, _ := cols.GetColumn(col); _col.KindDetails {
 			case typing.String, typing.Array, typing.Struct:
 				val = fmt.Sprintf("'%v'", val)
 			}

--- a/clients/snowflake/ddl.go
+++ b/clients/snowflake/ddl.go
@@ -39,7 +39,7 @@ func (s *Store) getTableConfig(ctx context.Context, fqName string, dropDeletedCo
 		}
 	}
 
-	tableToColumnTypes := make(map[string]typing.KindDetails)
+	var snowflakeColumns typing.Columns
 	for rows != nil && rows.Next() {
 		// figure out what columns were returned
 		// the column names will be the JSON object field keys
@@ -72,10 +72,13 @@ func (s *Store) getTableConfig(ctx context.Context, fqName string, dropDeletedCo
 			row[columnNameList[idx]] = strings.ToLower(fmt.Sprint(*interfaceVal))
 		}
 
-		tableToColumnTypes[row[describeNameCol]] = typing.SnowflakeTypeToKind(row[describeTypeCol])
+		snowflakeColumns.AddColumn(typing.Column{
+			Name:        row[describeNameCol],
+			KindDetails: typing.SnowflakeTypeToKind(row[describeTypeCol]),
+		})
 	}
 
-	sflkTableConfig := types.NewDwhTableConfig(tableToColumnTypes, nil, tableMissing, dropDeletedColumns)
+	sflkTableConfig := types.NewDwhTableConfig(snowflakeColumns, nil, tableMissing, dropDeletedColumns)
 	s.configMap.AddTableToConfig(fqName, sflkTableConfig)
 
 	return sflkTableConfig, nil

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -20,13 +20,21 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 		Schema:    "public",
 	}
 
-	config := types.NewDwhTableConfig(map[string]typing.KindDetails{
+	var cols typing.Columns
+	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":          typing.Integer,
 		"customer_id": typing.Integer,
 		"price":       typing.Float,
 		"name":        typing.String,
 		"created_at":  typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
-	}, nil, false, true)
+	} {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
+	}
+
+	config := types.NewDwhTableConfig(cols, nil, false, true)
 
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake), config)
 
@@ -53,14 +61,21 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 		Schema:    "public",
 	}
 
-	config := types.NewDwhTableConfig(map[string]typing.KindDetails{
+	var cols typing.Columns
+	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":          typing.Integer,
 		"customer_id": typing.Integer,
 		"price":       typing.Float,
 		"name":        typing.String,
 		"created_at":  typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
-	}, nil, false, true)
+	} {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
+	}
 
+	config := types.NewDwhTableConfig(cols, nil, false, true)
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake), config)
 
 	nameCol := typing.Column{
@@ -90,13 +105,21 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 }
 
 func (s *SnowflakeTestSuite) TestManipulateShouldDeleteColumn() {
-	tc := types.NewDwhTableConfig(map[string]typing.KindDetails{
+	var cols typing.Columns
+	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":          typing.Integer,
 		"customer_id": typing.Integer,
 		"price":       typing.Float,
 		"name":        typing.String,
 		"created_at":  typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
-	}, map[string]time.Time{
+	} {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
+	}
+
+	tc := types.NewDwhTableConfig(cols, map[string]time.Time{
 		"customer_id": time.Now(),
 	}, false, false)
 
@@ -114,6 +137,6 @@ func (s *SnowflakeTestSuite) TestGetTableConfig() {
 	assert.NoError(s.T(), err)
 
 	assert.True(s.T(), tableConfig.CreateTable)
-	assert.Equal(s.T(), len(tableConfig.Columns()), 0)
+	assert.Equal(s.T(), len(tableConfig.Columns().GetColumns()), 0)
 	assert.False(s.T(), tableConfig.DropDeletedColumns())
 }

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -31,8 +31,8 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake), config)
 
 	nameCol := typing.Column{
-		Name: "name",
-		Kind: typing.String,
+		Name:        "name",
+		KindDetails: typing.String,
 	}
 
 	tc := s.store.configMap.TableConfig(topicConfig.ToFqName(constants.Snowflake))
@@ -64,8 +64,8 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake), config)
 
 	nameCol := typing.Column{
-		Name: "name",
-		Kind: typing.String,
+		Name:        "name",
+		KindDetails: typing.String,
 	}
 
 	// Let's try to delete name.

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -82,12 +82,12 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 		strings.Join(tableValues, ","), tableData.TopicConfig.TableName, strings.Join(cols, ","))
 
 	return dml.MergeStatement(dml.MergeArgument{
-		FqTableName:   tableData.ToFqName(constants.Snowflake),
-		SubQuery:      subQuery,
-		IdempotentKey: tableData.IdempotentKey,
-		PrimaryKeys:   tableData.PrimaryKeys,
-		Columns:       cols,
-		ColumnToType:  *tableData.InMemoryColumns,
-		SoftDelete:    tableData.SoftDelete,
+		FqTableName:    tableData.ToFqName(constants.Snowflake),
+		SubQuery:       subQuery,
+		IdempotentKey:  tableData.IdempotentKey,
+		PrimaryKeys:    tableData.PrimaryKeys,
+		Columns:        cols,
+		ColumnsToTypes: *tableData.InMemoryColumns,
+		SoftDelete:     tableData.SoftDelete,
 	})
 }

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -87,7 +87,7 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 		IdempotentKey: tableData.IdempotentKey,
 		PrimaryKeys:   tableData.PrimaryKeys,
 		Columns:       cols,
-		ColumnToType:  tableData.InMemoryColumns,
+		ColumnToType:  *tableData.InMemoryColumns,
 		SoftDelete:    tableData.SoftDelete,
 	})
 }

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -38,7 +38,7 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 	for _, value := range tableData.RowsData {
 		var rowValues []string
 		for _, col := range cols {
-			colKind := tableData.InMemoryColumns.GetColumn(col)
+			colKind, _ := tableData.InMemoryColumns.GetColumn(col)
 			colVal := value[col]
 			if colVal != nil {
 				switch colKind.KindDetails.Kind {

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -14,12 +14,14 @@ import (
 )
 
 func (s *SnowflakeTestSuite) TestMergeNoDeleteFlag() {
-	cols := map[string]typing.KindDetails{
-		"id": typing.Integer,
-	}
+	var cols typing.Columns
+	cols.AddColumn(typing.Column{
+		Name:        "id",
+		KindDetails: typing.Integer,
+	})
 
 	tableData := &optimization.TableData{
-		InMemoryColumns: cols,
+		InMemoryColumns: &cols,
 		RowsData:        nil,
 		PrimaryKeys:     []string{"id"},
 		TopicConfig:     kafkalib.TopicConfig{},
@@ -32,10 +34,16 @@ func (s *SnowflakeTestSuite) TestMergeNoDeleteFlag() {
 }
 
 func (s *SnowflakeTestSuite) TestMerge() {
-	cols := map[string]typing.KindDetails{
+	var cols typing.Columns
+	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"NAME":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
+	} {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -56,7 +64,7 @@ func (s *SnowflakeTestSuite) TestMerge() {
 
 	primaryKeys := []string{"id"}
 	tableData := &optimization.TableData{
-		InMemoryColumns: cols,
+		InMemoryColumns: &cols,
 		RowsData:        rowData,
 		PrimaryKeys:     primaryKeys,
 		TopicConfig:     topicConfig,
@@ -79,7 +87,7 @@ func (s *SnowflakeTestSuite) TestMerge() {
 
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
-			switch cols[col] {
+			switch cols.GetColumn(col).KindDetails {
 			case typing.String, typing.Array, typing.Struct:
 				val = fmt.Sprintf("'%v'", val)
 			}
@@ -93,10 +101,16 @@ func (s *SnowflakeTestSuite) TestMerge() {
 }
 
 func (s *SnowflakeTestSuite) TestMergeWithSingleQuote() {
-	cols := map[string]typing.KindDetails{
+	var cols typing.Columns
+	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"NAME":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
+	} {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -113,7 +127,7 @@ func (s *SnowflakeTestSuite) TestMergeWithSingleQuote() {
 	}
 
 	tableData := &optimization.TableData{
-		InMemoryColumns: cols,
+		InMemoryColumns: &cols,
 		RowsData:        rowData,
 		PrimaryKeys:     []string{"id"},
 		TopicConfig:     topicConfig,
@@ -126,10 +140,16 @@ func (s *SnowflakeTestSuite) TestMergeWithSingleQuote() {
 }
 
 func (s *SnowflakeTestSuite) TestMergeJson() {
-	cols := map[string]typing.KindDetails{
+	var cols typing.Columns
+	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"meta":                       typing.Struct,
 		constants.DeleteColumnMarker: typing.Boolean,
+	} {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -146,7 +166,7 @@ func (s *SnowflakeTestSuite) TestMergeJson() {
 	}
 
 	tableData := &optimization.TableData{
-		InMemoryColumns: cols,
+		InMemoryColumns: &cols,
 		RowsData:        rowData,
 		PrimaryKeys:     []string{"id"},
 		TopicConfig:     topicConfig,

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -87,7 +87,7 @@ func (s *SnowflakeTestSuite) TestMerge() {
 
 	for _, rowData := range tableData.RowsData {
 		for col, val := range rowData {
-			switch cols.GetColumn(col).KindDetails {
+			switch _col, _ := cols.GetColumn(col); _col.KindDetails {
 			case typing.String, typing.Array, typing.Struct:
 				val = fmt.Sprintf("'%v'", val)
 			}

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -98,7 +98,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 		}
 	}
 
-	tableData.UpdateInMemoryColumns(tableConfig.Columns())
+	tableData.UpdateInMemoryColumns(tableConfig.Columns().GetColumns()...)
 	query, err := getMergeStatement(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the getMergeStatement query")

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -103,7 +103,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 		}
 	}
 
-	tableData.UpdateInMemoryColumns(tableConfig.Columns().GetColumns()...)
+	tableData.UpdateInMemoryColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 	query, err := getMergeStatement(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the getMergeStatement query")

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -49,7 +49,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 }
 
 func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) error {
-	if tableData.Rows() == 0 {
+	if tableData.Rows() == 0 || tableData.InMemoryColumns == nil {
 		// There's no rows. Let's skip.
 		return nil
 	}
@@ -68,7 +68,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, targetColumns, tableData.SoftDelete)
+	srcKeysMissing, targetKeysMissing := typing.Diff(*tableData.InMemoryColumns, targetColumns, tableData.SoftDelete)
 
 	// Keys that exist in CDC stream, but not in Snowflake
 	err = ddl.AlterTable(ctx, s, tableConfig, fqName, tableConfig.CreateTable, constants.Add, tableData.LatestCDCTs, targetKeysMissing...)

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -62,8 +62,13 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 
 	log := logger.FromContext(ctx)
 
+	var targetColumns typing.Columns
+	if tableConfig.Columns() != nil {
+		targetColumns = *tableConfig.Columns()
+	}
+
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, tableConfig.Columns(), tableData.SoftDelete)
+	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.InMemoryColumns, targetColumns, tableData.SoftDelete)
 
 	// Keys that exist in CDC stream, but not in Snowflake
 	err = ddl.AlterTable(ctx, s, tableConfig, fqName, tableConfig.CreateTable, constants.Add, tableData.LatestCDCTs, targetKeysMissing...)

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -20,11 +20,19 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	// I want to delete the value, so I update Postgres and set the cell to be null
 	// TableData will think the column is invalid and tableConfig will think column = string
 	// Before we call merge, it should reconcile it.
-	columns := map[string]typing.KindDetails{
+	colToKindDetailsMap := map[string]typing.KindDetails{
 		"id":                         typing.String,
 		"first_name":                 typing.String,
 		"invalid_column":             typing.Invalid,
 		constants.DeleteColumnMarker: typing.Boolean,
+	}
+
+	var cols typing.Columns
+	for colName, colKind := range colToKindDetailsMap {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: colKind,
+		})
 	}
 
 	rowsData := map[string]map[string]interface{}{
@@ -40,31 +48,49 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	}
 
 	tableData := &optimization.TableData{
-		InMemoryColumns: columns,
+		InMemoryColumns: &cols,
 		RowsData:        rowsData,
 		TopicConfig:     topicConfig,
 		PrimaryKeys:     []string{"id"},
 	}
 
-	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake), types.NewDwhTableConfig(
-		map[string]typing.KindDetails{
-			"id":                         typing.String,
-			"first_name":                 typing.String,
-			constants.DeleteColumnMarker: typing.Boolean,
-		}, nil, false, true))
+	anotherColToKindDetailsMap := map[string]typing.KindDetails{
+		"id":                         typing.String,
+		"first_name":                 typing.String,
+		constants.DeleteColumnMarker: typing.Boolean,
+	}
+
+	var anotherCols typing.Columns
+	for colName, kindDetails := range anotherColToKindDetailsMap {
+		anotherCols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: kindDetails,
+		})
+	}
+
+	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake),
+		types.NewDwhTableConfig(anotherCols, nil, false, true))
 
 	err := s.store.Merge(s.ctx, tableData)
-	assert.Equal(s.T(), tableData.InMemoryColumns["first_name"], typing.String)
+	assert.Equal(s.T(), tableData.InMemoryColumns.GetColumn("first_name").KindDetails, typing.String)
 	assert.NoError(s.T(), err)
 }
 
 func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
-	columns := map[string]typing.KindDetails{
+	colToKindDetailsMap := map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
 		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
+	}
+
+	var cols typing.Columns
+	for colName, colKind := range colToKindDetailsMap {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: colKind,
+		})
 	}
 
 	rowsData := make(map[string]map[string]interface{})
@@ -84,14 +110,14 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 	}
 
 	tableData := &optimization.TableData{
-		InMemoryColumns: columns,
+		InMemoryColumns: &cols,
 		RowsData:        rowsData,
 		TopicConfig:     topicConfig,
 		PrimaryKeys:     []string{"id"},
 	}
 
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake),
-		types.NewDwhTableConfig(columns, nil, false, true))
+		types.NewDwhTableConfig(cols, nil, false, true))
 
 	s.fakeStore.ExecReturnsOnCall(0, nil, fmt.Errorf("390114: Authentication token has expired. The user must authenticate again."))
 	err := s.store.Merge(s.ctx, tableData)
@@ -104,12 +130,20 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 }
 
 func (s *SnowflakeTestSuite) TestExecuteMerge() {
-	columns := map[string]typing.KindDetails{
+	colToKindDetailsMap := map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
 		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
+	}
+
+	var cols typing.Columns
+	for colName, colKind := range colToKindDetailsMap {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: colKind,
+		})
 	}
 
 	rowsData := make(map[string]map[string]interface{})
@@ -129,14 +163,14 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 	}
 
 	tableData := &optimization.TableData{
-		InMemoryColumns: columns,
+		InMemoryColumns: &cols,
 		RowsData:        rowsData,
 		TopicConfig:     topicConfig,
 		PrimaryKeys:     []string{"id"},
 	}
 
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake),
-		types.NewDwhTableConfig(columns, nil, false, true))
+		types.NewDwhTableConfig(cols, nil, false, true))
 	err := s.store.Merge(s.ctx, tableData)
 	assert.Nil(s.T(), err)
 	s.fakeStore.ExecReturns(nil, nil)
@@ -164,7 +198,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		}
 	}
 
-	columns := map[string]typing.KindDetails{
+	colToKindDetailsMap := map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
@@ -172,22 +206,42 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
+	var cols typing.Columns
+	for colName, colKind := range colToKindDetailsMap {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: colKind,
+		})
+	}
+
 	tableData := &optimization.TableData{
-		InMemoryColumns: columns,
+		InMemoryColumns: &cols,
 		RowsData:        rowsData,
 		TopicConfig:     topicConfig,
 		PrimaryKeys:     []string{"id"},
 	}
 
-	sflkColumns := map[string]typing.KindDetails{
+	snowflakeColToKindDetailsMap := map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"created_at":                 typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 	}
 
-	sflkColumns["new"] = typing.String
-	config := types.NewDwhTableConfig(sflkColumns, nil, false, true)
+	var sflkCols typing.Columns
+	for colName, colKind := range snowflakeColToKindDetailsMap {
+		cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: colKind,
+		})
+	}
+
+	sflkCols.AddColumn(typing.Column{
+		Name:        "new",
+		KindDetails: typing.String,
+	})
+
+	config := types.NewDwhTableConfig(sflkCols, nil, false, true)
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake), config)
 
 	err := s.store.Merge(s.ctx, tableData)
@@ -205,10 +259,13 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	// Now try to execute merge where 1 of the rows have the column now
 	for _, pkMap := range tableData.RowsData {
 		pkMap["new"] = "123"
-		tableData.InMemoryColumns = sflkColumns
+		tableData.InMemoryColumns = &sflkCols
 
 		// Since sflkColumns overwrote the format, let's set it correctly again.
-		tableData.InMemoryColumns["created_at"] = typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano))
+		tableData.InMemoryColumns.UpdateColumn(typing.Column{
+			Name:        "created_at",
+			KindDetails: typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
+		})
 		break
 	}
 

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -232,7 +232,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 	var sflkCols typing.Columns
 	for colName, colKind := range snowflakeColToKindDetailsMap {
-		cols.AddColumn(typing.Column{
+		sflkCols.AddColumn(typing.Column{
 			Name:        colName,
 			KindDetails: colKind,
 		})

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -72,7 +72,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		types.NewDwhTableConfig(anotherCols, nil, false, true))
 
 	err := s.store.Merge(s.ctx, tableData)
-	assert.Equal(s.T(), tableData.InMemoryColumns.GetColumn("first_name").KindDetails, typing.String)
+	_col, isOk := tableData.InMemoryColumns.GetColumn("first_name")
+	assert.True(s.T(), isOk)
+	assert.Equal(s.T(), _col.KindDetails, typing.String)
 	assert.NoError(s.T(), err)
 }
 
@@ -174,7 +176,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 	err := s.store.Merge(s.ctx, tableData)
 	assert.Nil(s.T(), err)
 	s.fakeStore.ExecReturns(nil, nil)
-	assert.Equal(s.T(), s.fakeStore.ExecCallCount(), 1, "called merge")
+	assert.Equal(s.T(), 1, s.fakeStore.ExecCallCount(), "called merge")
 }
 
 // TestExecuteMergeDeletionFlagRemoval is going to run execute merge twice.

--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -17,7 +17,9 @@ type Format interface {
 type Event interface {
 	GetExecutionTime() time.Time
 	GetData(ctx context.Context, pkMap map[string]interface{}, config *kafkalib.TopicConfig) map[string]interface{}
-	GetOptionalSchema(ctx  context.Context) map[string]typing.KindDetails
+	GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails
+	// GetColumns will inspect the envelope's payload right now and return.
+	GetColumns() *typing.Columns
 }
 
 // FieldLabelKind is used when the schema is turned on. Each schema object will be labelled.

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -79,6 +79,27 @@ func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]t
 	return nil
 }
 
+func (s *SchemaEventPayload) GetColumns() *typing.Columns {
+	// TODO Test
+	fieldsObject := s.Schema.GetSchemaFromLabel(cdc.After)
+	if fieldsObject == nil {
+		// AFTER schema does not exist.
+		return nil
+	}
+
+	var cols typing.Columns
+	for _, field := range fieldsObject.Fields {
+		cols.AddColumn(typing.Column{
+			Name: field.FieldName,
+			// We are purposefully doing this to ensure that the correct typing is set
+			// When we invoke event.Save()
+			KindDetails: typing.Invalid,
+		})
+	}
+
+	return &cols
+}
+
 func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]interface{}, tc *kafkalib.TopicConfig) map[string]interface{} {
 	retMap := make(map[string]interface{})
 	if len(s.Payload.AfterMap) == 0 {

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -80,7 +80,6 @@ func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]t
 }
 
 func (s *SchemaEventPayload) GetColumns() *typing.Columns {
-	// TODO Test
 	fieldsObject := s.Schema.GetSchemaFromLabel(cdc.After)
 	if fieldsObject == nil {
 		// AFTER schema does not exist.

--- a/lib/cdc/mysql/debezium_test.go
+++ b/lib/cdc/mysql/debezium_test.go
@@ -2,8 +2,12 @@ package mysql
 
 import (
 	"context"
+	"fmt"
+	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"time"
 )
 
@@ -297,4 +301,16 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 	assert.Equal(m.T(), evtData["first_name"], "Sally")
 	assert.Equal(m.T(), evtData["bool_test"], false)
 
+	cols := evt.GetColumns()
+	assert.NotNil(m.T(), cols)
+
+	for key := range evtData {
+		if strings.Contains(key, constants.ArtiePrefix) {
+			continue
+		}
+
+		col, isOk := cols.GetColumn(key)
+		assert.Equal(m.T(), true, isOk)
+		assert.Equal(m.T(), typing.Invalid, col.KindDetails, fmt.Sprintf("colName: %v, evtData key: %v", col.Name, key))
+	}
 }

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -34,6 +34,26 @@ type Source struct {
 	Table     string `json:"table"`
 }
 
+func (s *SchemaEventPayload) GetColumns() *typing.Columns {
+	fieldsObject := s.Schema.GetSchemaFromLabel(cdc.After)
+	if fieldsObject == nil {
+		// AFTER schema does not exist.
+		return nil
+	}
+
+	var cols typing.Columns
+	for _, field := range fieldsObject.Fields {
+		cols.AddColumn(typing.Column{
+			Name: field.FieldName,
+			// We are purposefully doing this to ensure that the correct typing is set
+			// When we invoke event.Save()
+			KindDetails: typing.Invalid,
+		})
+	}
+
+	return &cols
+}
+
 func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails {
 	fieldsObject := s.Schema.GetSchemaFromLabel(cdc.After)
 	if fieldsObject == nil {

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -16,7 +16,7 @@ func AlterTable(_ context.Context, dwh dwh.DataWarehouse, tc *types.DwhTableConf
 	var colSQLPart string
 	var err error
 	for _, col := range cols {
-		if col.Kind == typing.Invalid {
+		if col.KindDetails == typing.Invalid {
 			// Let's not modify the table if the column kind is invalid
 			continue
 		}
@@ -29,7 +29,7 @@ func AlterTable(_ context.Context, dwh dwh.DataWarehouse, tc *types.DwhTableConf
 		mutateCol = append(mutateCol, col)
 		switch columnOp {
 		case constants.Add:
-			colSQLPart = fmt.Sprintf("%s %s", col.Name, typing.KindToDWHType(col.Kind, dwh.Label()))
+			colSQLPart = fmt.Sprintf("%s %s", col.Name, typing.KindToDWHType(col.KindDetails, dwh.Label()))
 		case constants.Delete:
 			colSQLPart = fmt.Sprintf("%s", col.Name)
 		}

--- a/lib/dwh/ddl/ddl_bq_test.go
+++ b/lib/dwh/ddl/ddl_bq_test.go
@@ -119,12 +119,9 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 	assert.Equal(d.T(), newColsLen+existingColsLen, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns())
 	// Check by iterating over the columns
 	for _, column := range d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns() {
-		existingCol := existingCols.GetColumn(column.Name)
-		assert.NotNil(d.T(), existingCol)
+		existingCol, isOk := existingCols.GetColumn(column.Name)
+		assert.True(d.T(), isOk)
 		assert.Equal(d.T(), existingCol.KindDetails, column.KindDetails)
-		if existingCol == nil {
-
-		}
 	}
 }
 
@@ -165,8 +162,8 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 	assert.Equal(d.T(), existingColsLen, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns())
 	// Check by iterating over the columns
 	for _, column := range d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns() {
-		existingCol := existingCols.GetColumn(column.Name)
-		assert.NotNil(d.T(), existingCol)
+		existingCol, isOk := existingCols.GetColumn(column.Name)
+		assert.True(d.T(), isOk)
 		assert.Equal(d.T(), column.KindDetails, existingCol.KindDetails)
 	}
 }

--- a/lib/dwh/ddl/ddl_bq_test.go
+++ b/lib/dwh/ddl/ddl_bq_test.go
@@ -85,7 +85,6 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 		"foo": typing.String,
 		"bar": typing.String,
 	}
-	existingColsLen := len(existingColNameToKindDetailsMap)
 
 	newCols := map[string]typing.KindDetails{
 		"dusty":      typing.String,
@@ -93,8 +92,9 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 		"charlie":    typing.Boolean,
 		"robin":      typing.Float,
 	}
-	newColsLen := len(newCols)
 
+	newColsLen := len(newCols)
+	existingColsLen := len(existingColNameToKindDetailsMap)
 	var existingCols typing.Columns
 	for colName, kindDetails := range existingColNameToKindDetailsMap {
 		existingCols.AddColumn(typing.Column{Name: colName, KindDetails: kindDetails})
@@ -120,8 +120,13 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 	// Check by iterating over the columns
 	for _, column := range d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns() {
 		existingCol, isOk := existingCols.GetColumn(column.Name)
+		if !isOk {
+			// Check new cols?
+			existingCol.KindDetails, isOk = newCols[column.Name]
+		}
+
 		assert.True(d.T(), isOk)
-		assert.Equal(d.T(), existingCol.KindDetails, column.KindDetails)
+		assert.Equal(d.T(), existingCol.KindDetails, column.KindDetails, existingCol)
 	}
 }
 

--- a/lib/dwh/ddl/ddl_bq_test.go
+++ b/lib/dwh/ddl/ddl_bq_test.go
@@ -42,7 +42,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 	// Prior to deletion, there should be no colsToDelete
 	assert.Equal(d.T(), 0, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).ColumnsToDelete()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).ColumnsToDelete())
 	for name, kind := range columns {
-		err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Delete, ts, typing.Column{Name: name, Kind: kind})
+		err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Delete, ts, typing.Column{Name: name, KindDetails: kind})
 		assert.NoError(d.T(), err)
 	}
 
@@ -56,8 +56,8 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 	for name, kind := range columns {
 		err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Delete, ts.Add(2*constants.DeletionConfidencePadding),
 			typing.Column{
-				Name: name,
-				Kind: kind,
+				Name:        name,
+				KindDetails: kind,
 			})
 
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
@@ -99,7 +99,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 	var callIdx int
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)
 	for name, kind := range newCols {
-		err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Add, ts, typing.Column{Name: name, Kind: kind})
+		err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Add, ts, typing.Column{Name: name, KindDetails: kind})
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
 		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, name, typing.KindToDWHType(kind, d.bigQueryStore.Label())), query)
@@ -143,7 +143,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 		var sqlResult sql.Result
 		// BQ returning the same error because the column already exists.
 		d.fakeBigQueryStore.ExecReturnsOnCall(0, sqlResult, errors.New("Column already exists: _string at [1:39]"))
-		err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Add, ts, typing.Column{Name: name, Kind: kind})
+		err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Add, ts, typing.Column{Name: name, KindDetails: kind})
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
 		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, name, typing.KindToDWHType(kind, d.bigQueryStore.Label())), query)
@@ -167,7 +167,7 @@ func (d *DDLTestSuite) TestAlterTableCreateTable() {
 	ctx := context.Background()
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)
 
-	err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Add, time.Time{}, typing.Column{Name: "name", Kind: typing.String})
+	err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Add, time.Time{}, typing.Column{Name: "name", KindDetails: typing.String})
 	assert.Equal(d.T(), 1, d.fakeBigQueryStore.ExecCallCount())
 
 	query, _ := d.fakeBigQueryStore.ExecArgsForCall(0)
@@ -201,7 +201,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 	// Prior to deletion, there should be no colsToDelete
 	assert.Equal(d.T(), 0, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).ColumnsToDelete()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).ColumnsToDelete())
 	for name, kind := range columns {
-		err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Delete, ts, typing.Column{Name: name, Kind: kind})
+		err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Delete, ts, typing.Column{Name: name, KindDetails: kind})
 		assert.NoError(d.T(), err)
 	}
 
@@ -212,8 +212,8 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 	for name, kind := range columns {
 		err := ddl.AlterTable(ctx, d.bigQueryStore, tc, fqName, tc.CreateTable, constants.Delete, ts.Add(2*constants.DeletionConfidencePadding),
 			typing.Column{
-				Name: name,
-				Kind: kind,
+				Name:        name,
+				KindDetails: kind,
 			})
 		assert.NoError(d.T(), err)
 		assert.Equal(d.T(), 0, d.fakeBigQueryStore.ExecCallCount())

--- a/lib/dwh/ddl/ddl_sflk_test.go
+++ b/lib/dwh/ddl/ddl_sflk_test.go
@@ -20,12 +20,12 @@ func (d *DDLTestSuite) TestCreateTable() {
 	ctx := context.Background()
 	cols := []typing.Column{
 		{
-			Name: "key",
-			Kind: typing.String,
+			Name:        "key",
+			KindDetails: typing.String,
 		},
 		{
-			Name: "enabled",
-			Kind: typing.Boolean,
+			Name:        "enabled",
+			KindDetails: typing.Boolean,
 		},
 	}
 
@@ -48,12 +48,12 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 	// Test Structs and Arrays
 	cols := []typing.Column{
 		{
-			Name: "preferences",
-			Kind: typing.Struct,
+			Name:        "preferences",
+			KindDetails: typing.Struct,
 		},
 		{
-			Name: "array_col",
-			Kind: typing.Array,
+			Name:        "array_col",
+			KindDetails: typing.Array,
 		},
 	}
 
@@ -76,16 +76,16 @@ func (d *DDLTestSuite) TestAlterIdempotency() {
 	ctx := context.Background()
 	cols := []typing.Column{
 		{
-			Name: "created_at",
-			Kind: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
+			Name:        "created_at",
+			KindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 		},
 		{
-			Name: "id",
-			Kind: typing.Integer,
+			Name:        "id",
+			KindDetails: typing.Integer,
 		},
 		{
-			Name: "order_name",
-			Kind: typing.String,
+			Name:        "order_name",
+			KindDetails: typing.String,
 		},
 	}
 
@@ -108,16 +108,16 @@ func (d *DDLTestSuite) TestAlterTableAdd() {
 	// Test adding a bunch of columns
 	cols := []typing.Column{
 		{
-			Name: "created_at",
-			Kind: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
+			Name:        "created_at",
+			KindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 		},
 		{
-			Name: "id",
-			Kind: typing.Integer,
+			Name:        "id",
+			KindDetails: typing.Integer,
 		},
 		{
-			Name: "order_name",
-			Kind: typing.String,
+			Name:        "order_name",
+			KindDetails: typing.String,
 		},
 	}
 
@@ -135,7 +135,7 @@ func (d *DDLTestSuite) TestAlterTableAdd() {
 		var found bool
 		for _, expCol := range cols {
 			if found = col == expCol.Name; found {
-				assert.Equal(d.T(), kind, expCol.Kind, fmt.Sprintf("wrong col kind, col: %s", col))
+				assert.Equal(d.T(), kind, expCol.KindDetails, fmt.Sprintf("wrong col kind, col: %s", col))
 				break
 			}
 		}
@@ -150,16 +150,16 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	// Test adding a bunch of columns
 	cols := []typing.Column{
 		{
-			Name: "created_at",
-			Kind: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
+			Name:        "created_at",
+			KindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 		},
 		{
-			Name: "id",
-			Kind: typing.Integer,
+			Name:        "id",
+			KindDetails: typing.Integer,
 		},
 		{
-			Name: "name",
-			Kind: typing.String,
+			Name:        "name",
+			KindDetails: typing.String,
 		},
 	}
 
@@ -202,24 +202,24 @@ func (d *DDLTestSuite) TestAlterTableDelete() {
 	// Test adding a bunch of columns
 	cols := []typing.Column{
 		{
-			Name: "created_at",
-			Kind: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
+			Name:        "created_at",
+			KindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 		},
 		{
-			Name: "id",
-			Kind: typing.Integer,
+			Name:        "id",
+			KindDetails: typing.Integer,
 		},
 		{
-			Name: "name",
-			Kind: typing.String,
+			Name:        "name",
+			KindDetails: typing.String,
 		},
 		{
-			Name: "col_to_delete",
-			Kind: typing.String,
+			Name:        "col_to_delete",
+			KindDetails: typing.String,
 		},
 		{
-			Name: "answers",
-			Kind: typing.String,
+			Name:        "answers",
+			KindDetails: typing.String,
 		},
 	}
 

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -11,15 +11,12 @@ import (
 )
 
 type MergeArgument struct {
-	FqTableName   string
-	SubQuery      string
-	IdempotentKey string
-	PrimaryKeys   []string
-	// TODO refactor columns -> parsedColumns
-	Columns []string
-
-	//  TODO rename columnToType --> columns
-	ColumnToType typing.Columns
+	FqTableName    string
+	SubQuery       string
+	IdempotentKey  string
+	PrimaryKeys    []string
+	Columns        []string
+	ColumnsToTypes typing.Columns
 
 	// SpecialCastingRequired - This is used for columns that have JSON value. This is required for BigQuery
 	// We will be casting the value in this column as such: `TO_JSON_STRING(<columnName>)`
@@ -43,9 +40,9 @@ func MergeStatement(m MergeArgument) (string, error) {
 	var equalitySQLParts []string
 	for _, primaryKey := range m.PrimaryKeys {
 		equalitySQL := fmt.Sprintf("c.%s = cc.%s", primaryKey, primaryKey)
-		pkCol, isOk := m.ColumnToType.GetColumn(primaryKey)
+		pkCol, isOk := m.ColumnsToTypes.GetColumn(primaryKey)
 		if !isOk {
-			return "", fmt.Errorf("error: column: %s does not exist in columnToType: %v", primaryKey, m.ColumnToType)
+			return "", fmt.Errorf("error: column: %s does not exist in columnToType: %v", primaryKey, m.ColumnsToTypes)
 		}
 
 		if pkCol.KindDetails.Kind == typing.Struct.Kind {

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -11,7 +11,6 @@ import (
 )
 
 type MergeArgument struct {
-	// TODO: Test
 	FqTableName   string
 	SubQuery      string
 	IdempotentKey string

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -44,8 +44,8 @@ func MergeStatement(m MergeArgument) (string, error) {
 	var equalitySQLParts []string
 	for _, primaryKey := range m.PrimaryKeys {
 		equalitySQL := fmt.Sprintf("c.%s = cc.%s", primaryKey, primaryKey)
-		pkCol := m.ColumnToType.GetColumn(primaryKey)
-		if pkCol == nil {
+		pkCol, isOk := m.ColumnToType.GetColumn(primaryKey)
+		if !isOk {
 			return "", fmt.Errorf("error: column: %s does not exist in columnToType: %v", primaryKey, m.ColumnToType)
 		}
 

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -30,6 +30,12 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
+	var _cols typing.Columns
+	_cols.AddColumn(typing.Column{
+		Name:        "id",
+		KindDetails: typing.String,
+	})
+
 	for _, idempotentKey := range []string{"", "updated_at"} {
 		mergeSQL, err := MergeStatement(MergeArgument{
 			FqTableName:            fqTable,
@@ -37,7 +43,7 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 			IdempotentKey:          idempotentKey,
 			PrimaryKeys:            []string{"id"},
 			Columns:                cols,
-			ColumnToType:           map[string]typing.KindDetails{"id": typing.String},
+			ColumnToType:           _cols,
 			SpecialCastingRequired: false,
 			SoftDelete:             true,
 		})
@@ -67,6 +73,12 @@ func TestMergeStatement(t *testing.T) {
 		fmt.Sprintf("('%s', '%s', '%v', false)", "3", "dd", time.Now().Round(0).UTC()),
 	}
 
+	var _cols typing.Columns
+	_cols.AddColumn(typing.Column{
+		Name:        "id",
+		KindDetails: typing.String,
+	})
+
 	// select cc.foo, cc.bar from (values (12, 34), (44, 55)) as cc(foo, bar);
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
@@ -76,7 +88,7 @@ func TestMergeStatement(t *testing.T) {
 		IdempotentKey:          "",
 		PrimaryKeys:            []string{"id"},
 		Columns:                cols,
-		ColumnToType:           map[string]typing.KindDetails{"id": typing.String},
+		ColumnToType:           _cols,
 		SpecialCastingRequired: false,
 		SoftDelete:             false,
 	})
@@ -104,13 +116,19 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
+	var _cols typing.Columns
+	_cols.AddColumn(typing.Column{
+		Name:        "id",
+		KindDetails: typing.String,
+	})
+
 	mergeSQL, err := MergeStatement(MergeArgument{
 		FqTableName:            fqTable,
 		SubQuery:               subQuery,
 		IdempotentKey:          "updated_at",
 		PrimaryKeys:            []string{"id"},
 		Columns:                cols,
-		ColumnToType:           map[string]typing.KindDetails{"id": typing.String},
+		ColumnToType:           _cols,
 		SpecialCastingRequired: false,
 		SoftDelete:             false,
 	})
@@ -139,13 +157,23 @@ func TestMergeStatementCompositeKey(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
+	var _cols typing.Columns
+	_cols.AddColumn(typing.Column{
+		Name:        "id",
+		KindDetails: typing.String,
+	})
+	_cols.AddColumn(typing.Column{
+		Name:        "another_id",
+		KindDetails: typing.String,
+	})
+
 	mergeSQL, err := MergeStatement(MergeArgument{
 		FqTableName:            fqTable,
 		SubQuery:               subQuery,
 		IdempotentKey:          "updated_at",
 		PrimaryKeys:            []string{"id", "another_id"},
 		Columns:                cols,
-		ColumnToType:           map[string]typing.KindDetails{"id": typing.String, "another_id": typing.String},
+		ColumnToType:           _cols,
 		SpecialCastingRequired: false,
 		SoftDelete:             false,
 	})

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -43,7 +43,7 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 			IdempotentKey:          idempotentKey,
 			PrimaryKeys:            []string{"id"},
 			Columns:                cols,
-			ColumnToType:           _cols,
+			ColumnsToTypes:         _cols,
 			SpecialCastingRequired: false,
 			SoftDelete:             true,
 		})
@@ -88,7 +88,7 @@ func TestMergeStatement(t *testing.T) {
 		IdempotentKey:          "",
 		PrimaryKeys:            []string{"id"},
 		Columns:                cols,
-		ColumnToType:           _cols,
+		ColumnsToTypes:         _cols,
 		SpecialCastingRequired: false,
 		SoftDelete:             false,
 	})
@@ -128,7 +128,7 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 		IdempotentKey:          "updated_at",
 		PrimaryKeys:            []string{"id"},
 		Columns:                cols,
-		ColumnToType:           _cols,
+		ColumnsToTypes:         _cols,
 		SpecialCastingRequired: false,
 		SoftDelete:             false,
 	})
@@ -173,7 +173,7 @@ func TestMergeStatementCompositeKey(t *testing.T) {
 		IdempotentKey:          "updated_at",
 		PrimaryKeys:            []string{"id", "another_id"},
 		Columns:                cols,
-		ColumnToType:           _cols,
+		ColumnsToTypes:         _cols,
 		SpecialCastingRequired: false,
 		SoftDelete:             false,
 	})

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -37,14 +37,14 @@ func (tc *DwhTableConfig) DropDeletedColumns() bool {
 	return tc.dropDeletedColumns
 }
 
-func (tc *DwhTableConfig) Columns() typing.Columns {
+func (tc *DwhTableConfig) Columns() *typing.Columns {
 	// TODO in the future, columns should be wrapped with a type that has mutex support to avoid concurrent r/w panics
 	// or consider using sync.Map
 	if tc == nil {
-		return typing.Columns{}
+		return nil
 	}
 
-	return *tc.columns
+	return tc.columns
 }
 
 func (tc *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp constants.ColumnOperation, cols ...typing.Column) {

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -62,7 +62,7 @@ func (tc *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp const
 	switch columnOp {
 	case constants.Add:
 		for _, col := range cols {
-			table[col.Name] = col.Kind
+			table[col.Name] = col.KindDetails
 			// Delete from the permissions table, if exists.
 			delete(tc.columnsToDelete, col.Name)
 		}

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -66,7 +66,7 @@ func (tc *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp const
 	case constants.Delete:
 		for _, col := range cols {
 			// Delete from the permissions and in-memory table
-			tc.Columns().DeleteColumn(col.Name)
+			tc.columns.DeleteColumn(col.Name)
 			delete(tc.columnsToDelete, col.Name)
 		}
 	}

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -38,8 +38,6 @@ func (tc *DwhTableConfig) DropDeletedColumns() bool {
 }
 
 func (tc *DwhTableConfig) Columns() *typing.Columns {
-	// TODO in the future, columns should be wrapped with a type that has mutex support to avoid concurrent r/w panics
-	// or consider using sync.Map
 	if tc == nil {
 		return nil
 	}

--- a/lib/dwh/types/table_config_test.go
+++ b/lib/dwh/types/table_config_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/stretchr/testify/assert"
+	"sync"
 	"testing"
 	"time"
 )
@@ -18,4 +19,47 @@ func TestDwhTableConfig_ShouldDeleteColumn(t *testing.T) {
 	results = dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC())
 	assert.False(t, results)
 	assert.Equal(t, len(dwhTableConfig.ColumnsToDelete()), 1)
+}
+
+// TestDwhTableConfig_ColumnsConcurrency this file is meant to test the concurrency methods of .Columns()
+// In this test, we spin up 5 parallel Go-routines each making 100 calls to .Columns() and assert the validity of the data.
+func TestDwhTableConfig_ColumnsConcurrency(t *testing.T) {
+	var cols typing.Columns
+	cols.AddColumn(typing.Column{
+		Name:        "foo",
+		KindDetails: typing.Struct,
+	})
+	cols.AddColumn(typing.Column{
+		Name:        "bar",
+		KindDetails: typing.String,
+	})
+	cols.AddColumn(typing.Column{
+		Name:        "boolean",
+		KindDetails: typing.Boolean,
+	})
+
+	dwhTableCfg := NewDwhTableConfig(cols, nil, false, false)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(tableCfg *DwhTableConfig) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				assert.Equal(t, 3, len(tableCfg.Columns().GetColumns()), tableCfg.Columns().GetColumns())
+
+				kindDetails := typing.Integer
+				if (j % 2) == 0 {
+					kindDetails = typing.Array
+				}
+				tableCfg.Columns().UpdateColumn(typing.Column{
+					Name:        "foo",
+					KindDetails: kindDetails,
+				})
+				assert.Equal(t, 3, len(tableCfg.Columns().GetColumns()), tableCfg.Columns().GetColumns())
+			}
+		}(dwhTableCfg)
+	}
+
+	wg.Done()
 }

--- a/lib/dwh/types/table_config_test.go
+++ b/lib/dwh/types/table_config_test.go
@@ -1,13 +1,14 @@
 package types
 
 import (
+	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
 
 func TestDwhTableConfig_ShouldDeleteColumn(t *testing.T) {
-	dwhTableConfig := NewDwhTableConfig(nil, nil, false, false)
+	dwhTableConfig := NewDwhTableConfig(typing.Columns{}, nil, false, false)
 	results := dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC())
 	assert.False(t, results)
 	assert.Equal(t, len(dwhTableConfig.ColumnsToDelete()), 0)

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -39,6 +39,8 @@ func (t *TableData) Rows() uint {
 // Prior to merging, we will need to treat `tableConfig` as the source-of-truth and whenever there's discrepancies
 // We will prioritize using the values coming from (2) TableConfig. We also cannot simply do a replacement, as we have in-memory columns
 // That carry metadata for Artie Transfer. They are prefixed with __artie.
+
+// TODO rewrite this whole function
 func (t *TableData) UpdateInMemoryColumns(cols ...typing.Column) {
 	if t == nil {
 		return

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -11,7 +11,7 @@ import (
 )
 
 type TableData struct {
-	InMemoryColumns map[string]typing.KindDetails     // list of columns
+	InMemoryColumns typing.Columns                    // list of columns
 	RowsData        map[string]map[string]interface{} // pk -> { col -> val }
 	PrimaryKeys     []string
 
@@ -39,38 +39,37 @@ func (t *TableData) Rows() uint {
 // Prior to merging, we will need to treat `tableConfig` as the source-of-truth and whenever there's discrepancies
 // We will prioritize using the values coming from (2) TableConfig. We also cannot simply do a replacement, as we have in-memory columns
 // That carry metadata for Artie Transfer. They are prefixed with __artie.
-func (t *TableData) UpdateInMemoryColumns(cols map[string]typing.KindDetails) {
+func (t *TableData) UpdateInMemoryColumns(cols ...typing.Column) {
 	if t == nil {
 		return
 	}
 
-	for inMemCol, inMemKindDetails := range t.InMemoryColumns {
-		if inMemKindDetails.Kind == typing.Invalid.Kind {
-			// Don't copy this over.
-			// The being that the rows within tableData probably have the wrong colVal
-			// So it's better to skip even attempting to create this column from memory values.
-			// Whenever we get the first value that's a not-nil or invalid, this column type will be updated.
+	for index, inMemoryCol := range t.InMemoryColumns.GetColumns() {
+		if inMemoryCol.KindDetails.Kind == typing.Invalid.Kind {
+			// Don't copy this over because tableData has the wrong colVal
 			continue
 		}
 
-		// strings.ToLower() is used because certain destinations do not follow JSON standards.
-		// Snowflake and BigQuery consider: NaMe, NAME, name as the same value. Whereas JSON considers these as 3 distinct values.
-		tcKind, isOk := cols[strings.ToLower(inMemCol)]
-		if isOk {
-			// Update in-memory column type with whatever is specified by the destination
-			inMemKindDetails.Kind = tcKind.Kind
-			if tcKind.ExtendedTimeDetails != nil {
-				if inMemKindDetails.ExtendedTimeDetails == nil {
-					inMemKindDetails.ExtendedTimeDetails = &ext.NestedKind{}
+		var foundColumn *typing.Column
+		for _, col := range cols {
+			if col.Name == strings.ToLower(inMemoryCol.Name) {
+				foundColumn = &col
+				break
+			}
+		}
+
+		if foundColumn != nil {
+			inMemoryCol.KindDetails = foundColumn.KindDetails
+			if foundColumn.KindDetails.ExtendedTimeDetails != nil {
+				if inMemoryCol.KindDetails.ExtendedTimeDetails == nil {
+					inMemoryCol.KindDetails.ExtendedTimeDetails = &ext.NestedKind{}
 				}
 
 				// Don't have tcKind.ExtendedTimeDetails update the format since the DWH will not have that.
-				inMemKindDetails.ExtendedTimeDetails.Type = tcKind.ExtendedTimeDetails.Type
+				inMemoryCol.KindDetails.ExtendedTimeDetails.Type = foundColumn.KindDetails.ExtendedTimeDetails.Type
 			}
-
-			t.InMemoryColumns[inMemCol] = inMemKindDetails
 		}
+		t.InMemoryColumns.UpdateColumn(index, inMemoryCol)
 	}
-
 	return
 }

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -44,7 +44,7 @@ func (t *TableData) UpdateInMemoryColumns(cols ...typing.Column) {
 		return
 	}
 
-	for index, inMemoryCol := range t.InMemoryColumns.GetColumns() {
+	for _, inMemoryCol := range t.InMemoryColumns.GetColumns() {
 		if inMemoryCol.KindDetails.Kind == typing.Invalid.Kind {
 			// Don't copy this over because tableData has the wrong colVal
 			continue
@@ -69,7 +69,7 @@ func (t *TableData) UpdateInMemoryColumns(cols ...typing.Column) {
 				inMemoryCol.KindDetails.ExtendedTimeDetails.Type = foundColumn.KindDetails.ExtendedTimeDetails.Type
 			}
 		}
-		t.InMemoryColumns.UpdateColumn(index, inMemoryCol)
+		t.InMemoryColumns.UpdateColumn(inMemoryCol)
 	}
 	return
 }

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -11,7 +11,7 @@ import (
 )
 
 type TableData struct {
-	InMemoryColumns typing.Columns                    // list of columns
+	InMemoryColumns *typing.Columns                   // list of columns
 	RowsData        map[string]map[string]interface{} // pk -> { col -> val }
 	PrimaryKeys     []string
 
@@ -71,5 +71,6 @@ func (t *TableData) UpdateInMemoryColumns(cols ...typing.Column) {
 		}
 		t.InMemoryColumns.UpdateColumn(inMemoryCol)
 	}
+
 	return
 }

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -24,7 +24,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	}
 
 	tableData := &TableData{
-		InMemoryColumns: _cols,
+		InMemoryColumns: &_cols,
 	}
 
 	extCol := tableData.InMemoryColumns.GetColumn("do_not_change_format")

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -1,12 +1,11 @@
 package optimization
 
 import (
+	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/ext"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
-
-	"github.com/artie-labs/transfer/lib/typing"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTableData_UpdateInMemoryColumns(t *testing.T) {
@@ -42,7 +41,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 		"bar":                  typing.Boolean,
 		"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		tableData.UpdateInMemoryColumns(typing.Column{
+		tableData.UpdateInMemoryColumnsFromDestination(typing.Column{
 			Name:        name,
 			KindDetails: colKindDetails,
 		})
@@ -50,7 +49,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 
 	// It's saved back in the original format.
 	_, isOk = tableData.InMemoryColumns.GetColumn("foo")
-	assert.True(t, isOk)
+	assert.False(t, isOk)
 
 	_, isOk = tableData.InMemoryColumns.GetColumn("FOO")
 	assert.True(t, isOk)

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -27,9 +27,11 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 		InMemoryColumns: &_cols,
 	}
 
-	extCol := tableData.InMemoryColumns.GetColumn("do_not_change_format")
+	extCol, isOk := tableData.InMemoryColumns.GetColumn("do_not_change_format")
+	assert.True(t, isOk)
+
 	extCol.KindDetails.ExtendedTimeDetails.Format = time.RFC3339Nano
-	tableData.UpdateInMemoryColumns(typing.Column{
+	tableData.InMemoryColumns.UpdateColumn(typing.Column{
 		Name:        extCol.Name,
 		KindDetails: extCol.KindDetails,
 	})
@@ -47,19 +49,22 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	}
 
 	// It's saved back in the original format.
-	col := tableData.InMemoryColumns.GetColumn("foo")
-	assert.Nil(t, col)
+	_, isOk = tableData.InMemoryColumns.GetColumn("foo")
+	assert.True(t, isOk)
 
-	col = tableData.InMemoryColumns.GetColumn("FOO")
-	assert.NotNil(t, col)
+	_, isOk = tableData.InMemoryColumns.GetColumn("FOO")
+	assert.True(t, isOk)
 
-	col = tableData.InMemoryColumns.GetColumn("CHANGE_me")
+	col, isOk := tableData.InMemoryColumns.GetColumn("CHANGE_me")
+	assert.True(t, isOk)
 	assert.Equal(t, ext.DateTime.Type, col.KindDetails.ExtendedTimeDetails.Type)
 
-	col = tableData.InMemoryColumns.GetColumn("bar")
+	col, isOk = tableData.InMemoryColumns.GetColumn("bar")
+	assert.True(t, isOk)
 	assert.Equal(t, typing.Invalid, col.KindDetails)
 
-	col = tableData.InMemoryColumns.GetColumn("do_not_change_format")
+	col, isOk = tableData.InMemoryColumns.GetColumn("do_not_change_format")
+	assert.True(t, isOk)
 	assert.Equal(t, col.KindDetails.Kind, typing.ETime.Kind)
 	assert.Equal(t, col.KindDetails.ExtendedTimeDetails.Type, ext.DateTimeKindType, "correctly mapped type")
 	assert.Equal(t, col.KindDetails.ExtendedTimeDetails.Format, time.RFC3339Nano, "format has been preserved")

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -10,39 +10,57 @@ import (
 )
 
 func TestTableData_UpdateInMemoryColumns(t *testing.T) {
-	tableData := &TableData{
-		InMemoryColumns: map[string]typing.KindDetails{
-			"FOO":                  typing.String,
-			"bar":                  typing.Invalid,
-			"CHANGE_me":            typing.String,
-			"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType),
-		},
+	var _cols typing.Columns
+	for colName, colKind := range map[string]typing.KindDetails{
+		"FOO":                  typing.String,
+		"bar":                  typing.Invalid,
+		"CHANGE_me":            typing.String,
+		"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType),
+	} {
+		_cols.AddColumn(typing.Column{
+			Name:        colName,
+			KindDetails: colKind,
+		})
 	}
 
-	tableData.InMemoryColumns["do_not_change_format"].ExtendedTimeDetails.Format = time.RFC3339Nano
+	tableData := &TableData{
+		InMemoryColumns: _cols,
+	}
 
-	tableData.UpdateInMemoryColumns(map[string]typing.KindDetails{
+	extCol := tableData.InMemoryColumns.GetColumn("do_not_change_format")
+	extCol.KindDetails.ExtendedTimeDetails.Format = time.RFC3339Nano
+	tableData.UpdateInMemoryColumns(typing.Column{
+		Name:        extCol.Name,
+		KindDetails: extCol.KindDetails,
+	})
+
+	for name, colKindDetails := range map[string]typing.KindDetails{
 		"foo":                  typing.String,
 		"change_me":            typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 		"bar":                  typing.Boolean,
 		"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
-	})
+	} {
+		tableData.UpdateInMemoryColumns(typing.Column{
+			Name:        name,
+			KindDetails: colKindDetails,
+		})
+	}
 
 	// It's saved back in the original format.
-	_, isOk := tableData.InMemoryColumns["foo"]
-	assert.False(t, isOk)
+	col := tableData.InMemoryColumns.GetColumn("foo")
+	assert.Nil(t, col)
 
-	_, isOk = tableData.InMemoryColumns["FOO"]
-	assert.True(t, isOk)
+	col = tableData.InMemoryColumns.GetColumn("FOO")
+	assert.NotNil(t, col)
 
-	colType, _ := tableData.InMemoryColumns["CHANGE_me"]
-	assert.Equal(t, ext.DateTime.Type, colType.ExtendedTimeDetails.Type)
+	col = tableData.InMemoryColumns.GetColumn("CHANGE_me")
+	assert.Equal(t, ext.DateTime.Type, col.KindDetails.ExtendedTimeDetails.Type)
 
-	colType, _ = tableData.InMemoryColumns["bar"]
-	assert.Equal(t, typing.Invalid, colType)
+	col = tableData.InMemoryColumns.GetColumn("bar")
+	assert.Equal(t, typing.Invalid, col.KindDetails)
 
-	colType, _ = tableData.InMemoryColumns["do_not_change_format"]
-	assert.Equal(t, colType.Kind, typing.ETime.Kind)
-	assert.Equal(t, colType.ExtendedTimeDetails.Type, ext.DateTimeKindType, "correctly mapped type")
-	assert.Equal(t, colType.ExtendedTimeDetails.Format, time.RFC3339Nano, "format has been preserved")
+	col = tableData.InMemoryColumns.GetColumn("do_not_change_format")
+	assert.Equal(t, col.KindDetails.Kind, typing.ETime.Kind)
+	assert.Equal(t, col.KindDetails.ExtendedTimeDetails.Type, ext.DateTimeKindType, "correctly mapped type")
+	assert.Equal(t, col.KindDetails.ExtendedTimeDetails.Format, time.RFC3339Nano, "format has been preserved")
 }

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -13,6 +13,7 @@ type Columns struct {
 
 func (c *Columns) AddColumn(col Column) {
 	// TODO Test uniqueness
+	// What if there's no name
 	c.columns = append(c.columns, col)
 }
 

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -28,6 +28,10 @@ func (c *Columns) GetColumn(name string) *Column {
 }
 
 func (c *Columns) GetColumns() []Column {
+	if c == nil {
+		return []Column{}
+	}
+
 	return c.columns
 }
 

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -12,19 +12,27 @@ type Columns struct {
 }
 
 func (c *Columns) AddColumn(col Column) {
-	// TODO Test uniqueness
-	// What if there's no name
+	// TODO: Test
+	if col.Name == "" {
+		return
+	}
+
+	if _, isOk := c.GetColumn(col.Name); isOk {
+		// Column exists.
+		return
+	}
+
 	c.columns = append(c.columns, col)
 }
 
-func (c *Columns) GetColumn(name string) *Column {
+func (c *Columns) GetColumn(name string) (Column, bool) {
 	for _, column := range c.columns {
 		if column.Name == name {
-			return &column
+			return column, true
 		}
 	}
 
-	return nil
+	return Column{}, false
 }
 
 func (c *Columns) GetColumns() []Column {

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -1,7 +1,5 @@
 package typing
 
-// TODO Test this whole file.
-
 type Column struct {
 	Name        string
 	KindDetails KindDetails
@@ -12,7 +10,6 @@ type Columns struct {
 }
 
 func (c *Columns) AddColumn(col Column) {
-	// TODO: Test
 	if col.Name == "" {
 		return
 	}

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -1,5 +1,7 @@
 package typing
 
+// TODO Test this whole file.
+
 type Column struct {
 	Name        string
 	KindDetails KindDetails
@@ -28,8 +30,20 @@ func (c *Columns) GetColumns() []Column {
 	return c.columns
 }
 
-func (c *Columns) UpdateColumn(idx int, col Column) {
-	// TODO test length
-	// TODO test unique
-	c.columns[idx] = col
+func (c *Columns) UpdateColumn(updateCol Column) {
+	for index, col := range c.columns {
+		if col.Name == updateCol.Name {
+			c.columns[index] = updateCol
+			return
+		}
+	}
+}
+
+func (c *Columns) DeleteColumn(name string) {
+	for idx, column := range c.columns {
+		if column.Name == name {
+			c.columns = append(c.columns[:idx], c.columns[idx+1:]...)
+			return
+		}
+	}
 }

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -1,0 +1,35 @@
+package typing
+
+type Column struct {
+	Name        string
+	KindDetails KindDetails
+}
+
+type Columns struct {
+	columns []Column
+}
+
+func (c *Columns) AddColumn(col Column) {
+	// TODO Test uniqueness
+	c.columns = append(c.columns, col)
+}
+
+func (c *Columns) GetColumn(name string) *Column {
+	for _, column := range c.columns {
+		if column.Name == name {
+			return &column
+		}
+	}
+
+	return nil
+}
+
+func (c *Columns) GetColumns() []Column {
+	return c.columns
+}
+
+func (c *Columns) UpdateColumn(idx int, col Column) {
+	// TODO test length
+	// TODO test unique
+	c.columns[idx] = col
+}

--- a/lib/typing/columns_test.go
+++ b/lib/typing/columns_test.go
@@ -1,0 +1,59 @@
+package typing
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestColumns_Add_Duplicate(t *testing.T) {
+	var cols Columns
+	duplicateColumns := []Column{{Name: "foo"}, {Name: "foo"}, {Name: "foo"}, {Name: "foo"}, {Name: "foo"}, {Name: "foo"}}
+	for _, duplicateColumn := range duplicateColumns {
+		cols.AddColumn(duplicateColumn)
+	}
+
+	assert.Equal(t, len(cols.GetColumns()), 1, "AddColumn() de-duplicates")
+}
+
+func TestColumns_Mutation(t *testing.T) {
+	var cols Columns
+	colsToAdd := []Column{{Name: "foo", KindDetails: String}, {Name: "bar", KindDetails: Struct}}
+	// Insert
+	for _, colToAdd := range colsToAdd {
+		cols.AddColumn(colToAdd)
+	}
+
+	assert.Equal(t, len(cols.GetColumns()), 2)
+	fooCol, isOk := cols.GetColumn("foo")
+	assert.True(t, isOk)
+	assert.Equal(t, String, fooCol.KindDetails)
+
+	barCol, isOk := cols.GetColumn("bar")
+	assert.True(t, isOk)
+	assert.Equal(t, Struct, barCol.KindDetails)
+
+	// Update
+	cols.UpdateColumn(Column{
+		Name:        "foo",
+		KindDetails: Integer,
+	})
+
+	cols.UpdateColumn(Column{
+		Name:        "bar",
+		KindDetails: Boolean,
+	})
+
+	fooCol, isOk = cols.GetColumn("foo")
+	assert.True(t, isOk)
+	assert.Equal(t, Integer, fooCol.KindDetails)
+
+	barCol, isOk = cols.GetColumn("bar")
+	assert.True(t, isOk)
+	assert.Equal(t, Boolean, barCol.KindDetails)
+
+	// Delete
+	cols.DeleteColumn("foo")
+	assert.Equal(t, len(cols.GetColumns()), 1)
+	cols.DeleteColumn("bar")
+	assert.Equal(t, len(cols.GetColumns()), 0)
+}

--- a/lib/typing/diff.go
+++ b/lib/typing/diff.go
@@ -6,11 +6,6 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 )
 
-type Column struct {
-	Name string
-	Kind KindDetails
-}
-
 // shouldSkipColumn takes the `colName` and `softDelete` and will return whether we should skip this column when calculating the diff.
 func shouldSkipColumn(colName string, softDelete bool) bool {
 	if colName == constants.DeleteColumnMarker && softDelete {
@@ -45,8 +40,8 @@ func Diff(columnsInSource map[string]KindDetails, columnsInDestination map[strin
 		}
 
 		targKeyMissing = append(targKeyMissing, Column{
-			Name: name,
-			Kind: kind,
+			Name:        name,
+			KindDetails: kind,
 		})
 	}
 
@@ -56,8 +51,8 @@ func Diff(columnsInSource map[string]KindDetails, columnsInDestination map[strin
 		}
 
 		srcKeyMissing = append(srcKeyMissing, Column{
-			Name: name,
-			Kind: kind,
+			Name:        name,
+			KindDetails: kind,
 		})
 	}
 

--- a/lib/typing/diff.go
+++ b/lib/typing/diff.go
@@ -27,12 +27,9 @@ func shouldSkipColumn(colName string, softDelete bool) bool {
 
 // Diff - when given 2 maps, a source and target
 // It will provide a diff in the form of 2 variables
-// The other argument `softDelete` is used on whether we should ignore Artie's soft delete column.
-// srcKeyMissing - which key are missing from source that are present in target
-// targKeyMissing - which key are missing from target that are present in source
-func Diff(source map[string]KindDetails, target map[string]KindDetails, softDelete bool) (srcKeyMissing []Column, targKeyMissing []Column) {
-	src := CopyColMap(source)
-	targ := CopyColMap(target)
+func Diff(columnsInSource map[string]KindDetails, columnsInDestination map[string]KindDetails, softDelete bool) (srcKeyMissing []Column, targKeyMissing []Column) {
+	src := CopyColMap(columnsInSource)
+	targ := CopyColMap(columnsInDestination)
 
 	for key := range src {
 		_, isOk := targ[key]

--- a/lib/typing/diff_test.go
+++ b/lib/typing/diff_test.go
@@ -95,6 +95,29 @@ func TestDiffDelta2(t *testing.T) {
 	assert.Equal(t, len(targKeyMissing), 3, targKeyMissing) // Missing a, c, d
 }
 
+func TestDiffDeterministic(t *testing.T) {
+	retMap := map[string]bool{}
+	source := map[string]KindDetails{
+		"id":   Integer,
+		"name": String,
+	}
+
+	target := map[string]KindDetails{}
+	for i := 0; i < 500; i++ {
+		keysMissing, targetKeysMissing := Diff(source, target, false)
+		assert.Equal(t, 0, len(keysMissing), keysMissing)
+
+		var key string
+		for _, targetKeyMissing := range targetKeysMissing {
+			key += targetKeyMissing.Name
+		}
+
+		retMap[key] = false
+	}
+
+	assert.Equal(t, 1, len(retMap), retMap)
+}
+
 func TestCopyColMap(t *testing.T) {
 	oneMap := map[string]KindDetails{
 		"hello":      String,

--- a/lib/typing/diff_test.go
+++ b/lib/typing/diff_test.go
@@ -70,12 +70,6 @@ func TestDiffBasic(t *testing.T) {
 func TestDiffDelta1(t *testing.T) {
 	var sourceCols Columns
 	var targCols Columns
-
-	sourceCols.AddColumn(Column{
-		Name:        "",
-		KindDetails: KindDetails{},
-	})
-
 	for colName, kindDetails := range map[string]KindDetails{
 		"a": String,
 		"b": Boolean,
@@ -99,8 +93,8 @@ func TestDiffDelta1(t *testing.T) {
 	}
 
 	srcKeyMissing, targKeyMissing := Diff(sourceCols, targCols, false)
-	assert.Equal(t, len(srcKeyMissing), 2)  // Missing aa, cc
-	assert.Equal(t, len(targKeyMissing), 2) // Missing aa, cc
+	assert.Equal(t, len(srcKeyMissing), 2, srcKeyMissing)   // Missing aa, cc
+	assert.Equal(t, len(targKeyMissing), 2, targKeyMissing) // Missing aa, cc
 }
 
 func TestDiffDelta2(t *testing.T) {
@@ -190,7 +184,7 @@ func TestCopyColMap(t *testing.T) {
 	copiedCols := CloneColumns(cols)
 	assert.Equal(t, copiedCols, cols)
 
-	// Delete a row from copiedCols
-	copiedCols.columns = copiedCols.columns[1:]
+	//Delete a row from copiedCols
+	copiedCols.columns = append(copiedCols.columns[1:])
 	assert.NotEqual(t, copiedCols, cols)
 }

--- a/models/event.go
+++ b/models/event.go
@@ -14,20 +14,22 @@ import (
 )
 
 type Event struct {
-	Table         string
-	PrimaryKeyMap map[string]interface{}
-	Data          map[string]interface{} // json serialized column data
+	Table          string
+	PrimaryKeyMap  map[string]interface{}
+	Data           map[string]interface{} // json serialized column data
 	OptiomalSchema map[string]typing.KindDetails
-	ExecutionTime time.Time              // When the SQL command was executed
+	Columns        *typing.Columns
+	ExecutionTime  time.Time // When the SQL command was executed
 }
 
 func ToMemoryEvent(ctx context.Context, event cdc.Event, pkMap map[string]interface{}, tc *kafkalib.TopicConfig) Event {
 	return Event{
-		Table:         tc.TableName,
-		PrimaryKeyMap: pkMap,
-		ExecutionTime: event.GetExecutionTime(),
+		Table:          tc.TableName,
+		PrimaryKeyMap:  pkMap,
+		ExecutionTime:  event.GetExecutionTime(),
 		OptiomalSchema: event.GetOptionalSchema(ctx),
-		Data:          event.GetData(ctx, pkMap, tc),
+		Columns:        event.GetColumns(),
+		Data:           event.GetData(ctx, pkMap, tc),
 	}
 }
 

--- a/models/event_test.go
+++ b/models/event_test.go
@@ -19,7 +19,11 @@ func (f fakeEvent) GetExecutionTime() time.Time {
 	return time.Now()
 }
 
-func (f fakeEvent) GetOptionalSchema(ctx  context.Context) map[string]typing.KindDetails {
+func (f fakeEvent) GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails {
+	return nil
+}
+
+func (f fakeEvent) GetColumns() *typing.Columns {
 	return nil
 }
 

--- a/models/memory.go
+++ b/models/memory.go
@@ -63,14 +63,12 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 			PartitionsToLastMessage: map[string][]artie.Message{},
 		}
 	} else {
-		// TODO test
 		if e.Columns != nil {
 			// Iterate over this again just in case.
 			for _, col := range e.Columns.GetColumns() {
 				inMemoryDB.TableData[e.Table].InMemoryColumns.AddColumn(col)
 			}
 		}
-
 	}
 
 	// Update col if necessary
@@ -106,14 +104,13 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 
 		retrievedColumn, isOk := inMemoryDB.TableData[e.Table].InMemoryColumns.GetColumn(newColName)
 		if !isOk {
-			//  TOD: Test.
 			// This would only happen if the columns did not get passed in initially.
 			inMemoryDB.TableData[e.Table].InMemoryColumns.AddColumn(typing.Column{
 				Name:        newColName,
 				KindDetails: typing.ParseValue(_col, e.OptiomalSchema, val),
 			})
 		} else {
-			if retrievedColumn.KindDetails.Kind == typing.Invalid.Kind {
+			if retrievedColumn.KindDetails == typing.Invalid {
 				// If colType is Invalid, let's see if we can update it to a better type
 				// If everything is nil, we don't need to add a column
 				// However, it's important to create a column even if it's nil.

--- a/models/memory.go
+++ b/models/memory.go
@@ -85,7 +85,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 			// We are directly adding this column to our in-memory database
 			// This ensures that this column exists, we just have an invalid value (so we will not replicate over).
 			// However, this will ensure that we do not drop the column within the destination
-			inMemoryDB.TableData[e.Table].InMemoryColumns.UpdateColumn(typing.Column{
+			inMemoryDB.TableData[e.Table].InMemoryColumns.AddColumn(typing.Column{
 				Name:        newColName,
 				KindDetails: typing.Invalid,
 			})

--- a/models/memory.go
+++ b/models/memory.go
@@ -52,7 +52,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 	if !isOk {
 		inMemoryDB.TableData[e.Table] = &optimization.TableData{
 			RowsData:                map[string]map[string]interface{}{},
-			InMemoryColumns:         typing.Columns{},
+			InMemoryColumns:         &typing.Columns{},
 			PrimaryKeys:             e.PrimaryKeys(),
 			TopicConfig:             *topicConfig,
 			PartitionsToLastMessage: map[string][]artie.Message{},

--- a/models/memory.go
+++ b/models/memory.go
@@ -62,8 +62,6 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 	// Update col if necessary
 	sanitizedData := make(map[string]interface{})
 	for _col, val := range e.Data {
-		// TODO test _col case sensitive operation.
-
 		// columns need to all be normalized and lower cased.
 		newColName := strings.ToLower(_col)
 		// Columns here could contain spaces. Every destination treats spaces in a column differently.

--- a/models/memory.go
+++ b/models/memory.go
@@ -92,8 +92,8 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 			continue
 		}
 
-		retrievedColumn := inMemoryDB.TableData[e.Table].InMemoryColumns.GetColumn(newColName)
-		if retrievedColumn == nil {
+		retrievedColumn, isOk := inMemoryDB.TableData[e.Table].InMemoryColumns.GetColumn(newColName)
+		if !isOk {
 			inMemoryDB.TableData[e.Table].InMemoryColumns.AddColumn(typing.Column{
 				Name:        newColName,
 				KindDetails: typing.ParseValue(_col, e.OptiomalSchema, val),

--- a/models/memory.go
+++ b/models/memory.go
@@ -52,7 +52,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 	if !isOk {
 		inMemoryDB.TableData[e.Table] = &optimization.TableData{
 			RowsData:                map[string]map[string]interface{}{},
-			InMemoryColumns:         map[string]typing.KindDetails{},
+			InMemoryColumns:         typing.Columns{},
 			PrimaryKeys:             e.PrimaryKeys(),
 			TopicConfig:             *topicConfig,
 			PartitionsToLastMessage: map[string][]artie.Message{},
@@ -66,7 +66,6 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 
 		// columns need to all be normalized and lower cased.
 		newColName := strings.ToLower(_col)
-
 		// Columns here could contain spaces. Every destination treats spaces in a column differently.
 		// So far, Snowflake accepts them when escaped properly, however BigQuery does not accept it.
 		// Instead of making this more complicated for future destinations, we will escape the spaces by having double underscore `__`
@@ -86,21 +85,30 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 			// We are directly adding this column to our in-memory database
 			// This ensures that this column exists, we just have an invalid value (so we will not replicate over).
 			// However, this will ensure that we do not drop the column within the destination
-			inMemoryDB.TableData[e.Table].InMemoryColumns[newColName] = typing.Invalid
+			inMemoryDB.TableData[e.Table].InMemoryColumns.UpdateColumn(typing.Column{
+				Name:        newColName,
+				KindDetails: typing.Invalid,
+			})
 			continue
 		}
 
-		colTypeDetails, isOk := inMemoryDB.TableData[e.Table].InMemoryColumns[newColName]
-		if !isOk {
-			inMemoryDB.TableData[e.Table].InMemoryColumns[newColName] = typing.ParseValue(_col, e.OptiomalSchema, val)
+		retrievedColumn := inMemoryDB.TableData[e.Table].InMemoryColumns.GetColumn(newColName)
+		if retrievedColumn == nil {
+			inMemoryDB.TableData[e.Table].InMemoryColumns.AddColumn(typing.Column{
+				Name:        newColName,
+				KindDetails: typing.ParseValue(_col, e.OptiomalSchema, val),
+			})
 		} else {
-			if colTypeDetails.Kind == typing.Invalid.Kind {
+			if retrievedColumn.KindDetails.Kind == typing.Invalid.Kind {
 				// If colType is Invalid, let's see if we can update it to a better type
 				// If everything is nil, we don't need to add a column
 				// However, it's important to create a column even if it's nil.
 				// This is because we don't want to think that it's okay to drop a column in DWH
 				if kindDetails := typing.ParseValue(_col, e.OptiomalSchema, val); kindDetails.Kind != typing.Invalid.Kind {
-					inMemoryDB.TableData[e.Table].InMemoryColumns[newColName] = kindDetails
+					inMemoryDB.TableData[e.Table].InMemoryColumns.UpdateColumn(typing.Column{
+						Name:        newColName,
+						KindDetails: kindDetails,
+					})
 				}
 			}
 		}

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -54,7 +54,6 @@ func (m *ModelsTestSuite) TestSaveEvent() {
 	}
 
 	assert.Equal(m.T(), 2, found, optimization.InMemoryColumns)
-
 	badColumn := "other"
 	edgeCaseEvent := Event{
 		Table: "foo",
@@ -134,7 +133,7 @@ func (m *ModelsTestSuite) TestEventSaveOptionalSchema() {
 
 	column, isOk = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("created_at_date_no_schema")
 	assert.True(m.T(), isOk)
-	assert.Equal(m.T(), ext.Date.Type, column.KindDetails)
+	assert.Equal(m.T(), ext.Date.Type, column.KindDetails.ExtendedTimeDetails.Type)
 
 	column, isOk = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("json_object_string")
 	assert.True(m.T(), isOk)

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
+	"strconv"
 )
 
 var topicConfig = &kafkalib.TopicConfig{
@@ -142,4 +143,108 @@ func (m *ModelsTestSuite) TestEventSaveOptionalSchema() {
 	column, isOk = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("json_object_no_schema")
 	assert.True(m.T(), isOk)
 	assert.Equal(m.T(), typing.Struct, column.KindDetails)
+}
+
+func (m *ModelsTestSuite) TestEvent_SaveColumnsNoData() {
+	var cols typing.Columns
+	for i := 0; i < 50; i++ {
+		cols.AddColumn(typing.Column{Name: fmt.Sprint(i), KindDetails: typing.Invalid})
+	}
+
+	evt := Event{
+		Table:   "non_existent",
+		Columns: &cols,
+		Data: map[string]interface{}{
+			"1":                          "123",
+			constants.DeleteColumnMarker: true,
+		},
+		PrimaryKeyMap: map[string]interface{}{
+			"1": "123",
+		},
+	}
+	kafkaMsg := kafka.Message{}
+	_, err := evt.Save(m.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
+	assert.NoError(m.T(), err)
+
+	var prevKey string
+	for _, col := range inMemoryDB.TableData["non_existent"].InMemoryColumns.GetColumns() {
+		if col.Name == constants.DeleteColumnMarker {
+			continue
+		}
+
+		if prevKey == "" {
+			prevKey = col.Name
+			continue
+		}
+
+		currentKeyParsed, err := strconv.Atoi(col.Name)
+		assert.NoError(m.T(), err)
+
+		prevKeyParsed, err := strconv.Atoi(prevKey)
+		assert.NoError(m.T(), err)
+
+		// Testing ordering.
+		assert.True(m.T(), currentKeyParsed > prevKeyParsed, fmt.Sprintf("current key: %v, prevKey: %v", currentKeyParsed, prevKeyParsed))
+	}
+
+	// Now let's add more keys.
+	evt.Columns.AddColumn(typing.Column{Name: "foo", KindDetails: typing.Invalid})
+	var index int
+	for idx, col := range evt.Columns.GetColumns() {
+		if col.Name == "foo" {
+			index = idx
+		}
+	}
+
+	assert.Equal(m.T(), len(evt.Columns.GetColumns())-1, index, "new column inserted to the end")
+}
+
+func (m *ModelsTestSuite) TestEventSaveColumns() {
+	var cols typing.Columns
+	cols.AddColumn(typing.Column{
+		Name:        "randomCol",
+		KindDetails: typing.Invalid,
+	})
+	cols.AddColumn(typing.Column{
+		Name:        "anotherCOL",
+		KindDetails: typing.Invalid,
+	})
+	cols.AddColumn(typing.Column{
+		Name:        "created_at_date_string",
+		KindDetails: typing.Invalid,
+	})
+
+	event := Event{
+		Table:   "foo",
+		Columns: &cols,
+		PrimaryKeyMap: map[string]interface{}{
+			"id": "123",
+		},
+		Data: map[string]interface{}{
+			constants.DeleteColumnMarker: true,
+			"randomCol":                  "dusty",
+			"anotherCOL":                 13.37,
+			"created_at_date_string":     "2023-01-01",
+		},
+	}
+
+	kafkaMsg := kafka.Message{}
+	_, err := event.Save(m.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
+	assert.Nil(m.T(), err)
+
+	column, isOk := inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("randomcol")
+	assert.True(m.T(), isOk)
+	assert.Equal(m.T(), typing.String, column.KindDetails)
+
+	column, isOk = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("anothercol")
+	assert.True(m.T(), isOk)
+	assert.Equal(m.T(), typing.Float, column.KindDetails)
+
+	column, isOk = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("created_at_date_string")
+	assert.True(m.T(), isOk)
+	assert.Equal(m.T(), ext.DateKindType, column.KindDetails.ExtendedTimeDetails.Type)
+
+	column, isOk = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn(constants.DeleteColumnMarker)
+	assert.True(m.T(), isOk)
+	assert.Equal(m.T(), typing.Boolean, column.KindDetails)
 }

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -72,8 +72,8 @@ func (m *ModelsTestSuite) TestSaveEvent() {
 	newKafkaMsg := kafka.Message{}
 	_, err = edgeCaseEvent.Save(m.ctx, topicConfig, artie.NewMessage(&newKafkaMsg, nil, newKafkaMsg.Topic))
 	assert.NoError(m.T(), err)
-	inMemoryCol := GetMemoryDB().TableData["foo"].InMemoryColumns.GetColumn(badColumn)
-	assert.NotNil(m.T(), inMemoryCol)
+	inMemoryCol, isOk := GetMemoryDB().TableData["foo"].InMemoryColumns.GetColumn(badColumn)
+	assert.True(m.T(), isOk)
 	assert.Equal(m.T(), typing.Invalid, inMemoryCol.KindDetails)
 }
 
@@ -128,19 +128,19 @@ func (m *ModelsTestSuite) TestEventSaveOptionalSchema() {
 	_, err := event.Save(m.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(m.T(), err)
 
-	column := inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("created_at_date_string")
-	assert.NotNil(m.T(), column)
+	column, isOk := inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("created_at_date_string")
+	assert.True(m.T(), isOk)
 	assert.Equal(m.T(), typing.String, column.KindDetails)
 
-	column = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("created_at_date_no_schema")
-	assert.NotNil(m.T(), column)
+	column, isOk = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("created_at_date_no_schema")
+	assert.True(m.T(), isOk)
 	assert.Equal(m.T(), ext.Date.Type, column.KindDetails)
 
-	column = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("json_object_string")
-	assert.NotNil(m.T(), column)
+	column, isOk = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("json_object_string")
+	assert.True(m.T(), isOk)
 	assert.Equal(m.T(), typing.String, column.KindDetails)
 
-	column = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("json_object_no_schema")
-	assert.NotNil(m.T(), column)
+	column, isOk = inMemoryDB.TableData["foo"].InMemoryColumns.GetColumn("json_object_no_schema")
+	assert.True(m.T(), isOk)
 	assert.Equal(m.T(), typing.Struct, column.KindDetails)
 }


### PR DESCRIPTION
When Transfer adds multiple columns within one flush cycle, we end up having column ordering that is out of order. This issue becomes more apparent when Transfer is creating multiple columns at the same time (e.g. when Transfer first initializes and creates a new table).

The indeterministic ordering is happening due to the fact that we were previously iterating over a `map` to know which column to add. 

![image](https://user-images.githubusercontent.com/4412200/233678884-b2fd14b9-3580-4d0f-b17f-7ba9fb6c4499.png)

The change here is to come up with a new type called `typing.Columns` and it's an array of `typing.Column` with the added safety checks of uniqueness since we're using an array.

Work required:
- [x] Refactor
- [x] Fix tests
- [x] Add additional

Test this against:
- [x] MySQL
- [x] MongoDB
- [x] Postgres

DWHs:
- [x] Snowflake
- [x] BigQuery


Snowflake
![image](https://user-images.githubusercontent.com/4412200/233803091-3a44207a-d02e-40f1-a56b-fa86fb581e6b.png)

Postgres
![Screenshot 2023-04-22 at 12 31 07 PM](https://user-images.githubusercontent.com/4412200/233803083-3009d83d-7d61-47d6-b901-e673fd4d48f9.png)


