### PR TITLE
Don't use Snowflake temporary tables

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -166,6 +166,6 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		return err
 	}
 
-	ddl.DropTemporaryTable(ctx, s, tempAlterTableArgs.FqTableName)
+	_ = ddl.DropTemporaryTable(ctx, s, tempAlterTableArgs.FqTableName, false)
 	return nil
 }

--- a/clients/snowflake/cleanup.go
+++ b/clients/snowflake/cleanup.go
@@ -19,7 +19,7 @@ func shouldDelete(comment string) (shouldDelete bool) {
 	// expires:2023-05-26 05:57:48 UTC
 	if strings.HasPrefix(comment, constants.SnowflakeExpireCommentPrefix) {
 		trimmedComment := strings.TrimPrefix(comment, constants.SnowflakeExpireCommentPrefix)
-		ts, err := typing.FromBigQueryDateString(trimmedComment)
+		ts, err := typing.FromExpiresDateStringToTime(trimmedComment)
 		if err != nil {
 			return false
 		}

--- a/clients/snowflake/cleanup.go
+++ b/clients/snowflake/cleanup.go
@@ -1,0 +1,79 @@
+package snowflake
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/artie-labs/transfer/lib/config"
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/dwh/ddl"
+	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/logger"
+	"github.com/artie-labs/transfer/lib/typing"
+)
+
+func shouldDelete(comment string) (shouldDelete bool) {
+	// expires:2023-05-26 05:57:48 UTC
+	if strings.HasPrefix(comment, constants.SnowflakeExpireCommentPrefix) {
+		trimmedComment := strings.TrimPrefix(comment, constants.SnowflakeExpireCommentPrefix)
+		ts, err := typing.FromBigQueryDateString(trimmedComment)
+		if err != nil {
+			return false
+		}
+
+		// We should delete it if the time right now is AFTER the ts in the comment.
+		return time.Now().After(ts)
+	}
+
+	return false
+}
+
+func (s *Store) CleanUp(ctx context.Context) error {
+	logger.FromContext(ctx).Info("looking to see if there are any dangling artie temporary tables to delete...")
+
+	// Find all the database and schema pairings
+	// Then iterate over information schema
+	// Find anything that has __artie__ in the table name
+	// Find the comment
+	// If the table should be killed, it will drop it.
+	tcs, err := config.FromContext(ctx).Config.TopicConfigs()
+	if err != nil {
+		return err
+	}
+
+	dbAndSchemaPairs := kafkalib.GetUniqueDatabaseAndSchema(tcs)
+	for _, dbAndSchemaPair := range dbAndSchemaPairs {
+		_, err = s.Store.Exec(fmt.Sprintf("USE DATABASE %s", dbAndSchemaPair.Database))
+		if err != nil {
+			return err
+		}
+		_, err = s.Store.Exec(fmt.Sprintf("USE SCHEMA %s", dbAndSchemaPair.Schema))
+		if err != nil {
+			return err
+		}
+
+		// ILIKE is used to be case-insensitive since Snowflake stores all the tables in UPPER.
+		var rows *sql.Rows
+		rows, err = s.Store.Query(fmt.Sprintf(`SELECT table_name, comment FROM information_schema.tables where table_name ILIKE '%s'`, "%"+constants.ArtiePrefix+"%"))
+		if err != nil {
+			return err
+		}
+
+		for rows.Next() {
+			var tableName, comment string
+			err = rows.Scan(&tableName, &comment)
+			if err != nil {
+				return err
+			}
+
+			if shouldDelete(comment) {
+				ddl.DropTemporaryTable(ctx, s, fmt.Sprintf("%s.%s.%s", dbAndSchemaPair.Database, dbAndSchemaPair.Schema, tableName))
+			}
+		}
+	}
+
+	return nil
+}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -193,6 +193,6 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		return err
 	}
 
-	ddl.DropTemporaryTable(ctx, s, temporaryTableName)
+	_ = ddl.DropTemporaryTable(ctx, s, temporaryTableName, false)
 	return err
 }

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/artie-labs/transfer/lib/dwh/types"
 
@@ -52,8 +53,10 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 
 	// First call is to create the temp table
 	createQuery, _ := s.fakeStageStore.ExecArgsForCall(0)
-	assert.Equal(s.T(), fmt.Sprintf(`CREATE TEMP TABLE IF NOT EXISTS %s (user_id string,first_name string,last_name string) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"')`, tempTableName), createQuery)
 
