### PR TITLE
Handling all edge cases with TOAST

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/artie-labs/transfer/lib/stringutil"
 	"strings"
 	"time"
+
+	"github.com/artie-labs/transfer/lib/stringutil"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/dwh/ddl"
@@ -20,7 +21,7 @@ import (
 func merge(tableData *optimization.TableData) (string, error) {
 	var cols []string
 	// Given all the columns, diff this against SFLK.
-	for _, col := range tableData.InMemoryColumns.GetColumns() {
+	for _, col := range tableData.InMemoryColumns().GetColumns() {
 		if col.KindDetails == typing.Invalid {
 			// Don't update BQ
 			continue
@@ -34,7 +35,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 	for _, value := range tableData.RowsData() {
 		var colVals []string
 		for _, col := range cols {
-			colKind, _ := tableData.InMemoryColumns.GetColumn(col)
+			colKind, _ := tableData.InMemoryColumns().GetColumn(col)
 			colVal := value[col]
 			if colVal != nil {
 				switch colKind.KindDetails.Kind {
@@ -99,7 +100,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 		IdempotentKey:  tableData.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,
 		Columns:        cols,
-		ColumnsToTypes: *tableData.InMemoryColumns,
+		ColumnsToTypes: *tableData.InMemoryColumns(),
 		SoftDelete:     tableData.SoftDelete,
 		// BigQuery specifically needs it.
 		SpecialCastingRequired: true,
@@ -124,7 +125,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(*tableData.InMemoryColumns, targetColumns, tableData.SoftDelete)
+	srcKeysMissing, targetKeysMissing := typing.Diff(*tableData.InMemoryColumns(), targetColumns, tableData.SoftDelete)
 
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/stringutil"
-
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/dwh/ddl"
 	"github.com/artie-labs/transfer/lib/dwh/dml"
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/optimization"
+	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -21,7 +21,7 @@ import (
 func merge(tableData *optimization.TableData) (string, error) {
 	var cols []string
 	// Given all the columns, diff this against SFLK.
-	for _, col := range tableData.InMemoryColumns().GetColumns() {
+	for _, col := range tableData.ReadOnlyInMemoryCols().GetColumns() {
 		if col.KindDetails == typing.Invalid {
 			// Don't update BQ
 			continue
@@ -35,7 +35,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 	for _, value := range tableData.RowsData() {
 		var colVals []string
 		for _, col := range cols {
-			colKind, _ := tableData.InMemoryColumns().GetColumn(col)
+			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal := value[col]
 			if colVal != nil {
 				switch colKind.KindDetails.Kind {
@@ -100,7 +100,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 		IdempotentKey:  tableData.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,
 		Columns:        cols,
-		ColumnsToTypes: *tableData.InMemoryColumns(),
+		ColumnsToTypes: *tableData.ReadOnlyInMemoryCols(),
 		SoftDelete:     tableData.SoftDelete,
 		// BigQuery specifically needs it.
 		SpecialCastingRequired: true,
@@ -108,7 +108,7 @@ func merge(tableData *optimization.TableData) (string, error) {
 }
 
 func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
-	if tableData.Rows() == 0 || tableData.InMemoryColumns == nil {
+	if tableData.Rows() == 0 || tableData.ReadOnlyInMemoryCols() == nil {
 		// There's no rows or columns. Let's skip.
 		return nil
 	}
@@ -125,7 +125,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(*tableData.InMemoryColumns(), targetColumns, tableData.SoftDelete)
+	srcKeysMissing, targetKeysMissing := typing.Diff(*tableData.ReadOnlyInMemoryCols(), targetColumns, tableData.SoftDelete)
 
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -20,7 +20,6 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 
 	// Given all the columns, diff this against SFLK.
 	for _, column := range tableData.InMemoryColumns().GetColumns() {
-		fmt.Println("snowflake column", column, "kind", column.KindDetails.Kind)
 		if column.KindDetails.Kind == typing.Invalid.Kind {
 			// Don't update Snowflake
 			continue

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -19,7 +19,7 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 	var sflkCols []string
 
 	// Given all the columns, diff this against SFLK.
-	for _, column := range tableData.InMemoryColumns().GetColumns() {
+	for _, column := range tableData.ReadOnlyInMemoryCols().GetColumns() {
 		if column.KindDetails.Kind == typing.Invalid.Kind {
 			// Don't update Snowflake
 			continue
@@ -38,7 +38,7 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 	for _, value := range tableData.RowsData() {
 		var rowValues []string
 		for _, col := range cols {
-			colKind, _ := tableData.InMemoryColumns().GetColumn(col)
+			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal := value[col]
 			if colVal != nil {
 				switch colKind.KindDetails.Kind {
@@ -87,7 +87,7 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 		IdempotentKey:  tableData.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,
 		Columns:        cols,
-		ColumnsToTypes: *tableData.InMemoryColumns(),
+		ColumnsToTypes: *tableData.ReadOnlyInMemoryCols(),
 		SoftDelete:     tableData.SoftDelete,
 	})
 }

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -19,7 +19,8 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 	var sflkCols []string
 
 	// Given all the columns, diff this against SFLK.
-	for _, column := range tableData.InMemoryColumns.GetColumns() {
+	for _, column := range tableData.InMemoryColumns().GetColumns() {
+		fmt.Println("snowflake column", column, "kind", column.KindDetails.Kind)
 		if column.KindDetails.Kind == typing.Invalid.Kind {
 			// Don't update Snowflake
 			continue
@@ -38,7 +39,7 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 	for _, value := range tableData.RowsData() {
 		var rowValues []string
 		for _, col := range cols {
-			colKind, _ := tableData.InMemoryColumns.GetColumn(col)
+			colKind, _ := tableData.InMemoryColumns().GetColumn(col)
 			colVal := value[col]
 			if colVal != nil {
 				switch colKind.KindDetails.Kind {
@@ -87,7 +88,7 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 		IdempotentKey:  tableData.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,
 		Columns:        cols,
-		ColumnsToTypes: *tableData.InMemoryColumns,
+		ColumnsToTypes: *tableData.InMemoryColumns(),
 		SoftDelete:     tableData.SoftDelete,
 	})
 }

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -68,7 +68,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(*tableData.InMemoryColumns, targetColumns, tableData.SoftDelete)
+	srcKeysMissing, targetKeysMissing := typing.Diff(*tableData.InMemoryColumns(), targetColumns, tableData.SoftDelete)
 
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -49,7 +49,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 }
 
 func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) error {
-	if tableData.Rows() == 0 || tableData.InMemoryColumns == nil {
+	if tableData.Rows() == 0 || tableData.ReadOnlyInMemoryCols() == nil {
 		// There's no rows. Let's skip.
 		return nil
 	}
@@ -68,7 +68,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(*tableData.InMemoryColumns(), targetColumns, tableData.SoftDelete)
+	srcKeysMissing, targetKeysMissing := typing.Diff(*tableData.ReadOnlyInMemoryCols(), targetColumns, tableData.SoftDelete)
 
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,

--- a/lib/debezium/keys.go
+++ b/lib/debezium/keys.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	ToastUnavailableValuePlaceholder = "__debezium_unavailable_value"
+
 	KeyFormatJSON   = "org.apache.kafka.connect.json.JsonConverter"
 	KeyFormatString = "org.apache.kafka.connect.storage.StringConverter"
 

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -40,13 +40,13 @@ func (t *TableData) AddInMemoryCol(column typing.Column) {
 }
 
 func (t *TableData) ReadOnlyInMemoryCols() *typing.Columns {
-	var cols typing.Columns
-	if t.inMemoryColumns != nil {
-		for _, col := range t.inMemoryColumns.GetColumns() {
-			cols.AddColumn(col)
-		}
-	} else {
+	if t.inMemoryColumns == nil {
 		return nil
+	}
+
+	var cols typing.Columns
+	for _, col := range t.inMemoryColumns.GetColumns() {
+		cols.AddColumn(col)
 	}
 
 	return &cols

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -2,18 +2,19 @@ package optimization
 
 import (
 	"context"
+	"strings"
+	"time"
+
 	"github.com/artie-labs/transfer/lib/artie"
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/size"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/ext"
-	"strings"
-	"time"
 )
 
 type TableData struct {
-	InMemoryColumns *typing.Columns                   // list of columns
+	inMemoryColumns *typing.Columns                   // list of columns
 	rowsData        map[string]map[string]interface{} // pk -> { col -> val }
 	PrimaryKeys     []string
 
@@ -25,12 +26,33 @@ type TableData struct {
 
 	// This is used for the automatic schema detection
 	LatestCDCTs time.Time
-	approxSize int
+	approxSize  int
+}
+
+func (t *TableData) SetInMemoryColumns(columns *typing.Columns) {
+	t.inMemoryColumns = columns
+	return
+}
+
+func (t *TableData) AddInMemoryCol(column typing.Column) {
+	t.inMemoryColumns.AddColumn(column)
+	return
+}
+
+func (t *TableData) InMemoryColumns() *typing.Columns {
+	var cols typing.Columns
+	if t.inMemoryColumns != nil {
+		for _, col := range t.inMemoryColumns.GetColumns() {
+			cols.AddColumn(col)
+		}
+	}
+
+	return &cols
 }
 
 func NewTableData(inMemoryColumns *typing.Columns, primaryKeys []string, topicConfig kafkalib.TopicConfig) *TableData {
 	return &TableData{
-		InMemoryColumns:         inMemoryColumns,
+		inMemoryColumns:         inMemoryColumns,
 		rowsData:                map[string]map[string]interface{}{},
 		PrimaryKeys:             primaryKeys,
 		TopicConfig:             topicConfig,
@@ -77,7 +99,7 @@ func (t *TableData) Rows() uint {
 
 func (t *TableData) ShouldFlush(ctx context.Context) bool {
 	settings := config.FromContext(ctx)
-	return t.Rows() > settings.Config.BufferRows || t.approxSize > settings.Config.FlushSizeKb * 1024
+	return t.Rows() > settings.Config.BufferRows || t.approxSize > settings.Config.FlushSizeKb*1024
 }
 
 // UpdateInMemoryColumnsFromDestination - When running Transfer, we will have 2 column types.
@@ -91,7 +113,7 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(cols ...typing.Column) 
 		return
 	}
 
-	for _, inMemoryCol := range t.InMemoryColumns.GetColumns() {
+	for _, inMemoryCol := range t.inMemoryColumns.GetColumns() {
 		if inMemoryCol.KindDetails.Kind == typing.Invalid.Kind {
 			// Don't copy this over because tableData has the wrong colVal
 			continue
@@ -118,7 +140,7 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(cols ...typing.Column) 
 				inMemoryCol.KindDetails.ExtendedTimeDetails.Type = foundColumn.KindDetails.ExtendedTimeDetails.Type
 			}
 
-			t.InMemoryColumns.UpdateColumn(inMemoryCol)
+			t.inMemoryColumns.UpdateColumn(inMemoryCol)
 		}
 	}
 

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -39,12 +39,14 @@ func (t *TableData) AddInMemoryCol(column typing.Column) {
 	return
 }
 
-func (t *TableData) InMemoryColumns() *typing.Columns {
+func (t *TableData) ReadOnlyInMemoryCols() *typing.Columns {
 	var cols typing.Columns
 	if t.inMemoryColumns != nil {
 		for _, col := range t.inMemoryColumns.GetColumns() {
 			cols.AddColumn(col)
 		}
+	} else {
+		return nil
 	}
 
 	return &cols

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -13,6 +13,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTableData_ReadOnlyInMemoryCols(t *testing.T) {
+	// Making sure the columns are actually read only.
+	var cols typing.Columns
+	cols.AddColumn(typing.Column{
+		Name:        "name",
+		KindDetails: typing.String,
+	})
+
+	td := NewTableData(&cols, nil, kafkalib.TopicConfig{})
+	readOnlyCols := td.ReadOnlyInMemoryCols()
+	readOnlyCols.AddColumn(typing.Column{
+		Name:        "last_name",
+		KindDetails: typing.String,
+	})
+
+	// Check if last_name actually exists.
+	_, isOk := td.ReadOnlyInMemoryCols().GetColumn("last_name")
+	assert.False(t, isOk)
+
+	// Check length is 1.
+	assert.Equal(t, 1, len(td.ReadOnlyInMemoryCols().GetColumns()))
+}
+
 func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	var _cols typing.Columns
 	for colName, colKind := range map[string]typing.KindDetails{

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -3,13 +3,14 @@ package optimization
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestTableData_UpdateInMemoryColumns(t *testing.T) {
@@ -27,14 +28,14 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	}
 
 	tableData := &TableData{
-		InMemoryColumns: &_cols,
+		inMemoryColumns: &_cols,
 	}
 
-	extCol, isOk := tableData.InMemoryColumns.GetColumn("do_not_change_format")
+	extCol, isOk := tableData.ReadOnlyInMemoryCols().GetColumn("do_not_change_format")
 	assert.True(t, isOk)
 
 	extCol.KindDetails.ExtendedTimeDetails.Format = time.RFC3339Nano
-	tableData.InMemoryColumns.UpdateColumn(typing.Column{
+	tableData.inMemoryColumns.UpdateColumn(typing.Column{
 		Name:        extCol.Name,
 		KindDetails: extCol.KindDetails,
 	})
@@ -52,21 +53,21 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	}
 
 	// It's saved back in the original format.
-	_, isOk = tableData.InMemoryColumns.GetColumn("foo")
+	_, isOk = tableData.ReadOnlyInMemoryCols().GetColumn("foo")
 	assert.False(t, isOk)
 
-	_, isOk = tableData.InMemoryColumns.GetColumn("FOO")
+	_, isOk = tableData.ReadOnlyInMemoryCols().GetColumn("FOO")
 	assert.True(t, isOk)
 
-	col, isOk := tableData.InMemoryColumns.GetColumn("CHANGE_me")
+	col, isOk := tableData.ReadOnlyInMemoryCols().GetColumn("CHANGE_me")
 	assert.True(t, isOk)
 	assert.Equal(t, ext.DateTime.Type, col.KindDetails.ExtendedTimeDetails.Type)
 
-	col, isOk = tableData.InMemoryColumns.GetColumn("bar")
+	col, isOk = tableData.ReadOnlyInMemoryCols().GetColumn("bar")
 	assert.True(t, isOk)
 	assert.Equal(t, typing.Invalid, col.KindDetails)
 
-	col, isOk = tableData.InMemoryColumns.GetColumn("do_not_change_format")
+	col, isOk = tableData.ReadOnlyInMemoryCols().GetColumn("do_not_change_format")
 	assert.True(t, isOk)
 	assert.Equal(t, col.KindDetails.Kind, typing.ETime.Kind)
 	assert.Equal(t, col.KindDetails.ExtendedTimeDetails.Type, ext.DateTimeKindType, "correctly mapped type")
@@ -76,13 +77,13 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 func TestTableData_ShouldFlushRowLength(t *testing.T) {
 	ctx := context.Background()
 	ctx = config.InjectSettingsIntoContext(ctx, &config.Settings{Config: &config.Config{
-		FlushSizeKb:          500,
-		BufferRows:           2,
+		FlushSizeKb: 500,
+		BufferRows:  2,
 	}})
 
 	// Insert 3 rows and confirm that we need to flush.
 	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
-	for i := 0; i < 3; i ++ {
+	for i := 0; i < 3; i++ {
 		assert.False(t, td.ShouldFlush(ctx))
 		td.InsertRow(fmt.Sprint(i), map[string]interface{}{
 			"foo": "bar",
@@ -95,18 +96,18 @@ func TestTableData_ShouldFlushRowLength(t *testing.T) {
 func TestTableData_ShouldFlushRowSize(t *testing.T) {
 	ctx := context.Background()
 	ctx = config.InjectSettingsIntoContext(ctx, &config.Settings{Config: &config.Config{
-		FlushSizeKb:          5,
-		BufferRows:           20000,
+		FlushSizeKb: 5,
+		BufferRows:  20000,
 	}})
 
 	// Insert 3 rows and confirm that we need to flush.
 	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
-	for i := 0; i < 45; i ++ {
+	for i := 0; i < 45; i++ {
 		assert.False(t, td.ShouldFlush(ctx))
 		td.InsertRow(fmt.Sprint(i), map[string]interface{}{
-			"foo": "bar",
+			"foo":   "bar",
 			"array": []string{"foo", "bar", "dusty", "the aussie", "robin", "jacqueline", "charlie"},
-			"true": true,
+			"true":  true,
 			"false": false,
 			"nested": map[string]interface{}{
 				"foo": "bar",
@@ -115,9 +116,9 @@ func TestTableData_ShouldFlushRowSize(t *testing.T) {
 	}
 
 	td.InsertRow("33333", map[string]interface{}{
-		"foo": "bar",
+		"foo":   "bar",
 		"array": []string{"foo", "bar", "dusty", "the aussie", "robin", "jacqueline", "charlie"},
-		"true": true,
+		"true":  true,
 		"false": false,
 		"nested": map[string]interface{}{
 			"foo": "bar",

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -3,6 +3,9 @@ package typing
 type Column struct {
 	Name        string
 	KindDetails KindDetails
+	// ToastColumn indicates that the source column is a TOAST column and the value is unavailable
+	// We have stripped this out.
+	// Whenever we see the same column where there's an opposite value in `toastColumn`, we will trigger a flush
 	ToastColumn bool
 }
 

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -3,6 +3,7 @@ package typing
 type Column struct {
 	Name        string
 	KindDetails KindDetails
+	ToastColumn bool
 }
 
 type Columns struct {

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -117,7 +117,6 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 		if e.Columns != nil {
 			// Iterate over this again just in case.
 			for _, col := range e.Columns.GetColumns() {
-				fmt.Println("Are you getting added here?", col.Name, col.KindDetails.Kind)
 				inMemDB.TableData[e.Table].AddInMemoryCol(col)
 			}
 		}
@@ -148,7 +147,6 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 			// And the column type is not invalid.
 			col, isOk := inMemoryColumns.GetColumn(newColName)
 			if isOk && col.KindDetails != typing.Invalid && col.ToastColumn == false {
-				fmt.Println("early return here.", newColName)
 				return true, true, nil
 			}
 
@@ -168,7 +166,6 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 		}
 
 		retrievedColumn, isOk := inMemoryColumns.GetColumn(newColName)
-		fmt.Println("newColName", newColName, "retrievedColumnKind", retrievedColumn.KindDetails.Kind, "name", retrievedColumn.Name)
 		if !isOk {
 			// This would only happen if the columns did not get passed in initially.
 			inMemoryColumns.AddColumn(typing.Column{
@@ -183,7 +180,6 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 				// This is because we don't want to think that it's okay to drop a column in DWH
 				if kindDetails := typing.ParseValue(_col, e.OptiomalSchema, val); kindDetails.Kind != typing.Invalid.Kind {
 					if retrievedColumn.ToastColumn {
-						fmt.Println("or here?")
 						// Now that we are here, this means that we have a row that has a value for this toast column
 						// In order to prevent a mismatch, we will now force a flush and a re-process.
 						return true, true, nil

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -123,7 +123,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 	}
 
 	// Table columns
-	inMemoryColumns := inMemDB.TableData[e.Table].InMemoryColumns()
+	inMemoryColumns := inMemDB.TableData[e.Table].ReadOnlyInMemoryCols()
 
 	// Update col if necessary
 	sanitizedData := make(map[string]interface{})

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -157,6 +157,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 					// We will flush, then next message will be toastColumn = true.
 					return true, true, nil
 				} else {
+					// If the column exists, update the type and toast value just to be safe.
 					inMemoryColumns.UpdateColumn(typing.Column{
 						Name:        newColName,
 						KindDetails: typing.Invalid,
@@ -164,6 +165,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 					})
 				}
 			} else {
+				// If column doesn't exist, add it.
 				inMemoryColumns.AddColumn(typing.Column{
 					Name:        newColName,
 					KindDetails: typing.Invalid,
@@ -174,7 +176,6 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 		}
 
 		retrievedColumn, isOk := inMemoryColumns.GetColumn(newColName)
-		fmt.Println("eventData", e.Data, "retrievedCol", retrievedColumn, "isOk", isOk)
 		if !isOk {
 			// This would only happen if the columns did not get passed in initially.
 			inMemoryColumns.AddColumn(typing.Column{

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/artie-labs/transfer/lib/debezium"
+
 	"github.com/artie-labs/transfer/lib/artie"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -67,7 +69,7 @@ func (e *EventsTestSuite) TestSaveEvent() {
 			constants.DeleteColumnMarker: true,
 			expectedCol:                  "dusty",
 			anotherCol:                   13.37,
-			badColumn:                    "__debezium_unavailable_value",
+			badColumn:                    debezium.ToastUnavailableValuePlaceholder,
 		},
 	}
 

--- a/models/event/event_save_toast_test.go
+++ b/models/event/event_save_toast_test.go
@@ -3,13 +3,13 @@ package event
 import (
 	"fmt"
 
-	"github.com/artie-labs/transfer/lib/config/constants"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/artie-labs/transfer/lib/artie"
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/debezium"
 	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/models"
 	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
 )
 
 type flushEvent struct {
@@ -24,10 +24,10 @@ type testCase struct {
 
 func newTestEvent(pk int, data map[string]interface{}) Event {
 	var cols typing.Columns
-	for _, col := range []string{"id", "first_name", "last_name"} {
+	for _, col := range []string{"id", "first_name", "last_name", "email"} {
 		cols.AddColumn(typing.Column{
 			Name:        col,
-			KindDetails: typing.String,
+			KindDetails: typing.Invalid,
 		})
 	}
 
@@ -44,8 +44,28 @@ func newTestEvent(pk int, data map[string]interface{}) Event {
 	}
 }
 
-func (e *EventsTestSuite) TestEventSave_ToastScenarioOne() {
+func (e *EventsTestSuite) TestEventSave_Toast() {
 	testCases := []testCase{
+		// 1) Toast followed by normal value, same userId
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  "Tang",
+					}),
+				},
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": "Robin",
+						"last_name":  "Tang",
+					}),
+					shouldFlush:     true,
+					shouldReprocess: true,
+				},
+			},
+		},
+		// 2) Normal value followed by toast same userId
 		{
 			events: []flushEvent{
 				{
@@ -55,22 +75,218 @@ func (e *EventsTestSuite) TestEventSave_ToastScenarioOne() {
 					}),
 				},
 				{
-					Event: newTestEvent(2, map[string]interface{}{
-						"first_name": "Robin",
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
 						"last_name":  "Tang",
 					}),
+					shouldFlush:     true,
+					shouldReprocess: true,
+				},
+			},
+		},
+		// 3) Toast followed by Toast same userId
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  "Tang1",
+					}),
+				},
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  "Tang2",
+					}),
+				},
+			},
+		},
+		// 4) Normal followed by normal same userId
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": "Robin",
+						"last_name":  "Tang1",
+					}),
+				},
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": "Tangster",
+						"last_name":  "Tang2",
+					}),
+				},
+			},
+		},
+		// 5) Toast followed normal value, different userIds
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  "Tang1",
+					}),
+				},
+				{
+					Event: newTestEvent(123, map[string]interface{}{
+						"first_name": "Tangster",
+						"last_name":  "Tang2",
+					}),
+					shouldReprocess: true,
+					shouldFlush:     true,
+				},
+			},
+		},
+		// 6) Normal value followed by toast value, different userIds
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": "Tangster",
+						"last_name":  "Tang1",
+					}),
+				},
+				{
+					Event: newTestEvent(123, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  "Tang2",
+					}),
+					shouldReprocess: true,
+					shouldFlush:     true,
+				},
+			},
+		},
+		// 7) Toast followed by Toast different userIds
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  "Tang1",
+					}),
+				},
+				{
+					Event: newTestEvent(123, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  "Tang2",
+					}),
+				},
+			},
+		},
+		// 8) Normal followed by normal different userIds
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": "Robin2",
+						"last_name":  "Tang1",
+					}),
+				},
+				{
+					Event: newTestEvent(123, map[string]interface{}{
+						"first_name": "Robin1",
+						"last_name":  "Tang2",
+					}),
+				},
+			},
+		},
+		// 9) Higher number of toasts mixed with normal rows
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  debezium.ToastUnavailableValuePlaceholder,
+					}),
+				},
+				{
+					Event: newTestEvent(123, map[string]interface{}{
+						"first_name": "Robin1",
+						"last_name":  "Tang2",
+					}),
+					shouldFlush:     true,
+					shouldReprocess: true,
+				},
+			},
+		},
+		// 10) Mixed toast values with different user id
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  debezium.ToastUnavailableValuePlaceholder,
+						"email":      "robin@artie.so",
+					}),
+				},
+				{
+					Event: newTestEvent(123, map[string]interface{}{
+						"first_name": "Robin1",
+						"last_name":  "Tang",
+						"email":      "robin@artie.so",
+					}),
+					shouldFlush:     true,
+					shouldReprocess: true,
+				},
+			},
+		},
+		// 11) Multiple toast columns, but all the same.
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  debezium.ToastUnavailableValuePlaceholder,
+						"email":      "robin@artie.so",
+					}),
+				},
+				{
+					Event: newTestEvent(123, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  debezium.ToastUnavailableValuePlaceholder,
+						"email":      "jacqueline@artie.so",
+					}),
+				},
+			},
+		},
+		// 12) Multiple toast columns, same, but followed by normal.
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  debezium.ToastUnavailableValuePlaceholder,
+						"email":      "robin@artie.so",
+					}),
+				},
+				{
+					Event: newTestEvent(123, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  debezium.ToastUnavailableValuePlaceholder,
+						"email":      "jacqueline@artie.so",
+					}),
+				},
+				{
+					Event: newTestEvent(1234, map[string]interface{}{
+						"first_name": debezium.ToastUnavailableValuePlaceholder,
+						"last_name":  "Young",
+						"email":      "charlie@artie.so",
+					}),
+					shouldReprocess: true,
+					shouldFlush:     true,
 				},
 			},
 		},
 	}
 
 	for _, test := range testCases {
-		kafkaMsg := kafka.Message{}
-
+		// Flush after each test case.
+		e.ctx = models.LoadMemoryDB(e.ctx)
 		for _, evt := range test.events {
+			kafkaMsg := kafka.Message{}
 			flush, reprocess, err := evt.Event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
-			assert.Equal(e.T(), evt.shouldFlush, flush)
-			assert.Equal(e.T(), evt.shouldReprocess, reprocess)
+			assert.Equal(e.T(), evt.shouldFlush, flush, fmt.Sprintf("evt_data: %v, flush is %v", evt.Event.Data, flush))
+			assert.Equal(e.T(), evt.shouldReprocess, reprocess, fmt.Sprintf("evt_data: %v, reprocess is %v", evt.Event.Data, reprocess))
 			assert.NoError(e.T(), err)
 		}
 

--- a/models/event/event_save_toast_test.go
+++ b/models/event/event_save_toast_test.go
@@ -1,0 +1,79 @@
+package event
+
+import (
+	"fmt"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/artie-labs/transfer/lib/artie"
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/segmentio/kafka-go"
+)
+
+type flushEvent struct {
+	Event           Event
+	shouldFlush     bool
+	shouldReprocess bool
+}
+
+type testCase struct {
+	events []flushEvent
+}
+
+func newTestEvent(pk int, data map[string]interface{}) Event {
+	var cols typing.Columns
+	for _, col := range []string{"id", "first_name", "last_name"} {
+		cols.AddColumn(typing.Column{
+			Name:        col,
+			KindDetails: typing.String,
+		})
+	}
+
+	data[constants.DeleteColumnMarker] = false
+	data["id"] = pk
+
+	return Event{
+		Table:   "test_table",
+		Columns: &cols,
+		PrimaryKeyMap: map[string]interface{}{
+			"id": fmt.Sprint(pk),
+		},
+		Data: data,
+	}
+}
+
+func (e *EventsTestSuite) TestEventSave_ToastScenarioOne() {
+	testCases := []testCase{
+		{
+			events: []flushEvent{
+				{
+					Event: newTestEvent(1, map[string]interface{}{
+						"first_name": "Robin",
+						"last_name":  "Tang",
+					}),
+				},
+				{
+					Event: newTestEvent(2, map[string]interface{}{
+						"first_name": "Robin",
+						"last_name":  "Tang",
+					}),
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		kafkaMsg := kafka.Message{}
+
+		for _, evt := range test.events {
+			flush, reprocess, err := evt.Event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
+			assert.Equal(e.T(), evt.shouldFlush, flush)
+			assert.Equal(e.T(), evt.shouldReprocess, reprocess)
+			assert.NoError(e.T(), err)
+		}
+
+	}
+
+}

--- a/models/event/events_suite_test.go
+++ b/models/event/events_suite_test.go
@@ -23,6 +23,7 @@ func (e *EventsTestSuite) SetupTest() {
 	e.ctx = config.InjectSettingsIntoContext(e.ctx, &config.Settings{
 		Config: &config.Config{
 			FlushIntervalSeconds: 10,
+			FlushSizeKb:          1024,
 			BufferRows:           10,
 		},
 	})

--- a/models/event/events_suite_test.go
+++ b/models/event/events_suite_test.go
@@ -24,7 +24,7 @@ func (e *EventsTestSuite) SetupTest() {
 		Config: &config.Config{
 			FlushIntervalSeconds: 10,
 			FlushSizeKb:          1024,
-			BufferRows:           10,
+			BufferRows:           1000,
 		},
 	})
 

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -71,7 +71,7 @@ func processMessage(ctx context.Context, processArgs ProcessArgs) error {
 	}
 
 	if reprocessRow {
-		logger.FromContext(ctx).WithField("key", string(processArgs.Msg.Key())).Info("reprocessing this row")
+		logger.FromContext(ctx).WithField("key", string(processArgs.Msg.Key())).Info("this row was skipped to prevent a TOAST mismatch, re-processing this row...")
 		return processMessage(ctx, processArgs)
 	}
 	return nil

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -5,15 +5,25 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/jitter"
+	"github.com/artie-labs/transfer/lib/logger"
+
 	"github.com/artie-labs/transfer/lib/artie"
 	"github.com/artie-labs/transfer/lib/telemetry/metrics"
 	"github.com/artie-labs/transfer/models/event"
 )
 
-func processMessage(ctx context.Context, msg artie.Message, topicToConfigFmtMap map[string]TopicConfigFormatter, groupID string) (shouldFlush bool, err error) {
+type ProcessArgs struct {
+	Msg                    artie.Message
+	GroupID                string
+	TopicToConfigFormatMap map[string]TopicConfigFormatter
+	FlushChannel           chan bool
+}
+
+func processMessage(ctx context.Context, processArgs ProcessArgs) error {
 	tags := map[string]string{
-		"groupID": groupID,
-		"topic":   msg.Topic(),
+		"groupID": processArgs.GroupID,
+		"topic":   processArgs.Msg.Topic(),
 		"what":    "success",
 	}
 	st := time.Now()
@@ -21,35 +31,48 @@ func processMessage(ctx context.Context, msg artie.Message, topicToConfigFmtMap 
 		metrics.FromContext(ctx).Timing("process.message", time.Since(st), tags)
 	}()
 
-	topicConfig, isOk := topicToConfigFmtMap[msg.Topic()]
+	topicConfig, isOk := processArgs.TopicToConfigFormatMap[processArgs.Msg.Topic()]
 	if !isOk {
 		tags["what"] = "failed_topic_lookup"
-		return false, fmt.Errorf("failed to get topic name: %s", msg.Topic())
+		return fmt.Errorf("failed to get topic name: %s", processArgs.Msg.Topic())
 	}
 
 	tags["database"] = topicConfig.tc.Database
 	tags["schema"] = topicConfig.tc.Schema
 	tags["table"] = topicConfig.tc.TableName
 
-	pkMap, err := topicConfig.GetPrimaryKey(ctx, msg.Key(), topicConfig.tc)
+	pkMap, err := topicConfig.GetPrimaryKey(ctx, processArgs.Msg.Key(), topicConfig.tc)
 	if err != nil {
 		tags["what"] = "marshall_pk_err"
-		return false, fmt.Errorf("cannot unmarshall key, key: %s, err: %v", string(msg.Key()), err)
+		return fmt.Errorf("cannot unmarshall key, key: %s, err: %v", string(processArgs.Msg.Key()), err)
 	}
 
-	_event, err := topicConfig.GetEventFromBytes(ctx, msg.Value())
+	_event, err := topicConfig.GetEventFromBytes(ctx, processArgs.Msg.Value())
 	if err != nil {
 		tags["what"] = "marshall_value_err"
-		return false, fmt.Errorf("cannot unmarshall event, err: %v", err)
+		return fmt.Errorf("cannot unmarshall event, err: %v", err)
 	}
 
 	evt := event.ToMemoryEvent(ctx, _event, pkMap, topicConfig.tc)
-	shouldFlush, err = evt.Save(ctx, topicConfig.tc, msg)
+	shouldFlush, reprocessRow, err := evt.Save(ctx, topicConfig.tc, processArgs.Msg)
 	if err != nil {
 		tags["what"] = "save_fail"
 		err = fmt.Errorf("event failed to save, err: %v", err)
 	}
 
-	// Using a named return, don't need to pass
-	return
+	// Flush first, then reprocess row.
+	if shouldFlush {
+		processArgs.FlushChannel <- true
+		// Jitter-sleep is necessary to allow the flush process to acquire the table lock
+		// If it doesn't then the flush process may be over-exhausted since the lock got acquired by `processMessage(...)`.
+		// This then leads us to make unnecessary flushes.
+		jitterDuration := jitter.JitterMs(500, 1)
+		time.Sleep(time.Duration(jitterDuration) * time.Millisecond)
+	}
+
+	if reprocessRow {
+		logger.FromContext(ctx).WithField("key", string(processArgs.Msg.Key())).Info("reprocessing this row")
+		return processMessage(ctx, processArgs)
+	}
+	return nil
 }


### PR DESCRIPTION
# What is a TOAST column?
TOAST stands for "The Oversized-Attribute Storage Technique" in PostgreSQL. It's a system that PostgreSQL uses to store large data values efficiently. PostgreSQL and Oracle have a hard limit of 8KB (this is the default page size, it can be increased up to 32KB at compile time) on the size of a single row of data. 

PostgreSQL and Oracle have an optimization for CDC such that if the column value did not get changed, it will simply emit a stub placeholder. Debezium returns that as “[__debezium_unavailable](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-toasted-values)”. One could change the replica identity, however that results in additional compute resources from the database.

# Why is this important?
Previously, Artie Transfer would just ignore this column as such:

For instance, if we saw a row such as:
```json
{ "id": 123, "foo": "bar", "hello": "__debezium_unavailable_value"}
```

We would store it as:
```json
{ "id": 123, "foo": "bar"}
```

We would then in turn invoke a Snowflake MERGE command and merge only the “id” and “foo” columns. This works well when the flush cycle only contains rows that have all either been updated with TOAST values or not unchanged. 

This starts to cause issues when there are mixed rows within our in-memory database.

# Why does this happen?
This happens because we need to replay all of our in-memory rows into a SQL table so we can invoke a MERGE command.

# Example
![image](https://github.com/artie-labs/transfer/assets/4412200/88408adb-b885-4305-8a48-f82bcd312443)
![image](https://github.com/artie-labs/transfer/assets/4412200/464c6e18-607a-4207-a6e6-eb76107395b7)
![image](https://github.com/artie-labs/transfer/assets/4412200/a4426bd0-6983-49fd-a635-6a58c1037969)

# The theoretical limit
![image](https://github.com/artie-labs/transfer/assets/4412200/e39beab5-9515-4da1-8ff2-925b500afcf8)

Debezium has a couple of recommendations, however - it’ll require changes to the database:

[Change REPLICA IDENTITY FULL](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-toasted-values)
[Add a database trigger to emit the old value](https://debezium.io/blog/2019/10/08/handling-unchanged-postgres-toast-values/)

This may create performance concerns and will require each database to have this configured. Rather, what we plan to do to support this within Transfer is to trigger a flush cycle before and after each row we process that has a TOAST column unavailable value placeholder (which indicates no change). 

Notably, this will incur additional flush cycles, however we are optimizing for accuracy over efficiency. Once this is rolled out, we can then perform more sophisticated MERGE commands (such as inter-column merge), only FLUSH when there’s a column mismatch and others.

# Our solution
We have now added a new data type to our in-memory columns to indicate whether this is a row that contains scrubbed TOAST values or not.

Whenever there's a mismatch with the incoming row:

1) Column `foo` w/ `TOAST=true`, and new row has `foo=bar`, instead of combining the mismatched data types, we will force a flush and then re-process the new row where `foo=bar`

2) Column `foo` w/ `TOAST=false` which indicates in-memory pool contains actual values for the column `foo`. When we get an unavailable placeholder value for `foo`, we will force a flush and then re-process.

