### PR TITLE
BigQuery - Better handle on Arrays

### DIFF
--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -44,7 +44,7 @@ func CastColVal(colVal interface{}, colKind typing.Column) (string, error) {
 				}
 			}
 		case typing.Array.Kind:
-			colVal = array.ToArrayString(colVal)
+			colVal = array.InterfaceToArrayStringEscaped(colVal)
 		}
 	} else {
 		if colKind.KindDetails == typing.String {

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -1,0 +1,66 @@
+package bigquery
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/stringutil"
+	"github.com/artie-labs/transfer/lib/typing/ext"
+
+	"github.com/artie-labs/transfer/lib/typing"
+)
+
+func CastColVal(colVal interface{}, colKind typing.Column) (string, error) {
+	if colVal != nil {
+		switch colKind.KindDetails.Kind {
+		case typing.ETime.Kind:
+			extTime, err := ext.ParseFromInterface(colVal)
+			if err != nil {
+				return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
+			}
+
+			switch extTime.NestedKind.Type {
+			case ext.DateTimeKindType:
+				colVal = fmt.Sprintf("PARSE_DATETIME('%s', '%v')", RFC3339Format, extTime.String(time.RFC3339Nano))
+			case ext.DateKindType:
+				colVal = fmt.Sprintf("PARSE_DATE('%s', '%v')", PostgresDateFormat, extTime.String(ext.Date.Format))
+			case ext.TimeKindType:
+				colVal = fmt.Sprintf("PARSE_TIME('%s', '%v')", PostgresTimeFormatNoTZ, extTime.String(ext.PostgresTimeFormatNoTZ))
+			}
+		// All the other types do not need string wrapping.
+		case typing.String.Kind, typing.Struct.Kind:
+			colVal = stringutil.Wrap(colVal)
+			colVal = stringutil.LineBreaksToCarriageReturns(fmt.Sprint(colVal))
+			if colKind.KindDetails == typing.Struct {
+				if strings.Contains(fmt.Sprint(colVal), constants.ToastUnavailableValuePlaceholder) {
+					colVal = typing.BigQueryJSON(fmt.Sprintf(`{"key": "%s"}`, constants.ToastUnavailableValuePlaceholder))
+				} else {
+					// This is how you cast string -> JSON
+					colVal = fmt.Sprintf("JSON %s", colVal)
+				}
+			}
+		case typing.Array.Kind:
+			// We need to marshall, so we can escape the strings.
+			// https://go.dev/play/p/BcCwUSCeTmT
+			colValBytes, err := json.Marshal(colVal)
+			if err != nil {
+				return "", err
+			}
+
+			colVal = stringutil.Wrap(string(colValBytes))
+		}
+	} else {
+		if colKind.KindDetails == typing.String {
+			// BigQuery does not like null as a string for CTEs.
+			// It throws this error: Value of type INT64 cannot be assigned to column name, which has type STRING
+			colVal = "''"
+		} else {
+			colVal = "null"
+		}
+	}
+
+	return fmt.Sprint(colVal), nil
+}

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -44,7 +44,11 @@ func CastColVal(colVal interface{}, colKind typing.Column) (string, error) {
 				}
 			}
 		case typing.Array.Kind:
