### PR TITLE
[BigQuery] Migrate to use TIMESTAMPS instead of DATETIME

### DIFF
--- a/lib/typing/bigquery.go
+++ b/lib/typing/bigquery.go
@@ -72,7 +72,9 @@ func kindToBigQuery(kindDetails KindDetails) string {
 	case ETime.Kind:
 		switch kindDetails.ExtendedTimeDetails.Type {
 		case ext.DateTimeKindType:
-			return "datetime"
+			// https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#datetime_type
+			// We should be using TIMESTAMP since it's an absolute point in time.
+			return "timestamp"
 		case ext.DateKindType:
 			return "date"
 		case ext.TimeKindType:


### PR DESCRIPTION
This is a f/u to the Snowflake PR: https://github.com/artie-labs/transfer/pull/111.

TL;DR - We should not be using DATETIME because it makes it difficult to join with other timestamp columns, and DATETIME (without timezone) is not absolute.

![image](https://github.com/artie-labs/transfer/assets/4412200/53a787d6-f5aa-40ec-b406-7044d0798d3c)

This will be included in the `2.x` releases, if anyone is upgrading from `1.x`, use this script to migrate the columns:

```sql
-- 1. Add a new column with TIMESTAMP_TZ data type
ALTER TABLE customers.customers_test2 ADD COLUMN timestamp_1_test_new TIMESTAMP;

-- 2. Update the new column with the converted data
UPDATE customers.customers_test2 SET timestamp_1_test_new = TIMESTAMP(timestamp_1_test, "UTC") WHERE timestamp_1_test is not null;

-- 3. Drop the old column
ALTER TABLE customers.customers_test2 DROP COLUMN timestamp_1_test;

-- 4. Rename the new column to the old column's name
ALTER TABLE customers.customers_test2 RENAME COLUMN timestamp_1_test_new TO timestamp_1_test;
```