### PR TITLE
Snowflake Escape special characters

### DIFF
--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/stringutil"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 
 	"github.com/artie-labs/transfer/lib/typing"
@@ -35,7 +37,8 @@ func CastColValStaging(colVal interface{}, colKind typing.Column) (string, error
 			colValString = extTime.String("")
 		}
 
-	case typing.Struct.Kind:
+	case typing.Struct.Kind, typing.String.Kind:
+		colValString = stringutil.Wrap(colVal, true)
 		if colKind.KindDetails == typing.Struct {
 			if strings.Contains(fmt.Sprint(colVal), constants.ToastUnavailableValuePlaceholder) {
 				colVal = map[string]interface{}{


### PR DESCRIPTION
Sometimes, if a column that has been quoted by the CSV writer (which Snowflake will attempt to escape from) contains a `\` value.

It'll mess with the sequence for Snowflake since we're not escaping it correctly with `\\`.