### PR TITLE
Adding zero-precision loss for parsing time.Time

### DIFF
--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -51,13 +51,11 @@ func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 	var potentialFormat string
 	var potentialTime time.Time
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		ts, err := time.Parse(supportedDateTimeLayout, dtString)
+		ts, exactMatch, err := ParseTimeExactMatch(dtString, supportedDateTimeLayout)
 		if err == nil {
 			potentialFormat = supportedDateTimeLayout
 			potentialTime = ts
-			// Now let's parse ts back with the original layout.
-			// Does it match exactly with the dtString? If so, then it's identical.
-			if ts.Format(supportedDateTimeLayout) == dtString {
+			if exactMatch {
 				return NewExtendedTime(ts, DateTimeKindType, supportedDateTimeLayout)
 			}
 		}
@@ -65,17 +63,18 @@ func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 
 	// Now check DATE formats
 	for _, supportedDateFormat := range supportedDateFormats {
-		date, err := time.Parse(supportedDateFormat, dtString)
-		if err == nil {
-			return NewExtendedTime(date, DateKindType, supportedDateFormat)
+		ts, exactMatch, err := ParseTimeExactMatch(dtString, supportedDateFormat)
+		if err == nil && exactMatch {
+			return NewExtendedTime(ts, DateKindType, supportedDateFormat)
 		}
 	}
 
 	// Now check TIME formats
 	for _, supportedTimeFormat := range supportedTimeFormats {
-		_time, err := time.Parse(supportedTimeFormat, dtString)
-		if err == nil {
-			return NewExtendedTime(_time, TimeKindType, supportedTimeFormat)
+		ts, exactMatch, err := ParseTimeExactMatch(dtString, supportedTimeFormat)
+		if err == nil && exactMatch {
+			return NewExtendedTime(ts, TimeKindType, supportedTimeFormat)
+
 		}
 	}
 

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -25,15 +25,15 @@ func ParseFromInterface(val interface{}) (*ExtendedTime, error) {
 }
 
 // ParseTimeExactMatch is a wrapper around time.Parse() and will return an extra boolean to indicate if it was an exact match or not.
-// Parameters: potentialDateTimeString, layout
+// Parameters: layout, potentialDateTimeString
 // Returns: time.Time object, exactLayout (boolean), error
-func ParseTimeExactMatch(potentialDateTimeStr, layout string) (time.Time, bool, error) {
-	ts, err := time.Parse(potentialDateTimeStr, layout)
+func ParseTimeExactMatch(layout, potentialDateTimeString string) (time.Time, bool, error) {
+	ts, err := time.Parse(layout, potentialDateTimeString)
 	if err != nil {
 		return ts, false, err
 	}
 
-	return ts, ts.Format(layout) == potentialDateTimeStr, nil
+	return ts, ts.Format(layout) == potentialDateTimeString, nil
 }
 
 // ParseExtendedDateTime  will take a string and check if the string is of the following types:
@@ -51,7 +51,7 @@ func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 	var potentialFormat string
 	var potentialTime time.Time
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		ts, exactMatch, err := ParseTimeExactMatch(dtString, supportedDateTimeLayout)
+		ts, exactMatch, err := ParseTimeExactMatch(supportedDateTimeLayout, dtString)
 		if err == nil {
 			potentialFormat = supportedDateTimeLayout
 			potentialTime = ts
@@ -63,7 +63,7 @@ func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 
 	// Now check DATE formats
 	for _, supportedDateFormat := range supportedDateFormats {
-		ts, exactMatch, err := ParseTimeExactMatch(dtString, supportedDateFormat)
+		ts, exactMatch, err := ParseTimeExactMatch(supportedDateFormat, dtString)
 		if err == nil && exactMatch {
 			return NewExtendedTime(ts, DateKindType, supportedDateFormat)
 		}
@@ -71,7 +71,7 @@ func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 
 	// Now check TIME formats
 	for _, supportedTimeFormat := range supportedTimeFormats {
-		ts, exactMatch, err := ParseTimeExactMatch(dtString, supportedTimeFormat)
+		ts, exactMatch, err := ParseTimeExactMatch(supportedTimeFormat, dtString)
 		if err == nil && exactMatch {
 			return NewExtendedTime(ts, TimeKindType, supportedTimeFormat)
 

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -84,3 +84,15 @@ func TestParseExtendedDateTime_Timestamp(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.String(""))
 }
+
+func TestTimeLayout(t *testing.T) {
+	ts := time.Now()
+
+	for _, supportedFormat := range supportedTimeFormats {
+		parsedTsString := ts.Format(supportedFormat)
+		extTime, err := ParseExtendedDateTime(parsedTsString)
+		assert.NoError(t, err)
+		assert.Equal(t, parsedTsString, extTime.String(""))
+	}
+
+}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -1,4 +1,4 @@
-5package ext
+package ext
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -1,4 +1,4 @@
-package ext
+5package ext
 
 import (
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
As indicated by the comments in `parse.go`, the motivation of this is to expand zero-precision loss for parsing:
* datetime
* date
* time

values that can be in a wide variety of different layouts. 

This PR enhances from this: https://github.com/artie-labs/transfer/pull/84, where we provided this guarantee on a datetime object. Where we changed the function from: `give me a layout that works` to also consider if we should give that layout (since going from `YYYY-MM-DD HH-MM-SS:ms` to `YYYY-MM-DD` would a huge precision loss, but still pass the "give me a layout that works" check.)

However, there are many different ways to express `date` (YYYY-MM-DD, MM-DD-YYYY) and similarly with time (include ns, ms, etc).

This PR will test every single layout and early exit upon any exact matches.

If it doesn't find anything, then it will default to the next best thing and use a datetime layout to reduce precision loss. Finally, if it doesn't find anything and there's no next best thing, it will error.