### PR TITLE
[Typing Library] Early exit for nil value

### DIFF
--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -3,10 +3,11 @@ package typing
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/typing/ext"
 	"reflect"
 	"strings"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
 type KindDetails struct {
@@ -80,6 +81,10 @@ func IsJSON(str string) bool {
 }
 
 func ParseValue(key string, optionalSchema map[string]KindDetails, val interface{}) KindDetails {
+	if val == nil {
+		return Invalid
+	}
+
 	if len(optionalSchema) > 0 {
 		// If the column exists in the schema, let's early exit.
 		kindDetail, isOk := optionalSchema[key]

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -3,12 +3,19 @@ package typing
 import (
 	"errors"
 	"fmt"
-	"github.com/artie-labs/transfer/lib/typing/ext"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"strings"
 	"testing"
+
+	"github.com/artie-labs/transfer/lib/typing/ext"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestNil(t *testing.T) {
+	assert.Equal(t, ParseValue("", nil, ""), String)
+	assert.Equal(t, ParseValue("", nil, "nil"), String)
+	assert.Equal(t, ParseValue("", nil, nil), Invalid)
+}
 
 func TestJSONString(t *testing.T) {
 	assert.Equal(t, true, IsJSON(`{"hello": "world"}`))

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -190,6 +190,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 				// This is because we don't want to think that it's okay to drop a column in DWH
 				if kindDetails := typing.ParseValue(_col, e.OptiomalSchema, val); kindDetails.Kind != typing.Invalid.Kind {
 					if retrievedColumn.ToastColumn {
+						fmt.Println("Returning here #2", retrievedColumn.ToastColumn, retrievedColumn.Name, retrievedColumn.KindDetails.Kind, kindDetails.Kind, "val", val, "val is nil", val == nil)
 						// To prevent a mismatch, we are early returning here because by getting here.
 						// Since by getting here, this row has a real value back from a TOAST column.
 						return true, true, nil

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -190,7 +190,6 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 				// This is because we don't want to think that it's okay to drop a column in DWH
 				if kindDetails := typing.ParseValue(_col, e.OptiomalSchema, val); kindDetails.Kind != typing.Invalid.Kind {
 					if retrievedColumn.ToastColumn {
-						fmt.Println("Returning here #2", retrievedColumn.ToastColumn, retrievedColumn.Name, retrievedColumn.KindDetails.Kind, kindDetails.Kind, "val", val, "val is nil", val == nil)
 						// To prevent a mismatch, we are early returning here because by getting here.
 						// Since by getting here, this row has a real value back from a TOAST column.
 						return true, true, nil


### PR DESCRIPTION
As per title.

Right now, we'll end up deferring the `nil` value as part of the `optionalSchema`.

However, we should actually be early escaping `NULL` value. By not doing so, coupled with the PR #100, we are flushing too often.