-			colVal = array.InterfaceToArrayStringEscaped(colVal)
+			var err error
+			colVal, err = array.InterfaceToArrayStringEscaped(colVal)
+			if err != nil {
+				return "", err
+			}
 		}
 	} else {
 		if colKind.KindDetails == typing.String {

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -50,7 +50,7 @@ func CastColVal(colVal interface{}, colKind typing.Column) (string, error) {
 				return "", err
 			}
 
-			colVal = stringutil.Wrap(string(colValBytes))
+			colVal = string(colValBytes)
 		}
 	} else {
 		if colKind.KindDetails == typing.String {

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -1,10 +1,11 @@
 package bigquery
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/artie-labs/transfer/lib/array"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/stringutil"
@@ -43,14 +44,7 @@ func CastColVal(colVal interface{}, colKind typing.Column) (string, error) {
 				}
 			}
 		case typing.Array.Kind:
-			// We need to marshall, so we can escape the strings.
-			// https://go.dev/play/p/BcCwUSCeTmT
-			colValBytes, err := json.Marshal(colVal)
-			if err != nil {
-				return "", err
-			}
-
-			colVal = string(colValBytes)
+			colVal = array.ToArrayString(colVal)
 		}
 	} else {
 		if colKind.KindDetails == typing.String {

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -41,7 +41,7 @@ func TestCastColVal(t *testing.T) {
 			name:           "array",
 			colVal:         []int{1, 2, 3, 4, 5},
 			colKind:        typing.Column{KindDetails: typing.Array},
-			expectedString: `'[1,2,3,4,5]'`,
+			expectedString: `[1 2 3 4 5]`,
 		},
 	}
 

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -41,7 +41,7 @@ func TestCastColVal(t *testing.T) {
 			name:           "array",
 			colVal:         []int{1, 2, 3, 4, 5},
 			colKind:        typing.Column{KindDetails: typing.Array},
-			expectedString: `[1 2 3 4 5]`,
+			expectedString: `['1','2','3','4','5']`,
 		},
 	}
 

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -1,0 +1,53 @@
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/artie-labs/transfer/lib/typing"
+)
+
+func TestCastColVal(t *testing.T) {
+	type _testCase struct {
+		name    string
+		colVal  interface{}
+		colKind typing.Column
+
+		expectedErr    error
+		expectedString string
+	}
+
+	testCases := []_testCase{
+		{
+			name:           "escaping string",
+			colVal:         "foo",
+			colKind:        typing.Column{KindDetails: typing.String},
+			expectedString: "'foo'",
+		},
+		{
+			name:           "123 as int",
+			colVal:         123,
+			colKind:        typing.Column{KindDetails: typing.Integer},
+			expectedString: "123",
+		},
+		{
+			name:           "struct",
+			colVal:         `{"hello": "world"}`,
+			colKind:        typing.Column{KindDetails: typing.Struct},
+			expectedString: `JSON '{"hello": "world"}'`,
+		},
+		{
+			name:           "array",
+			colVal:         []int{1, 2, 3, 4, 5},
+			colKind:        typing.Column{KindDetails: typing.Array},
+			expectedString: `'[1,2,3,4,5]'`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualString, actualErr := CastColVal(testCase.colVal, testCase.colKind)
+		assert.Equal(t, testCase.expectedErr, actualErr, testCase.name)
+		assert.Equal(t, testCase.expectedString, actualString, testCase.name)
+	}
+}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -141,7 +141,6 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	log.WithField("query", query).Debug("executing...")
-	fmt.Println(query)
 	_, err = s.Exec(query)
 	return err
 }

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -141,6 +141,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	log.WithField("query", query).Debug("executing...")
+	fmt.Println(query)
 	_, err = s.Exec(query)
 	return err
 }

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -28,9 +28,7 @@ func StringsJoinAddPrefix(args StringsJoinAddPrefixArgs) string {
 
 // ColumnsUpdateQuery will take a list of columns + tablePrefix and return
 // columnA = tablePrefix.columnA, columnB = tablePrefix.columnB. This is the Update syntax that Snowflake requires
-func ColumnsUpdateQuery(columns []string, columnsToTypes typing.Columns, tablePrefix string, bigQueryTypeCasting bool) string {
-	// TODO - deprecate tablePrefix as an arg (it's redundant).
-
+func ColumnsUpdateQuery(columns []string, columnsToTypes typing.Columns, bigQueryTypeCasting bool) string {
 	// NOTE: columns and sflkCols must be the same.
 	var _columns []string
 	for _, column := range columns {
@@ -39,26 +37,32 @@ func ColumnsUpdateQuery(columns []string, columnsToTypes typing.Columns, tablePr
 			if columnType.KindDetails == typing.Struct {
 				if bigQueryTypeCasting {
 					_columns = append(_columns,
-						fmt.Sprintf("%s= CASE WHEN TO_JSON_STRING(%s.%s) != %s THEN %s.%s ELSE c.%s END",
-							column, tablePrefix, column,
-							fmt.Sprintf(`'{"key": "%s"}'`, constants.ToastUnavailableValuePlaceholder),
-							tablePrefix, column, column))
+						fmt.Sprintf(`%s= CASE WHEN TO_JSON_STRING(cc.%s) != '{"key": "%s"}' THEN cc.%s ELSE c.%s END`,
+							// col CASE when TO_JSON_STRING(cc.col) != { 'key': TOAST_UNAVAILABLE_VALUE }
+							column, column, constants.ToastUnavailableValuePlaceholder,
+							// cc.col ELSE c.col END
+							column, column))
 				} else {
 					_columns = append(_columns,
-						fmt.Sprintf("%s= CASE WHEN %s.%s != {'key': '%s'} THEN %s.%s ELSE c.%s END",
-							column, tablePrefix, column,
-							constants.ToastUnavailableValuePlaceholder, tablePrefix, column, column))
+						fmt.Sprintf("%s= CASE WHEN cc.%s != {'key': '%s'} THEN %s.%s ELSE c.%s END",
+							// col CASE WHEN cc.col
+							column, column,
+							// { 'key': TOAST_UNAVAILABLE_VALUE } THEN cc.col ELSE c.col END",
+							constants.ToastUnavailableValuePlaceholder, column, column))
 				}
 			} else {
 				// t.column3 = CASE WHEN t.column3 != '__debezium_unavailable_value' THEN t.column3 ELSE s.column3 END
 				_columns = append(_columns,
-					fmt.Sprintf("%s= CASE WHEN %s.%s != '%s' THEN %s.%s ELSE c.%s END", column, tablePrefix, column,
-						constants.ToastUnavailableValuePlaceholder, tablePrefix, column, column))
+					fmt.Sprintf("%s= CASE WHEN cc.%s != '%s' THEN cc.%s ELSE c.%s END",
+						// col = CASE WHEN cc.col != TOAST_UNAVAILABLE_VALUE
+						column, column, constants.ToastUnavailableValuePlaceholder,
+						// THEN cc.col ELSE c.col END
+						column, column))
 			}
 
 		} else {
-			// This is to make it look like: objCol = cc.objCol::variant
-			_columns = append(_columns, fmt.Sprintf("%s=%s.%s", column, tablePrefix, column))
+			// This is to make it look like: objCol = cc.objCol
+			_columns = append(_columns, fmt.Sprintf("%s=cc.%s", column, column))
 		}
 
 	}

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -2,11 +2,30 @@ package array
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/typing"
 )
