### PR TITLE
[BigQuery] NULL String typing fix for CTEs

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -70,7 +70,13 @@ func merge(tableData *optimization.TableData) (string, error) {
 					colVal = stringutil.Wrap(string(colValBytes))
 				}
 			} else {
-				colVal = "null"
+				if colKind == typing.String {
+					// BigQuery does not like null as a string for CTEs.
+					// It throws this error: Value of type INT64 cannot be assigned to column name, which has type STRING
+					colVal = "''"
+				} else {
+					colVal = "null"
+				}
 			}
 
 			if firstRow {

--- a/clients/bigquery/merge_test.go
+++ b/clients/bigquery/merge_test.go
@@ -154,6 +154,7 @@ func (b *BigQueryTestSuite) TestMergeSimpleCompositeKey() {
 		"id":                         typing.String,
 		"idA":                        typing.String,
 		"name":                       typing.String,
+		"nullable_string":            typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 	}
 
@@ -186,7 +187,6 @@ func (b *BigQueryTestSuite) TestMergeSimpleCompositeKey() {
 	}
 
 	mergeSQL, err := merge(tableData)
-
 	assert.NoError(b.T(), err, "merge failed")
 	// Check if MERGE INTO FQ Table exists.
 	assert.True(b.T(), strings.Contains(mergeSQL, "MERGE INTO shop.customer c"), mergeSQL)
@@ -209,6 +209,9 @@ func (b *BigQueryTestSuite) TestMergeSimpleCompositeKey() {
 			})
 		}
 	}
+
+	// Check null string fix.
+	assert.True(b.T(), strings.Contains(mergeSQL, fmt.Sprintf(`'' as nullable_string`)), mergeSQL)
 }
 
 func (b *BigQueryTestSuite) TestMergeJSONKeyAndCompositeHybrid() {


### PR DESCRIPTION
BigQuery's MERGE does not like `NULL` as a value for the column string.

It ends up throwing an error, so we are now passing `''` instead.