### PR TITLE
Refactor TableData to hide `rowData`

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -31,7 +31,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 
 	var rowValues []string
 	firstRow := true
-	for _, value := range tableData.RowsData {
+	for _, value := range tableData.RowsData() {
 		var colVals []string
 		for _, col := range cols {
 			colKind, _ := tableData.InMemoryColumns.GetColumn(col)

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -35,7 +35,7 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 		sflkCols = append(sflkCols, sflkCol)
 	}
 
-	for _, value := range tableData.RowsData {
+	for _, value := range tableData.RowsData() {
 		var rowValues []string
 		for _, col := range cols {
 			colKind, _ := tableData.InMemoryColumns.GetColumn(col)

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -47,11 +47,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		Schema:    "public",
 	}
 
-	tableData := &optimization.TableData{
-		InMemoryColumns: &cols,
-		RowsData:        rowsData,
-		TopicConfig:     topicConfig,
-		PrimaryKeys:     []string{"id"},
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig)
+	for pk, row := range rowsData {
+		tableData.InsertRow(pk, row)
 	}
 
 	anotherColToKindDetailsMap := map[string]typing.KindDetails{
@@ -111,11 +109,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		Schema:    "public",
 	}
 
-	tableData := &optimization.TableData{
-		InMemoryColumns: &cols,
-		RowsData:        rowsData,
-		TopicConfig:     topicConfig,
-		PrimaryKeys:     []string{"id"},
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig)
+	for pk, row := range rowsData {
+		tableData.InsertRow(pk, row)
 	}
 
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake),
@@ -164,11 +160,9 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 		Schema:    "public",
 	}
 
-	tableData := &optimization.TableData{
-		InMemoryColumns: &cols,
-		RowsData:        rowsData,
-		TopicConfig:     topicConfig,
-		PrimaryKeys:     []string{"id"},
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig)
+	for pk, row := range rowsData {
+		tableData.InsertRow(pk ,row)
 	}
 
 	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake),
@@ -216,11 +210,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		})
 	}
 
