### PR TITLE
[Enhancement] Make `tableName` optional

### DIFF
--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -12,14 +12,14 @@ import (
 )
 
 func (s *Store) getTableConfig(_ context.Context, tableData *optimization.TableData) (*types.DwhTableConfig, error) {
-	fqName := tableData.ToFqName(constants.BigQuery)
+	fqName := tableData.ToFqName(constants.BigQuery, tableData.Name())
 	tc := s.configMap.TableConfig(fqName)
 	if tc != nil {
 		return tc, nil
 	}
 
 	rows, err := s.Query(fmt.Sprintf("SELECT ddl FROM %s.INFORMATION_SCHEMA.TABLES where table_name = '%s' LIMIT 1;",
-		tableData.Database, tableData.TableName))
+		tableData.Database, tableData.Name()))
 	if err != nil {
 		// The query will not fail if the table doesn't exist. It will simply return 0 rows.
 		// It WILL fail if the dataset doesn't exist or if it encounters any other forms of error.

--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *Store) getTableConfig(_ context.Context, tableData *optimization.TableData) (*types.DwhTableConfig, error) {
-	fqName := tableData.ToFqName(constants.BigQuery, tableData.Name())
+	fqName := tableData.ToFqName(constants.BigQuery)
 	tc := s.configMap.TableConfig(fqName)
 	if tc != nil {
 		return tc, nil

--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -19,7 +19,7 @@ func (s *Store) getTableConfig(_ context.Context, tableData *optimization.TableD
 	}
 
 	rows, err := s.Query(fmt.Sprintf("SELECT ddl FROM %s.INFORMATION_SCHEMA.TABLES where table_name = '%s' LIMIT 1;",
-		tableData.Database, tableData.Name()))
+		tableData.TopicConfig.Database, tableData.Name()))
 	if err != nil {
 		// The query will not fail if the table doesn't exist. It will simply return 0 rows.
 		// It WILL fail if the dataset doesn't exist or if it encounters any other forms of error.
@@ -39,7 +39,7 @@ func (s *Store) getTableConfig(_ context.Context, tableData *optimization.TableD
 	}
 
 	// Table doesn't exist if the information schema query returned nothing.
-	tableConfig, err := parseSchemaQuery(sqlRow, len(sqlRow) == 0, tableData.DropDeletedColumns)
+	tableConfig, err := parseSchemaQuery(sqlRow, len(sqlRow) == 0, tableData.TopicConfig.DropDeletedColumns)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -69,7 +69,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,
 		Tc:          tableConfig,
-		FqTableName: tableData.ToFqName(s.Label(), tableData.Name()),
+		FqTableName: tableData.ToFqName(s.Label()),
 		CreateTable: tableConfig.CreateTable(),
 		ColumnOp:    constants.Add,
 		CdcTime:     tableData.LatestCDCTs,
@@ -88,7 +88,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	deleteAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,
 		Tc:          tableConfig,
-		FqTableName: tableData.ToFqName(s.Label(), tableData.Name()),
+		FqTableName: tableData.ToFqName(s.Label()),
 		CreateTable: false,
 		ColumnOp:    constants.Delete,
 		CdcTime:     tableData.LatestCDCTs,
@@ -121,7 +121,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	tempAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:            s,
 		Tc:             tableConfig,
-		FqTableName:    fmt.Sprintf("%s_%s", tableData.ToFqName(s.Label(), tableData.Name()), tableData.TempTableSuffix()),
+		FqTableName:    fmt.Sprintf("%s_%s", tableData.ToFqName(s.Label()), tableData.TempTableSuffix()),
 		CreateTable:    true,
 		TemporaryTable: true,
 		ColumnOp:       constants.Add,
@@ -146,7 +146,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	mergeQuery, err := dml.MergeStatement(dml.MergeArgument{
-		FqTableName:    tableData.ToFqName(constants.BigQuery, tableData.Name()),
+		FqTableName:    tableData.ToFqName(constants.BigQuery),
 		SubQuery:       tempAlterTableArgs.FqTableName,
 		IdempotentKey:  tableData.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -97,7 +97,7 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 		strings.Join(tableValues, ","), tableData.Name(), strings.Join(colsToUpdate, ","))
 
 	return dml.MergeStatement(dml.MergeArgument{
-		FqTableName:    tableData.ToFqName(constants.Snowflake, tableData.Name()),
+		FqTableName:    tableData.ToFqName(constants.Snowflake),
 		SubQuery:       subQuery,
 		IdempotentKey:  tableData.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -94,10 +94,10 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 	}
 
 	subQuery := fmt.Sprintf("SELECT %s FROM (values %s) as %s(%s)", strings.Join(colsToUpdateEscaped, ","),
-		strings.Join(tableValues, ","), tableData.TopicConfig.TableName, strings.Join(colsToUpdate, ","))
+		strings.Join(tableValues, ","), tableData.Name(), strings.Join(colsToUpdate, ","))
 
 	return dml.MergeStatement(dml.MergeArgument{
-		FqTableName:    tableData.ToFqName(constants.Snowflake),
+		FqTableName:    tableData.ToFqName(constants.Snowflake, tableData.Name()),
 		SubQuery:       subQuery,
 		IdempotentKey:  tableData.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -99,10 +99,10 @@ func getMergeStatement(tableData *optimization.TableData) (string, error) {
 	return dml.MergeStatement(dml.MergeArgument{
 		FqTableName:    tableData.ToFqName(constants.Snowflake),
 		SubQuery:       subQuery,
-		IdempotentKey:  tableData.IdempotentKey,
+		IdempotentKey:  tableData.TopicConfig.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,
 		Columns:        colsToUpdate,
 		ColumnsToTypes: *tableData.ReadOnlyInMemoryCols(),
-		SoftDelete:     tableData.SoftDelete,
+		SoftDelete:     tableData.TopicConfig.SoftDelete,
 	})
 }

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -130,7 +130,7 @@ func (s *SnowflakeTestSuite) TestMergeNoDeleteFlag() {
 		KindDetails: typing.Integer,
 	})
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, kafkalib.TopicConfig{})
+	tableData := optimization.NewTableData(&cols, []string{"id"}, kafkalib.TopicConfig{}, "foo")
 	_, err := getMergeStatement(tableData)
 	assert.Error(s.T(), err, "getMergeStatement failed")
 
@@ -166,7 +166,7 @@ func (s *SnowflakeTestSuite) TestMerge() {
 	}
 
 	primaryKeys := []string{"id"}
-	tableData := optimization.NewTableData(&cols, primaryKeys, topicConfig)
+	tableData := optimization.NewTableData(&cols, primaryKeys, topicConfig, "bar")
 	for pk, row := range rowData {
 		tableData.InsertRow(pk, row)
 	}
@@ -226,7 +226,7 @@ func (s *SnowflakeTestSuite) TestMergeWithSingleQuote() {
 		Schema:    "public",
 	}
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig)
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "abc")
 	for pk, row := range rowData {
 		tableData.InsertRow(pk, row)
 	}
