### PR TITLE
[Enhancement] Adding jitter sleep after signaling flush

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/viant/bigquery v0.2.1-0.20230129024722-24ed6fd5555f
 	go.mongodb.org/mongo-driver v1.11.0
+	golang.org/x/exp v0.0.0-20191002040644-a1355ae1e2c3
 	google.golang.org/api v0.103.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/lib/db/mock/db.go
+++ b/lib/db/mock/db.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"database/sql"
+	"fmt"
 	"github.com/artie-labs/transfer/lib/mocks"
 )
 
@@ -12,11 +13,11 @@ type DB struct {
 }
 
 func (m *DB) Exec(query string, args ...any) (sql.Result, error) {
-	//fmt.Println("Mock DB is executing", "query", query, "args", args)
+	fmt.Println("Mock DB is executing", "query", query, "args", args)
 	return m.Fake.Exec(query, args)
 }
 
 func (m *DB) Query(query string, args ...any) (*sql.Rows, error) {
-	//fmt.Println("Mock DB is querying", "query", query, "args", args)
+	fmt.Println("Mock DB is querying", "query", query, "args", args)
 	return m.Fake.Query(query, args)
 }

--- a/lib/db/mock/db.go
+++ b/lib/db/mock/db.go
@@ -2,8 +2,6 @@ package mock
 
 import (
 	"database/sql"
-	"fmt"
-
 	"github.com/artie-labs/transfer/lib/mocks"
 )
 
@@ -14,11 +12,11 @@ type DB struct {
 }
 
 func (m *DB) Exec(query string, args ...any) (sql.Result, error) {
-	fmt.Println("Mock DB is executing", "query", query, "args", args)
+	//fmt.Println("Mock DB is executing", "query", query, "args", args)
 	return m.Fake.Exec(query, args)
 }
 
 func (m *DB) Query(query string, args ...any) (*sql.Rows, error) {
-	fmt.Println("Mock DB is querying", "query", query, "args", args)
+	//fmt.Println("Mock DB is querying", "query", query, "args", args)
 	return m.Fake.Query(query, args)
 }

--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -1,0 +1,14 @@
+package jitter
+
+import (
+	"golang.org/x/exp/rand"
+	"math"
+)
+
+const maxSeconds = 20
+
+func Jitter(baseSeconds, attempts int) int {
+	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+	// sleep = random_between(0, min(cap, base * 2 ** attempt))
+	return rand.Intn(int(math.Min(maxSeconds, float64(baseSeconds)*math.Pow(2, float64(attempts)))))
+}

--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -10,5 +10,5 @@ const maxMilliSeconds = 3500
 func JitterMs(baseMilliSeconds, attempts int) int {
 	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 	// sleep = random_between(0, min(cap, base * 2 ** attempt))
-	return rand.Intn(int(math.Min(3500, float64(baseMilliSeconds)*math.Pow(2, float64(attempts)))))
+	return rand.Intn(int(math.Min(maxMilliSeconds, float64(baseMilliSeconds)*math.Pow(2, float64(attempts)))))
 }

--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -5,10 +5,10 @@ import (
 	"math"
 )
 
-const maxSeconds = 20
+const maxMilliSeconds = 3500
 
-func Jitter(baseSeconds, attempts int) int {
+func JitterMs(baseMilliSeconds, attempts int) int {
 	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 	// sleep = random_between(0, min(cap, base * 2 ** attempt))
-	return rand.Intn(int(math.Min(maxSeconds, float64(baseSeconds)*math.Pow(2, float64(attempts)))))
+	return rand.Intn(int(math.Min(3500, float64(baseMilliSeconds)*math.Pow(2, float64(attempts)))))
 }

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -3,7 +3,9 @@ package consumer
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"github.com/artie-labs/transfer/lib/artie"
+	"github.com/artie-labs/transfer/lib/jitter"
 	awsCfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/segmentio/kafka-go/sasl/aws_msk_iam_v2"
 	"github.com/segmentio/kafka-go/sasl/plain"
@@ -104,6 +106,12 @@ func StartConsumer(ctx context.Context, flushChan chan bool) {
 
 				if shouldFlush {
 					flushChan <- true
+					// Jitter-sleep is necessary to allow the flush process to acquire the table lock
+					// If it doesn't then the flush process may be over-exhausted since the lock got acquired by `processMessage(...)`.
+					// This then leads us to make unnecessary flushes.
+					jitterDuration := jitter.Jitter(3, 1)
+					fmt.Println("jitterDuration", jitterDuration)
+					time.Sleep(time.Duration(jitterDuration) * time.Second)
 				}
 			}
 		}(topic)

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -3,7 +3,6 @@ package consumer
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"github.com/artie-labs/transfer/lib/artie"
 	"github.com/artie-labs/transfer/lib/jitter"
 	awsCfg "github.com/aws/aws-sdk-go-v2/config"
@@ -109,9 +108,8 @@ func StartConsumer(ctx context.Context, flushChan chan bool) {
 					// Jitter-sleep is necessary to allow the flush process to acquire the table lock
 					// If it doesn't then the flush process may be over-exhausted since the lock got acquired by `processMessage(...)`.
 					// This then leads us to make unnecessary flushes.
-					jitterDuration := jitter.Jitter(3, 1)
-					fmt.Println("jitterDuration", jitterDuration)
-					time.Sleep(time.Duration(jitterDuration) * time.Second)
+					jitterDuration := jitter.JitterMs(500, 1)
+					time.Sleep(time.Duration(jitterDuration) * time.Millisecond)
 				}
 			}
 		}(topic)

--- a/processes/consumer/pubsub.go
+++ b/processes/consumer/pubsub.go
@@ -98,8 +98,8 @@ func StartSubscriber(ctx context.Context, flushChan chan bool) {
 					// Jitter-sleep is necessary to allow the flush process to acquire the table lock
 					// If it doesn't then the flush process may be over-exhausted since the lock got acquired by `processMessage(...)`.
 					// This then leads us to make unnecessary flushes.
-					jitterDuration := jitter.Jitter(3, 1)
-					time.Sleep(time.Duration(jitterDuration) * time.Second)
+					jitterDuration := jitter.JitterMs(500, 1)
+					time.Sleep(time.Duration(jitterDuration) * time.Millisecond)
 				}
 			})
 


### PR DESCRIPTION
This is an optimization to make our flushes more efficient.

It is indeterministic on if the flush process will start before the `processMessage` function iterates.

Right now, `processMessage` will send a signal to `flush` and the flush process will ack it and acquire a lock.
However, it's not guaranteed and thus we may signal additional flushes and slow down throughput by flushing too prematurely.

Solution here is to add a low sleep jitter to allow the flush process to pick up the signal and acquire the lock, which prevents the `processMessage` process from saving more events into our in-memory database.