### PR TITLE
Snowflake to use TIMESTAMP with TIME ZONE instead of TIMESTAMP_NTZ

### DIFF
--- a/lib/typing/snowflake.go
+++ b/lib/typing/snowflake.go
@@ -1,8 +1,9 @@
 package typing
 
 import (
-	"github.com/artie-labs/transfer/lib/typing/ext"
 	"strings"
+
+	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
 type SnowflakeKind string
@@ -82,7 +83,11 @@ func kindToSnowflake(kindDetails KindDetails) string {
 	case ETime.Kind:
 		switch kindDetails.ExtendedTimeDetails.Type {
 		case ext.DateTimeKindType:
-			return "datetime"
+			// We are not using `TIMESTAMP_NTZ` because Snowflake does not join on this data very well.
+			// It ends up trying to parse this data into a TIMESTAMP_TZ and messes with the join order.
+			// Specifically, if my location is in SF, it'll try to parse TIMESTAMP_NTZ into PST then into UTC.
+			// When it was already stored as UTC.
+			return "timestamp with time zone"
 		case ext.DateKindType:
 			return "date"
 		case ext.TimeKindType:

--- a/lib/typing/snowflake.go
+++ b/lib/typing/snowflake.go
@@ -87,7 +87,7 @@ func kindToSnowflake(kindDetails KindDetails) string {
 			// It ends up trying to parse this data into a TIMESTAMP_TZ and messes with the join order.
 			// Specifically, if my location is in SF, it'll try to parse TIMESTAMP_NTZ into PST then into UTC.
 			// When it was already stored as UTC.
-			return "timestamp with time zone"
+			return "timestamp_tz"
 		case ext.DateKindType:
 			return "date"
 		case ext.TimeKindType:


### PR DESCRIPTION
Snowflake's `TIMESTAMP_NTZ` (of which datetime is an alias for) - is buggy when it comes to JOINs and working with other datasets that uses TIME ZONE (where TZ = UTC).

As mentioned in the comments, Snowflake will try to parse this column out into the session's local TZ and then parse it back into UTC which messes with the actual values.