@@ -262,7 +262,7 @@ func (s *SnowflakeTestSuite) TestMergeJson() {
 		Schema:    "public",
 	}
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig)
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "def")
 	for pk, row := range rowData {
 		tableData.InsertRow(pk, row)
 	}
@@ -307,7 +307,7 @@ func (s *SnowflakeTestSuite) TestMergeJSONKey() {
 	}
 
 	primaryKeys := []string{"id"}
-	tableData := optimization.NewTableData(&cols, primaryKeys, topicConfig)
+	tableData := optimization.NewTableData(&cols, primaryKeys, topicConfig, "ghi")
 	for pk, row := range rowData {
 		tableData.InsertRow(pk, row)
 	}

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -130,7 +130,7 @@ func (s *SnowflakeTestSuite) TestMergeNoDeleteFlag() {
 		KindDetails: typing.Integer,
 	})
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, kafkalib.TopicConfig{}, "foo")
+	tableData := optimization.NewTableData(&cols, []string{"id"}, kafkalib.TopicConfig{}, "")
 	_, err := getMergeStatement(tableData)
 	assert.Error(s.T(), err, "getMergeStatement failed")
 
@@ -166,7 +166,7 @@ func (s *SnowflakeTestSuite) TestMerge() {
 	}
 
 	primaryKeys := []string{"id"}
-	tableData := optimization.NewTableData(&cols, primaryKeys, topicConfig, "bar")
+	tableData := optimization.NewTableData(&cols, primaryKeys, topicConfig, "")
 	for pk, row := range rowData {
 		tableData.InsertRow(pk, row)
 	}
@@ -226,7 +226,7 @@ func (s *SnowflakeTestSuite) TestMergeWithSingleQuote() {
 		Schema:    "public",
 	}
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "abc")
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "")
 	for pk, row := range rowData {
 		tableData.InsertRow(pk, row)
 	}
@@ -262,7 +262,7 @@ func (s *SnowflakeTestSuite) TestMergeJson() {
 		Schema:    "public",
 	}
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "def")
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "")
 	for pk, row := range rowData {
 		tableData.InsertRow(pk, row)
 	}
@@ -307,7 +307,7 @@ func (s *SnowflakeTestSuite) TestMergeJSONKey() {
 	}
 
 	primaryKeys := []string{"id"}
-	tableData := optimization.NewTableData(&cols, primaryKeys, topicConfig, "ghi")
+	tableData := optimization.NewTableData(&cols, primaryKeys, topicConfig, "")
 	for pk, row := range rowData {
 		tableData.InsertRow(pk, row)
 	}

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -66,7 +66,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 		return nil
 	}
 
-	fqName := tableData.ToFqName(constants.Snowflake)
+	fqName := tableData.ToFqName(constants.Snowflake, tableData.Name())
 	tableConfig, err := s.getTableConfig(ctx, fqName, tableData.DropDeletedColumns)
 	if err != nil {
 		return err

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -66,7 +66,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 		return nil
 	}
 
-	fqName := tableData.ToFqName(constants.Snowflake, tableData.Name())
+	fqName := tableData.ToFqName(constants.Snowflake)
 	tableConfig, err := s.getTableConfig(ctx, fqName, tableData.DropDeletedColumns)
 	if err != nil {
 		return err

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -67,7 +67,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	fqName := tableData.ToFqName(constants.Snowflake)
-	tableConfig, err := s.getTableConfig(ctx, fqName, tableData.DropDeletedColumns)
+	tableConfig, err := s.getTableConfig(ctx, fqName, tableData.TopicConfig.DropDeletedColumns)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 	log := logger.FromContext(ctx)
 
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(), tableData.SoftDelete)
+	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(), tableData.TopicConfig.SoftDelete)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,
 		Tc:          tableConfig,

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -48,6 +48,8 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	}
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
+	assert.Equal(s.T(), topicConfig.TableName, tableData.Name(), "override is working")
+
 	for pk, row := range rowsData {
 		tableData.InsertRow(pk, row)
 	}

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -47,7 +47,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		Schema:    "public",
 	}
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig)
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
 	for pk, row := range rowsData {
 		tableData.InsertRow(pk, row)
 	}
@@ -66,7 +66,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		})
 	}
 
-	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake),
+	s.store.configMap.AddTableToConfig(tableData.ToFqName(constants.Snowflake),
 		types.NewDwhTableConfig(&anotherCols, nil, false, true))
 
 	err := s.store.Merge(s.ctx, tableData)
@@ -109,12 +109,12 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		Schema:    "public",
 	}
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig)
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
 	for pk, row := range rowsData {
 		tableData.InsertRow(pk, row)
 	}
 
-	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake),
+	s.store.configMap.AddTableToConfig(tableData.ToFqName(constants.Snowflake),
 		types.NewDwhTableConfig(&cols, nil, false, true))
 
 	s.fakeStore.ExecReturnsOnCall(0, nil, fmt.Errorf("390114: Authentication token has expired. The user must authenticate again."))
@@ -160,12 +160,12 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 		Schema:    "public",
 	}
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig)
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
 	for pk, row := range rowsData {
 		tableData.InsertRow(pk, row)
 	}
 
-	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake),
+	s.store.configMap.AddTableToConfig(tableData.ToFqName(constants.Snowflake),
 		types.NewDwhTableConfig(&cols, nil, false, true))
 	err := s.store.Merge(s.ctx, tableData)
 	assert.Nil(s.T(), err)
@@ -209,7 +209,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		})
 	}
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig)
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
 	for pk, row := range rowsData {
 		tableData.InsertRow(pk, row)
 	}
@@ -235,7 +235,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	})
 
 	config := types.NewDwhTableConfig(&sflkCols, nil, false, true)
-	s.store.configMap.AddTableToConfig(topicConfig.ToFqName(constants.Snowflake), config)
+	s.store.configMap.AddTableToConfig(tableData.ToFqName(constants.Snowflake), config)
 
 	err := s.store.Merge(s.ctx, tableData)
 	assert.Nil(s.T(), err)
@@ -243,10 +243,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	assert.Equal(s.T(), s.fakeStore.ExecCallCount(), 1, "called merge")
 
 	// Check the temp deletion table now.
-	assert.Equal(s.T(), len(s.store.configMap.TableConfig(topicConfig.ToFqName(constants.Snowflake)).ReadOnlyColumnsToDelete()), 1,
-		s.store.configMap.TableConfig(topicConfig.ToFqName(constants.Snowflake)).ReadOnlyColumnsToDelete())
+	assert.Equal(s.T(), len(s.store.configMap.TableConfig(tableData.ToFqName(constants.Snowflake)).ReadOnlyColumnsToDelete()), 1,
+		s.store.configMap.TableConfig(tableData.ToFqName(constants.Snowflake)).ReadOnlyColumnsToDelete())
 
