### PR TITLE
[Enhancement] Improve time ms precision for timestamp w/ time zone types

### DIFF
--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/cdc/util"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -14,8 +13,6 @@ import (
 type Debezium string
 
 func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Event, error) {
-	fmt.Println("event", string(bytes))
-
 	var event util.SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.

--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/cdc/util"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -13,6 +14,8 @@ import (
 type Debezium string
 
 func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Event, error) {
+	fmt.Println("event", string(bytes))
+
 	var event util.SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -51,7 +51,6 @@ func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 	}
 
 	if potentialFormat != "" {
-		// TODO test
 		return NewExtendedTime(potentialTime, DateTimeKindType, potentialFormat)
 	}
 

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -36,12 +36,12 @@ func ParseFromInterface(val interface{}) (*ExtendedTime, error) {
 func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 	// Check all the timestamp formats
 	var potentialFormat string
-	var ts time.Time
-	var err error
+	var potentialTime time.Time
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		ts, err = time.Parse(supportedDateTimeLayout, dtString)
+		ts, err := time.Parse(supportedDateTimeLayout, dtString)
 		if err == nil {
 			potentialFormat = supportedDateTimeLayout
+			potentialTime = ts
 			// Now let's parse ts back with the original layout.
 			// Does it match exactly with the dtString? If so, then it's identical.
 			if ts.Format(supportedDateTimeLayout) == dtString {
@@ -51,8 +51,9 @@ func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 	}
 
 	if potentialFormat != "" {
+		fmt.Println("here?")
 		// TODO test
-		return NewExtendedTime(ts, DateTimeKindType, potentialFormat)
+		return NewExtendedTime(potentialTime, DateTimeKindType, potentialFormat)
 	}
 
 	// Now check dates

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -51,7 +51,6 @@ func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 	}
 
 	if potentialFormat != "" {
-		fmt.Println("here?")
 		// TODO test
 		return NewExtendedTime(potentialTime, DateTimeKindType, potentialFormat)
 	}

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -35,11 +35,24 @@ func ParseFromInterface(val interface{}) (*ExtendedTime, error) {
 // overlaying or mutating any format and timezone shifts.
 func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 	// Check all the timestamp formats
+	var potentialFormat string
+	var ts time.Time
+	var err error
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		ts, err := time.Parse(supportedDateTimeLayout, dtString)
+		ts, err = time.Parse(supportedDateTimeLayout, dtString)
 		if err == nil {
-			return NewExtendedTime(ts, DateTimeKindType, supportedDateTimeLayout)
+			potentialFormat = supportedDateTimeLayout
+			// Now let's parse ts back with the original layout.
+			// Does it match exactly with the dtString? If so, then it's identical.
+			if ts.Format(supportedDateTimeLayout) == dtString {
+				return NewExtendedTime(ts, DateTimeKindType, supportedDateTimeLayout)
+			}
 		}
+	}
+
+	if potentialFormat != "" {
+		// TODO test
+		return NewExtendedTime(ts, DateTimeKindType, potentialFormat)
 	}
 
 	// Now check dates

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -1,6 +1,7 @@
 package ext
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -58,6 +59,7 @@ func TestParseFromInterfaceDateTime(t *testing.T) {
 			layout = supportedDateTimeLayout
 		}
 
+		fmt.Println("layout", layout, "supportedDateTimeLayout", supportedDateTimeLayout)
 		// Without passing an override format, this should return the same preserved dt format.
 		assert.Equal(t, et.String(layout), now.Format(supportedDateTimeLayout))
 	}
@@ -84,4 +86,11 @@ func TestParseFromInterfaceDate(t *testing.T) {
 		// Without passing an override format, this should return the same preserved dt format.
 		assert.Equal(t, et.String(""), now.Format(supportedDateFormat))
 	}
+}
+
+func TestParseExtendedDateTime_Timestamp(t *testing.T) {
+	tsString := "2023-04-24T17:29:05.69944Z"
+	extTime, err := ParseExtendedDateTime(tsString)
+	assert.NoError(t, err)
+	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.String(""))
 }

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -1,7 +1,6 @@
 package ext
 
 import (
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -54,14 +53,8 @@ func TestParseFromInterfaceDateTime(t *testing.T) {
 		assert.Equal(t, et.NestedKind.Type, DateTimeKindType)
 
 		// There's a known edge case between Ruby and Unix Date for single digit day formats and both layouts conform.
-		var layout string
-		if supportedDateTimeLayout == time.UnixDate || supportedDateTimeLayout == time.RubyDate {
-			layout = supportedDateTimeLayout
-		}
-
-		fmt.Println("layout", layout, "supportedDateTimeLayout", supportedDateTimeLayout)
 		// Without passing an override format, this should return the same preserved dt format.
-		assert.Equal(t, et.String(layout), now.Format(supportedDateTimeLayout))
+		assert.Equal(t, et.String(supportedDateTimeLayout), now.Format(supportedDateTimeLayout))
 	}
 }
 

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -51,10 +51,7 @@ func TestParseFromInterfaceDateTime(t *testing.T) {
 		et, err := ParseFromInterface(now.Format(supportedDateTimeLayout))
 		assert.NoError(t, err)
 		assert.Equal(t, et.NestedKind.Type, DateTimeKindType)
-
-		// There's a known edge case between Ruby and Unix Date for single digit day formats and both layouts conform.
-		// Without passing an override format, this should return the same preserved dt format.
-		assert.Equal(t, et.String(supportedDateTimeLayout), now.Format(supportedDateTimeLayout))
+		assert.Equal(t, et.String(""), now.Format(supportedDateTimeLayout))
 	}
 }
 

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -10,8 +10,6 @@ const (
 	PostgresTimeFormatNoTZ = "15:04:05.999999" // microsecond precision, used because certain destinations do not like `Time` types to specify tz locale
 )
 
