### PR TITLE
[BigQuery] Escaping multi-lines with a carriage return

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -55,6 +55,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 				// All the other types do not need string wrapping.
 				case typing.String.Kind, typing.Struct.Kind:
 					colVal = stringutil.Wrap(colVal)
+					colVal = stringutil.LineBreaksToCarriageReturns(fmt.Sprint(colVal))
 					if colKind.KindDetails == typing.Struct {
 						// This is how you cast string -> JSON
 						colVal = fmt.Sprintf("JSON %s", colVal)

--- a/lib/stringutil/strings.go
+++ b/lib/stringutil/strings.go
@@ -36,3 +36,7 @@ func EscapeSpaces(col string) (escaped bool, newString string) {
 	subStr := " "
 	return strings.Contains(col, subStr), strings.ReplaceAll(col, subStr, "__")
 }
+
+func LineBreaksToCarriageReturns(paragraph string) string {
+	return strings.ReplaceAll(paragraph, "\n", `\n`)
+}

--- a/lib/stringutil/strings_test.go
+++ b/lib/stringutil/strings_test.go
@@ -40,3 +40,24 @@ func TestEscapeSpaces(t *testing.T) {
 		assert.Equal(t, expected["space"], containsSpace)
 	}
 }
+
+func TestLineBreaksToCarriageReturns(t *testing.T) {
+	paragraph := `Dog
+walked
+over
+the
+hill
+`
+	text := LineBreaksToCarriageReturns(paragraph)
+	assert.Equal(t, `Dog\nwalked\nover\nthe\nhill\n`, text, paragraph)
+
+	nonParagraphs := []string{
+		"foo", "思翰", "Gene Capron", "aba4195bde80192dff98f2cab0ecdca954482826",
+		"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAFzSURBVDjLY/j//z8DPlxYWFgAxA9ANDZ5BiIMeASlH5BswPz58+uampo2kuUCkGYgPg/EQvgsweZk5rlz5zYSoxnDAKBmprq6umONjY1vsmdeamvd9Pzc1N2vv/Zse/k0a/6jZWGT7hWGTLhrEdR7hwOrAfPmzWtob29/XlRc9qdjw8P76fMeTU2c9WBi5LQH7UB6ftS0B9MDe+7k+XfeCvRpu6Xr1XJTEMPP2TMvlkzZ8fhn9JSb+ujO9e+6ZebbcSvMu/Wmm2fzDSv3hmuGsHh+BAptkJ9Llj3e2LDu2SVcfvZqucHm0XhD163+mplLzVVtjHgGar7asO75bUKB51R9Vdih4ooqRkprXPfsXsfm558JGQDCtqWXmDAEi5Y+PjNhx4v/QL8aE2MIhkD8zAcbJ+189d+z5UYOWQZ4t9xsnLjj5f/A3ltLyDIAGDXe7Zue/89b/OiZY8UVNpINAEaNUOWqp38qVj3+DwykQEIGAABS5b0Ghvs3EQAAAABJRU5ErkJggg==",
+		"64529513d746ff455a986505", "gcapron6x@gizmodo.com",
+	}
+
+	for _, nonParagraph := range nonParagraphs {
+		assert.Equal(t, nonParagraph, LineBreaksToCarriageReturns(nonParagraph))
+	}
+}


### PR DESCRIPTION
This is required for BigQuery as multi-line strings do not compile. Snowflake does not have this issue

![image](https://user-images.githubusercontent.com/4412200/236256399-ec180e07-7d9c-4f03-ad40-3542ddd5d6e4.png)
![image](https://user-images.githubusercontent.com/4412200/236256441-b9756b60-4ced-4f51-9b0d-e5d8ee647820.png)