+
+func ToArrayString(val interface{}) []string {
+	var vals []string
+	if val == nil {
+		return vals
+	}
+
+	list := reflect.ValueOf(val)
+	if list.Kind() != reflect.Slice {
+		return vals
+	}
+
+	for i := 0; i < list.Len(); i++ {
+		vals = append(vals, fmt.Sprint(list.Index(i).Interface()))
+	}
+
+	return vals
+}
 
 type StringsJoinAddPrefixArgs struct {
 	Vals      []string

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -2,6 +2,7 @@ package array
 
 import (
 	"fmt"
+	"github.com/artie-labs/transfer/lib/stringutil"
 	"reflect"
 	"strings"
 
@@ -9,22 +10,22 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func ToArrayString(val interface{}) []string {
-	var vals []string
+func InterfaceToArrayStringEscaped(val interface{}) string {
 	if val == nil {
-		return vals
+		return ""
 	}
 
 	list := reflect.ValueOf(val)
 	if list.Kind() != reflect.Slice {
-		return vals
+		return ""
 	}
 
+	var vals []string
 	for i := 0; i < list.Len(); i++ {
-		vals = append(vals, fmt.Sprint(list.Index(i).Interface()))
+		vals = append(vals, stringutil.Wrap(list.Index(i).Interface()))
 	}
 
-	return vals
+	return fmt.Sprintf("[%s]", strings.Join(vals, ","))
 }
 
 type StringsJoinAddPrefixArgs struct {

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -10,6 +10,41 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestToArrayString(t *testing.T) {
+	type _testCase struct {
+		name string
+		val  interface{}
+
+		expectedList []string
+	}
+
+	testCases := []_testCase{
+		{
+			name: "nil",
+		},
+		{
+			name:         "list of numbers",
+			val:          []int{1, 2, 3, 4, 5},
+			expectedList: []string{"1", "2", "3", "4", "5"},
+		},
+		{
+			name:         "list of strings",
+			val:          []string{"abc", "def", "ghi"},
+			expectedList: []string{"abc", "def", "ghi"},
+		},
+		{
+			name:         "list of bools",
+			val:          []bool{true, false, true},
+			expectedList: []string{"true", "false", "true"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.expectedList, ToArrayString(testCase.val), testCase.name)
+	}
+
+}
+
 func TestColumnsUpdateQuery(t *testing.T) {
 	type testCase struct {
 		name           string

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -15,7 +15,7 @@ func TestToArrayString(t *testing.T) {
 		name string
 		val  interface{}
 
-		expectedList []string
+		expectedList string
 	}
 
 	testCases := []_testCase{
@@ -25,22 +25,22 @@ func TestToArrayString(t *testing.T) {
 		{
 			name:         "list of numbers",
 			val:          []int{1, 2, 3, 4, 5},
-			expectedList: []string{"1", "2", "3", "4", "5"},
+			expectedList: "['1','2','3','4','5']",
 		},
 		{
 			name:         "list of strings",
 			val:          []string{"abc", "def", "ghi"},
-			expectedList: []string{"abc", "def", "ghi"},
+			expectedList: "['abc','def','ghi']",
 		},
 		{
 			name:         "list of bools",
 			val:          []bool{true, false, true},
-			expectedList: []string{"true", "false", "true"},
+			expectedList: "['true','false','true']",
 		},
 	}
 
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.expectedList, ToArrayString(testCase.val), testCase.name)
+		assert.Equal(t, testCase.expectedList, InterfaceToArrayStringEscaped(testCase.val), testCase.name)
 	}
 
 }

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -15,7 +15,6 @@ func TestColumnsUpdateQuery(t *testing.T) {
 		name           string
 		columns        []string
 		columnsToTypes typing.Columns
-		tablePrefix    string
 		expectedString string
 		bigQuery       bool
 	}
@@ -72,35 +71,31 @@ func TestColumnsUpdateQuery(t *testing.T) {
 			name:           "happy path",
 			columns:        fooBarCols,
 			columnsToTypes: happyPathCols,
-			tablePrefix:    "cc",
 			expectedString: "foo=cc.foo,bar=cc.bar",
 		},
 		{
 			name:           "string and toast",
 			columns:        fooBarCols,
 			columnsToTypes: stringAndToastCols,
-			tablePrefix:    "cc",
 			expectedString: "foo= CASE WHEN cc.foo != '__debezium_unavailable_value' THEN cc.foo ELSE c.foo END,bar=cc.bar",
 		},
 		{
 			name:           "struct, string and toast string",
 			columns:        lastCaseCols,
 			columnsToTypes: lastCaseColTypes,
-			tablePrefix:    "cc",
 			expectedString: "a1= CASE WHEN cc.a1 != {'key': '__debezium_unavailable_value'} THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3",
 		},
 		{
 			name:           "struct, string and toast string (bigquery)",
 			columns:        lastCaseCols,
 			columnsToTypes: lastCaseColTypes,
-			tablePrefix:    "cc",
 			bigQuery:       true,
 			expectedString: `a1= CASE WHEN TO_JSON_STRING(cc.a1) != '{"key": "__debezium_unavailable_value"}' THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3`,
 		},
 	}
 
 	for _, _testCase := range testCases {
-		actualQuery := ColumnsUpdateQuery(_testCase.columns, _testCase.columnsToTypes, _testCase.tablePrefix, _testCase.bigQuery)
+		actualQuery := ColumnsUpdateQuery(_testCase.columns, _testCase.columnsToTypes, _testCase.bigQuery)
 		assert.Equal(t, _testCase.expectedString, actualQuery, _testCase.name)
 	}
 

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -16,11 +16,18 @@ func TestToArrayString(t *testing.T) {
 		val  interface{}
 
 		expectedList string
+		expectedErr  error
 	}
 
 	testCases := []_testCase{
 		{
 			name: "nil",
+		},
+		{
+			name:         "wrong data type",
+			val:          true,
+			expectedList: "",
+			expectedErr:  fmt.Errorf("wrong data type"),
 		},
 		{
 			name:         "list of numbers",
@@ -37,10 +44,36 @@ func TestToArrayString(t *testing.T) {
 			val:          []bool{true, false, true},
 			expectedList: "['true','false','true']",
 		},
+		{
+			name: "array of nested objects",
+			val: []map[string]interface{}{
+				{
+					"foo": "bar",
+				},
+				{
+					"hello": "world",
+				},
+			},
+			expectedList: `['{"foo":"bar"}','{"hello":"world"}']`,
+		},
+		{
+			name: "array of nested lists",
+			val: [][]string{
+				{
+					"foo", "bar",
+				},
+				{
+					"abc", "def",
+				},
+			},
+			expectedList: `['[foo bar]','[abc def]']`,
+		},
 	}
 
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.expectedList, InterfaceToArrayStringEscaped(testCase.val), testCase.name)
+		actualString, actualErr := InterfaceToArrayStringEscaped(testCase.val)
+		assert.Equal(t, testCase.expectedList, actualString, testCase.name)
+		assert.Equal(t, testCase.expectedErr, actualErr, testCase.name)
 	}
 
 }

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -16,7 +16,7 @@ type AlterTableArgs struct {
 	Tc          *types.DwhTableConfig
 	FqTableName string
 	CreateTable bool
-	ColumnOp constants.ColumnOperation
+	ColumnOp    constants.ColumnOperation
 
 	CdcTime time.Time
 }

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -69,7 +69,7 @@ func MergeStatement(m MergeArgument) (string, error) {
 					);
 		`, m.FqTableName, m.SubQuery, strings.Join(equalitySQLParts, " and "),
 			// Update + Soft Deletion
-			idempotentClause, array.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, "cc", m.BigQueryTypeCasting),
+			idempotentClause, array.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, m.BigQueryTypeCasting),
 			// Insert
 			constants.DeleteColumnMarker, strings.Join(m.Columns, ","),
 			array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
@@ -110,7 +110,7 @@ func MergeStatement(m MergeArgument) (string, error) {
 		// Delete
 		constants.DeleteColumnMarker,
 		// Update
-		constants.DeleteColumnMarker, idempotentClause, array.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, "cc", m.BigQueryTypeCasting),
+		constants.DeleteColumnMarker, idempotentClause, array.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, m.BigQueryTypeCasting),
 		// Insert
 		constants.DeleteColumnMarker, strings.Join(m.Columns, ","),
 		array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{


### PR DESCRIPTION
In this PR, we are making 3 improvements.

1) Removing `tablePrefix` as a clean up task
2) Modularizing BigQuery MERGE
3) Fixing the way we insert arrays, arrays of nested objects, arrays of nested arrays, etc.
