### PR TITLE
[Snowflake] Distinguishing NULL and empty strings

### DIFF
--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -18,7 +18,8 @@ import (
 // This is necessary because CSV writers require values to in `string`.
 func CastColValStaging(colVal interface{}, colKind typing.Column) (string, error) {
 	if colVal == nil {
-		return "", fmt.Errorf("colVal is nil")
+		// \\N needs to match NULL_IF(...) from ddl.go
+		return `\\N`, nil
 	}
 
 	colValString := fmt.Sprint(colVal)

--- a/clients/snowflake/cast_test.go
+++ b/clients/snowflake/cast_test.go
@@ -36,6 +36,24 @@ func evaluateTestCase(t *testing.T, testCase _testCase) {
 func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 	testCases := []_testCase{
 		{
+			name:   "empty string",
+			colVal: "",
+			colKind: typing.Column{
+				KindDetails: typing.String,
+			},
+
+			expectedString: "",
+		},
+		{
+			name:   "null value (string, not that it matters)",
+			colVal: nil,
+			colKind: typing.Column{
+				KindDetails: typing.String,
+			},
+
+			expectedString: `\\N`,
+		},
+		{
 			name:   "string",
 			colVal: "foo",
 			colKind: typing.Column{

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -90,7 +90,7 @@ func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableNa
 
 				row = append(row, castedValue)
 			} else {
-				row = append(row, "")
+				row = append(row, `\\N`)
 			}
 		}
 

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -81,17 +81,13 @@ func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableNa
 		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate() {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal := value[col]
-			if colVal != nil {
-				// Check
-				castedValue, castErr := CastColValStaging(colVal, colKind)
-				if castErr != nil {
-					return "", castErr
-				}
-
-				row = append(row, castedValue)
-			} else {
-				row = append(row, `\\N`)
+			// Check
+			castedValue, castErr := CastColValStaging(colVal, colKind)
+			if castErr != nil {
+				return "", castErr
 			}
+
+			row = append(row, castedValue)
 		}
 
 		if err = writer.Write(row); err != nil {

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -55,7 +55,7 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 	createQuery, _ := s.fakeStageStore.ExecArgsForCall(0)
 
 	prefixQuery := fmt.Sprintf(
-		`CREATE TABLE IF NOT EXISTS %s (user_id string,first_name string,last_name string) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"') COMMENT=`, tempTableName)
+		`CREATE TABLE IF NOT EXISTS %s (user_id string,first_name string,last_name string) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE) COMMENT=`, tempTableName)
 	containsPrefix := strings.HasPrefix(createQuery, prefixQuery)
 	assert.True(s.T(), containsPrefix, fmt.Sprintf("createQuery:%v, prefixQuery:%s", createQuery, prefixQuery))
 	resourceName := addPrefixToTableName(tempTableName, "%")

--- a/clients/snowflake/sweep_test.go
+++ b/clients/snowflake/sweep_test.go
@@ -101,7 +101,6 @@ func (s *SnowflakeTestSuite) TestSweep() {
 	})
 
 	assert.NoError(s.T(), s.stageStore.Sweep(s.ctx))
-	fmt.Println(s.fakeStageStore.QueryCallCount())
 	query, _ := s.fakeStageStore.QueryArgsForCall(0)
 	assert.Equal(s.T(), `SELECT table_name, comment FROM db.information_schema.tables where table_name ILIKE '%__artie%' AND table_schema = UPPER('schema')`, query)
 }

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -110,7 +110,7 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 				// TEMPORARY Table syntax - https://docs.snowflake.com/en/sql-reference/sql/create-table
 				// PURGE syntax - https://docs.snowflake.com/en/sql-reference/sql/copy-into-table#purging-files-after-loading
 				// FIELD_OPTIONALLY_ENCLOSED_BY - is needed because CSV will try to escape any values that have `"`
-				sqlQuery = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (%s) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"') COMMENT='%s'`,
+				sqlQuery = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (%s) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE) COMMENT='%s'`,
 					args.FqTableName, strings.Join(colSQLParts, ","),
 					// Comment on the table
 					fmt.Sprintf("%s%s", constants.SnowflakeExpireCommentPrefix, expiryString))

--- a/lib/dwh/ddl/ddl_temp_test.go
+++ b/lib/dwh/ddl/ddl_temp_test.go
@@ -82,9 +82,10 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 	assert.NoError(d.T(), err)
 	assert.Equal(d.T(), 1, d.fakeSnowflakeStagesStore.ExecCallCount())
 	query, _ := d.fakeSnowflakeStagesStore.ExecArgsForCall(0)
+
 	assert.Contains(d.T(),
 		query,
-		`CREATE TABLE IF NOT EXISTS db.schema.tempTableName (foo string,bar float) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"') COMMENT=`,
+		`CREATE TABLE IF NOT EXISTS db.schema.tempTableName (foo string,bar float) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE) COMMENT=`,
 		query)
 
 	// BigQuery

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -120,7 +120,7 @@ func (e *EventsTestSuite) TestEventSaveOptionalSchema() {
 			"json_object_string":         `{"foo": "bar"}`,
 			"json_object_no_schema":      `{"foo": "bar"}`,
 		},
-		OptiomalSchema: map[string]typing.KindDetails{
+		OptionalSchema: map[string]typing.KindDetails{
 			// Explicitly casting this as a string.
 			"created_at_date_string": typing.String,
 			"json_object_string":     typing.String,


### PR DESCRIPTION
With the Snowflake Stage method, we were not distinguishing the two because Snowflake's default for TSV/CSV uploader has `EMPTY_FIELD_AS_NULL=true`.

[Docs](https://docs.snowflake.com/en/user-guide/data-unload-considerations)
To get explicit empty strings, we needed to modify 2 settings:
* `EMPTY_FIELD_AS_NULL = FALSE`
* Set `NULL_IF = \\N` (which is default, but setting it just in case).