-	tableData := &optimization.TableData{
-		InMemoryColumns: &cols,
-		RowsData:        rowsData,
-		TopicConfig:     topicConfig,
-		PrimaryKeys:     []string{"id"},
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig)
+	for pk, row := range rowsData {
+		tableData.InsertRow(pk, row)
 	}
 
 	snowflakeColToKindDetailsMap := map[string]typing.KindDetails{
@@ -259,7 +251,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	assert.True(s.T(), isOk)
 
 	// Now try to execute merge where 1 of the rows have the column now
-	for _, pkMap := range tableData.RowsData {
+	for _, pkMap := range tableData.RowsData() {
 		pkMap["new"] = "123"
 		tableData.InMemoryColumns = &sflkCols
 
@@ -282,13 +274,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 }
 
 func (s *SnowflakeTestSuite) TestExecuteMergeExitEarly() {
-	err := s.store.Merge(s.ctx, &optimization.TableData{
-		InMemoryColumns:         nil,
-		RowsData:                nil,
-		TopicConfig:             kafkalib.TopicConfig{},
-		PartitionsToLastMessage: nil,
-		LatestCDCTs:             time.Time{},
-	})
-
+	tableData := optimization.NewTableData(nil, nil, kafkalib.TopicConfig{})
+	err := s.store.Merge(s.ctx, tableData)
 	assert.Nil(s.T(), err)
 }

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -40,8 +40,14 @@ func (t *TableData) InsertRow(pk string, rowData map[string]interface{}) {
 	return
 }
 
+// RowsData returns a read only map of tableData's rowData.
 func (t *TableData) RowsData() map[string]map[string]interface{} {
-	return t.rowsData
+	_rowsData := make(map[string]map[string]interface{}, len(t.rowsData))
+	for k, v := range t.rowsData {
+		_rowsData[k] = v
+	}
+
+	return _rowsData
 }
 
 func (t *TableData) Rows() uint {

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -1,12 +1,32 @@
 package optimization
 
 import (
+	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
+
+func TestTableData_InsertRow(t *testing.T) {
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	assert.Equal(t, 0, int(td.Rows()))
+
+	// See if we can add rows to the private method.
+	td.RowsData()["foo"] = map[string]interface{}{
+		"foo": "bar",
+	}
+
+	assert.Equal(t, 0, int(td.Rows()))
+
+	// Now insert the right way.
+	td.InsertRow("foo", map[string]interface{}{
+		"foo": "bar",
+	})
+
+	assert.Equal(t, 1, int(td.Rows()))
+}
 
 func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	var _cols typing.Columns

--- a/models/flush/flush_test.go
+++ b/models/flush/flush_test.go
@@ -37,7 +37,7 @@ func (f *FlushTestSuite) TestMemoryBasic() {
 		kafkaMsg := kafka.Message{Partition: 1, Offset: 1}
 		_, err := event.Save(f.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 		assert.Nil(f.T(), err)
-		assert.Equal(f.T(), len(models.GetMemoryDB().TableData["foo"].RowsData), i+1)
+		assert.Equal(f.T(), int(models.GetMemoryDB().TableData["foo"].Rows()), i+1)
 	}
 }
 
@@ -108,7 +108,7 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 
 	// Verify all the tables exist.
 	for idx := range tableNames {
-		tableConfig := models.GetMemoryDB().TableData[tableNames[idx]].RowsData
+		tableConfig := models.GetMemoryDB().TableData[tableNames[idx]].RowsData()
 		assert.Equal(f.T(), len(tableConfig), 5)
 	}
 

--- a/models/memory.go
+++ b/models/memory.go
@@ -55,13 +55,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 			columns = e.Columns
 		}
 
-		inMemoryDB.TableData[e.Table] = &optimization.TableData{
-			RowsData:                map[string]map[string]interface{}{},
-			InMemoryColumns:         columns,
-			PrimaryKeys:             e.PrimaryKeys(),
-			TopicConfig:             *topicConfig,
-			PartitionsToLastMessage: map[string][]artie.Message{},
-		}
+		inMemoryDB.TableData[e.Table] = optimization.NewTableData(columns, e.PrimaryKeys(), *topicConfig)
 	} else {
 		if e.Columns != nil {
 			// Iterate over this again just in case.
@@ -129,7 +123,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 
 	// Swap out sanitizedData <> data.
 	e.Data = sanitizedData
-	inMemoryDB.TableData[e.Table].RowsData[e.PrimaryKeyValue()] = e.Data
+	inMemoryDB.TableData[e.Table].InsertRow(e.PrimaryKeyValue(), e.Data)
 	// If the message is Kafka, then we only need the latest one
 	// If it's pubsub, we will store all of them in memory. This is because GCP pub/sub REQUIRES us to ack every single message
 	if message.Kind() == artie.Kafka {

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -93,7 +93,8 @@ func (m *ModelsTestSuite) TestEvent_SaveCasing() {
 	kafkaMsg := kafka.Message{}
 	_, err := event.Save(m.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(m.T(), err)
-	rowData := inMemoryDB.TableData["foo"].RowsData[event.PrimaryKeyValue()]
+	
+	rowData := inMemoryDB.TableData["foo"].RowsData()[event.PrimaryKeyValue()]
 	expectedColumns := []string{"randomcol", "anothercol"}
 	for _, expectedColumn := range expectedColumns {
 		_, isOk := rowData[expectedColumn]

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -120,16 +120,16 @@ func TestProcessMessageFailures(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Check that there are corresponding row(s) in the memory DB
-		assert.Equal(t, len(memoryDB.TableData[table].RowsData), idx)
+		assert.Equal(t, len(memoryDB.TableData[table].RowsData()), idx)
 	}
 
 	// Tombstone means deletion
-	val, isOk := memoryDB.TableData[table].RowsData["id=1"][constants.DeleteColumnMarker]
+	val, isOk := memoryDB.TableData[table].RowsData()["id=1"][constants.DeleteColumnMarker]
 	assert.True(t, isOk)
 	assert.True(t, val.(bool))
 
 	// Non tombstone = no delete.
-	val, isOk = memoryDB.TableData[table].RowsData["id=2"][constants.DeleteColumnMarker]
+	val, isOk = memoryDB.TableData[table].RowsData()["id=2"][constants.DeleteColumnMarker]
 	assert.True(t, isOk)
 	assert.False(t, val.(bool))
 


### PR DESCRIPTION
As per title.

This is a pre-requisite for https://github.com/artie-labs/transfer/pull/89 since this PR is currently calculating the whole `tableData` object each time, which incurs ~5-50ms overhead per row which is unacceptable.

For context - the current row performance is about 0.5ms to 1ms to process.

This PR creates a sole entry point for folks to do any sort of mutation within our in-memory pool.