+	prefixQuery := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (user_id string,first_name string,last_name string) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"')`, tempTableName)
+	containsPrefix := strings.HasPrefix(createQuery, prefixQuery)
+	assert.True(s.T(), containsPrefix, fmt.Sprintf("createQuery:%v, prefixQuery:%s", createQuery, prefixQuery))
 	resourceName := addPrefixToTableName(tempTableName, "%")
 	// Second call is a PUT
 	putQuery, _ := s.fakeStageStore.ExecArgsForCall(1)

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -54,7 +54,8 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 	// First call is to create the temp table
 	createQuery, _ := s.fakeStageStore.ExecArgsForCall(0)
 
-	prefixQuery := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (user_id string,first_name string,last_name string) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"')`, tempTableName)
+	prefixQuery := fmt.Sprintf(
+		`CREATE TABLE IF NOT EXISTS %s (user_id string,first_name string,last_name string) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"') COMMENT=`, tempTableName)
 	containsPrefix := strings.HasPrefix(createQuery, prefixQuery)
 	assert.True(s.T(), containsPrefix, fmt.Sprintf("createQuery:%v, prefixQuery:%s", createQuery, prefixQuery))
 	resourceName := addPrefixToTableName(tempTableName, "%")

--- a/clients/snowflake/sweep.go
+++ b/clients/snowflake/sweep.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/dwh/ddl"
+
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/dwh/ddl"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -31,9 +32,8 @@ func shouldDelete(comment string) (shouldDelete bool) {
 	return false
 }
 
