### PR TITLE
[Enhancement] Parity with Kafka bootstrap.servers

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"fmt"
-	"github.com/artie-labs/transfer/lib/numbers"
-	"gopkg.in/yaml.v3"
 	"io"
 	"os"
+
+	"github.com/artie-labs/transfer/lib/numbers"
+	"gopkg.in/yaml.v3"
 
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -14,7 +15,7 @@ import (
 
 const (
 	defaultFlushTimeSeconds = 10
-	defaultFlushSizeKb = 25 * 1024 // 25 mb
+	defaultFlushSizeKb      = 25 * 1024 // 25 mb
 
 	flushIntervalSecondsStart = 5
 	flushIntervalSecondsEnd   = 6 * 60 * 60
@@ -36,6 +37,9 @@ type Pubsub struct {
 }
 
 type Kafka struct {
+	// Comma-separated Kafka servers to port.
+	// e.g. host1:port1,host2:port2,...
+	// Following kafka's spec mentioned here: https://kafka.apache.org/documentation/#producerconfigs_bootstrap.servers
 	BootstrapServer string                  `yaml:"bootstrapServer"`
 	GroupID         string                  `yaml:"groupID"`
 	Username        string                  `yaml:"username"`

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -2,13 +2,14 @@ package config
 
 import (
 	"fmt"
-	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/kafkalib"
 	"io"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/kafkalib"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -454,5 +455,23 @@ func TestConfig_Validate(t *testing.T) {
 		cfg.FlushSizeKb = num
 		assert.Contains(t, cfg.Validate().Error(), "config is invalid, flush size pool has to be a positive number")
 	}
+}
 
+func TestCfg_KafkaBootstrapServers(t *testing.T) {
+	kafka := Kafka{
+		BootstrapServer: "localhost:9092",
+	}
+
+	assert.Equal(t, []string{"localhost:9092"}, strings.Split(kafka.BootstrapServer, ","))
+
+	kafkaWithMultipleBrokers := Kafka{
+		BootstrapServer: "a:9092,b:9093,c:9094",
+	}
+
+	var brokers []string
+	for _, broker := range strings.Split(kafkaWithMultipleBrokers.BootstrapServer, ",") {
+		brokers = append(brokers, broker)
+	}
+
+	assert.Equal(t, []string{"a:9092", "b:9093", "c:9094"}, brokers)
 }


### PR DESCRIPTION
Normally, you only need to specify one broker within the cluster to get access to the rest (also known as "bootstrap servers").

Problem is that during a maintenance window, a particular broker may be taken down or become unresponsive for a brief moment in time.

AWS recommends this:
>  3. Ensure clients are configured to use multiple broker connection strings. Having multiple brokers in a client’s connection string allows for failover if a specific broker supporting client I/O begins to be patched. For information about how to get a connection string with multiple brokers, see Getting the Bootstrap Brokers for an Amazon MSK Cluster [1].

Which is the impetus for this PR. We are also following the same [standard Kafka for accepting](https://kafka.apache.org/documentation/#producerconfigs_bootstrap.servers) `bootstrap.servers`.