-	_, isOk := s.store.configMap.TableConfig(topicConfig.ToFqName(constants.Snowflake)).ReadOnlyColumnsToDelete()["new"]
+	_, isOk := s.store.configMap.TableConfig(tableData.ToFqName(constants.Snowflake)).ReadOnlyColumnsToDelete()["new"]
 	assert.True(s.T(), isOk)
 
 	// Now try to execute merge where 1 of the rows have the column now
@@ -271,12 +271,12 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	assert.Equal(s.T(), s.fakeStore.ExecCallCount(), 2, "called merge again")
 
 	// Caught up now, so columns should be 0.
-	assert.Equal(s.T(), len(s.store.configMap.TableConfig(topicConfig.ToFqName(constants.Snowflake)).ReadOnlyColumnsToDelete()), 0,
-		s.store.configMap.TableConfig(topicConfig.ToFqName(constants.Snowflake)).ReadOnlyColumnsToDelete())
+	assert.Equal(s.T(), len(s.store.configMap.TableConfig(tableData.ToFqName(constants.Snowflake)).ReadOnlyColumnsToDelete()), 0,
+		s.store.configMap.TableConfig(tableData.ToFqName(constants.Snowflake)).ReadOnlyColumnsToDelete())
 }
 
 func (s *SnowflakeTestSuite) TestExecuteMergeExitEarly() {
-	tableData := optimization.NewTableData(nil, nil, kafkalib.TopicConfig{})
+	tableData := optimization.NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
 	err := s.store.Merge(s.ctx, tableData)
 	assert.Nil(s.T(), err)
 }

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -106,7 +106,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		return nil
 	}
 
-	fqName := tableData.ToFqName(constants.Snowflake)
+	fqName := tableData.ToFqName(constants.Snowflake, tableData.Name())
 	tableConfig, err := s.getTableConfig(ctx, fqName, tableData.DropDeletedColumns)
 	if err != nil {
 		return err
@@ -167,14 +167,14 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	}
 
 	tableData.UpdateInMemoryColumnsFromDestination(tableConfig.Columns().GetColumns()...)
-	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(s.Label()), tableData.TempTableSuffix())
+	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(s.Label(), tableData.Name()), tableData.TempTableSuffix())
 	if err = s.prepareTempTable(ctx, tableData, tableConfig, temporaryTableName); err != nil {
 		return err
 	}
 
 	// Prepare merge statement
 	mergeQuery, err := dml.MergeStatement(dml.MergeArgument{
-		FqTableName:    tableData.ToFqName(constants.Snowflake),
+		FqTableName:    tableData.ToFqName(constants.Snowflake, tableData.Name()),
 		SubQuery:       temporaryTableName,
 		IdempotentKey:  tableData.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -106,7 +106,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		return nil
 	}
 
-	fqName := tableData.ToFqName(constants.Snowflake, tableData.Name())
+	fqName := tableData.ToFqName(constants.Snowflake)
 	tableConfig, err := s.getTableConfig(ctx, fqName, tableData.DropDeletedColumns)
 	if err != nil {
 		return err
@@ -167,14 +167,14 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	}
 
 	tableData.UpdateInMemoryColumnsFromDestination(tableConfig.Columns().GetColumns()...)
-	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(s.Label(), tableData.Name()), tableData.TempTableSuffix())
+	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(s.Label()), tableData.TempTableSuffix())
 	if err = s.prepareTempTable(ctx, tableData, tableConfig, temporaryTableName); err != nil {
 		return err
 	}
 
 	// Prepare merge statement
 	mergeQuery, err := dml.MergeStatement(dml.MergeArgument{
-		FqTableName:    tableData.ToFqName(constants.Snowflake, tableData.Name()),
+		FqTableName:    tableData.ToFqName(constants.Snowflake),
 		SubQuery:       temporaryTableName,
 		IdempotentKey:  tableData.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -28,7 +28,7 @@ func generateTableData(rows int) (string, *optimization.TableData) {
 		})
 	}
 
-	td := optimization.NewTableData(cols, []string{"user_id"}, kafkalib.TopicConfig{}, "foo")
+	td := optimization.NewTableData(cols, []string{"user_id"}, kafkalib.TopicConfig{}, "")
 	for i := 0; i < rows; i++ {
 		key := fmt.Sprint(i)
 		rowData := map[string]interface{}{

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -28,7 +28,7 @@ func generateTableData(rows int) (string, *optimization.TableData) {
 		})
 	}
 
