### PR TITLE
Escaping strings correctly

### DIFF
--- a/lib/stringutil/strings.go
+++ b/lib/stringutil/strings.go
@@ -21,9 +21,11 @@ func Wrap(colVal interface{}, noQuotes bool) string {
 	colVal = strings.ReplaceAll(fmt.Sprint(colVal), `\`, `\\`)
 	// The normal string escape is to do for O'Reilly is O\\'Reilly, but Snowflake escapes via \'
 	if noQuotes {
-		return strings.ReplaceAll(fmt.Sprint(colVal), "'", `\'`)
+		return fmt.Sprint(colVal)
 	}
 
+	// When there is quote wrapping `foo -> 'foo'`, we'll need to escape `'` so the value compiles.
+	// However, if there are no quote wrapping, we should not need to escape.
 	return fmt.Sprintf("'%s'", strings.ReplaceAll(fmt.Sprint(colVal), "'", `\'`))
 }
 

--- a/lib/stringutil/strings_test.go
+++ b/lib/stringutil/strings_test.go
@@ -27,6 +27,12 @@ func TestWrap(t *testing.T) {
 			expectedString: "hello",
 		},
 		{
+			name:           "string (no quotes)",
+			colVal:         "bobby o'reilly",
+			noQuotes:       true,
+			expectedString: "bobby o'reilly",
+		},
+		{
 			name:           "string that requires escaping",
 			colVal:         "bobby o'reilly",
 			expectedString: `'bobby o\'reilly'`,
@@ -34,7 +40,7 @@ func TestWrap(t *testing.T) {
 		{
 			name:           "string that requires escaping (no quotes)",
 			colVal:         "bobby o'reilly",
-			expectedString: `bobby o\'reilly`,
+			expectedString: `bobby o'reilly`,
 			noQuotes:       true,
 		},
 		{


### PR DESCRIPTION
Since `stringutil.Wrap` takes the optionality of a quote, we should be selective about escaping. Previously, regardless of quotes - we were escaping.


Expected results:

| quote | value before | value after |
| ---- | --- | ---- |
| yes | bill o'reilly | `'bill o\'reilly'` |
| no | bill o'reilly | `bill o'reilly` | 


