### PR TITLE
Flush rules to be cognizant of in-memory database size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,4 @@ release:
 .PHONY: bench_size
 bench_size:
 	go test ./lib/size -bench=Bench -benchtime=10s
+	go test ./lib/optimization -bench=Bench -benchtime=10s

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,7 @@ build:
 .PHONY: release
 release:
 	goreleaser release --clean
+
+.PHONY: bench_size
+bench_size:
+	go test ./lib/size -bench=Bench -benchtime=10s

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultFlushTimeSeconds = 10
-	defaultFlushSizeKb = 10 * 1024 // 10 mb
+	defaultFlushSizeKb = 25 * 1024 // 25 mb
 
 	flushIntervalSecondsStart = 5
 	flushIntervalSecondsEnd   = 6 * 60 * 60

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultFlushTimeSeconds = 10
-	defaultFlushSizeKb = 900
+	defaultFlushSizeKb = 10 * 1024 // 10 mb
 
 	flushIntervalSecondsStart = 5
 	flushIntervalSecondsEnd   = 6 * 60 * 60
@@ -75,13 +75,16 @@ type Config struct {
 	Output constants.DestinationKind `yaml:"outputSource"`
 	Queue  constants.QueueKind       `yaml:"queue"`
 
+	// Flush rules
 	FlushIntervalSeconds int  `yaml:"flushIntervalSeconds"`
 	FlushSizeKb          int  `yaml:"flushSizeKb"`
 	BufferRows           uint `yaml:"bufferRows"`
 
+	// Supported message queues
 	Pubsub *Pubsub
 	Kafka  *Kafka
 
+	// Supported destinations
 	BigQuery  *BigQuery  `yaml:"bigquery"`
 	Snowflake *Snowflake `yaml:"snowflake"`
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -412,6 +412,7 @@ func TestConfig_Validate(t *testing.T) {
 
 	cfg.Output = constants.Snowflake
 	cfg.Queue = constants.PubSub
+	cfg.FlushSizeKb = 5
 	assert.Contains(t, cfg.Validate().Error(), "no pubsub topic configs")
 
 	pubsub.TopicConfigs = []*kafkalib.TopicConfig{
@@ -448,4 +449,10 @@ func TestConfig_Validate(t *testing.T) {
 	cfg.BufferRows = 500
 	cfg.FlushIntervalSeconds = 600
 	assert.Nil(t, cfg.Validate())
+
+	for _, num := range []int{-500, -300, -5, 0} {
+		cfg.FlushSizeKb = num
+		assert.Contains(t, cfg.Validate().Error(), "config is invalid, flush size pool has to be a positive number")
+	}
+
 }

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -77,7 +77,6 @@ func (t *TableData) Rows() uint {
 func (t *TableData) ShouldFlush(ctx context.Context) bool {
 	// TODO Test
 	settings := config.FromContext(ctx)
-
 	return t.Rows() > settings.Config.BufferRows || t.approxSize > settings.Config.FlushSizeKb * 1024
 }
 

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -2,6 +2,7 @@ package optimization
 
 import (
 	"context"
+	"fmt"
 	"github.com/artie-labs/transfer/lib/artie"
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -25,7 +26,6 @@ type TableData struct {
 
 	// This is used for the automatic schema detection
 	LatestCDCTs time.Time
-
 	approxSize int
 }
 
@@ -41,13 +41,13 @@ func NewTableData(inMemoryColumns *typing.Columns, primaryKeys []string, topicCo
 }
 
 func (t *TableData) InsertRow(pk string, rowData map[string]interface{}) {
-	// TODO: Test.
 	newRowSize := size.GetApproxSize(rowData)
 	prevRow, isOk := t.rowsData[pk]
 	if isOk {
 		// Since the new row is taking over, let's update the approx size.
-		prevSize := size.GetApproxSize(prevRow)
-		t.approxSize += newRowSize - prevSize
+		prevRowSize := size.GetApproxSize(prevRow)
+		fmt.Println("prevSize", prevRowSize, "newRowSize", newRowSize, "approxSize", t.approxSize)
+		t.approxSize += newRowSize - prevRowSize
 	} else {
 		t.approxSize += newRowSize
 	}

--- a/lib/optimization/event_bench_test.go
+++ b/lib/optimization/event_bench_test.go
@@ -1,0 +1,56 @@
+package optimization
+
+import (
+	"fmt"
+	"github.com/artie-labs/transfer/lib/kafkalib"
+	"testing"
+	"time"
+)
+
+func BenchmarkTableData_ApproxSize_TallTable(b *testing.B) {
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	for n := 0; n < b.N; n++ {
+		td.InsertRow(fmt.Sprint(n), map[string]interface{}{
+			"id":   n,
+			"name": "Robin",
+			"dog":  "dusty the mini aussie",
+		})
+	}
+}
+
+func BenchmarkTableData_ApproxSize_WideTable(b *testing.B) {
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	for n := 0; n < b.N; n++ {
+		td.InsertRow(fmt.Sprint(n), map[string]interface{}{
+			"id":                 n,
+			"name":               "Robin",
+			"dog":                "dusty the mini aussie",
+			"favorite_fruits":    []string{"strawberry", "kiwi", "oranges"},
+			"random":             false,
+			"team":               []string{"charlie", "jacqueline"},
+			"email":              "robin@artie.so",
+			"favorite_languages": []string{"go", "sql"},
+			"favorite_databases": []string{"postgres", "bigtable"},
+			"created_at":         time.Now(),
+			"updated_at":         time.Now(),
+			"negative_number":    -500,
+			"nestedObject": map[string]interface{}{
+				"foo": "bar",
+				"abc": "def",
+			},
+			"array_of_objects": []map[string]interface{}{
+				{
+					"foo": "bar",
+				},
+				{
+					"foo_nested": map[string]interface{}{
+						"foo_foo": "bar_bar",
+					},
+				},
+			},
+			"is_deleted":   false,
+			"lorem_ipsum":  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec elementum aliquet mi at efficitur. Praesent at erat ac elit faucibus convallis. Donec fermentum tellus eu nunc ornare, non convallis justo facilisis. In hac habitasse platea dictumst. Praesent eu ante vitae erat semper finibus eget ac mauris. Duis gravida cursus enim, nec sagittis arcu placerat sed. Integer semper orci justo, nec rhoncus libero convallis sed.",
+			"lorem_ipsum2": "Fusce vitae elementum tortor. Vestibulum consectetur ante id nibh ullamcorper, quis sodales turpis tempor. Duis pellentesque suscipit nibh porta posuere. In libero massa, efficitur at ultricies sit amet, vulputate ac ante. In euismod erat eget nulla blandit pretium. Ut tempor ante vel congue venenatis. Vestibulum at metus nec nibh iaculis consequat suscipit ac leo. Maecenas vitae rutrum nulla, quis ultrices justo. Aliquam ipsum ex, luctus ac diam eget, tempor tempor risus.",
+		})
+	}
+}

--- a/lib/optimization/event_insert_test.go
+++ b/lib/optimization/event_insert_test.go
@@ -1,0 +1,84 @@
+package optimization
+
+import (
+	"fmt"
+	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/size"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTableData_InsertRow(t *testing.T) {
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	assert.Equal(t, 0, int(td.Rows()))
+
+	// See if we can add rows to the private method.
+	td.RowsData()["foo"] = map[string]interface{}{
+		"foo": "bar",
+	}
+
+	assert.Equal(t, 0, int(td.Rows()))
+
+	// Now insert the right way.
+	td.InsertRow("foo", map[string]interface{}{
+		"foo": "bar",
+	})
+
+	assert.Equal(t, 1, int(td.Rows()))
+}
+
+func TestTableData_InsertRowApproxSize(t *testing.T) {
+	// In this test, we'll insert 1000 rows, update X and then delete Y
+	// Does the size then match up? We will iterate over a map to take advantage of the in-deterministic ordering of a map
+	// So we can test multiple updates, deletes, etc.
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	numInsertRows := 1000
+	numUpdateRows := 420
+	numDeleteRows := 250
+
+	for i := 0; i < numInsertRows; i ++ {
+		td.InsertRow(fmt.Sprint(i), map[string]interface{}{
+			"foo": "bar",
+			"array": []int{1, 2, 3, 4, 5},
+			"boolean": true,
+			"nested_object": map[string]interface{}{
+				"nested": map[string]interface{}{
+					"foo": "bar",
+					"true": false,
+				},
+			},
+		})
+	}
+
+	var updateCount int
+	for updateKey := range td.RowsData() {
+		updateCount += 1
+		td.InsertRow(updateKey, map[string]interface{}{
+			"foo": "foo",
+			"bar": "bar",
+		})
+
+		if updateCount > numUpdateRows {
+			break
+		}
+	}
+
+	var deleteCount int
+	for deleteKey := range td.RowsData() {
+		deleteCount += 1
+		td.InsertRow(deleteKey, map[string]interface{}{
+			"__artie_deleted": true,
+		})
+
+		if deleteCount > numDeleteRows {
+			break
+		}
+	}
+
+	var actualSize int
+	for _, rowData := range td.RowsData() {
+		actualSize += size.GetApproxSize(rowData)
+	}
+
+	assert.Equal(t, td.approxSize, actualSize)
+}

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -1,32 +1,12 @@
 package optimization
 
 import (
-	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
-
-func TestTableData_InsertRow(t *testing.T) {
-	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
-	assert.Equal(t, 0, int(td.Rows()))
-
-	// See if we can add rows to the private method.
-	td.RowsData()["foo"] = map[string]interface{}{
-		"foo": "bar",
-	}
-
-	assert.Equal(t, 0, int(td.Rows()))
-
-	// Now insert the right way.
-	td.InsertRow("foo", map[string]interface{}{
-		"foo": "bar",
-	})
-
-	assert.Equal(t, 1, int(td.Rows()))
-}
 
 func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	var _cols typing.Columns

--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -1,0 +1,28 @@
+package size
+
+import (
+	"bytes"
+	"encoding/gob"
+	//"fmt"
+	//"unsafe"
+)
+
+// GetRealSizeOf will encode the actual variable into bytes and then check the length
+// We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal
+// Lifted this from: https://stackoverflow.com/a/60508928
+func GetRealSizeOf(v interface{}) (int, error) {
+	b := new(bytes.Buffer)
+	if err := gob.NewEncoder(b).Encode(v); err != nil {
+		return 0, err
+	}
+	return b.Len(), nil
+}
+
+func CrossedThreshold(value interface{}, bytesLimit int) (bool, error) {
+	valBytes, err := GetRealSizeOf(value)
+	if err != nil {
+		return false, err
+	}
+
+	return bytesLimit > valBytes, nil
+}

--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -7,10 +7,10 @@ import (
 	//"unsafe"
 )
 
-// GetRealSizeOf will encode the actual variable into bytes and then check the length
+// getRealSizeOf will encode the actual variable into bytes and then check the length
 // We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal
 // Lifted this from: https://stackoverflow.com/a/60508928
-func GetRealSizeOf(v interface{}) (int, error) {
+func getRealSizeOf(v interface{}) (int, error) {
 	b := new(bytes.Buffer)
 	if err := gob.NewEncoder(b).Encode(v); err != nil {
 		return 0, err
@@ -18,15 +18,15 @@ func GetRealSizeOf(v interface{}) (int, error) {
 	return b.Len(), nil
 }
 
-func CrossedThreshold(value interface{}, bytesLimit int) (bool, error) {
-	valBytes, err := GetRealSizeOf(value)
+func CrossedThreshold(value interface{}, kbLimit int) (bool, error) {
+	valBytes, err := getRealSizeOf(value)
 	if err != nil {
 		return false, err
 	}
 
-	return bytesLimit > valBytes, nil
+	return valBytes > kbToBytes(kbLimit), nil
 }
 
-func KilobytesToBytes(kbNum int) int {
+func kbToBytes(kbNum int) int {
 	return kbNum * 1024
 }

--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -1,21 +1,16 @@
 package size
 
 import (
-	"bytes"
-	"encoding/gob"
-	//"fmt"
-	//"unsafe"
+	"fmt"
 )
 
-// getRealSizeOf will encode the actual variable into bytes and then check the length
-// We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal
-// Lifted this from: https://stackoverflow.com/a/60508928
+// getRealSizeOf will encode the actual variable into bytes and then check the length (approx) by using string encoding.
+// We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal.
+// We also chose not to use gob.NewEncoder because it does not work for all data types and had a huge computational overhead.
 func getRealSizeOf(v interface{}) (int, error) {
-	b := new(bytes.Buffer)
-	if err := gob.NewEncoder(b).Encode(v); err != nil {
-		return 0, err
-	}
-	return b.Len(), nil
+	valString := fmt.Sprint(v)
+
+	return len([]byte(valString)), nil
 }
 
 func CrossedThreshold(value interface{}, kbLimit int) (bool, error) {

--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -26,3 +26,7 @@ func CrossedThreshold(value interface{}, bytesLimit int) (bool, error) {
 
 	return bytesLimit > valBytes, nil
 }
+
+func KilobytesToBytes(kbNum int) int {
+	return kbNum * 1024
+}

--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -4,24 +4,11 @@ import (
 	"fmt"
 )
 
-// getRealSizeOf will encode the actual variable into bytes and then check the length (approx) by using string encoding.
+// GetApproxSize will encode the actual variable into bytes and then check the length (approx) by using string encoding.
 // We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal.
 // We also chose not to use gob.NewEncoder because it does not work for all data types and had a huge computational overhead.
-func getRealSizeOf(v interface{}) (int, error) {
+// Another bonus is that there is no possible way for this to error out.
+func GetApproxSize(v interface{}) int {
 	valString := fmt.Sprint(v)
-
-	return len([]byte(valString)), nil
-}
-
-func CrossedThreshold(value interface{}, kbLimit int) (bool, error) {
-	valBytes, err := getRealSizeOf(value)
-	if err != nil {
-		return false, err
-	}
-
-	return valBytes > kbToBytes(kbLimit), nil
-}
-
-func kbToBytes(kbNum int) int {
-	return kbNum * 1024
+	return len([]byte(valString))
 }

--- a/lib/size/size_bench_test.go
+++ b/lib/size/size_bench_test.go
@@ -1,0 +1,69 @@
+package size
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func BenchmarkCrossedThreshold_TallTable(b *testing.B) {
+	rowsData := make(map[string]map[string]interface{})
+	for i := 0; i < 5000; i ++ {
+		rowsData[fmt.Sprint(i)] = map[string]interface{}{
+			"id": i,
+			"name": "Robin",
+			"dog": "dusty the mini aussie",
+		}
+	}
+
+	for n := 0; n < b.N; n ++ {
+		_, err := CrossedThreshold(rowsData, 900)
+		if err != nil {
+			b.Errorf("failed to check crossed threshold, err: %v", err)
+		}
+	}
+}
+
+func BenchmarkCrossedThreshold_WideTable(b *testing.B) {
+	rowsData := make(map[string]map[string]interface{})
+	for i := 0; i < 5000; i ++ {
+		rowsData[fmt.Sprint(i)] = map[string]interface{}{
+			"id": i,
+			"name": "Robin",
+			"dog": "dusty the mini aussie",
+			"favorite_fruits": []string{"strawberry", "kiwi", "oranges"},
+			"random": false,
+			"team": []string{"charlie", "jacqueline"},
+			"email": "robin@artie.so",
+			"favorite_languages": []string{"go", "sql"},
+			"favorite_databases": []string{"postgres", "bigtable"},
+			"created_at": time.Now(),
+			"updated_at": time.Now(),
+			"negative_number": -500,
+			"nestedObject": map[string]interface{}{
+				"foo": "bar",
+				"abc": "def",
+			},
+			"array_of_objects": []map[string]interface{}{
+				{
+					"foo": "bar",
+				},
+				{
+					"foo_nested": map[string]interface{}{
+						"foo_foo": "bar_bar",
+					},
+				},
+			},
+			"is_deleted": false,
+			"lorem_ipsum": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec elementum aliquet mi at efficitur. Praesent at erat ac elit faucibus convallis. Donec fermentum tellus eu nunc ornare, non convallis justo facilisis. In hac habitasse platea dictumst. Praesent eu ante vitae erat semper finibus eget ac mauris. Duis gravida cursus enim, nec sagittis arcu placerat sed. Integer semper orci justo, nec rhoncus libero convallis sed.",
+			"lorem_ipsum2": "Fusce vitae elementum tortor. Vestibulum consectetur ante id nibh ullamcorper, quis sodales turpis tempor. Duis pellentesque suscipit nibh porta posuere. In libero massa, efficitur at ultricies sit amet, vulputate ac ante. In euismod erat eget nulla blandit pretium. Ut tempor ante vel congue venenatis. Vestibulum at metus nec nibh iaculis consequat suscipit ac leo. Maecenas vitae rutrum nulla, quis ultrices justo. Aliquam ipsum ex, luctus ac diam eget, tempor tempor risus.",
+		}
+	}
+
+	for n := 0; n < b.N; n ++ {
+		_, err := CrossedThreshold(rowsData, 900)
+		if err != nil {
+			b.Errorf("failed to check crossed threshold, err: %v", err)
+		}
+	}
+}

--- a/lib/size/size_bench_test.go
+++ b/lib/size/size_bench_test.go
@@ -17,10 +17,7 @@ func BenchmarkCrossedThreshold_TallTable(b *testing.B) {
 	}
 
 	for n := 0; n < b.N; n ++ {
-		_, err := CrossedThreshold(rowsData, 900)
-		if err != nil {
-			b.Errorf("failed to check crossed threshold, err: %v", err)
-		}
+		GetApproxSize(rowsData)
 	}
 }
 
@@ -61,9 +58,6 @@ func BenchmarkCrossedThreshold_WideTable(b *testing.B) {
 	}
 
 	for n := 0; n < b.N; n ++ {
-		_, err := CrossedThreshold(rowsData, 900)
-		if err != nil {
-			b.Errorf("failed to check crossed threshold, err: %v", err)
-		}
+		GetApproxSize(rowsData)
 	}
 }

--- a/lib/size/size_bench_test.go
+++ b/lib/size/size_bench_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func BenchmarkCrossedThreshold_TallTable(b *testing.B) {
+func BenchmarkGetApproxSize_TallTable(b *testing.B) {
 	rowsData := make(map[string]map[string]interface{})
 	for i := 0; i < 5000; i ++ {
 		rowsData[fmt.Sprint(i)] = map[string]interface{}{
@@ -21,7 +21,7 @@ func BenchmarkCrossedThreshold_TallTable(b *testing.B) {
 	}
 }
 
-func BenchmarkCrossedThreshold_WideTable(b *testing.B) {
+func BenchmarkGetApproxSize_WideTable(b *testing.B) {
 	rowsData := make(map[string]map[string]interface{})
 	for i := 0; i < 5000; i ++ {
 		rowsData[fmt.Sprint(i)] = map[string]interface{}{

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -28,20 +28,7 @@ func TestVariableToBytes(t *testing.T) {
 	stat, err := os.Stat(filePath)
 	assert.NoError(t, err)
 
-	size, err := getRealSizeOf(rowsData)
+	size := GetApproxSize(rowsData)
 	assert.NoError(t, err)
 	assert.Equal(t, int(stat.Size()), size)
-
-	// This file should be 75 kb, so let's test the limit.
-	sizeToCrossedMap := map[int]bool{
-		100: false,
-		50: true,
-		30: true,
-	}
-
-	for thresholdSize, crossed := range sizeToCrossedMap {
-		actuallyCrossed, err := CrossedThreshold(rowsData, thresholdSize)
-		assert.NoError(t, err)
-		assert.Equal(t, crossed, actuallyCrossed)
-	}
 }

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -1,0 +1,40 @@
+package size
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestVariableToBytes(t *testing.T) {
+	filePath := "/tmp/size_test"
+	assert.NoError(t, os.RemoveAll(filePath))
+
+	rowsData := make(map[string]map[string]interface{}) // pk -> { col -> val }
+	for i := 0; i < 500; i ++ {
+		rowsData[fmt.Sprintf("key-%v", i)] = map[string]interface{}{
+			"id": fmt.Sprintf("key-%v", i),
+			"artie": "transfer",
+			"dusty": "the mini aussie",
+			"next_puppy": true,
+			"team": []string{"charlie", "robin", "jacqueline"},
+		}
+	}
+
+
+
+	err := os.WriteFile(filePath, []byte(fmt.Sprint(rowsData)), os.ModePerm)
+	assert.NoError(t, err)
+
+	stat, err := os.Stat(filePath)
+	assert.NoError(t, err)
+
+	fmt.Println("stat", stat.Size())
+
+	bytes, err := GetRealSizeOf(rowsData)
+	assert.NoError(t, err)
+	fmt.Println("GetRealSizeOf", bytes)
+
+	assert.False(t, true)
+}

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -1,6 +1,8 @@
 package size
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"os"
@@ -22,19 +24,18 @@ func TestVariableToBytes(t *testing.T) {
 		}
 	}
 
+	b := new(bytes.Buffer)
+	err := gob.NewEncoder(b).Encode(rowsData)
+	assert.NoError(t, err)
 
-
-	err := os.WriteFile(filePath, []byte(fmt.Sprint(rowsData)), os.ModePerm)
+	err = os.WriteFile(filePath, b.Bytes(), os.ModePerm)
 	assert.NoError(t, err)
 
 	stat, err := os.Stat(filePath)
 	assert.NoError(t, err)
 
-	fmt.Println("stat", stat.Size())
-
-	bytes, err := GetRealSizeOf(rowsData)
+	size, err := GetRealSizeOf(rowsData)
 	assert.NoError(t, err)
-	fmt.Println("GetRealSizeOf", bytes)
 
-	assert.False(t, true)
+	assert.Equal(t, int(stat.Size()), size)
 }

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -1,8 +1,6 @@
 package size
 
 import (
-	"bytes"
-	"encoding/gob"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"os"
@@ -24,11 +22,7 @@ func TestVariableToBytes(t *testing.T) {
 		}
 	}
 
-	b := new(bytes.Buffer)
-	err := gob.NewEncoder(b).Encode(rowsData)
-	assert.NoError(t, err)
-
-	err = os.WriteFile(filePath, b.Bytes(), os.ModePerm)
+	err := os.WriteFile(filePath, []byte(fmt.Sprint(rowsData)), os.ModePerm)
 	assert.NoError(t, err)
 
 	stat, err := os.Stat(filePath)

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -34,8 +34,22 @@ func TestVariableToBytes(t *testing.T) {
 	stat, err := os.Stat(filePath)
 	assert.NoError(t, err)
 
-	size, err := GetRealSizeOf(rowsData)
+	size, err := getRealSizeOf(rowsData)
 	assert.NoError(t, err)
-
 	assert.Equal(t, int(stat.Size()), size)
+
+	// This file should be 75 kb, so let's test the limit.
+	sizeToCrossedMap := map[int]bool{
+		100: false,
+		50: true,
+		30: true,
+	}
+
+	for thresholdSize, crossed := range sizeToCrossedMap {
+		actuallyCrossed, err := CrossedThreshold(rowsData, thresholdSize)
+		assert.NoError(t, err)
+
+		fmt.Println("crossed", crossed, "actuallyCrossed", actuallyCrossed, "size", size, "thresholdSize", thresholdSize)
+		assert.Equal(t, crossed, actuallyCrossed)
+	}
 }

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -48,8 +48,6 @@ func TestVariableToBytes(t *testing.T) {
 	for thresholdSize, crossed := range sizeToCrossedMap {
 		actuallyCrossed, err := CrossedThreshold(rowsData, thresholdSize)
 		assert.NoError(t, err)
-
-		fmt.Println("crossed", crossed, "actuallyCrossed", actuallyCrossed, "size", size, "thresholdSize", thresholdSize)
 		assert.Equal(t, crossed, actuallyCrossed)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 	logger.FromContext(ctx).WithFields(map[string]interface{}{
 		"flush_interval_seconds": settings.Config.FlushIntervalSeconds,
 		"buffer_pool_size":       settings.Config.BufferRows,
+		"flush_pool_size (kb)": settings.Config.FlushSizeKb,
 	}).Info("config is loaded")
 
 	flushChan := make(chan bool)

--- a/models/memory.go
+++ b/models/memory.go
@@ -144,6 +144,9 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 
 	settings := config.FromContext(ctx)
 	shouldFlushBasedOnRows := inMemoryDB.TableData[e.Table].Rows() > settings.Config.BufferRows
+
+	// Note this function adds anywhere from 5 to 58ms overhead depending on how wide the table is (when pool rows is at 5k)
+	// We _could_ optimize this by only looking at the newest row added, but it's error-prone (because it could just update an exising row or delete).
 	shouldFlushBasedOnSize, err := size.CrossedThreshold(inMemoryDB.TableData[e.Table].RowsData, settings.Config.FlushSizeKb)
 	if err != nil {
 		logger.FromContext(ctx).WithError(err).Warn("failed to calculate threshold")

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -24,6 +24,7 @@ func TestProcessMessageFailures(t *testing.T) {
 		Config: &config.Config{
 			FlushIntervalSeconds: 10,
 			BufferRows:           10,
+			FlushSizeKb:          900,
 		},
 		VerboseLogging: false,
 	})


### PR DESCRIPTION
Addresses https://github.com/artie-labs/transfer/issues/68

This is necessary because Snowflake and BigQuery both have their limits on how big (in kb) a request can be. Snowflake's API docs specify 1 MB [src](https://docs.snowflake.com/en/user-guide/query-size-limits)...but the actual limit is significantly higher.

Through this PR, I've tested 25 mb payloads without any issue. However, this does happen...especially for tables with TOAST columns. The current workaround is to just reduce the number of items from the `bufferRow` but that's not robust.

This PR will allow users to specify an additional merge rule, and our merge rules will now look like:
1. Flush interval time (default 10s)
2. Pool rows (default to 15k) - number of rows.
3. Pool size (default to 25 mb) - size of the in-memory db.

Whichever one is invoked first will trigger a flush cycle.

TODOs:
- [x] Update documentation -> https://docs.artie.so/running-transfer/options
- [x] Provide benchmarking
- [x] Tests
- [x] Impl