-func (s *Store) CleanUp(ctx context.Context) error {
+func (s *Store) Sweep(ctx context.Context) error {
 	logger.FromContext(ctx).Info("looking to see if there are any dangling artie temporary tables to delete...")
-
 	// Find all the database and schema pairings
 	// Then iterate over information schema
 	// Find anything that has __artie__ in the table name
@@ -46,18 +46,12 @@ func (s *Store) CleanUp(ctx context.Context) error {
 
 	dbAndSchemaPairs := kafkalib.GetUniqueDatabaseAndSchema(tcs)
 	for _, dbAndSchemaPair := range dbAndSchemaPairs {
-		_, err = s.Store.Exec(fmt.Sprintf("USE DATABASE %s", dbAndSchemaPair.Database))
-		if err != nil {
-			return err
-		}
-		_, err = s.Store.Exec(fmt.Sprintf("USE SCHEMA %s", dbAndSchemaPair.Schema))
-		if err != nil {
-			return err
-		}
-
 		// ILIKE is used to be case-insensitive since Snowflake stores all the tables in UPPER.
 		var rows *sql.Rows
-		rows, err = s.Store.Query(fmt.Sprintf(`SELECT table_name, comment FROM information_schema.tables where table_name ILIKE '%s'`, "%"+constants.ArtiePrefix+"%"))
+		rows, err = s.Store.Query(fmt.Sprintf(
+			`SELECT table_name, comment FROM %s.information_schema.tables where table_name ILIKE '%s' AND table_schema = UPPER('%s')`,
+			dbAndSchemaPair.Database,
+			"%"+constants.ArtiePrefix+"%", dbAndSchemaPair.Schema))
 		if err != nil {
 			return err
 		}
@@ -70,7 +64,11 @@ func (s *Store) CleanUp(ctx context.Context) error {
 			}
 
 			if shouldDelete(comment) {
-				ddl.DropTemporaryTable(ctx, s, fmt.Sprintf("%s.%s.%s", dbAndSchemaPair.Database, dbAndSchemaPair.Schema, tableName))
+				err = ddl.DropTemporaryTable(ctx, s,
+					fmt.Sprintf("%s.%s.%s", dbAndSchemaPair.Database, dbAndSchemaPair.Schema, tableName), true)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/clients/snowflake/sweep.go
+++ b/clients/snowflake/sweep.go
@@ -33,6 +33,10 @@ func shouldDelete(comment string) (shouldDelete bool) {
 }
 
 func (s *Store) Sweep(ctx context.Context) error {
+	if !s.useStaging {
+		return nil
+	}
+
 	logger.FromContext(ctx).Info("looking to see if there are any dangling artie temporary tables to delete...")
 	// Find all the database and schema pairings
 	// Then iterate over information schema
@@ -56,7 +60,7 @@ func (s *Store) Sweep(ctx context.Context) error {
 			return err
 		}
 
-		for rows.Next() {
+		for rows != nil && rows.Next() {
 			var tableName, comment string
 			err = rows.Scan(&tableName, &comment)
 			if err != nil {

--- a/clients/snowflake/sweep_test.go
+++ b/clients/snowflake/sweep_test.go
@@ -1,0 +1,107 @@
+package snowflake
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/artie-labs/transfer/lib/config"
+	"github.com/artie-labs/transfer/lib/kafkalib"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/stretchr/testify/assert"
+)
+
+func (s *SnowflakeTestSuite) TestShouldDelete() {
+	type _testCase struct {
+		name         string
+		comment      string
+		expectDelete bool
+	}
+	now := time.Now()
+	oneHourAgo := now.Add(-1 * time.Hour)
+	oneHourFromNow := now.Add(1 * time.Hour)
+	testCases := []_testCase{
+		{
+			name:         "random",
+			comment:      "random",
+			expectDelete: false,
+		},
+		{
+			name:         "one hour from now, but no expires: prefix",
+			comment:      typing.ExpiresDate(oneHourFromNow),
+			expectDelete: false,
+		},
+		{
+			name:         "one hour ago, but no expires: prefix",
+			comment:      typing.ExpiresDate(oneHourAgo),
+			expectDelete: false,
+		},
+		{
+			name:         "one hour ago, with prefix, but extra space",
+			comment:      fmt.Sprintf("%s %s", constants.SnowflakeExpireCommentPrefix, typing.ExpiresDate(oneHourAgo)),
+			expectDelete: false,
+		},
+		{
+			name:         "one hour from now, with prefix, but extra space",
+			comment:      fmt.Sprintf("%s %s", constants.SnowflakeExpireCommentPrefix, typing.ExpiresDate(oneHourFromNow)),
+			expectDelete: false,
+		},
+		{
+			name:         "one hour ago (expired)",
+			comment:      fmt.Sprintf("%s%s", constants.SnowflakeExpireCommentPrefix, typing.ExpiresDate(oneHourAgo)),
+			expectDelete: true,
+		},
+		{
+			name:         "one hour from now (not yet expired)",
+			comment:      fmt.Sprintf("%s%s", constants.SnowflakeExpireCommentPrefix, typing.ExpiresDate(oneHourFromNow)),
+			expectDelete: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualShouldDelete := shouldDelete(testCase.comment)
+		assert.Equal(s.T(), testCase.expectDelete, actualShouldDelete, testCase.name)
+	}
+}
+
+func (s *SnowflakeTestSuite) TestSweep() {
+	// This is a no-op, since store isn't a store w/ stages.
+	assert.NoError(s.T(), s.store.Sweep(s.ctx))
+
+	s.ctx = config.InjectSettingsIntoContext(s.ctx, &config.Settings{
+		Config: &config.Config{
+			Queue:                constants.Kafka,
+			Output:               constants.SnowflakeStages,
+			BufferRows:           5,
+			FlushSizeKb:          50,
+			FlushIntervalSeconds: 50,
+			Kafka: &config.Kafka{
+				GroupID:         "artie",
+				BootstrapServer: "localhost:9092",
+				TopicConfigs: []*kafkalib.TopicConfig{
+					{
+
+						Database:  "db",
+						Schema:    "schema",
+						TableName: "table1",
+						Topic:     "topic1",
+						CDCFormat: constants.DBZPostgresFormat,
+					},
+					{
+						Database:  "db",
+						Schema:    "schema",
+						TableName: "table2",
+						Topic:     "topic2",
+						CDCFormat: constants.DBZPostgresFormat,
+					},
+				},
+			},
+		},
+	})
+
+	assert.NoError(s.T(), s.stageStore.Sweep(s.ctx))
+	fmt.Println(s.fakeStageStore.QueryCallCount())
+	query, _ := s.fakeStageStore.QueryArgsForCall(0)
+	assert.Equal(s.T(), `SELECT table_name, comment FROM db.information_schema.tables where table_name ILIKE '%__artie%' AND table_schema = UPPER('schema')`, query)
+}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -75,6 +75,21 @@ func (k *Kafka) String() string {
 		k.BootstrapServer, k.GroupID, k.Username != "", k.Password != "")
 }
 
+func (c *Config) TopicConfigs() ([]*kafkalib.TopicConfig, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+
+	switch c.Queue {
+	case constants.Kafka:
+		return c.Kafka.TopicConfigs, nil
+	case constants.PubSub:
+		return c.Pubsub.TopicConfigs, nil
+	}
+
+	return nil, fmt.Errorf("unsupported queue: %v", c.Queue)
+}
+
 type Config struct {
 	Output constants.DestinationKind `yaml:"outputSource"`
 	Queue  constants.QueueKind       `yaml:"queue"`

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -5,9 +5,10 @@ import "time"
 const (
 	ToastUnavailableValuePlaceholder = "__debezium_unavailable_value"
 
-	ArtiePrefix               = "__artie"
-	DeleteColumnMarker        = ArtiePrefix + "_delete"
-	DeletionConfidencePadding = 4 * time.Hour
+	SnowflakeExpireCommentPrefix = "expires:"
+	ArtiePrefix                  = "__artie"
+	DeleteColumnMarker           = ArtiePrefix + "_delete"
+	DeletionConfidencePadding    = 4 * time.Hour
 
 	// DBZPostgresFormat is the only supported CDC format right now
 	DBZPostgresFormat    = "debezium.postgres"

--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -22,16 +22,6 @@ func Open(ctx context.Context, driverName, dsn string) Store {
 		}).Fatal("Failed to start a SQL client")
 	}
 
-	if driverName == "snowflake" {
-		// This is required because Golang's SQL driver will spin up additional connections.
-		// However, Snowflake temporary tables only last for the duration of the session.
-		// This means, at scale - we can run into a scenario where one Go-routine has been allocated a new connection
-		// Which does not have visibility into the previously created temporary table.
-		// https://github.com/snowflakedb/gosnowflake/issues/181#issuecomment-411904223
-		db.SetMaxIdleConns(1)
-		db.SetMaxOpenConns(1)
-	}
-
 	err = db.Ping()
 	if err != nil {
 		logger.FromContext(ctx).WithFields(map[string]interface{}{

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -113,7 +113,7 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 				sqlQuery = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (%s) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"') COMMENT='%s'`,
 					args.FqTableName, strings.Join(colSQLParts, ","),
 					// Comment on the table
-					fmt.Sprintf("%s:%s", constants.SnowflakeExpireCommentPrefix, expiryString))
+					fmt.Sprintf("%s%s", constants.SnowflakeExpireCommentPrefix, expiryString))
 			default:
 				return fmt.Errorf("unexpected dwh: %v trying to create a temporary table", args.Dwh.Label())
 			}

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -94,24 +94,26 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 	if args.CreateTable {
 		var sqlQuery string
 		if args.TemporaryTable {
+			expiryString := typing.BigQueryDate(time.Now().UTC().Add(constants.BigQueryTempTableTTL))
 			switch args.Dwh.Label() {
 			case constants.BigQuery:
-				expiry := time.Now().UTC().Add(constants.BigQueryTempTableTTL)
 				sqlQuery = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (%s) OPTIONS (expiration_timestamp = TIMESTAMP("%s"))`,
-					args.FqTableName, strings.Join(colSQLParts, ","), typing.BigQueryDate(expiry))
+					args.FqTableName, strings.Join(colSQLParts, ","), expiryString)
 			// Not enabled for constants.Snowflake yet
 			case constants.SnowflakeStages:
 				// TEMPORARY Table syntax - https://docs.snowflake.com/en/sql-reference/sql/create-table
 				// PURGE syntax - https://docs.snowflake.com/en/sql-reference/sql/copy-into-table#purging-files-after-loading
 				// FIELD_OPTIONALLY_ENCLOSED_BY - is needed because CSV will try to escape any values that have `"`
-				sqlQuery = fmt.Sprintf(`CREATE TEMP TABLE IF NOT EXISTS %s (%s) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"')`,
-					args.FqTableName, strings.Join(colSQLParts, ","))
+				sqlQuery = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (%s) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"') COMMENT='%s'`,
+					args.FqTableName, strings.Join(colSQLParts, ","), fmt.Sprintf("expires:%s", expiryString))
 			default:
 				return fmt.Errorf("unexpected dwh: %v trying to create a temporary table", args.Dwh.Label())
 			}
 		} else {
 			sqlQuery = fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", args.FqTableName, strings.Join(colSQLParts, ","))
 		}
+
+		fmt.Println("sqlQuery", sqlQuery)
 
 		_, err = args.Dwh.Exec(sqlQuery)
 		if ColumnAlreadyExistErr(err, args.Dwh.Label()) {

--- a/lib/dwh/ddl/ddl_temp_test.go
+++ b/lib/dwh/ddl/ddl_temp_test.go
@@ -82,8 +82,9 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 	assert.NoError(d.T(), err)
 	assert.Equal(d.T(), 1, d.fakeSnowflakeStagesStore.ExecCallCount())
 	query, _ := d.fakeSnowflakeStagesStore.ExecArgsForCall(0)
-	assert.Equal(d.T(),
-		`CREATE TEMP TABLE IF NOT EXISTS db.schema.tempTableName (foo string,bar float) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"')`,
+	assert.Contains(d.T(),
+		query,
+		`CREATE TABLE IF NOT EXISTS db.schema.tempTableName (foo string,bar float) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"') COMMENT=`,
 		query)
 
 	// BigQuery

--- a/lib/dwh/ddl/ddl_test.go
+++ b/lib/dwh/ddl/ddl_test.go
@@ -21,8 +21,8 @@ func (d *DDLTestSuite) Test_DropTemporaryTable() {
 	// Should not do anything to Snowflake since it's not supported.
 	for _, table := range doNotDropTables {
 		tableWithSuffix := fmt.Sprintf("%s_%s", table, constants.ArtiePrefix)
-		ddl.DropTemporaryTable(d.ctx, d.snowflakeStore, table)
-		ddl.DropTemporaryTable(d.ctx, d.snowflakeStore, tableWithSuffix)
+		_ = ddl.DropTemporaryTable(d.ctx, d.snowflakeStore, table, false)
+		_ = ddl.DropTemporaryTable(d.ctx, d.snowflakeStore, tableWithSuffix, false)
 		assert.Equal(d.T(), 0, d.fakeSnowflakeStore.ExecCallCount())
 	}
 
@@ -35,14 +35,14 @@ func (d *DDLTestSuite) Test_DropTemporaryTable() {
 		}
 
 		for _, doNotDropTable := range doNotDropTables {
-			ddl.DropTemporaryTable(d.ctx, _dwh, doNotDropTable)
+			_ = ddl.DropTemporaryTable(d.ctx, _dwh, doNotDropTable, false)
 
 			assert.Equal(d.T(), 0, fakeStore.ExecCallCount())
 		}
 
 		for index, table := range doNotDropTables {
 			fullTableName := fmt.Sprintf("%s_%s", table, constants.ArtiePrefix)
-			ddl.DropTemporaryTable(d.ctx, _dwh, fullTableName)
+			_ = ddl.DropTemporaryTable(d.ctx, _dwh, fullTableName, false)
 
 			count := index + 1
 			assert.Equal(d.T(), count, fakeStore.ExecCallCount())

--- a/lib/dwh/utils/load.go
+++ b/lib/dwh/utils/load.go
@@ -32,7 +32,7 @@ func DataWarehouse(ctx context.Context, store *db.Store) dwh.DataWarehouse {
 		return snowflake.LoadSnowflake(ctx, store, false)
 	case constants.SnowflakeStages:
 		s := snowflake.LoadSnowflake(ctx, store, true)
-		if err := s.CleanUp(ctx); err != nil {
+		if err := s.Sweep(ctx); err != nil {
 			logger.FromContext(ctx).WithError(err).Fatalf("failed to clean up snowflake")
 		}
 

--- a/lib/dwh/utils/load.go
+++ b/lib/dwh/utils/load.go
@@ -31,7 +31,12 @@ func DataWarehouse(ctx context.Context, store *db.Store) dwh.DataWarehouse {
 	case constants.Snowflake:
 		return snowflake.LoadSnowflake(ctx, store, false)
 	case constants.SnowflakeStages:
-		return snowflake.LoadSnowflake(ctx, store, true)
+		s := snowflake.LoadSnowflake(ctx, store, true)
+		if err := s.CleanUp(ctx); err != nil {
+			logger.FromContext(ctx).WithError(err).Fatalf("failed to clean up snowflake")
+		}
+
+		return s
 	case constants.BigQuery:
 		return bigquery.LoadBigQuery(ctx, store)
 	}

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -7,6 +7,30 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 )
 
+type DatabaseSchemaPair struct {
+	Database string
+	Schema   string
+}
+
+// GetUniqueDatabaseAndSchema - does not guarantee ordering.
+func GetUniqueDatabaseAndSchema(tcs []*TopicConfig) []DatabaseSchemaPair {
+	dbMap := make(map[string]DatabaseSchemaPair)
+	for _, tc := range tcs {
+		key := fmt.Sprintf("%s###%s", tc.Database, tc.Schema)
+		dbMap[key] = DatabaseSchemaPair{
+			Database: tc.Database,
+			Schema:   tc.Schema,
+		}
+	}
+
+	var pairs []DatabaseSchemaPair
+	for _, pair := range dbMap {
+		pairs = append(pairs, pair)
+	}
+
+	return pairs
+}
+
 type TopicConfig struct {
 	Database           string `yaml:"db"`
 	TableName          string `yaml:"tableName"`

--- a/lib/typing/bigquery.go
+++ b/lib/typing/bigquery.go
@@ -85,12 +85,12 @@ func kindToBigQuery(kindDetails KindDetails) string {
 
 const bqLayout = "2006-01-02 15:04:05 MST"
 
-func BigQueryDate(time time.Time) string {
+func ExpiresDate(time time.Time) string {
 	// BigQuery expects the timestamp to look in this format: 2023-01-01 00:00:00 UTC
 	// This is used as part of table options.
 	return time.Format(bqLayout)
 }
 
-func FromBigQueryDateString(tsString string) (time.Time, error) {
+func FromExpiresDateStringToTime(tsString string) (time.Time, error) {
 	return time.Parse(bqLayout, tsString)
 }

--- a/lib/typing/bigquery.go
+++ b/lib/typing/bigquery.go
@@ -83,9 +83,14 @@ func kindToBigQuery(kindDetails KindDetails) string {
 	return kindDetails.Kind
 }
 
+const bqLayout = "2006-01-02 15:04:05 MST"
+
 func BigQueryDate(time time.Time) string {
 	// BigQuery expects the timestamp to look in this format: 2023-01-01 00:00:00 UTC
 	// This is used as part of table options.
-	layout := "2006-01-02 15:04:05 MST"
-	return time.Format(layout)
+	return time.Format(bqLayout)
+}
+
+func FromBigQueryDateString(tsString string) (time.Time, error) {
+	return time.Parse(bqLayout, tsString)
 }

--- a/lib/typing/bigquery_test.go
+++ b/lib/typing/bigquery_test.go
@@ -3,6 +3,7 @@ package typing
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
@@ -57,5 +58,22 @@ func TestBigQueryTypeNoDataLoss(t *testing.T) {
 
 	for _, kindDetail := range kindDetails {
 		assert.Equal(t, kindDetail, BigQueryTypeToKind(kindToBigQuery(kindDetail)))
+	}
+}
+
+func TestExpiresDate(t *testing.T) {
+	// We should be able to go back and forth.
+	// Note: The format does not have ns precision because we don't need it.
+	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		tsString := ExpiresDate(birthday)
+		ts, err := FromExpiresDateStringToTime(tsString)
+		assert.NoError(t, err)
+		assert.Equal(t, birthday, ts)
+	}
+
+	for _, badString := range []string{"foo", "bad_string", " 2022-09-01"} {
+		_, err := FromExpiresDateStringToTime(badString)
+		assert.Error(t, err, badString)
 	}
 }


### PR DESCRIPTION
Snowflake TEMP tables are session based and do not have a TTL setting. 

This creates a concurrency problem since the Snowflake SQL driver (which is based on Go's sql/driver) and leverages connection pooling.

Whenever a new connection is spawned, it may not have reference to the temporary table. This effectively caps our parallelism at 1. 

I have fixed it here: https://github.com/artie-labs/transfer/commit/e2ed85c766038b0cff0be66cfca854a10be576e1 and filed a bug with Snowflake here: https://github.com/snowflakedb/gosnowflake/issues/805.

However, this has been around since inception and is unlikely to get fixed. Also, Snowflake tables do not have a concept of table expiration (unlike [BigQuery](https://cloud.google.com/bigquery/docs/managing-tables#updating_a_tables_expiration_time))

This PR does the following --

1) The "temporary" tables we create will have a COMMENT where the format looks like this - `expires:EXPIRY_TIMESTAMP`
2)  If our process fails to delete the table, whenever it spins up next - it will do the following:
* Look through either Kafka or PubSub for the topicConfigs
* Get a list of unique db/schema pairing
* Look through each db/schema for the `INFORMATION_SCHEMA`
* Find any tables that contain the `__artie__` prefix
* Try to parse the comment
* If `NOW` is after the expiration ts in the comment, we are safe to drop.
* Then we issue `DROP_TEMPORARY_TABLE` which has additional guardrails and is idempotent-safe.


I also considered using tags from this blog post: https://medium.com/snowflake/kill-those-snowflake-tables-3e202d51e557, but it requires the usage of `TAG` which is an enterprise feature.
