### PR TITLE
Escaping TOASTed JSON columns

### DIFF
--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -28,7 +28,14 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 		sflkCol := column.Name
 		switch column.KindDetails.Kind {
 		case typing.Struct.Kind, typing.Array.Kind:
-			sflkCol = fmt.Sprintf("PARSE_JSON(%s) %s", column.Name, column.Name)
+			if column.ToastColumn {
+				//  CASE WHEN col = 'unavail' THEN col ELSE PARSE_JSON(col) END col
+				sflkCol = fmt.Sprintf("CASE WHEN %s = '%s' THEN {'key': '%s'} ELSE PARSE_JSON(%s) END %s", column.Name,
+					constants.ToastUnavailableValuePlaceholder, constants.ToastUnavailableValuePlaceholder,
+					column.Name, column.Name)
+			} else {
+				sflkCol = fmt.Sprintf("PARSE_JSON(%s) %s", column.Name, column.Name)
+			}
 		}
 
 		cols = append(cols, column.Name)

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -24,11 +24,11 @@ func escapeCols(cols []typing.Column) (colsToUpdate []string, colsToUpdateEscape
 			continue
 		}
 
-		sflkCol := column.Name
+		escapedCol := column.Name
 		switch column.KindDetails.Kind {
 		case typing.Struct.Kind, typing.Array.Kind:
 			if column.ToastColumn {
-				sflkCol = fmt.Sprintf("CASE WHEN %s = '%s' THEN {'key': '%s'} ELSE PARSE_JSON(%s) END %s",
+				escapedCol = fmt.Sprintf("CASE WHEN %s = '%s' THEN {'key': '%s'} ELSE PARSE_JSON(%s) END %s",
 					// Comparing the column against placeholder
 					column.Name, constants.ToastUnavailableValuePlaceholder,
 					// Casting placeholder as a JSON object
@@ -36,12 +36,12 @@ func escapeCols(cols []typing.Column) (colsToUpdate []string, colsToUpdateEscape
 					// Regular parsing.
 					column.Name, column.Name)
 			} else {
-				sflkCol = fmt.Sprintf("PARSE_JSON(%s) %s", column.Name, column.Name)
+				escapedCol = fmt.Sprintf("PARSE_JSON(%s) %s", column.Name, column.Name)
 			}
 		}
 
 		colsToUpdate = append(colsToUpdate, column.Name)
-		colsToUpdateEscaped = append(colsToUpdateEscaped, sflkCol)
+		colsToUpdateEscaped = append(colsToUpdateEscaped, escapedCol)
 	}
 
 	return

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -29,9 +29,12 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 		switch column.KindDetails.Kind {
 		case typing.Struct.Kind, typing.Array.Kind:
 			if column.ToastColumn {
-				//  CASE WHEN col = 'unavail' THEN col ELSE PARSE_JSON(col) END col
-				sflkCol = fmt.Sprintf("CASE WHEN %s = '%s' THEN {'key': '%s'} ELSE PARSE_JSON(%s) END %s", column.Name,
-					constants.ToastUnavailableValuePlaceholder, constants.ToastUnavailableValuePlaceholder,
+				sflkCol = fmt.Sprintf("CASE WHEN %s = '%s' THEN {'key': '%s'} ELSE PARSE_JSON(%s) END %s",
+					// Comparing the column against placeholder
+					column.Name, constants.ToastUnavailableValuePlaceholder,
+					// Casting placeholder as a JSON object
+					constants.ToastUnavailableValuePlaceholder,
+					// Regular parsing.
 					column.Name, column.Name)
 			} else {
 				sflkCol = fmt.Sprintf("PARSE_JSON(%s) %s", column.Name, column.Name)

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -17,7 +17,6 @@ import (
 // 1) colsToUpdate - list of columns to update
 // 2) list of columns to update (escaped).
 func escapeCols(cols []typing.Column) (colsToUpdate []string, colsToUpdateEscaped []string) {
-	// Given all the columns, diff this against SFLK.
 	for _, column := range cols {
 		if column.KindDetails.Kind == typing.Invalid.Kind {
 			// Don't update Snowflake

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -2,6 +2,7 @@ package snowflake
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -124,12 +125,16 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 	tableData.UpdateInMemoryColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 	query, err := getMergeStatement(tableData)
 	if err != nil {
+		fmt.Println("query", query)
 		log.WithError(err).Warn("failed to generate the getMergeStatement query")
 		return err
 	}
 
 	log.WithField("query", query).Debug("executing...")
 	_, err = s.Exec(query)
+	if err != nil {
+		fmt.Println("query", query)
+	}
 	return err
 }
 

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -2,7 +2,6 @@ package snowflake
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -125,16 +124,12 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 	tableData.UpdateInMemoryColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 	query, err := getMergeStatement(tableData)
 	if err != nil {
-		fmt.Println("query", query)
 		log.WithError(err).Warn("failed to generate the getMergeStatement query")
 		return err
 	}
 
 	log.WithField("query", query).Debug("executing...")
 	_, err = s.Exec(query)
-	if err != nil {
-		fmt.Println("query", query)
-	}
 	return err
 }
 

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -35,10 +35,18 @@ func ColumnsUpdateQuery(columns []string, columnsToTypes typing.Columns, tablePr
 	for _, column := range columns {
 		columnType, isOk := columnsToTypes.GetColumn(column)
 		if isOk && columnType.ToastColumn {
-			// t.column3 = CASE WHEN t.column3 != '__debezium_unavailable_value' THEN t.column3 ELSE s.column3 END
-			_columns = append(_columns,
-				fmt.Sprintf("%s= CASE WHEN %s.%s != '%s' THEN %s.%s ELSE c.%s END", column, tablePrefix, column,
-					constants.ToastUnavailableValuePlaceholder, tablePrefix, column, column))
+			if columnType.KindDetails == typing.Struct {
+				_columns = append(_columns,
+					fmt.Sprintf("%s= CASE WHEN %s.%s != {'key': '%s'} THEN %s.%s ELSE c.%s END",
+						column, tablePrefix, column,
+						constants.ToastUnavailableValuePlaceholder, tablePrefix, column, column))
+			} else {
+				// t.column3 = CASE WHEN t.column3 != '__debezium_unavailable_value' THEN t.column3 ELSE s.column3 END
+				_columns = append(_columns,
+					fmt.Sprintf("%s= CASE WHEN %s.%s != '%s' THEN %s.%s ELSE c.%s END", column, tablePrefix, column,
+						constants.ToastUnavailableValuePlaceholder, tablePrefix, column, column))
+			}
+
 		} else {
 			// This is to make it look like: objCol = cc.objCol::variant
 			_columns = append(_columns, fmt.Sprintf("%s=%s.%s", column, tablePrefix, column))

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -29,9 +29,10 @@ func StringsJoinAddPrefix(args StringsJoinAddPrefixArgs) string {
 // ColumnsUpdateQuery will take a list of columns + tablePrefix and return
 // columnA = tablePrefix.columnA, columnB = tablePrefix.columnB. This is the Update syntax that Snowflake requires
 func ColumnsUpdateQuery(columns []string, columnsToTypes typing.Columns, tablePrefix string) string {
+	// TODO - deprecate tablePrefix as an arg (it's redundant).
+
 	// NOTE: columns and sflkCols must be the same.
 	var _columns []string
-
 	for _, column := range columns {
 		columnType, isOk := columnsToTypes.GetColumn(column)
 		if isOk && columnType.ToastColumn {

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -28,7 +28,7 @@ func StringsJoinAddPrefix(args StringsJoinAddPrefixArgs) string {
 
 // ColumnsUpdateQuery will take a list of columns + tablePrefix and return
 // columnA = tablePrefix.columnA, columnB = tablePrefix.columnB. This is the Update syntax that Snowflake requires
-func ColumnsUpdateQuery(columns []string, columnsToTypes typing.Columns, tablePrefix string) string {
+func ColumnsUpdateQuery(columns []string, columnsToTypes typing.Columns, tablePrefix string, bigQueryTypeCasting bool) string {
 	// TODO - deprecate tablePrefix as an arg (it's redundant).
 
 	// NOTE: columns and sflkCols must be the same.
@@ -37,10 +37,18 @@ func ColumnsUpdateQuery(columns []string, columnsToTypes typing.Columns, tablePr
 		columnType, isOk := columnsToTypes.GetColumn(column)
 		if isOk && columnType.ToastColumn {
 			if columnType.KindDetails == typing.Struct {
-				_columns = append(_columns,
-					fmt.Sprintf("%s= CASE WHEN %s.%s != {'key': '%s'} THEN %s.%s ELSE c.%s END",
-						column, tablePrefix, column,
-						constants.ToastUnavailableValuePlaceholder, tablePrefix, column, column))
+				if bigQueryTypeCasting {
+					_columns = append(_columns,
+						fmt.Sprintf("%s= CASE WHEN TO_JSON_STRING(%s.%s) != %s THEN %s.%s ELSE c.%s END",
+							column, tablePrefix, column,
+							fmt.Sprintf(`'{"key": "%s"}'`, constants.ToastUnavailableValuePlaceholder),
+							tablePrefix, column, column))
+				} else {
+					_columns = append(_columns,
+						fmt.Sprintf("%s= CASE WHEN %s.%s != {'key': '%s'} THEN %s.%s ELSE c.%s END",
+							column, tablePrefix, column,
+							constants.ToastUnavailableValuePlaceholder, tablePrefix, column, column))
+				}
 			} else {
 				// t.column3 = CASE WHEN t.column3 != '__debezium_unavailable_value' THEN t.column3 ELSE s.column3 END
 				_columns = append(_columns,

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -4,9 +4,98 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/typing"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestColumnsUpdateQuery(t *testing.T) {
+	type testCase struct {
+		name           string
+		columns        []string
+		columnsToTypes typing.Columns
+		tablePrefix    string
+		expectedString string
+	}
+
+	fooBarCols := []string{"foo", "bar"}
+
+	var (
+		happyPathCols      typing.Columns
+		stringAndToastCols typing.Columns
+		lastCaseColTypes   typing.Columns
+	)
+	for _, col := range fooBarCols {
+		happyPathCols.AddColumn(typing.Column{
+			Name:        col,
+			KindDetails: typing.String,
+			ToastColumn: false,
+		})
+	}
+	for _, col := range fooBarCols {
+		var toastCol bool
+		if col == "foo" {
+			toastCol = true
+		}
+
+		stringAndToastCols.AddColumn(typing.Column{
+			Name:        col,
+			KindDetails: typing.String,
+			ToastColumn: toastCol,
+		})
+	}
+
+	lastCaseCols := []string{"a1", "b2", "c3"}
+
+	for _, lastCaseCol := range lastCaseCols {
+		kd := typing.String
+		var toast bool
+		// a1 - struct + toast, b2 - string + toast, c3 = regular string.
+		if lastCaseCol == "a1" {
+			kd = typing.Struct
+			toast = true
+		} else if lastCaseCol == "b2" {
+			toast = true
+		}
+
+		lastCaseColTypes.AddColumn(typing.Column{
+			Name:        lastCaseCol,
+			KindDetails: kd,
+			ToastColumn: toast,
+		})
+	}
+
+	testCases := []testCase{
+		{
+			name:           "happy path",
+			columns:        fooBarCols,
+			columnsToTypes: happyPathCols,
+			tablePrefix:    "cc",
+			expectedString: "foo=cc.foo,bar=cc.bar",
+		},
+		{
+			name:           "string and toast",
+			columns:        fooBarCols,
+			columnsToTypes: stringAndToastCols,
+			tablePrefix:    "cc",
+			expectedString: "foo= CASE WHEN cc.foo != '__debezium_unavailable_value' THEN cc.foo ELSE c.foo END,bar=cc.bar",
+		},
+		{
+			name:           "struct, string and toast string",
+			columns:        lastCaseCols,
+			columnsToTypes: lastCaseColTypes,
+			tablePrefix:    "cc",
+			expectedString: "a1= CASE WHEN cc.a1 != {'key': '__debezium_unavailable_value'} THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3",
+		},
+	}
+
+	for _, _testCase := range testCases {
+		actualQuery := ColumnsUpdateQuery(_testCase.columns, _testCase.columnsToTypes, _testCase.tablePrefix)
+		assert.Equal(t, _testCase.expectedString, actualQuery, _testCase.name)
+	}
+
+}
 
 func TestStringsJoinAddPrefix(t *testing.T) {
 	foo := []string{

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -89,6 +89,14 @@ func TestColumnsUpdateQuery(t *testing.T) {
 			tablePrefix:    "cc",
 			expectedString: "a1= CASE WHEN cc.a1 != {'key': '__debezium_unavailable_value'} THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3",
 		},
+		{
+			name:           "struct, string and toast string (bigquery)",
+			columns:        lastCaseCols,
+			columnsToTypes: lastCaseColTypes,
+			tablePrefix:    "cc",
+			bigQuery:       true,
+			expectedString: `a1= CASE WHEN TO_JSON_STRING(cc.a1) != '{"key": "__debezium_unavailable_value"}' THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3`,
+		},
 	}
 
 	for _, _testCase := range testCases {

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -17,6 +17,7 @@ func TestColumnsUpdateQuery(t *testing.T) {
 		columnsToTypes typing.Columns
 		tablePrefix    string
 		expectedString string
+		bigQuery       bool
 	}
 
 	fooBarCols := []string{"foo", "bar"}
@@ -91,7 +92,7 @@ func TestColumnsUpdateQuery(t *testing.T) {
 	}
 
 	for _, _testCase := range testCases {
-		actualQuery := ColumnsUpdateQuery(_testCase.columns, _testCase.columnsToTypes, _testCase.tablePrefix)
+		actualQuery := ColumnsUpdateQuery(_testCase.columns, _testCase.columnsToTypes, _testCase.tablePrefix, _testCase.bigQuery)
 		assert.Equal(t, _testCase.expectedString, actualQuery, _testCase.name)
 	}
 

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -19,10 +19,10 @@ type MergeArgument struct {
 	Columns        []string
 	ColumnsToTypes typing.Columns
 
-	// SpecialCastingRequired - This is used for columns that have JSON value. This is required for BigQuery
+	// BigQueryTypeCasting - This is used for columns that have JSON value. This is required for BigQuery
 	// We will be casting the value in this column as such: `TO_JSON_STRING(<columnName>)`
-	SpecialCastingRequired bool
-	SoftDelete             bool
+	BigQueryTypeCasting bool
+	SoftDelete          bool
 }
 
 func MergeStatement(m MergeArgument) (string, error) {
@@ -46,7 +46,7 @@ func MergeStatement(m MergeArgument) (string, error) {
 			return "", fmt.Errorf("error: column: %s does not exist in columnToType: %v", primaryKey, m.ColumnsToTypes)
 		}
 
-		if m.SpecialCastingRequired && pkCol.KindDetails.Kind == typing.Struct.Kind {
+		if m.BigQueryTypeCasting && pkCol.KindDetails.Kind == typing.Struct.Kind {
 			// BigQuery requires special casting to compare two JSON objects.
 			equalitySQL = fmt.Sprintf("TO_JSON_STRING(c.%s) = TO_JSON_STRING(cc.%s)", primaryKey, primaryKey)
 		}
@@ -69,7 +69,7 @@ func MergeStatement(m MergeArgument) (string, error) {
 					);
 		`, m.FqTableName, m.SubQuery, strings.Join(equalitySQLParts, " and "),
 			// Update + Soft Deletion
-			idempotentClause, array.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, "cc"),
+			idempotentClause, array.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, "cc", m.BigQueryTypeCasting),
 			// Insert
 			constants.DeleteColumnMarker, strings.Join(m.Columns, ","),
 			array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
@@ -110,7 +110,7 @@ func MergeStatement(m MergeArgument) (string, error) {
 		// Delete
 		constants.DeleteColumnMarker,
 		// Update
-		constants.DeleteColumnMarker, idempotentClause, array.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, "cc"),
+		constants.DeleteColumnMarker, idempotentClause, array.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, "cc", m.BigQueryTypeCasting),
 		// Insert
 		constants.DeleteColumnMarker, strings.Join(m.Columns, ","),
 		array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -2,12 +2,13 @@ package dml
 
 import (
 	"fmt"
-	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/typing"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMergeStatementSoftDelete(t *testing.T) {
@@ -38,14 +39,14 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 
 	for _, idempotentKey := range []string{"", "updated_at"} {
 		mergeSQL, err := MergeStatement(MergeArgument{
-			FqTableName:            fqTable,
-			SubQuery:               subQuery,
-			IdempotentKey:          idempotentKey,
-			PrimaryKeys:            []string{"id"},
-			Columns:                cols,
-			ColumnsToTypes:         _cols,
-			SpecialCastingRequired: false,
-			SoftDelete:             true,
+			FqTableName:         fqTable,
+			SubQuery:            subQuery,
+			IdempotentKey:       idempotentKey,
+			PrimaryKeys:         []string{"id"},
+			Columns:             cols,
+			ColumnsToTypes:      _cols,
+			BigQueryTypeCasting: false,
+			SoftDelete:          true,
 		})
 		assert.NoError(t, err)
 		assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
@@ -83,14 +84,14 @@ func TestMergeStatement(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 	mergeSQL, err := MergeStatement(MergeArgument{
-		FqTableName:            fqTable,
-		SubQuery:               subQuery,
-		IdempotentKey:          "",
-		PrimaryKeys:            []string{"id"},
-		Columns:                cols,
-		ColumnsToTypes:         _cols,
-		SpecialCastingRequired: false,
-		SoftDelete:             false,
+		FqTableName:         fqTable,
+		SubQuery:            subQuery,
+		IdempotentKey:       "",
+		PrimaryKeys:         []string{"id"},
+		Columns:             cols,
+		ColumnsToTypes:      _cols,
+		BigQueryTypeCasting: false,
+		SoftDelete:          false,
 	})
 	assert.NoError(t, err)
 	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
@@ -123,14 +124,14 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 	})
 
 	mergeSQL, err := MergeStatement(MergeArgument{
-		FqTableName:            fqTable,
-		SubQuery:               subQuery,
-		IdempotentKey:          "updated_at",
-		PrimaryKeys:            []string{"id"},
-		Columns:                cols,
-		ColumnsToTypes:         _cols,
-		SpecialCastingRequired: false,
-		SoftDelete:             false,
+		FqTableName:         fqTable,
+		SubQuery:            subQuery,
+		IdempotentKey:       "updated_at",
+		PrimaryKeys:         []string{"id"},
+		Columns:             cols,
+		ColumnsToTypes:      _cols,
+		BigQueryTypeCasting: false,
+		SoftDelete:          false,
 	})
 	assert.NoError(t, err)
 	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
@@ -168,14 +169,14 @@ func TestMergeStatementCompositeKey(t *testing.T) {
 	})
 
 	mergeSQL, err := MergeStatement(MergeArgument{
-		FqTableName:            fqTable,
-		SubQuery:               subQuery,
-		IdempotentKey:          "updated_at",
-		PrimaryKeys:            []string{"id", "another_id"},
-		Columns:                cols,
-		ColumnsToTypes:         _cols,
-		SpecialCastingRequired: false,
-		SoftDelete:             false,
+		FqTableName:         fqTable,
+		SubQuery:            subQuery,
+		IdempotentKey:       "updated_at",
+		PrimaryKeys:         []string{"id", "another_id"},
+		Columns:             cols,
+		ColumnsToTypes:      _cols,
+		BigQueryTypeCasting: false,
+		SoftDelete:          false,
 	})
 	assert.NoError(t, err)
 	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)

--- a/lib/typing/bigquery.go
+++ b/lib/typing/bigquery.go
@@ -1,9 +1,15 @@
 package typing
 
 import (
-	"github.com/artie-labs/transfer/lib/typing/ext"
+	"fmt"
 	"strings"
+
+	"github.com/artie-labs/transfer/lib/typing/ext"
 )
+
+func BigQueryJSON(json interface{}) string {
+	return fmt.Sprintf(`JSON '%v'`, json)
+}
 
 func BigQueryTypeToKind(bqType string) KindDetails {
 	bqType = strings.ToLower(bqType)

--- a/lib/typing/bigquery_test.go
+++ b/lib/typing/bigquery_test.go
@@ -2,10 +2,16 @@ package typing
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
+
+func TestBigQueryJSON(t *testing.T) {
+	jsonString := `{"foo": "bar"}`
+	assert.Equal(t, `JSON '{"foo": "bar"}'`, BigQueryJSON(jsonString))
+}
 
 func TestBigQueryTypeToKind(t *testing.T) {
 	bqColToExpectedKind := map[string]KindDetails{


### PR DESCRIPTION
Postgres JSON and JSONB are TOASTable column.

However, it will currently fail on 2 things.
1) It will try to cast `__debezium_unavailable_value` to JSON.
2) Try to compare a JSON / VARIANT column against a STRING.

This PR will correctly cast both.

JSON version of unavailable value
```json
{"key": "__debezium_unavailable_value"}
```
