### PR TITLE
Implementing per table flush

### DIFF
--- a/lib/db/mock/db.go
+++ b/lib/db/mock/db.go
@@ -3,9 +3,6 @@ package mock
 import (
 	"database/sql"
 	"fmt"
-	"time"
-
-	"github.com/artie-labs/transfer/lib/jitter"
 
 	"github.com/artie-labs/transfer/lib/mocks"
 )
@@ -17,8 +14,6 @@ type DB struct {
 }
 
 func (m *DB) Exec(query string, args ...any) (sql.Result, error) {
-	jitterDuration := jitter.JitterMs(500, 1)
-	time.Sleep(time.Duration(jitterDuration) * time.Millisecond)
 	fmt.Println("Mock DB is executing", "query", query, "args", args)
 	return m.Fake.Exec(query, args)
 }

--- a/lib/db/mock/db.go
+++ b/lib/db/mock/db.go
@@ -3,6 +3,10 @@ package mock
 import (
 	"database/sql"
 	"fmt"
+	"time"
+
+	"github.com/artie-labs/transfer/lib/jitter"
+
 	"github.com/artie-labs/transfer/lib/mocks"
 )
 
@@ -13,6 +17,8 @@ type DB struct {
 }
 
 func (m *DB) Exec(query string, args ...any) (sql.Result, error) {
+	jitterDuration := jitter.JitterMs(500, 1)
+	time.Sleep(time.Duration(jitterDuration) * time.Millisecond)
 	fmt.Println("Mock DB is executing", "query", query, "args", args)
 	return m.Fake.Exec(query, args)
 }

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -94,34 +94,38 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 		return false, errors.New("topicConfig is missing")
 	}
 
-	inMemDB := models.GetMemoryDB(ctx)
-	inMemDB.Lock()
-	defer inMemDB.Unlock()
-
 	if !e.IsValid() {
 		return false, errors.New("event not valid")
 	}
 
+	inMemDB := models.GetMemoryDB(ctx)
 	// Does the table exist?
-	_, isOk := inMemDB.TableData[e.Table]
+	_, isOk := inMemDB.GetTableData(e.Table)
 	if !isOk {
 		columns := &typing.Columns{}
 		if e.Columns != nil {
 			columns = e.Columns
 		}
 
-		inMemDB.TableData[e.Table] = optimization.NewTableData(columns, e.PrimaryKeys(), *topicConfig, e.Table)
+		inMemDB.NewTableData(e.Table, optimization.NewTableData(columns, e.PrimaryKeys(), *topicConfig, e.Table))
 	} else {
 		if e.Columns != nil {
 			// Iterate over this again just in case.
 			for _, col := range e.Columns.GetColumns() {
-				inMemDB.TableData[e.Table].AddInMemoryCol(col)
+				td, _ := inMemDB.GetTableData(e.Table)
+				td.Lock()
+				td.AddInMemoryCol(col)
+				td.Unlock()
 			}
 		}
 	}
 
+	td, _ := inMemDB.GetTableData(e.Table)
+	td.Lock()
+	defer td.Unlock()
+
 	// Table columns
-	inMemoryColumns := inMemDB.TableData[e.Table].ReadOnlyInMemoryCols()
+	inMemoryColumns := td.ReadOnlyInMemoryCols()
 	// Update col if necessary
 	sanitizedData := make(map[string]interface{})
 	for _col, val := range e.Data {
@@ -166,19 +170,19 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 	}
 
 	// Now we commit the table columns.
-	inMemDB.TableData[e.Table].SetInMemoryColumns(inMemoryColumns)
+	td.SetInMemoryColumns(inMemoryColumns)
 
 	// Swap out sanitizedData <> data.
 	e.Data = sanitizedData
-	inMemDB.TableData[e.Table].InsertRow(e.PrimaryKeyValue(), e.Data)
+	td.InsertRow(e.PrimaryKeyValue(), e.Data)
 	// If the message is Kafka, then we only need the latest one
 	// If it's pubsub, we will store all of them in memory. This is because GCP pub/sub REQUIRES us to ack every single message
 	if message.Kind() == artie.Kafka {
-		inMemDB.TableData[e.Table].PartitionsToLastMessage[message.Partition()] = []artie.Message{message}
+		td.PartitionsToLastMessage[message.Partition()] = []artie.Message{message}
 	} else {
-		inMemDB.TableData[e.Table].PartitionsToLastMessage[message.Partition()] = append(inMemDB.TableData[e.Table].PartitionsToLastMessage[message.Partition()], message)
+		td.PartitionsToLastMessage[message.Partition()] = append(td.PartitionsToLastMessage[message.Partition()], message)
 	}
 