-	td := optimization.NewTableData(cols, []string{"user_id"}, kafkalib.TopicConfig{})
+	td := optimization.NewTableData(cols, []string{"user_id"}, kafkalib.TopicConfig{}, "foo")
 	for i := 0; i < rows; i++ {
 		key := fmt.Sprint(i)
 		rowData := map[string]interface{}{

--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -2,8 +2,9 @@ package cdc
 
 import (
 	"context"
-	"github.com/artie-labs/transfer/lib/typing"
 	"time"
+
+	"github.com/artie-labs/transfer/lib/typing"
 
 	"github.com/artie-labs/transfer/lib/kafkalib"
 )
@@ -16,6 +17,7 @@ type Format interface {
 
 type Event interface {
 	GetExecutionTime() time.Time
+	GetTableName() string
 	GetData(ctx context.Context, pkMap map[string]interface{}, config *kafkalib.TopicConfig) map[string]interface{}
 	GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails
 	// GetColumns will inspect the envelope's payload right now and return.

--- a/lib/cdc/format/format.go
+++ b/lib/cdc/format/format.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"context"
+
 	"github.com/artie-labs/transfer/lib/cdc/mysql"
 
 	"github.com/artie-labs/transfer/lib/cdc"
@@ -16,7 +17,7 @@ var (
 	mySQL mysql.Debezium
 )
 
-func GetFormatParser(ctx context.Context, label string) cdc.Format {
+func GetFormatParser(ctx context.Context, label, topic string) cdc.Format {
 	validFormats := []cdc.Format{
 		&d, &m, &mySQL,
 	}
@@ -24,7 +25,10 @@ func GetFormatParser(ctx context.Context, label string) cdc.Format {
 	for _, validFormat := range validFormats {
 		for _, fmtLabel := range validFormat.Labels() {
 			if fmtLabel == label {
-				logger.FromContext(ctx).WithField("label", fmtLabel).Info("Loaded CDC Format parser...")
+				logger.FromContext(ctx).WithFields(map[string]interface{}{
+					"label": label,
+					"topic": topic,
+				}).Info("Loaded CDC Format parser...")
 				return validFormat
 			}
 		}

--- a/lib/cdc/format/format_test.go
+++ b/lib/cdc/format/format_test.go
@@ -2,10 +2,11 @@ package format
 
 import (
 	"context"
-	"github.com/artie-labs/transfer/lib/config"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
 
 	"github.com/stretchr/testify/assert"
 
@@ -20,7 +21,7 @@ func TestGetFormatParser(t *testing.T) {
 
 	validFormats := []string{constants.DBZPostgresAltFormat, constants.DBZPostgresFormat, constants.DBZMongoFormat}
 	for _, validFormat := range validFormats {
-		assert.NotNil(t, GetFormatParser(ctx, validFormat))
+		assert.NotNil(t, GetFormatParser(ctx, validFormat, "topicA"))
 	}
 }
 
@@ -43,6 +44,6 @@ func testOsExit(t *testing.T, testFunc func(*testing.T)) {
 func TestGetFormatParserFatal(t *testing.T) {
 	// This test cannot be iterated because it forks a separate process to do `go test -test.run=...`
 	testOsExit(t, func(t *testing.T) {
-		GetFormatParser(context.Background(), "foo")
+		GetFormatParser(context.Background(), "foo", "topicB")
 	})
 }

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -3,9 +3,10 @@ package mongo
 import (
 	"context"
 	"encoding/json"
+	"time"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/debezium"
-	"time"
 
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -72,6 +73,10 @@ func (d *Debezium) GetPrimaryKey(ctx context.Context, key []byte, tc *kafkalib.T
 
 func (s *SchemaEventPayload) GetExecutionTime() time.Time {
 	return time.UnixMilli(s.Payload.Source.TsMs).UTC()
+}
+
+func (s *SchemaEventPayload) GetTableName() string {
+	return s.Payload.Source.Collection
 }
 
 func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails {

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -3,10 +3,11 @@ package mongo
 import (
 	"context"
 	"encoding/json"
+	"time"
+
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/debezium"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
@@ -91,6 +92,7 @@ func (p *MongoTestSuite) TestMongoDBEventOrder() {
 	schemaEvt, isOk := evt.(*SchemaEventPayload)
 	assert.True(p.T(), isOk)
 	assert.Equal(p.T(), time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC), schemaEvt.GetExecutionTime())
+	assert.Equal(p.T(), "orders", schemaEvt.GetTableName())
 }
 
 func (p *MongoTestSuite) TestMongoDBEventCustomer() {
@@ -143,6 +145,7 @@ func (p *MongoTestSuite) TestMongoDBEventCustomer() {
 	assert.Equal(p.T(), evtData[constants.DeleteColumnMarker], false)
 	assert.Equal(p.T(), evt.GetExecutionTime(),
 		time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC))
+	assert.Equal(p.T(), "customers", evt.GetTableName())
 }
 
 func (p *MongoTestSuite) TestMongoDBEventCustomerBefore() {
@@ -180,6 +183,7 @@ func (p *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 	evt, err := p.Debezium.GetEventFromBytes(ctx, []byte(payload))
 	assert.NoError(p.T(), err)
 	evtData := evt.GetData(context.Background(), map[string]interface{}{"_id": 1003}, &kafkalib.TopicConfig{})
+	assert.Equal(p.T(), "customers123", evt.GetTableName())
 
 	assert.Equal(p.T(), evtData["_id"], 1003)
 	assert.Equal(p.T(), evtData[constants.DeleteColumnMarker], true)

--- a/lib/cdc/mysql/debezium_test.go
+++ b/lib/cdc/mysql/debezium_test.go
@@ -3,12 +3,13 @@ package mysql
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"time"
 )
 
 func (m *MySQLTestSuite) TestGetEventFromBytes() {
@@ -292,6 +293,7 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 	evt, err := m.Debezium.GetEventFromBytes(context.Background(), []byte(payload))
 	assert.NoError(m.T(), err)
 	assert.Equal(m.T(), time.Date(2023, time.March, 13, 19, 19, 24, 0, time.UTC), evt.GetExecutionTime())
+	assert.Equal(m.T(), "customers", evt.GetTableName())
 
 	kvMap := map[string]interface{}{
 		"id": 1001,
@@ -300,7 +302,6 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 	assert.Equal(m.T(), evtData["id"], 1001)
 	assert.Equal(m.T(), evtData["first_name"], "Sally")
 	assert.Equal(m.T(), evtData["bool_test"], false)
-
 	cols := evt.GetColumns()
 	assert.NotNil(m.T(), cols)
 

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -2,10 +2,11 @@ package postgres
 
 import (
 	"context"
+	"time"
+
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/ext"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -85,6 +86,7 @@ func (p *PostgresTestSuite) TestPostgresEvent() {
 	assert.Equal(p.T(), evtData["nested"], map[string]interface{}{"object": "foo"})
 	assert.Equal(p.T(), time.Date(2022, time.November, 16,
 		4, 1, 53, 308000000, time.UTC), evt.GetExecutionTime())
+	assert.Equal(p.T(), "orders", evt.GetTableName())
 }
 
 func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
@@ -200,4 +202,5 @@ func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 
 	assert.Equal(p.T(), time.Date(2023, time.February, 2,
 		17, 54, 11, 451000000, time.UTC), evt.GetExecutionTime())
+	assert.Equal(p.T(), "customers", evt.GetTableName())
 }

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -3,14 +3,15 @@ package util
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/debezium"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/typing"
-	"strconv"
-	"time"
 )
 
 // SchemaEventPayload is our struct for an event with schema enabled. For reference, this is an example payload https://gist.github.com/Tang8330/3b9989ed8c659771958fe481f248397a
@@ -78,6 +79,10 @@ func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]t
 
 func (s *SchemaEventPayload) GetExecutionTime() time.Time {
 	return time.UnixMilli(s.Payload.Source.TsMs).UTC()
+}
+
+func (s *SchemaEventPayload) GetTableName() string {
+	return s.Payload.Source.Table
 }
 
 func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]interface{}, tc *kafkalib.TopicConfig) map[string]interface{} {

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -31,8 +31,8 @@ func GetUniqueDatabaseAndSchema(tcs []*TopicConfig) []DatabaseSchemaPair {
 }
 
 type TopicConfig struct {
-	Database string `yaml:"db"`
-	//TableName          string `yaml:"tableName"`
+	Database           string `yaml:"db"`
+	TableName          string `yaml:"tableName"`
 	Schema             string `yaml:"schema"`
 	Topic              string `yaml:"topic"`
 	IdempotentKey      string `yaml:"idempotentKey"`
@@ -57,8 +57,8 @@ func (t *TopicConfig) String() string {
 	}
 
 	return fmt.Sprintf(
-		"db=%s, schema=%s, topic=%s, idempotentKey=%s, cdcFormat=%s, dropDeletedColumns=%v",
-		t.Database, t.Schema, t.Topic, t.IdempotentKey, t.CDCFormat, t.DropDeletedColumns)
+		"db=%s, schema=%s, tableNameOverride=%s, topic=%s, idempotentKey=%s, cdcFormat=%s, dropDeletedColumns=%v",
+		t.Database, t.Schema, t.TableName, t.Topic, t.IdempotentKey, t.CDCFormat, t.DropDeletedColumns)
 }
 
 func (t *TopicConfig) Valid() bool {

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/artie-labs/transfer/lib/array"
-	"github.com/artie-labs/transfer/lib/config/constants"
 )
 
 type DatabaseSchemaPair struct {
@@ -91,15 +90,4 @@ func (t *TopicConfig) ToCacheKey(partition int64) string {
 
 func ToCacheKey(topic string, partition int64) string {
 	return fmt.Sprintf("%s#%d", topic, partition)
-}
-
-// ToFqName is the fully-qualified table name in DWH
-func (t *TopicConfig) ToFqName(kind constants.DestinationKind, tableName string) string {
-	switch kind {
-	case constants.BigQuery:
-		// BigQuery doesn't use schema
-		return fmt.Sprintf("%s.%s", t.Database, tableName)
-	default:
-		return fmt.Sprintf("%s.%s.%s", t.Database, t.Schema, tableName)
-	}
 }

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -32,8 +32,8 @@ func GetUniqueDatabaseAndSchema(tcs []*TopicConfig) []DatabaseSchemaPair {
 }
 
 type TopicConfig struct {
-	Database           string `yaml:"db"`
-	TableName          string `yaml:"tableName"`
+	Database string `yaml:"db"`
+	//TableName          string `yaml:"tableName"`
 	Schema             string `yaml:"schema"`
 	Topic              string `yaml:"topic"`
 	IdempotentKey      string `yaml:"idempotentKey"`
@@ -58,8 +58,8 @@ func (t *TopicConfig) String() string {
 	}
 
 	return fmt.Sprintf(
-		"db=%s, tableName=%s, schema=%s, topic=%s, idempotentKey=%s, cdcFormat=%s, dropDeletedColumns=%v",
-		t.Database, t.TableName, t.Schema, t.Topic, t.IdempotentKey, t.CDCFormat, t.DropDeletedColumns)
+		"db=%s, schema=%s, topic=%s, idempotentKey=%s, cdcFormat=%s, dropDeletedColumns=%v",
+		t.Database, t.Schema, t.Topic, t.IdempotentKey, t.CDCFormat, t.DropDeletedColumns)
 }
 
 func (t *TopicConfig) Valid() bool {
@@ -68,7 +68,7 @@ func (t *TopicConfig) Valid() bool {
 	}
 
 	// IdempotentKey is optional.
-	empty := array.Empty([]string{t.Database, t.TableName, t.Schema, t.Topic, t.CDCFormat})
+	empty := array.Empty([]string{t.Database, t.Schema, t.Topic, t.CDCFormat})
 	if empty {
 		return false
 	}
@@ -94,12 +94,12 @@ func ToCacheKey(topic string, partition int64) string {
 }
 
 // ToFqName is the fully-qualified table name in DWH
-func (t *TopicConfig) ToFqName(kind constants.DestinationKind) string {
+func (t *TopicConfig) ToFqName(kind constants.DestinationKind, tableName string) string {
 	switch kind {
 	case constants.BigQuery:
 		// BigQuery doesn't use schema
-		return fmt.Sprintf("%s.%s", t.Database, t.TableName)
+		return fmt.Sprintf("%s.%s", t.Database, tableName)
 	default:
-		return fmt.Sprintf("%s.%s.%s", t.Database, t.Schema, t.TableName)
+		return fmt.Sprintf("%s.%s.%s", t.Database, t.Schema, tableName)
 	}
 }

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -118,12 +118,12 @@ func TestTopicConfig_String(t *testing.T) {
 		CDCFormat:     "f",
 	}
 
-	assert.True(t, strings.Contains(tc.String(), tc.TableName), tc.String())
-	assert.True(t, strings.Contains(tc.String(), tc.Database), tc.String())
-	assert.True(t, strings.Contains(tc.String(), tc.Schema), tc.String())
-	assert.True(t, strings.Contains(tc.String(), tc.Topic), tc.String())
-	assert.True(t, strings.Contains(tc.String(), tc.IdempotentKey), tc.String())
-	assert.True(t, strings.Contains(tc.String(), tc.CDCFormat), tc.String())
+	assert.True(t, strings.Contains(tc.String(), fmt.Sprintf("tableNameOverride=%s", tc.TableName)), tc.String())
+	assert.True(t, strings.Contains(tc.String(), fmt.Sprintf("db=%s", tc.Database)), tc.String())
+	assert.True(t, strings.Contains(tc.String(), fmt.Sprintf("schema=%s", tc.Schema)), tc.String())
+	assert.True(t, strings.Contains(tc.String(), fmt.Sprintf("topic=%s", tc.Topic)), tc.String())
+	assert.True(t, strings.Contains(tc.String(), fmt.Sprintf("idempotentKey=%s", tc.IdempotentKey)), tc.String())
+	assert.True(t, strings.Contains(tc.String(), fmt.Sprintf("cdcFormat=%s", tc.CDCFormat)), tc.String())
 }
 
 func TestTopicConfig_Validate(t *testing.T) {

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -67,6 +67,12 @@ func (t *TableData) ReadOnlyInMemoryCols() *typing.Columns {
 }
 
 func NewTableData(inMemoryColumns *typing.Columns, primaryKeys []string, topicConfig kafkalib.TopicConfig, name string) *TableData {
+	tableName := name
+	if topicConfig.TableName != "" {
+		// TableName override.
+		tableName = topicConfig.TableName
+	}
+
 	return &TableData{
 		inMemoryColumns:         inMemoryColumns,
 		rowsData:                map[string]map[string]interface{}{},
@@ -74,7 +80,7 @@ func NewTableData(inMemoryColumns *typing.Columns, primaryKeys []string, topicCo
 		TopicConfig:             topicConfig,
 		PartitionsToLastMessage: map[string][]artie.Message{},
 		temporaryTableSuffix:    fmt.Sprintf("%s_%s", constants.ArtiePrefix, stringutil.Random(10)),
-		name:                    name,
+		name:                    tableName,
 	}
 }
 

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -40,13 +40,7 @@ type TableData struct {
 	name string
 }
 
-// TODO - test
 func (t *TableData) Name() string {
-	// Check override first
-	if t.TopicConfig.TableName != "" {
-		return t.TopicConfig.TableName
-	}
-
 	return t.name
 }
 
@@ -74,12 +68,6 @@ func (t *TableData) ReadOnlyInMemoryCols() *typing.Columns {
 }
 
 func NewTableData(inMemoryColumns *typing.Columns, primaryKeys []string, topicConfig kafkalib.TopicConfig, name string) *TableData {
-	tableName := name
-	if topicConfig.TableName != "" {
-		// TableName override.
-		tableName = topicConfig.TableName
-	}
-
 	return &TableData{
 		inMemoryColumns:         inMemoryColumns,
 		rowsData:                map[string]map[string]interface{}{},
@@ -87,7 +75,7 @@ func NewTableData(inMemoryColumns *typing.Columns, primaryKeys []string, topicCo
 		TopicConfig:             topicConfig,
 		PartitionsToLastMessage: map[string][]artie.Message{},
 		temporaryTableSuffix:    fmt.Sprintf("%s_%s", constants.ArtiePrefix, stringutil.Random(10)),
-		name:                    tableName,
+		name:                    stringutil.Override(name, topicConfig.TableName),
 	}
 }
 

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -22,7 +22,7 @@ type TableData struct {
 	rowsData        map[string]map[string]interface{} // pk -> { col -> val }
 	PrimaryKeys     []string
 
-	kafkalib.TopicConfig
+	TopicConfig kafkalib.TopicConfig
 	// Partition to the latest offset(s).
 	// For Kafka, we only need the last message to commit the offset
 	// However, pub/sub requires every single message to be acked
@@ -36,10 +36,17 @@ type TableData struct {
 	temporaryTableSuffix string
 
 	// Name of the table in the destination
+	// Prefer calling .Name() everywhere
 	name string
 }
 
+// TODO - test
 func (t *TableData) Name() string {
+	// Check override first
+	if t.TopicConfig.TableName != "" {
+		return t.TopicConfig.TableName
+	}
+
 	return t.name
 }
 
@@ -127,9 +134,9 @@ func (t *TableData) ToFqName(kind constants.DestinationKind) string {
 	switch kind {
 	case constants.BigQuery:
 		// BigQuery doesn't use schema
-		return fmt.Sprintf("%s.%s", t.Database, t.name)
+		return fmt.Sprintf("%s.%s", t.TopicConfig.Database, t.Name())
 	default:
-		return fmt.Sprintf("%s.%s.%s", t.Database, t.Schema, t.name)
+		return fmt.Sprintf("%s.%s.%s", t.TopicConfig.Database, t.TopicConfig.Schema, t.Name())
 	}
 }
 

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -35,6 +35,7 @@ type TableData struct {
 	// BigQuery specific. We are creating a temporary table to execute a merge, in order to avoid in-memory tables via UNION ALL.
 	temporaryTableSuffix string
 
+	// Name of the table in the destination
 	name string
 }
 
@@ -114,6 +115,16 @@ func (t *TableData) RowsData() map[string]map[string]interface{} {
 	}
 
 	return _rowsData
+}
+
+func (t *TableData) ToFqName(kind constants.DestinationKind) string {
+	switch kind {
+	case constants.BigQuery:
+		// BigQuery doesn't use schema
+		return fmt.Sprintf("%s.%s", t.Database, t.name)
+	default:
+		return fmt.Sprintf("%s.%s.%s", t.Database, t.Schema, t.name)
+	}
 }
 
 func (t *TableData) Rows() uint {

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -34,6 +34,12 @@ type TableData struct {
 
 	// BigQuery specific. We are creating a temporary table to execute a merge, in order to avoid in-memory tables via UNION ALL.
 	temporaryTableSuffix string
+
+	name string
+}
+
+func (t *TableData) Name() string {
+	return t.name
 }
 
 func (t *TableData) SetInMemoryColumns(columns *typing.Columns) {
@@ -59,7 +65,7 @@ func (t *TableData) ReadOnlyInMemoryCols() *typing.Columns {
 	return &cols
 }
 
-func NewTableData(inMemoryColumns *typing.Columns, primaryKeys []string, topicConfig kafkalib.TopicConfig) *TableData {
+func NewTableData(inMemoryColumns *typing.Columns, primaryKeys []string, topicConfig kafkalib.TopicConfig, name string) *TableData {
 	return &TableData{
 		inMemoryColumns:         inMemoryColumns,
 		rowsData:                map[string]map[string]interface{}{},
@@ -67,6 +73,7 @@ func NewTableData(inMemoryColumns *typing.Columns, primaryKeys []string, topicCo
 		TopicConfig:             topicConfig,
 		PartitionsToLastMessage: map[string][]artie.Message{},
 		temporaryTableSuffix:    fmt.Sprintf("%s_%s", constants.ArtiePrefix, stringutil.Random(10)),
+		name:                    name,
 	}
 }
 

--- a/lib/optimization/event_bench_test.go
+++ b/lib/optimization/event_bench_test.go
@@ -2,13 +2,14 @@ package optimization
 
 import (
 	"fmt"
-	"github.com/artie-labs/transfer/lib/kafkalib"
 	"testing"
 	"time"
+
+	"github.com/artie-labs/transfer/lib/kafkalib"
 )
 
 func BenchmarkTableData_ApproxSize_TallTable(b *testing.B) {
-	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "tallTable")
 	for n := 0; n < b.N; n++ {
 		td.InsertRow(fmt.Sprint(n), map[string]interface{}{
 			"id":   n,
@@ -19,7 +20,7 @@ func BenchmarkTableData_ApproxSize_TallTable(b *testing.B) {
 }
 
 func BenchmarkTableData_ApproxSize_WideTable(b *testing.B) {
-	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "wideTable")
 	for n := 0; n < b.N; n++ {
 		td.InsertRow(fmt.Sprint(n), map[string]interface{}{
 			"id":                 n,

--- a/lib/optimization/event_insert_test.go
+++ b/lib/optimization/event_insert_test.go
@@ -101,7 +101,7 @@ func TestInsertRow_Toast(t *testing.T) {
 
 	for _, testCase := range testCases {
 		// Wipe the table data per test run.
-		td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+		td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
 		for _, rowData := range testCase.rowsDataToUpdate {
 			td.InsertRow(testCase.primaryKey, rowData)
 		}
@@ -117,7 +117,7 @@ func TestInsertRow_Toast(t *testing.T) {
 }
 
 func TestTableData_InsertRow(t *testing.T) {
-	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
 	assert.Equal(t, 0, int(td.Rows()))
 
 	// See if we can add rows to the private method.
@@ -139,7 +139,7 @@ func TestTableData_InsertRowApproxSize(t *testing.T) {
 	// In this test, we'll insert 1000 rows, update X and then delete Y
 	// Does the size then match up? We will iterate over a map to take advantage of the in-deterministic ordering of a map
 	// So we can test multiple updates, deletes, etc.
-	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
 	numInsertRows := 1000
 	numUpdateRows := 420
 	numDeleteRows := 250

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -6,12 +6,52 @@ import (
 	"testing"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/config/constants"
+
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNewTableData_TableName(t *testing.T) {
+	type _testCase struct {
+		name                    string
+		tableName               string
+		overrideName            string
+		expectedName            string
+		expectedSnowflakeFqName string
+		expectedBigQueryFqName  string
+	}
+
+	testCases := []_testCase{
+		{
+			name:                    "no override is provided",
+			tableName:               "food",
+			expectedName:            "food",
+			expectedSnowflakeFqName: "..food",
+			expectedBigQueryFqName:  ".food",
+		},
+		{
+			name:                    "override is provided",
+			tableName:               "food",
+			overrideName:            "drinks",
+			expectedName:            "drinks",
+			expectedSnowflakeFqName: "..drinks", // db, schema
+			expectedBigQueryFqName:  ".drinks",  // data set only
+		},
+	}
+
+	for _, testCase := range testCases {
+		td := NewTableData(nil, nil, kafkalib.TopicConfig{TableName: testCase.overrideName}, testCase.tableName)
+		assert.Equal(t, testCase.expectedName, td.Name(), testCase.name)
+		assert.Equal(t, testCase.expectedName, td.name, testCase.name)
+		assert.Equal(t, testCase.expectedSnowflakeFqName, td.ToFqName(constants.SnowflakeStages))
+		assert.Equal(t, testCase.expectedSnowflakeFqName, td.ToFqName(constants.Snowflake))
+		assert.Equal(t, testCase.expectedBigQueryFqName, td.ToFqName(constants.BigQuery))
+	}
+}
 
 func TestTableData_ReadOnlyInMemoryCols(t *testing.T) {
 	// Making sure the columns are actually read only.

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -21,7 +21,7 @@ func TestTableData_ReadOnlyInMemoryCols(t *testing.T) {
 		KindDetails: typing.String,
 	})
 
-	td := NewTableData(&cols, nil, kafkalib.TopicConfig{})
+	td := NewTableData(&cols, nil, kafkalib.TopicConfig{}, "foo")
 	readOnlyCols := td.ReadOnlyInMemoryCols()
 	readOnlyCols.AddColumn(typing.Column{
 		Name:        "last_name",
@@ -105,7 +105,7 @@ func TestTableData_ShouldFlushRowLength(t *testing.T) {
 	}})
 
 	// Insert 3 rows and confirm that we need to flush.
-	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
 	for i := 0; i < 3; i++ {
 		assert.False(t, td.ShouldFlush(ctx))
 		td.InsertRow(fmt.Sprint(i), map[string]interface{}{
@@ -124,7 +124,7 @@ func TestTableData_ShouldFlushRowSize(t *testing.T) {
 	}})
 
 	// Insert 3 rows and confirm that we need to flush.
-	td := NewTableData(nil, nil, kafkalib.TopicConfig{})
+	td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
 	for i := 0; i < 45; i++ {
 		assert.False(t, td.ShouldFlush(ctx))
 		td.InsertRow(fmt.Sprint(i), map[string]interface{}{

--- a/lib/stringutil/strings.go
+++ b/lib/stringutil/strings.go
@@ -7,6 +7,22 @@ import (
 	"time"
 )
 
+// Override - pass in a list of vals, the right most value that is not empty will override.
+func Override(vals ...string) string {
+	if len(vals) == 0 {
+		return ""
+	}
+
+	var retVal string
+	for _, val := range vals {
+		if val != "" {
+			retVal = val
+		}
+	}
+
+	return retVal
+}
+
 func Reverse(val string) string {
 	var reverseParts []rune
 	valRune := []rune(val)

--- a/lib/stringutil/strings_test.go
+++ b/lib/stringutil/strings_test.go
@@ -6,6 +6,56 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestOverride(t *testing.T) {
+	type _testCase struct {
+		name        string
+		vals        []string
+		expectedVal string
+	}
+
+	testCases := []_testCase{
+		{
+			name:        "empty",
+			expectedVal: "",
+		},
+		{
+			name:        "empty (empty list)",
+			vals:        []string{},
+			expectedVal: "",
+		},
+		{
+			name:        "empty (list w/ empty val)",
+			vals:        []string{""},
+			expectedVal: "",
+		},
+		{
+			name:        "one value",
+			vals:        []string{"hi"},
+			expectedVal: "hi",
+		},
+		{
+			name:        "override (2 vals)",
+			vals:        []string{"hi", "latest"},
+			expectedVal: "latest",
+		},
+		{
+			name:        "override (3 vals)",
+			vals:        []string{"hi", "", "latest"},
+			expectedVal: "latest",
+		},
+		{
+			name:        "override (all empty)",
+			vals:        []string{"hii", "", ""},
+			expectedVal: "hii",
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualVal := Override(testCase.vals...)
+		assert.Equal(t, testCase.expectedVal, actualVal, testCase.name)
+	}
+}
+
 func TestWrap(t *testing.T) {
 	type _testCase struct {
 		name           string

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -29,8 +29,14 @@ type Event struct {
 }
 
 func ToMemoryEvent(ctx context.Context, event cdc.Event, pkMap map[string]interface{}, tc *kafkalib.TopicConfig) Event {
+	table := event.GetTableName()
+	if tc.TableName != "" {
+		// Overwritten by topicConfig
+		table = tc.TableName
+	}
+
 	return Event{
-		Table:          event.GetTableName(),
+		Table:          table,
 		PrimaryKeyMap:  pkMap,
 		ExecutionTime:  event.GetExecutionTime(),
 		OptionalSchema: event.GetOptionalSchema(ctx),

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -30,7 +30,7 @@ type Event struct {
 
 func ToMemoryEvent(ctx context.Context, event cdc.Event, pkMap map[string]interface{}, tc *kafkalib.TopicConfig) Event {
 	return Event{
-		Table:          tc.TableName,
+		Table:          event.GetTableName(),
 		PrimaryKeyMap:  pkMap,
 		ExecutionTime:  event.GetExecutionTime(),
 		OptionalSchema: event.GetOptionalSchema(ctx),
@@ -110,7 +110,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 			columns = e.Columns
 		}
 
-		inMemDB.TableData[e.Table] = optimization.NewTableData(columns, e.PrimaryKeys(), *topicConfig)
+		inMemDB.TableData[e.Table] = optimization.NewTableData(columns, e.PrimaryKeys(), *topicConfig, e.Table)
 	} else {
 		if e.Columns != nil {
 			// Iterate over this again just in case.

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -29,14 +29,8 @@ type Event struct {
 }
 
 func ToMemoryEvent(ctx context.Context, event cdc.Event, pkMap map[string]interface{}, tc *kafkalib.TopicConfig) Event {
-	table := event.GetTableName()
-	if tc.TableName != "" {
-		// Overwritten by topicConfig
-		table = tc.TableName
-	}
-
 	return Event{
-		Table:          table,
+		Table:          stringutil.Override(event.GetTableName(), tc.TableName),
 		PrimaryKeyMap:  pkMap,
 		ExecutionTime:  event.GetExecutionTime(),
 		OptionalSchema: event.GetOptionalSchema(ctx),

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -53,10 +53,14 @@ func (e *EventsTestSuite) TestEvent_IsValid() {
 
 func (e *EventsTestSuite) TestEvent_TableName() {
 	var f fakeEvent
-	evt := ToMemoryEvent(context.Background(), f, idMap, &kafkalib.TopicConfig{
+	// Don't pass in tableName.
+	evt := ToMemoryEvent(context.Background(), f, idMap, &kafkalib.TopicConfig{})
+	assert.Equal(e.T(), f.GetTableName(), evt.Table)
+
+	// Now pass it in, it should override.
+	evt = ToMemoryEvent(context.Background(), f, idMap, &kafkalib.TopicConfig{
 		TableName: "orders",
 	})
-
 	assert.Equal(e.T(), "orders", evt.Table)
 }
 

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -20,6 +20,10 @@ func (f fakeEvent) GetExecutionTime() time.Time {
 	return time.Now()
 }
 
+func (f fakeEvent) GetTableName() string {
+	return "foo"
+}
+
 func (f fakeEvent) GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails {
 	return nil
 }

--- a/models/flush/flush.go
+++ b/models/flush/flush.go
@@ -40,8 +40,8 @@ func Flush(ctx context.Context) error {
 			tags := map[string]string{
 				"what":     "success",
 				"table":    _tableName,
-				"database": _tableData.Database,
-				"schema":   _tableData.Schema,
+				"database": _tableData.TopicConfig.Database,
+				"schema":   _tableData.TopicConfig.Schema,
 			}
 
 			err := utils.FromContext(ctx).Merge(ctx, _tableData)
@@ -50,7 +50,7 @@ func Flush(ctx context.Context) error {
 				log.WithError(err).WithFields(logFields).Warn("Failed to execute merge...not going to flush memory")
 			} else {
 				log.WithFields(logFields).Info("Merge success, clearing memory...")
-				commitErr := consumer.CommitOffset(ctx, _tableData.Topic, _tableData.PartitionsToLastMessage)
+				commitErr := consumer.CommitOffset(ctx, _tableData.TopicConfig.Topic, _tableData.PartitionsToLastMessage)
 				if commitErr == nil {
 					flushChan <- _tableName
 				} else {

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -65,7 +65,7 @@ func StartConsumer(ctx context.Context, flushChan chan bool) {
 	for _, topicConfig := range settings.Config.Kafka.TopicConfigs {
 		topicToConfigFmtMap[topicConfig.Topic] = TopicConfigFormatter{
 			tc:     topicConfig,
-			Format: format.GetFormatParser(ctx, topicConfig.CDCFormat),
+			Format: format.GetFormatParser(ctx, topicConfig.CDCFormat, topicConfig.Topic),
 		}
 		topics = append(topics, topicConfig.Topic)
 	}

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -37,7 +37,7 @@ func processMessage(ctx context.Context, processArgs ProcessArgs) error {
 
 	tags["database"] = topicConfig.tc.Database
 	tags["schema"] = topicConfig.tc.Schema
-	tags["table"] = topicConfig.tc.TableName
+	//tags["table"] = topicConfig.tc.TableName
 
 	pkMap, err := topicConfig.GetPrimaryKey(ctx, processArgs.Msg.Key(), topicConfig.tc)
 	if err != nil {

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -37,7 +37,6 @@ func processMessage(ctx context.Context, processArgs ProcessArgs) error {
 
 	tags["database"] = topicConfig.tc.Database
 	tags["schema"] = topicConfig.tc.Schema
-	//tags["table"] = topicConfig.tc.TableName
 
 	pkMap, err := topicConfig.GetPrimaryKey(ctx, processArgs.Msg.Key(), topicConfig.tc)
 	if err != nil {
@@ -52,6 +51,8 @@ func processMessage(ctx context.Context, processArgs ProcessArgs) error {
 	}
 
 	evt := event.ToMemoryEvent(ctx, _event, pkMap, topicConfig.tc)
+	// Table name is only available after event has been casted
+	tags["table"] = evt.Table
 	shouldFlush, err := evt.Save(ctx, topicConfig.tc, processArgs.Msg)
 	if err != nil {
 		tags["what"] = "save_fail"

--- a/processes/consumer/pubsub.go
+++ b/processes/consumer/pubsub.go
@@ -62,7 +62,7 @@ func StartSubscriber(ctx context.Context, flushChan chan bool) {
 	for _, topicConfig := range settings.Config.Pubsub.TopicConfigs {
 		topicToConfigFmtMap[topicConfig.Topic] = TopicConfigFormatter{
 			tc:     topicConfig,
-			Format: format.GetFormatParser(ctx, topicConfig.CDCFormat),
+			Format: format.GetFormatParser(ctx, topicConfig.CDCFormat, topicConfig.Topic),
 		}
 		topics = append(topics, topicConfig.Topic)
 	}


### PR DESCRIPTION
In this PR, we are doing 2 things:

1. Making `tableName` within the `topicConfig` optional. This is because Debezium already provides this within the message. By making this change, we'll also allow other users to use only one topic for their whole pipeline setup. 


Which would evolve to look something like this: (after this PR and another one to allow passing in subscriptionName) 

![image](https://github.com/artie-labs/transfer/assets/4412200/e0dcb25f-12d9-4b29-8667-5af114233bf7)

This would be more ideal with the GCP pub/sub configuration since Debezium server does not support automatic topic creation (only in Kafka, because they delegated this to Kafka Connect or Kafka Broker - if you are using the standalone deployment).

3. Adding `topicName` to the logger
```bash
robins-mbp:transfer robintang$ go run main.go --config .personal/custom_snapshot/transfer.yaml
INFO[0000] invalid or no exporter kind passed in, skipping...  exporterKind=
INFO[0002] looking to see if there are any dangling artie temporary tables to delete...
INFO[0003] config is loaded                              buffer_pool_size=9999 flush_interval_seconds=5 flush_pool_size (kb)=10000000
INFO[0003] Starting pool channel...
INFO[0003] Starting pool timer...
INFO[0003] Starting Kafka consumer...bootstrapServer=localhost:29092, groupID=transfer2, user_set=false, pass_set=false
INFO[0003] Loaded CDC Format parser...                   label=debezium.postgres.wal2json topic=sales.snap
INFO[0003] Loaded CDC Format parser...                   label=debezium.postgres.wal2json topic=users.snap
INFO[0003] Loaded CDC Format parser...                   label=debezium.postgres.wal2json topic=dbserver1.public.posts
INFO[0003] Loaded CDC Format parser...                   label=debezium.postgres.wal2json topic=dbserver1.inventory.customers
```