-// 2023-04-24 17:20:16.625612+00
-
 var supportedDateTimeLayouts = []string{
 	time.RFC3339Nano,
 	ISO8601,

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -13,7 +13,7 @@ const (
 // 2023-04-24 17:20:16.625612+00
 
 var supportedDateTimeLayouts = []string{
-	//time.RFC3339Nano,
+	time.RFC3339Nano,
 	ISO8601,
 	time.Layout,
 	time.ANSIC,

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -3,16 +3,17 @@ package ext
 import "time"
 
 const (
-	ISO8601 = "2006-01-02T15:04:05-07:00"
-
-	PostgresDateFormat = "2006-01-02"
-
+	ISO8601                = "2006-01-02T15:04:05-07:00"
+	PostgresDateFormat     = "2006-01-02"
 	PostgresTimeFormat     = "15:04:05.999999-07" // microsecond precision
 	AdditionalTimeFormat   = "15:04:05.999999Z07"
 	PostgresTimeFormatNoTZ = "15:04:05.999999" // microsecond precision, used because certain destinations do not like `Time` types to specify tz locale
 )
 
+// 2023-04-24 17:20:16.625612+00
+
 var supportedDateTimeLayouts = []string{
+	time.RFC3339Nano,
 	ISO8601,
 	time.Layout,
 	time.ANSIC,

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -13,7 +13,7 @@ const (
 // 2023-04-24 17:20:16.625612+00
 
 var supportedDateTimeLayouts = []string{
-	time.RFC3339Nano,
+	//time.RFC3339Nano,
 	ISO8601,
 	time.Layout,
 	time.ANSIC,

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -33,9 +33,9 @@ func TestJSONString(t *testing.T) {
 
 func TestParseValueBasic(t *testing.T) {
 	// Floats
-	assert.Equal(t, ParseValue("", nil,7.5), Float)
+	assert.Equal(t, ParseValue("", nil, 7.5), Float)
 	assert.Equal(t, ParseValue("", nil, -7.4999999), Float)
-	assert.Equal(t, ParseValue("", nil,7.0), Float)
+	assert.Equal(t, ParseValue("", nil, 7.0), Float)
 
 	// Integers
 	assert.Equal(t, ParseValue("", nil, 9), Integer)
@@ -108,6 +108,7 @@ func TestDateTime(t *testing.T) {
 
 		// Test the parseDT function as well.
 		ts, err := ext.ParseExtendedDateTime(fmt.Sprint(possibleDate))
+		fmt.Println("possibleDate", possibleDate, "ts", ts)
 		assert.NoError(t, err, err)
 		assert.False(t, ts.IsZero(), ts)
 	}

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -117,6 +117,13 @@ func TestDateTime(t *testing.T) {
 	assert.Nil(t, ts)
 }
 
+func TestDateTime_Fallback(t *testing.T) {
+	dtString := "Mon Jan 02 15:04:05.69944 -0700 2006"
+	ts, err := ext.ParseExtendedDateTime(dtString)
+	assert.NoError(t, err)
+	assert.NotEqual(t, ts.String(""), dtString)
+}
+
 func TestTime(t *testing.T) {
 	kindDetails := ParseValue("", nil, "00:18:11.13116+00")
 	// 00:42:26.693631Z

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -108,7 +108,7 @@ func TestDateTime(t *testing.T) {
 
 		// Test the parseDT function as well.
 		ts, err := ext.ParseExtendedDateTime(fmt.Sprint(possibleDate))
-		fmt.Println("possibleDate", possibleDate, "ts", ts)
+		fmt.Println("possibleDate", possibleDate, "ts", ts, "err", err)
 		assert.NoError(t, err, err)
 		assert.False(t, ts.IsZero(), ts)
 	}

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -108,7 +108,6 @@ func TestDateTime(t *testing.T) {
 
 		// Test the parseDT function as well.
 		ts, err := ext.ParseExtendedDateTime(fmt.Sprint(possibleDate))
-		fmt.Println("possibleDate", possibleDate, "ts", ts, "err", err)
 		assert.NoError(t, err, err)
 		assert.False(t, ts.IsZero(), ts)
 	}


### PR DESCRIPTION
## Problem

Debezium handles `Timestamp`, `Date` and `Time` all differently depending on your setup.

More specifically, `TIMESTAMP WITH TIMEZONE` is casted as a `STRING`. `TIMESTAMP WITHOUT TIMEZONE` whereas Debezium casts the latter as a DBZ datetype.

**What's the problem?**

Transfer supports 10 different time layouts and if any of them work, we were previously returning the first layout.
Well, if you have ms and/or ns precision, it will still "work" as in, getting casted to a more generic layout. However, we then lose precision.

## Fix

We now have a stricter parsing rule where:
1) We take the original timestamp string
2) Take a layout that works, parse the `time.Time` we got from (1) and diff the strings

(2) would have not worked in the past because we lost ms precision. If the two outcomes both work, we then know that was the right layout.

If neither works, we then keep trying. Once we reach the end and none of them fit perfectly, we then have a fallback layout that did work (just not perfect).

## Verification
![image](https://user-images.githubusercontent.com/4412200/234120524-61f2aac7-bc81-482e-96de-1deb5efd8bba.png)

![image](https://user-images.githubusercontent.com/4412200/234120556-1b0c9853-776f-45ff-ba19-ee453315578a.png)