-	inMemDB.TableData[e.Table].LatestCDCTs = e.ExecutionTime
-	return inMemDB.TableData[e.Table].ShouldFlush(ctx), nil
+	td.LatestCDCTs = e.ExecutionTime
+	return td.ShouldFlush(ctx), nil
 }

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -114,9 +114,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 		if e.Columns != nil {
 			// Iterate over this again just in case.
 			for _, col := range e.Columns.GetColumns() {
-				//td.Lock()
 				td.AddInMemoryCol(col)
-				//td.Unlock()
 			}
 		}
 	}

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -100,10 +100,9 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 
 	inMemDB := models.GetMemoryDB(ctx)
 	// Does the table exist?
-	td := inMemDB.GetTableData(e.Table)
+	td := inMemDB.GetOrCreateTableData(e.Table)
 	td.Lock()
 	defer td.Unlock()
-
 	if td.Empty() {
 		columns := &typing.Columns{}
 		if e.Columns != nil {
@@ -115,9 +114,9 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 		if e.Columns != nil {
 			// Iterate over this again just in case.
 			for _, col := range e.Columns.GetColumns() {
-				td.Lock()
+				//td.Lock()
 				td.AddInMemoryCol(col)
-				td.Unlock()
+				//td.Unlock()
 			}
 		}
 	}

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -100,7 +100,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 
 	inMemDB := models.GetMemoryDB(ctx)
 	// Does the table exist?
-	_, isOk := inMemDB.GetTableData(e.Table)
+	td, isOk := inMemDB.GetTableData(e.Table)
 	if !isOk {
 		columns := &typing.Columns{}
 		if e.Columns != nil {
@@ -108,11 +108,11 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 		}
 
 		inMemDB.NewTableData(e.Table, optimization.NewTableData(columns, e.PrimaryKeys(), *topicConfig, e.Table))
+		td, _ = inMemDB.GetTableData(e.Table)
 	} else {
 		if e.Columns != nil {
 			// Iterate over this again just in case.
 			for _, col := range e.Columns.GetColumns() {
-				td, _ := inMemDB.GetTableData(e.Table)
 				td.Lock()
 				td.AddInMemoryCol(col)
 				td.Unlock()
@@ -120,7 +120,6 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 		}
 	}
 
-	td, _ := inMemDB.GetTableData(e.Table)
 	td.Lock()
 	defer td.Unlock()
 

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -43,7 +43,7 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	_, err := event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(e.T(), err)
 
-	optimization, _ := models.GetMemoryDB(e.ctx).GetTableData("foo")
+	optimization := models.GetMemoryDB(e.ctx).GetOrCreateTableData("foo")
 	// Check the in-memory DB columns.
 	var found int
 	for _, col := range optimization.ReadOnlyInMemoryCols().GetColumns() {
@@ -75,9 +75,7 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	_, err = edgeCaseEvent.Save(e.ctx, topicConfig, artie.NewMessage(&newKafkaMsg, nil, newKafkaMsg.Topic))
 	assert.NoError(e.T(), err)
 
-	td, isOk := models.GetMemoryDB(e.ctx).GetTableData("foo")
-	assert.True(e.T(), isOk)
-
+	td := models.GetMemoryDB(e.ctx).GetOrCreateTableData("foo")
 	inMemCol, isOk := td.ReadOnlyInMemoryCols().GetColumn(badColumn)
 	assert.True(e.T(), isOk)
 	assert.Equal(e.T(), typing.Invalid, inMemCol.KindDetails)
@@ -100,9 +98,7 @@ func (e *EventsTestSuite) TestEvent_SaveCasing() {
 	_, err := event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(e.T(), err)
 
-	td, isOk := models.GetMemoryDB(e.ctx).GetTableData("foo")
-	assert.True(e.T(), isOk)
-
+	td := models.GetMemoryDB(e.ctx).GetOrCreateTableData("foo")
 	rowData := td.RowsData()[event.PrimaryKeyValue()]
 	expectedColumns := []string{"randomcol", "anothercol"}
 	for _, expectedColumn := range expectedColumns {
@@ -138,9 +134,7 @@ func (e *EventsTestSuite) TestEventSaveOptionalSchema() {
 	_, err := event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(e.T(), err)
 
-	td, isOk := models.GetMemoryDB(e.ctx).GetTableData("foo")
-	assert.True(e.T(), isOk)
-
+	td := models.GetMemoryDB(e.ctx).GetOrCreateTableData("foo")
 	column, isOk := td.ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
 	assert.True(e.T(), isOk)
 	assert.Equal(e.T(), typing.String, column.KindDetails)
@@ -179,8 +173,7 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	_, err := evt.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.NoError(e.T(), err)
 
-	td, isOk := models.GetMemoryDB(e.ctx).GetTableData("non_existent")
-	assert.True(e.T(), isOk)
+	td := models.GetMemoryDB(e.ctx).GetOrCreateTableData("non_existent")
 	var prevKey string
 	for _, col := range td.ReadOnlyInMemoryCols().GetColumns() {
 		if col.Name == constants.DeleteColumnMarker {
@@ -247,8 +240,7 @@ func (e *EventsTestSuite) TestEventSaveColumns() {
 	_, err := event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(e.T(), err)
 
-	td, isOk := models.GetMemoryDB(e.ctx).GetTableData("foo")
-	assert.True(e.T(), isOk)
+	td := models.GetMemoryDB(e.ctx).GetOrCreateTableData("foo")
 
 	column, isOk := td.ReadOnlyInMemoryCols().GetColumn("randomcol")
 	assert.True(e.T(), isOk)

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -43,7 +43,7 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	_, err := event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(e.T(), err)
 
-	optimization := models.GetMemoryDB(e.ctx).TableData["foo"]
+	optimization, _ := models.GetMemoryDB(e.ctx).GetTableData("foo")
 	// Check the in-memory DB columns.
 	var found int
 	for _, col := range optimization.ReadOnlyInMemoryCols().GetColumns() {
@@ -74,9 +74,13 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	newKafkaMsg := kafka.Message{}
 	_, err = edgeCaseEvent.Save(e.ctx, topicConfig, artie.NewMessage(&newKafkaMsg, nil, newKafkaMsg.Topic))
 	assert.NoError(e.T(), err)
-	inMemoryCol, isOk := models.GetMemoryDB(e.ctx).TableData["foo"].ReadOnlyInMemoryCols().GetColumn(badColumn)
+
+	td, isOk := models.GetMemoryDB(e.ctx).GetTableData("foo")
 	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), typing.Invalid, inMemoryCol.KindDetails)
+
+	inMemCol, isOk := td.ReadOnlyInMemoryCols().GetColumn(badColumn)
+	assert.True(e.T(), isOk)
+	assert.Equal(e.T(), typing.Invalid, inMemCol.KindDetails)
 }
 
 func (e *EventsTestSuite) TestEvent_SaveCasing() {
@@ -96,7 +100,10 @@ func (e *EventsTestSuite) TestEvent_SaveCasing() {
 	_, err := event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(e.T(), err)
 
-	rowData := models.GetMemoryDB(e.ctx).TableData["foo"].RowsData()[event.PrimaryKeyValue()]
+	td, isOk := models.GetMemoryDB(e.ctx).GetTableData("foo")
+	assert.True(e.T(), isOk)
+
+	rowData := td.RowsData()[event.PrimaryKeyValue()]
 	expectedColumns := []string{"randomcol", "anothercol"}
 	for _, expectedColumn := range expectedColumns {
 		_, isOk := rowData[expectedColumn]
@@ -131,19 +138,22 @@ func (e *EventsTestSuite) TestEventSaveOptionalSchema() {
 	_, err := event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(e.T(), err)
 
-	column, isOk := models.GetMemoryDB(e.ctx).TableData["foo"].ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
+	td, isOk := models.GetMemoryDB(e.ctx).GetTableData("foo")
+	assert.True(e.T(), isOk)
+
+	column, isOk := td.ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
 	assert.True(e.T(), isOk)
 	assert.Equal(e.T(), typing.String, column.KindDetails)
 
-	column, isOk = models.GetMemoryDB(e.ctx).TableData["foo"].ReadOnlyInMemoryCols().GetColumn("created_at_date_no_schema")
+	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("created_at_date_no_schema")
 	assert.True(e.T(), isOk)
 	assert.Equal(e.T(), ext.Date.Type, column.KindDetails.ExtendedTimeDetails.Type)
 
-	column, isOk = models.GetMemoryDB(e.ctx).TableData["foo"].ReadOnlyInMemoryCols().GetColumn("json_object_string")
+	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("json_object_string")
 	assert.True(e.T(), isOk)
 	assert.Equal(e.T(), typing.String, column.KindDetails)
 
-	column, isOk = models.GetMemoryDB(e.ctx).TableData["foo"].ReadOnlyInMemoryCols().GetColumn("json_object_no_schema")
+	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("json_object_no_schema")
 	assert.True(e.T(), isOk)
 	assert.Equal(e.T(), typing.Struct, column.KindDetails)
 }
@@ -169,8 +179,10 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	_, err := evt.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.NoError(e.T(), err)
 
+	td, isOk := models.GetMemoryDB(e.ctx).GetTableData("non_existent")
+	assert.True(e.T(), isOk)
 	var prevKey string
-	for _, col := range models.GetMemoryDB(e.ctx).TableData["non_existent"].ReadOnlyInMemoryCols().GetColumns() {
+	for _, col := range td.ReadOnlyInMemoryCols().GetColumns() {
 		if col.Name == constants.DeleteColumnMarker {
 			continue
 		}
@@ -235,19 +247,22 @@ func (e *EventsTestSuite) TestEventSaveColumns() {
 	_, err := event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 	assert.Nil(e.T(), err)
 
-	column, isOk := models.GetMemoryDB(e.ctx).TableData["foo"].ReadOnlyInMemoryCols().GetColumn("randomcol")
+	td, isOk := models.GetMemoryDB(e.ctx).GetTableData("foo")
+	assert.True(e.T(), isOk)
+
+	column, isOk := td.ReadOnlyInMemoryCols().GetColumn("randomcol")
 	assert.True(e.T(), isOk)
 	assert.Equal(e.T(), typing.String, column.KindDetails)
 
-	column, isOk = models.GetMemoryDB(e.ctx).TableData["foo"].ReadOnlyInMemoryCols().GetColumn("anothercol")
+	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("anothercol")
 	assert.True(e.T(), isOk)
 	assert.Equal(e.T(), typing.Float, column.KindDetails)
 
-	column, isOk = models.GetMemoryDB(e.ctx).TableData["foo"].ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
+	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
 	assert.True(e.T(), isOk)
 	assert.Equal(e.T(), ext.DateKindType, column.KindDetails.ExtendedTimeDetails.Type)
 
-	column, isOk = models.GetMemoryDB(e.ctx).TableData["foo"].ReadOnlyInMemoryCols().GetColumn(constants.DeleteColumnMarker)
+	column, isOk = td.ReadOnlyInMemoryCols().GetColumn(constants.DeleteColumnMarker)
 	assert.True(e.T(), isOk)
 	assert.Equal(e.T(), typing.Boolean, column.KindDetails)
 }

--- a/models/flush/flush.go
+++ b/models/flush/flush.go
@@ -23,8 +23,8 @@ func Flush(ctx context.Context) error {
 
 	// Read lock to examine the map of tables
 	models.GetMemoryDB(ctx).RLock()
-	defer models.GetMemoryDB(ctx).RUnlock()
 	allTables := models.GetMemoryDB(ctx).TableData()
+	models.GetMemoryDB(ctx).RUnlock()
 
 	// Create a channel where the buffer is the number of tables, so it doesn't block.
 	flushChan := make(chan string, len(allTables))

--- a/models/memory.go
+++ b/models/memory.go
@@ -54,15 +54,19 @@ func GetMemoryDB(ctx context.Context) *DatabaseData {
 	return db
 }
 
-func (d *DatabaseData) GetTableData(tableName string) *TableData {
-	d.RLock()
-	defer d.RUnlock()
-	_, isOk := d.tableData[tableName]
-	if !isOk {
-		d.tableData[tableName] = &TableData{}
+func (d *DatabaseData) GetOrCreateTableData(tableName string) *TableData {
+	d.Lock()
+	defer d.Unlock()
+
+	table, exists := d.tableData[tableName]
+	if !exists {
+		table = &TableData{
+			Mutex: sync.Mutex{},
+		}
+		d.tableData[tableName] = table
 	}
 
-	return d.tableData[tableName]
+	return table
 }
 
 func (d *DatabaseData) ClearTableConfig(tableName string) {

--- a/models/memory.go
+++ b/models/memory.go
@@ -10,14 +10,12 @@ import (
 
 const dbKey = "__db"
 
+// TableData is a wrapper around *optimization.TableData which stores the actual underlying tableData.
+// The wrapper here is just to have a mutex. Any of the ptr methods on *TableData will require callers to use their own locks.
+// We did this because certain operations require different locking patterns
 type TableData struct {
 	*optimization.TableData
 	sync.Mutex
-}
-
-type DatabaseData struct {
-	tableData map[string]*TableData
-	sync.RWMutex
 }
 
 func (t *TableData) Wipe() {
@@ -31,6 +29,11 @@ func (t *TableData) Empty() bool {
 func (t *TableData) SetTableData(td *optimization.TableData) {
 	t.TableData = td
 	return
+}
+
+type DatabaseData struct {
+	tableData map[string]*TableData
+	sync.RWMutex
 }
 
 func LoadMemoryDB(ctx context.Context) context.Context {

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -26,9 +26,17 @@ func TestTableData_Complete(t *testing.T) {
 	assert.True(t, isOk)
 
 	// Add the td struct
-	td.TableData = &optimization.TableData{}
+	td.SetTableData(&optimization.TableData{})
 	assert.False(t, td.Empty())
 
+	// Wipe via tableData.Wipe()
 	td.Wipe()
+	assert.True(t, td.Empty())
+
+	// Wipe via ClearTableConfig(...)
+	td.SetTableData(&optimization.TableData{})
+	assert.False(t, td.Empty())
+
+	db.ClearTableConfig(tableName)
 	assert.True(t, td.Empty())
 }

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -1,1 +1,34 @@
 package models
+
+import (
+	"context"
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/optimization"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTableData_Complete(t *testing.T) {
+	ctx := context.Background()
+	ctx = LoadMemoryDB(ctx)
+
+	db := GetMemoryDB(ctx)
+	tableName := "table"
+
+	// TableData does not exist
+	_, isOk := db.TableData()[tableName]
+	assert.False(t, isOk)
+
+	td := db.GetOrCreateTableData(tableName)
+	assert.True(t, td.Empty())
+	_, isOk = db.TableData()[tableName]
+	assert.True(t, isOk)
+
+	// Add the td struct
+	td.TableData = &optimization.TableData{}
+	assert.False(t, td.Empty())
+
+	td.Wipe()
+	assert.True(t, td.Empty())
+}

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -17,6 +17,9 @@ type Args struct {
 	SpecificTable string
 }
 
+// Flush will merge and commit the offset on the specified topics within `args.SpecificTable`.
+// If the table list is empty, it'll flush everything. This is the default behavior for the time duration based flush.
+// Table specific flushes will be triggered based on the size of the pool (length and size wise).
 func Flush(args Args) error {
 	if models.GetMemoryDB(args.Context) == nil {
 		return nil

--- a/processes/consumer/flush_suite_test.go
+++ b/processes/consumer/flush_suite_test.go
@@ -1,4 +1,4 @@
-package flush
+package consumer
 
 import (
 	"context"
@@ -10,7 +10,6 @@ import (
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/mocks"
 	"github.com/artie-labs/transfer/models"
-	"github.com/artie-labs/transfer/processes/consumer"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -41,7 +40,7 @@ func (f *FlushTestSuite) SetupTest() {
 	f.ctx = models.LoadMemoryDB(f.ctx)
 
 	f.fakeConsumer = &mocks.FakeConsumer{}
-	consumer.SetKafkaConsumer(map[string]kafkalib.Consumer{"foo": f.fakeConsumer})
+	SetKafkaConsumer(map[string]kafkalib.Consumer{"foo": f.fakeConsumer})
 }
 
 func TestFlushTestSuite(t *testing.T) {

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -41,8 +41,7 @@ func (f *FlushTestSuite) TestMemoryBasic() {
 		_, err := evt.Save(f.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
 		assert.Nil(f.T(), err)
 
-		td, isOk := models.GetMemoryDB(f.ctx).GetTableData("foo")
-		assert.True(f.T(), isOk)
+		td := models.GetMemoryDB(f.ctx).GetOrCreateTableData("foo")
 		assert.Equal(f.T(), int(td.Rows()), i+1)
 	}
 }
@@ -113,8 +112,7 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 
 	// Verify all the tables exist.
 	for idx := range tableNames {
-		td, isOk := models.GetMemoryDB(f.ctx).GetTableData(tableNames[idx])
-		assert.True(f.T(), isOk)
+		td := models.GetMemoryDB(f.ctx).GetOrCreateTableData(tableNames[idx])
 		tableConfig := td.RowsData()
 		assert.Equal(f.T(), len(tableConfig), 5)
 	}

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -1,4 +1,4 @@
-package flush
+package consumer
 
 import (
 	"fmt"
@@ -119,7 +119,7 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 		assert.Equal(f.T(), len(tableConfig), 5)
 	}
 
-	assert.Nil(f.T(), Flush(f.ctx), "flush failed")
+	assert.Nil(f.T(), Flush(Args{Context: f.ctx}), "flush failed")
 	assert.Equal(f.T(), f.fakeConsumer.CommitMessagesCallCount(), len(tableNames)) // Commit 3 times because 3 topics.
 
 	for i := 0; i < len(tableNames); i++ {

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -26,7 +26,7 @@ func SetKafkaConsumer(_topicToConsumer map[string]kafkalib.Consumer) {
 	topicToConsumer = _topicToConsumer
 }
 
-func StartConsumer(ctx context.Context, flushChan chan bool) {
+func StartConsumer(ctx context.Context) {
 	log := logger.FromContext(ctx)
 	settings := config.FromContext(ctx)
 	log.Info("Starting Kafka consumer...", settings.Config.Kafka)
@@ -109,7 +109,6 @@ func StartConsumer(ctx context.Context, flushChan chan bool) {
 					Msg:                    msg,
 					GroupID:                kafkaConsumer.Config().GroupID,
 					TopicToConfigFormatMap: topicToConfigFmtMap,
-					FlushChannel:           flushChan,
 				})
 				if processErr != nil {
 					log.WithError(processErr).WithFields(logFields).Warn("skipping message...")

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -49,6 +49,7 @@ func TestProcessMessageFailures(t *testing.T) {
 
 	err := processMessage(ctx, processArgs)
 	assert.True(t, strings.Contains(err.Error(), "failed to get topic"), err.Error())
+	assert.Equal(t, 0, len(models.GetMemoryDB(ctx).TableData()))
 
 	var mgo mongo.Debezium
 	const (
@@ -82,6 +83,7 @@ func TestProcessMessageFailures(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(),
 		fmt.Sprintf("err: format: %s is not supported", topicToConfigFmtMap[msg.Topic()].tc.CDCKeyFormat)), err.Error())
 	assert.True(t, strings.Contains(err.Error(), "cannot unmarshall key"), err.Error())
+	assert.Equal(t, 0, len(models.GetMemoryDB(ctx).TableData()))
 
 	topicToConfigFmtMap[msg.Topic()].tc.CDCKeyFormat = "org.apache.kafka.connect.storage.StringConverter"
 
@@ -136,8 +138,6 @@ func TestProcessMessageFailures(t *testing.T) {
 		assert.NoError(t, err)
 
 		td := memoryDB.GetOrCreateTableData(table)
-		// TODO: figure out how to check if it tried to flush
-
 		// Check that there are corresponding row(s) in the memory DB
 		assert.Equal(t, len(td.RowsData()), idx)
 	}
@@ -163,5 +163,5 @@ func TestProcessMessageFailures(t *testing.T) {
 
 	err = processMessage(ctx, processArgs)
 	assert.Error(t, err)
-	// TODO: figure out how to check if it tried to flush
+	assert.True(t, td.Rows() > 0)
 }

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -135,16 +135,14 @@ func TestProcessMessageFailures(t *testing.T) {
 		err = processMessage(ctx, processArgs)
 		assert.NoError(t, err)
 
-		td, isOk := memoryDB.GetTableData(table)
-		assert.True(t, isOk)
+		td := memoryDB.GetOrCreateTableData(table)
 		// TODO: figure out how to check if it tried to flush
 
 		// Check that there are corresponding row(s) in the memory DB
 		assert.Equal(t, len(td.RowsData()), idx)
 	}
 
-	td, isOk := memoryDB.GetTableData(table)
-	assert.True(t, isOk)
+	td := memoryDB.GetOrCreateTableData(table)
 
 	// Tombstone means deletion
 	val, isOk := td.RowsData()["id=1"][constants.DeleteColumnMarker]

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -145,17 +145,23 @@ func TestProcessMessageFailures(t *testing.T) {
 		assert.Equal(t, 0, len(flushChan))
 		assert.NoError(t, err)
 
+		td, isOk := memoryDB.GetTableData(table)
+		assert.True(t, isOk)
+
 		// Check that there are corresponding row(s) in the memory DB
-		assert.Equal(t, len(memoryDB.TableData[table].RowsData()), idx)
+		assert.Equal(t, len(td.RowsData()), idx)
 	}
 
+	td, isOk := memoryDB.GetTableData(table)
+	assert.True(t, isOk)
+
 	// Tombstone means deletion
-	val, isOk := memoryDB.TableData[table].RowsData()["id=1"][constants.DeleteColumnMarker]
+	val, isOk := td.RowsData()["id=1"][constants.DeleteColumnMarker]
 	assert.True(t, isOk)
 	assert.True(t, val.(bool))
 
 	// Non tombstone = no delete.
-	val, isOk = memoryDB.TableData[table].RowsData()["id=2"][constants.DeleteColumnMarker]
+	val, isOk = td.RowsData()["id=2"][constants.DeleteColumnMarker]
 	assert.True(t, isOk)
 	assert.False(t, val.(bool))
 

--- a/processes/consumer/pubsub.go
+++ b/processes/consumer/pubsub.go
@@ -55,7 +55,7 @@ func findOrCreateSubscription(ctx context.Context, client *gcp_pubsub.Client, to
 	return sub, err
 }
 
-func StartSubscriber(ctx context.Context, flushChan chan bool) {
+func StartSubscriber(ctx context.Context) {
 	log := logger.FromContext(ctx)
 	settings := config.FromContext(ctx)
 	client, clientErr := gcp_pubsub.NewClient(ctx, settings.Config.Pubsub.ProjectID,
@@ -100,7 +100,6 @@ func StartSubscriber(ctx context.Context, flushChan chan bool) {
 						Msg:                    msg,
 						GroupID:                subName,
 						TopicToConfigFormatMap: topicToConfigFmtMap,
-						FlushChannel:           flushChan,
 					})
 					if processErr != nil {
 						log.WithError(processErr).WithFields(logFields).Warn("skipping message...")


### PR DESCRIPTION
Fixes https://github.com/artie-labs/transfer/issues/97

This is our latest iteration to make `tableFlushTime` truly the same time it takes to flush the table.
As you can recall from the PR linked from the issue, it was `CUM_SUM(tableFlush)`, we got it down to `MAX(tableFlush)`.

These are the main modifications:

## Flush mechanics

Previously, we were flushing the whole database. This is because our lock was at the database level. We did not differentiate between:

1) Time-based trigger flush
2) Individual table triggered flush

Now, only (1) is flushing the whole database.
(2) will only trigger the flush for the specified table.

This is to avoid front-runners triggering redundant flushes for slower tables.

## Locking has moved from db to table

We still have a lock on the db, but it's meant for admin purposes. The actual lock is now at the table level, and to do this, we created a wrapper around `*optimization.TableData`. The sole purpose of this wrapper is to attach a mutex so we can have effective locking between processing and flushing.

