### PR TITLE
Escaping column names for DWHs

### DIFF
--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -30,14 +30,10 @@ func CastColVal(colVal interface{}, colKind typing.Column) (interface{}, error) 
 			case ext.TimeKindType:
 				colVal = extTime.String(typing.StreamingTimeFormat)
 			}
-		// All the other types do not need string wrapping.
-		// TODO - what does typing.String.Kind do?
-		case typing.String.Kind, typing.Struct.Kind:
+		case typing.Struct.Kind:
 			if colKind.KindDetails == typing.Struct {
 				if strings.Contains(fmt.Sprint(colVal), constants.ToastUnavailableValuePlaceholder) {
-					colVal = map[string]interface{}{
-						"key": constants.ToastUnavailableValuePlaceholder,
-					}
+					colVal = fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder)
 				}
 			}
 		case typing.Array.Kind:

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -1,8 +1,11 @@
 package bigquery
 
 import (
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
 
@@ -57,6 +60,12 @@ func TestCastColVal(t *testing.T) {
 			colVal:        `{"hello": "world"}`,
 			colKind:       typing.Column{KindDetails: typing.Struct},
 			expectedValue: `{"hello": "world"}`,
+		},
+		{
+			name:          "struct w/ toast",
+			colVal:        constants.ToastUnavailableValuePlaceholder,
+			colKind:       typing.Column{KindDetails: typing.Struct},
+			expectedValue: fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder),
 		},
 		{
 			name:          "array",

--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -104,7 +104,6 @@ func parseSchemaQuery(row string, createTable, dropDeletedColumns bool) (*types.
 			return nil, fmt.Errorf("unexpected colType, colType: %s, parts: %v", colType, parts)
 		}
 
-		// TODO: test - BigQuery will return the column back escaped.
 		bigQueryColumns.AddColumn(typing.NewColumn(typing.UnescapeColumnName(parts[0], constants.BigQuery), typing.BigQueryTypeToKind(strings.Join(parts[1:], " "))))
 	}
 

--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -104,10 +104,7 @@ func parseSchemaQuery(row string, createTable, dropDeletedColumns bool) (*types.
 			return nil, fmt.Errorf("unexpected colType, colType: %s, parts: %v", colType, parts)
 		}
 
-		bigQueryColumns.AddColumn(typing.Column{
-			Name:        parts[0],
-			KindDetails: typing.BigQueryTypeToKind(strings.Join(parts[1:], " ")),
-		})
+		bigQueryColumns.AddColumn(typing.NewColumn(parts[0], typing.BigQueryTypeToKind(strings.Join(parts[1:], " "))))
 	}
 
 	return types.NewDwhTableConfig(&bigQueryColumns, nil, createTable, dropDeletedColumns), nil

--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -104,7 +104,8 @@ func parseSchemaQuery(row string, createTable, dropDeletedColumns bool) (*types.
 			return nil, fmt.Errorf("unexpected colType, colType: %s, parts: %v", colType, parts)
 		}
 
-		bigQueryColumns.AddColumn(typing.NewColumn(parts[0], typing.BigQueryTypeToKind(strings.Join(parts[1:], " "))))
+		// TODO: test - BigQuery will return the column back escaped.
+		bigQueryColumns.AddColumn(typing.NewColumn(typing.UnescapeColumnName(parts[0], constants.BigQuery), typing.BigQueryTypeToKind(strings.Join(parts[1:], " "))))
 	}
 
 	return types.NewDwhTableConfig(&bigQueryColumns, nil, createTable, dropDeletedColumns), nil

--- a/clients/bigquery/ddl_test.go
+++ b/clients/bigquery/ddl_test.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"fmt"
+
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,7 @@ func (b *BigQueryTestSuite) TestParseSchemaQuery() {
 		assert.Equal(b.T(), true, tableConfig.DropDeletedColumns())
 		assert.Equal(b.T(), len(tableConfig.Columns().GetColumns()), 2, tableConfig.Columns)
 		for _, col := range tableConfig.Columns().GetColumns() {
-			assert.Equal(b.T(), col.KindDetails, typing.String, fmt.Sprintf("col: %s, kind: %v incorrect", col.Name, col.KindDetails))
+			assert.Equal(b.T(), col.KindDetails, typing.String, fmt.Sprintf("col: %s, kind: %v incorrect", col.Name(false), col.KindDetails))
 		}
 	}
 }

--- a/clients/bigquery/ddl_test.go
+++ b/clients/bigquery/ddl_test.go
@@ -30,12 +30,13 @@ func (b *BigQueryTestSuite) TestParseSchemaQuery() {
 
 func (b *BigQueryTestSuite) TestParseSchemaQueryComplex() {
 	// This test will test every single data type.
-	tableConfig, err := parseSchemaQuery("CREATE TABLE `artie-labs.mock.customers`(string_field_0 STRING,string_field_1 STRING,field2 INT64,field3 ARRAY<INT64>,field4 FLOAT64,field5 NUMERIC,field6 BIGNUMERIC,field7 BOOL,field8 TIMESTAMP,field9 DATE,field10 TIME,field11 DATETIME,field12 STRUCT<foo STRING>,field13 JSON, field14 TIME)OPTIONS(expiration_timestamp=TIMESTAMP 2023-03-26T20:03:44.504Z);",
-		false, false)
+	reservedKeywordCol := "`select`"
+	unparsedQuery := fmt.Sprintf("CREATE TABLE `artie-labs.mock.customers`(string_field_0 STRING,string_field_1 STRING,field2 INT64,field3 ARRAY<INT64>,field4 FLOAT64,field5 NUMERIC,field6 BIGNUMERIC,field7 BOOL,field8 TIMESTAMP,field9 DATE,field10 TIME,field11 DATETIME,field12 STRUCT<foo STRING>,field13 JSON, field14 TIME, %s STRING)OPTIONS(expiration_timestamp=TIMESTAMP 2023-03-26T20:03:44.504Z);", reservedKeywordCol)
+	tableConfig, err := parseSchemaQuery(unparsedQuery, false, false)
 
 	assert.NoError(b.T(), err, err)
 	assert.Equal(b.T(), false, tableConfig.DropDeletedColumns())
-	assert.Equal(b.T(), len(tableConfig.Columns().GetColumns()), 15, tableConfig.Columns)
+	assert.Equal(b.T(), len(tableConfig.Columns().GetColumns()), 16, tableConfig.Columns)
 
 	anticipatedColumns := map[string]typing.KindDetails{
 		"string_field_0": typing.String,
@@ -53,6 +54,7 @@ func (b *BigQueryTestSuite) TestParseSchemaQueryComplex() {
 		"field12":        typing.Struct,
 		"field13":        typing.Struct,
 		"field14":        typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType),
+		"select":         typing.String,
 	}
 
 	for anticipatedCol, anticipatedKind := range anticipatedColumns {

--- a/clients/bigquery/ddl_test.go
+++ b/clients/bigquery/ddl_test.go
@@ -23,7 +23,7 @@ func (b *BigQueryTestSuite) TestParseSchemaQuery() {
 		assert.Equal(b.T(), true, tableConfig.DropDeletedColumns())
 		assert.Equal(b.T(), len(tableConfig.Columns().GetColumns()), 2, tableConfig.Columns)
 		for _, col := range tableConfig.Columns().GetColumns() {
-			assert.Equal(b.T(), col.KindDetails, typing.String, fmt.Sprintf("col: %s, kind: %v incorrect", col.Name(false), col.KindDetails))
+			assert.Equal(b.T(), col.KindDetails, typing.String, fmt.Sprintf("col: %s, kind: %v incorrect", col.Name(nil), col.KindDetails))
 		}
 	}
 }

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -33,7 +33,7 @@ func merge(tableData *optimization.TableData) ([]*Row, error) {
 	var rows []*Row
 	for _, value := range tableData.RowsData() {
 		data := make(map[string]bigquery.Value)
-		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate() {
+		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(false) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal, err := CastColVal(value[col], colKind)
 			if err != nil {
@@ -150,7 +150,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		SubQuery:       tempAlterTableArgs.FqTableName,
 		IdempotentKey:  tableData.TopicConfig.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,
-		Columns:        tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(),
+		Columns:        tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(true),
 		ColumnsToTypes: *tableData.ReadOnlyInMemoryCols(),
 		SoftDelete:     tableData.TopicConfig.SoftDelete,
 		BigQuery:       true,

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -105,7 +105,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	for colToDelete := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, col := range srcKeysMissing {
-			if found = col.Name == colToDelete; found {
+			if found = col.Name(false) == colToDelete; found {
 				// Found it.
 				break
 			}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -64,7 +64,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	log := logger.FromContext(ctx)
-	// Check if all the columns exist in Snowflake
+	// Check if all the columns exist in BigQuery
 	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(), tableData.TopicConfig.SoftDelete)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,
@@ -75,14 +75,14 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		CdcTime:     tableData.LatestCDCTs,
 	}
 
-	// Keys that exist in CDC stream, but not in Snowflake
+	// Keys that exist in CDC stream, but not in BigQuery
 	err = ddl.AlterTable(ctx, createAlterTableArgs, targetKeysMissing...)
 	if err != nil {
 		log.WithError(err).Warn("failed to apply alter table")
 		return err
 	}
 
-	// Keys that exist in Snowflake, but don't exist in our CDC stream.
+	// Keys that exist in BigQuery, but don't exist in our CDC stream.
 	// createTable is set to false because table creation requires a column to be added
 	// Which means, we'll only do it upon Add columns.
 	deleteAlterTableArgs := ddl.AlterTableArgs{
@@ -117,6 +117,9 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		}
 	}
 
+	// Infer the right data types from BigQuery before temp table creation.
+	tableData.UpdateInMemoryColumnsFromDestination(tableConfig.Columns().GetColumns()...)
+
 	// Start temporary table creation
 	tempAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:            s,
@@ -132,7 +135,6 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 	// End temporary table creation
 
-	tableData.UpdateInMemoryColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 	rows, err := merge(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")

--- a/clients/bigquery/merge_test.go
+++ b/clients/bigquery/merge_test.go
@@ -1,1 +1,0 @@
-package bigquery

--- a/clients/snowflake/ddl.go
+++ b/clients/snowflake/ddl.go
@@ -73,10 +73,7 @@ func (s *Store) getTableConfig(ctx context.Context, fqName string, dropDeletedCo
 			row[columnNameList[idx]] = strings.ToLower(fmt.Sprint(*interfaceVal))
 		}
 
-		snowflakeColumns.AddColumn(typing.Column{
-			Name:        row[describeNameCol],
-			KindDetails: typing.SnowflakeTypeToKind(row[describeTypeCol]),
-		})
+		snowflakeColumns.AddColumn(typing.NewColumn(row[describeNameCol], typing.SnowflakeTypeToKind(row[describeTypeCol])))
 	}
 
 	sflkTableConfig := types.NewDwhTableConfig(&snowflakeColumns, nil, tableMissing, dropDeletedColumns)

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -24,24 +24,17 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 		"name":        typing.String,
 		"created_at":  typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		cols.AddColumn(typing.NewColumn(colName, kindDetails))
 	}
 
 	config := types.NewDwhTableConfig(&cols, nil, false, true)
 
 	s.store.configMap.AddTableToConfig(fqName, config)
 
-	nameCol := typing.Column{
-		Name:        "name",
-		KindDetails: typing.String,
-	}
-
+	nameCol := typing.NewColumn("name", typing.String)
 	tc := s.store.configMap.TableConfig(fqName)
 
-	val := tc.ShouldDeleteColumn(nameCol.Name, time.Now().Add(-1*6*time.Hour))
+	val := tc.ShouldDeleteColumn(nameCol.Name(false), time.Now().Add(-1*6*time.Hour))
 	assert.False(s.T(), val, "should not try to delete this column")
 	assert.Equal(s.T(), len(s.store.configMap.TableConfig(fqName).ReadOnlyColumnsToDelete()), 1)
 
@@ -61,36 +54,29 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 		"name":        typing.String,
 		"created_at":  typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		cols.AddColumn(typing.NewColumn(colName, kindDetails))
 	}
 
 	config := types.NewDwhTableConfig(&cols, nil, false, true)
 	s.store.configMap.AddTableToConfig(fqName, config)
 
-	nameCol := typing.Column{
-		Name:        "name",
-		KindDetails: typing.String,
-	}
-
+	nameCol := typing.NewColumn("name", typing.String)
 	// Let's try to delete name.
-	allowed := s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name, time.Now().Add(-1*(6*time.Hour)))
+	allowed := s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(false), time.Now().Add(-1*(6*time.Hour)))
 
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete")
 
 	// Process tried to delete, but it's lagged.
-	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name, time.Now().Add(-1*(6*time.Hour)))
+	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(false), time.Now().Add(-1*(6*time.Hour)))
 
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete")
 
 	// Process now caught up, and is asking if we can delete, should still be no.
-	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name, time.Now())
+	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(false), time.Now())
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete still")
 
 	// Process is finally ahead, has permission to delete now.
-	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name,
+	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(false),
 		time.Now().Add(2*constants.DeletionConfidencePadding))
 
 	assert.Equal(s.T(), allowed, true, "should now be allowed to delete")
@@ -105,10 +91,7 @@ func (s *SnowflakeTestSuite) TestManipulateShouldDeleteColumn() {
 		"name":        typing.String,
 		"created_at":  typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		cols.AddColumn(typing.NewColumn(colName, kindDetails))
 	}
 
 	tc := types.NewDwhTableConfig(&cols, map[string]time.Time{

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -34,7 +34,7 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 	nameCol := typing.NewColumn("name", typing.String)
 	tc := s.store.configMap.TableConfig(fqName)
 
-	val := tc.ShouldDeleteColumn(nameCol.Name(false), time.Now().Add(-1*6*time.Hour))
+	val := tc.ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*6*time.Hour))
 	assert.False(s.T(), val, "should not try to delete this column")
 	assert.Equal(s.T(), len(s.store.configMap.TableConfig(fqName).ReadOnlyColumnsToDelete()), 1)
 
@@ -62,21 +62,21 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 
 	nameCol := typing.NewColumn("name", typing.String)
 	// Let's try to delete name.
-	allowed := s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(false), time.Now().Add(-1*(6*time.Hour)))
+	allowed := s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*(6*time.Hour)))
 
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete")
 
 	// Process tried to delete, but it's lagged.
-	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(false), time.Now().Add(-1*(6*time.Hour)))
+	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*(6*time.Hour)))
 
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete")
 
 	// Process now caught up, and is asking if we can delete, should still be no.
-	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(false), time.Now())
+	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil), time.Now())
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete still")
 
 	// Process is finally ahead, has permission to delete now.
-	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(false),
+	allowed = s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil),
 		time.Now().Add(2*constants.DeletionConfidencePadding))
 
 	assert.Equal(s.T(), allowed, true, "should now be allowed to delete")

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -25,23 +25,28 @@ func escapeCols(cols []typing.Column) (colsToUpdate []string, colsToUpdateEscape
 			continue
 		}
 
-		escapedCol := column.Name(true)
+		nameArgs := &typing.NameArgs{
+			Escape:   true,
+			DestKind: constants.SnowflakeStages,
+		}
+
+		escapedCol := column.Name(nameArgs)
 		switch column.KindDetails.Kind {
 		case typing.Struct.Kind, typing.Array.Kind:
 			if column.ToastColumn {
 				escapedCol = fmt.Sprintf("CASE WHEN %s = '%s' THEN {'key': '%s'} ELSE PARSE_JSON(%s) END %s",
 					// Comparing the column against placeholder
-					column.Name(true), constants.ToastUnavailableValuePlaceholder,
+					column.Name(nameArgs), constants.ToastUnavailableValuePlaceholder,
 					// Casting placeholder as a JSON object
 					constants.ToastUnavailableValuePlaceholder,
 					// Regular parsing.
-					column.Name(true), column.Name(true))
+					column.Name(nameArgs), column.Name(nameArgs))
 			} else {
-				escapedCol = fmt.Sprintf("PARSE_JSON(%s) %s", column.Name(true), column.Name(true))
+				escapedCol = fmt.Sprintf("PARSE_JSON(%s) %s", column.Name(nameArgs), column.Name(nameArgs))
 			}
 		}
 
-		colsToUpdate = append(colsToUpdate, column.Name(false))
+		colsToUpdate = append(colsToUpdate, column.Name(nil))
 		colsToUpdateEscaped = append(colsToUpdateEscaped, escapedCol)
 	}
 

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -25,23 +25,23 @@ func escapeCols(cols []typing.Column) (colsToUpdate []string, colsToUpdateEscape
 			continue
 		}
 
-		escapedCol := column.Name
+		escapedCol := column.Name(true)
 		switch column.KindDetails.Kind {
 		case typing.Struct.Kind, typing.Array.Kind:
 			if column.ToastColumn {
 				escapedCol = fmt.Sprintf("CASE WHEN %s = '%s' THEN {'key': '%s'} ELSE PARSE_JSON(%s) END %s",
 					// Comparing the column against placeholder
-					column.Name, constants.ToastUnavailableValuePlaceholder,
+					column.Name(true), constants.ToastUnavailableValuePlaceholder,
 					// Casting placeholder as a JSON object
 					constants.ToastUnavailableValuePlaceholder,
 					// Regular parsing.
-					column.Name, column.Name)
+					column.Name(true), column.Name(true))
 			} else {
-				escapedCol = fmt.Sprintf("PARSE_JSON(%s) %s", column.Name, column.Name)
+				escapedCol = fmt.Sprintf("PARSE_JSON(%s) %s", column.Name(true), column.Name(true))
 			}
 		}
 
-		colsToUpdate = append(colsToUpdate, column.Name)
+		colsToUpdate = append(colsToUpdate, column.Name(false))
 		colsToUpdateEscaped = append(colsToUpdateEscaped, escapedCol)
 	}
 

--- a/clients/snowflake/merge.go
+++ b/clients/snowflake/merge.go
@@ -48,6 +48,7 @@ func escapeCols(cols []typing.Column) (colsToUpdate []string, colsToUpdateEscape
 	return
 }
 
+// TODO - this needs to be patched to support keyword substitution.
 func getMergeStatement(ctx context.Context, tableData *optimization.TableData) (string, error) {
 	var tableValues []string
 	colsToUpdate, colsToUpdateEscaped := escapeCols(tableData.ReadOnlyInMemoryCols().GetColumns())

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -28,11 +28,10 @@ func (s *SnowflakeTestSuite) TestEscapeCols() {
 	)
 
 	for _, col := range []string{"foo", "bar"} {
-		happyPathCols.AddColumn(typing.Column{
-			Name:        col,
-			KindDetails: typing.String,
-			ToastColumn: false,
-		})
+		_col := typing.NewColumn(col, typing.String)
+		_col.ToastColumn = false
+
+		happyPathCols.AddColumn(_col)
 	}
 
 	for _, col := range []string{"foo", "bar", "xyz"} {
@@ -41,11 +40,9 @@ func (s *SnowflakeTestSuite) TestEscapeCols() {
 			kd = typing.Struct
 		}
 
-		happyPathStructCols.AddColumn(typing.Column{
-			Name:        col,
-			KindDetails: kd,
-			ToastColumn: false,
-		})
+		_col := typing.NewColumn(col, kd)
+		_col.ToastColumn = false
+		happyPathStructCols.AddColumn(_col)
 	}
 
 	for _, col := range []string{"foo", "bar", "xyz", "abc"} {
@@ -58,11 +55,10 @@ func (s *SnowflakeTestSuite) TestEscapeCols() {
 			kd = typing.Array
 		}
 
-		happyPathStructArrayCols.AddColumn(typing.Column{
-			Name:        col,
-			KindDetails: kd,
-			ToastColumn: false,
-		})
+		_col := typing.NewColumn(col, kd)
+		_col.ToastColumn = false
+
+		happyPathStructArrayCols.AddColumn(_col)
 	}
 
 	for _, col := range []string{"foo", "bar", "xyz", "abc", "dusty"} {
@@ -81,11 +77,10 @@ func (s *SnowflakeTestSuite) TestEscapeCols() {
 			kd = typing.Struct
 		}
 
-		happyPathStructArrayWithToastStructCols.AddColumn(typing.Column{
-			Name:        col,
-			KindDetails: kd,
-			ToastColumn: toast,
-		})
+		_col := typing.NewColumn(col, kd)
+		_col.ToastColumn = toast
+
+		happyPathStructArrayWithToastStructCols.AddColumn(_col)
 	}
 
 	testCases := []_testCase{
@@ -125,10 +120,7 @@ func (s *SnowflakeTestSuite) TestEscapeCols() {
 
 func (s *SnowflakeTestSuite) TestMergeNoDeleteFlag() {
 	var cols typing.Columns
-	cols.AddColumn(typing.Column{
-		Name:        "id",
-		KindDetails: typing.Integer,
-	})
+	cols.AddColumn(typing.NewColumn("id", typing.Integer))
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, kafkalib.TopicConfig{}, "")
 	_, err := getMergeStatement(s.ctx, tableData)
@@ -143,10 +135,7 @@ func (s *SnowflakeTestSuite) TestMerge() {
 		"NAME":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 	} {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		cols.AddColumn(typing.NewColumn(colName, kindDetails))
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -207,10 +196,7 @@ func (s *SnowflakeTestSuite) TestMergeWithSingleQuote() {
 		"NAME":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 	} {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		cols.AddColumn(typing.NewColumn(colName, kindDetails))
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -243,10 +229,7 @@ func (s *SnowflakeTestSuite) TestMergeJson() {
 		"meta":                       typing.Struct,
 		constants.DeleteColumnMarker: typing.Boolean,
 	} {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		cols.AddColumn(typing.NewColumn(colName, kindDetails))
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -281,10 +264,7 @@ func (s *SnowflakeTestSuite) TestMergeJSONKey() {
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 	} {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		cols.AddColumn(typing.NewColumn(colName, kindDetails))
 	}
 
 	rowData := make(map[string]map[string]interface{})

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -115,7 +115,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 	for colToDelete := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, col := range srcKeysMissing {
-			if found = col.Name == colToDelete; found {
+			if found = col.Name(false) == colToDelete; found {
 				// Found it.
 				break
 			}

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -116,7 +116,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 	for colToDelete := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, col := range srcKeysMissing {
-			if found = col.Name(false) == colToDelete; found {
+			if found = col.Name(nil) == colToDelete; found {
 				// Found it.
 				break
 			}

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -2,7 +2,6 @@ package snowflake
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -134,8 +133,6 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 		log.WithError(err).Warn("failed to generate the getMergeStatement query")
 		return err
 	}
-
-	fmt.Println("query", query)
 
 	log.WithField("query", query).Debug("executing...")
 	_, err = s.Exec(query)

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -2,6 +2,7 @@ package snowflake
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -133,6 +134,8 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 		log.WithError(err).Warn("failed to generate the getMergeStatement query")
 		return err
 	}
+
+	fmt.Println("query", query)
 
 	log.WithField("query", query).Debug("executing...")
 	_, err = s.Exec(query)

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -29,10 +29,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 
 	var cols typing.Columns
 	for colName, colKind := range colToKindDetailsMap {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: colKind,
-		})
+		cols.AddColumn(typing.NewColumn(colName, colKind))
 	}
 
 	rowsData := map[string]map[string]interface{}{
@@ -62,10 +59,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 
 	var anotherCols typing.Columns
 	for colName, kindDetails := range anotherColToKindDetailsMap {
-		anotherCols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		anotherCols.AddColumn(typing.NewColumn(colName, kindDetails))
 	}
 
 	s.store.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake),
@@ -89,10 +83,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 
 	var cols typing.Columns
 	for colName, colKind := range colToKindDetailsMap {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: colKind,
-		})
+		cols.AddColumn(typing.NewColumn(colName, colKind))
 	}
 
 	rowsData := make(map[string]map[string]interface{})
@@ -140,10 +131,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 
 	var cols typing.Columns
 	for colName, colKind := range colToKindDetailsMap {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: colKind,
-		})
+		cols.AddColumn(typing.NewColumn(colName, colKind))
 	}
 
 	rowsData := make(map[string]map[string]interface{})
@@ -205,10 +193,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 	var cols typing.Columns
 	for colName, colKind := range colToKindDetailsMap {
-		cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: colKind,
-		})
+		cols.AddColumn(typing.NewColumn(colName, colKind))
 	}
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
@@ -225,17 +210,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 	var sflkCols typing.Columns
 	for colName, colKind := range snowflakeColToKindDetailsMap {
-		sflkCols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: colKind,
-		})
+		sflkCols.AddColumn(typing.NewColumn(colName, colKind))
 	}
 
-	sflkCols.AddColumn(typing.Column{
-		Name:        "new",
-		KindDetails: typing.String,
-	})
-
+	sflkCols.AddColumn(typing.NewColumn("new", typing.String))
 	config := types.NewDwhTableConfig(&sflkCols, nil, false, true)
 	s.store.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake), config)
 
@@ -258,11 +236,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 		inMemColumns := tableData.ReadOnlyInMemoryCols()
 		// Since sflkColumns overwrote the format, let's set it correctly again.
-		inMemColumns.UpdateColumn(typing.Column{
-			Name:        "created_at",
-			KindDetails: typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
-		})
-
+		inMemColumns.UpdateColumn(typing.NewColumn("created_at", typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano))))
 		tableData.SetInMemoryColumns(inMemColumns)
 		break
 	}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -48,7 +48,7 @@ func (s *Store) prepareTempTable(ctx context.Context, tableData *optimization.Ta
 
 	_, err = s.Exec(fmt.Sprintf("COPY INTO %s (%s) FROM (SELECT %s FROM @%s)",
 		// Copy into temporary tables (column ...)
-		tempTableName, strings.Join(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(), ","),
+		tempTableName, strings.Join(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(true), ","),
 		// Escaped columns, TABLE NAME
 		escapeColumns(tableData.ReadOnlyInMemoryCols(), ","), addPrefixToTableName(tempTableName, "%")))
 
@@ -78,7 +78,7 @@ func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableNa
 	writer.Comma = '\t'
 	for _, value := range tableData.RowsData() {
 		var row []string
-		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate() {
+		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(false) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal := value[col]
 			// Check
@@ -178,7 +178,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		SubQuery:       temporaryTableName,
 		IdempotentKey:  tableData.TopicConfig.IdempotentKey,
 		PrimaryKeys:    tableData.PrimaryKeys,
-		Columns:        tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(),
+		Columns:        tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(true),
 		ColumnsToTypes: *tableData.ReadOnlyInMemoryCols(),
 		SoftDelete:     tableData.TopicConfig.SoftDelete,
 	})

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -154,7 +154,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	for colToDelete := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, col := range srcKeysMissing {
-			if found = col.Name == colToDelete; found {
+			if found = col.Name(false) == colToDelete; found {
 				// Found it.
 				break
 			}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -48,7 +48,10 @@ func (s *Store) prepareTempTable(ctx context.Context, tableData *optimization.Ta
 
 	_, err = s.Exec(fmt.Sprintf("COPY INTO %s (%s) FROM (SELECT %s FROM @%s)",
 		// Copy into temporary tables (column ...)
-		tempTableName, strings.Join(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(true), ","),
+		tempTableName, strings.Join(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(&typing.NameArgs{
+			Escape:   true,
+			DestKind: s.Label(),
+		}), ","),
 		// Escaped columns, TABLE NAME
 		escapeColumns(tableData.ReadOnlyInMemoryCols(), ","), addPrefixToTableName(tempTableName, "%")))
 
@@ -78,7 +81,7 @@ func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableNa
 	writer.Comma = '\t'
 	for _, value := range tableData.RowsData() {
 		var row []string
-		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(false) {
+		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(nil) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal := value[col]
 			// Check
@@ -154,7 +157,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	for colToDelete := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, col := range srcKeysMissing {
-			if found = col.Name(false) == colToDelete; found {
+			if found = col.Name(nil) == colToDelete; found {
 				// Found it.
 				break
 			}
@@ -174,11 +177,14 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 
 	// Prepare merge statement
 	mergeQuery, err := dml.MergeStatement(dml.MergeArgument{
-		FqTableName:    tableData.ToFqName(ctx, constants.Snowflake),
-		SubQuery:       temporaryTableName,
-		IdempotentKey:  tableData.TopicConfig.IdempotentKey,
-		PrimaryKeys:    tableData.PrimaryKeys,
-		Columns:        tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(true),
+		FqTableName:   tableData.ToFqName(ctx, constants.Snowflake),
+		SubQuery:      temporaryTableName,
+		IdempotentKey: tableData.TopicConfig.IdempotentKey,
+		PrimaryKeys:   tableData.PrimaryKeys,
+		Columns: tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(&typing.NameArgs{
+			Escape:   true,
+			DestKind: s.Label(),
+		}),
 		ColumnsToTypes: *tableData.ReadOnlyInMemoryCols(),
 		SoftDelete:     tableData.TopicConfig.SoftDelete,
 	})

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -22,10 +22,7 @@ func generateTableData(rows int) (string, *optimization.TableData) {
 	randomTableName := fmt.Sprintf("temp_%s_%s", constants.ArtiePrefix, stringutil.Random(10))
 	cols := &typing.Columns{}
 	for _, col := range []string{"user_id", "first_name", "last_name"} {
-		cols.AddColumn(typing.Column{
-			Name:        col,
-			KindDetails: typing.String,
-		})
+		cols.AddColumn(typing.NewColumn(col, typing.String))
 	}
 
 	td := optimization.NewTableData(cols, []string{"user_id"}, kafkalib.TopicConfig{}, "")

--- a/clients/snowflake/util.go
+++ b/clients/snowflake/util.go
@@ -24,7 +24,7 @@ func addPrefixToTableName(fqTableName string, prefix string) string {
 // It'll return like this: $1, $2, $3
 func escapeColumns(columns *typing.Columns, delimiter string) string {
 	var escapedCols []string
-	for index, col := range columns.GetColumnsToUpdate(false) {
+	for index, col := range columns.GetColumnsToUpdate(nil) {
 		colKind, _ := columns.GetColumn(col)
 		escapedCol := fmt.Sprintf("$%d", index+1)
 		switch colKind.KindDetails {

--- a/clients/snowflake/util.go
+++ b/clients/snowflake/util.go
@@ -24,7 +24,7 @@ func addPrefixToTableName(fqTableName string, prefix string) string {
 // It'll return like this: $1, $2, $3
 func escapeColumns(columns *typing.Columns, delimiter string) string {
 	var escapedCols []string
-	for index, col := range columns.GetColumnsToUpdate() {
+	for index, col := range columns.GetColumnsToUpdate(false) {
 		colKind, _ := columns.GetColumn(col)
 		escapedCol := fmt.Sprintf("$%d", index+1)
 		switch colKind.KindDetails {

--- a/clients/snowflake/util_test.go
+++ b/clients/snowflake/util_test.go
@@ -57,26 +57,14 @@ func TestEscapeColumns(t *testing.T) {
 		happyPathAndJSONAndArrayCols typing.Columns
 	)
 
-	happyPathCols.AddColumn(typing.Column{
-		Name:        "foo",
-		KindDetails: typing.String,
-	})
-	happyPathCols.AddColumn(typing.Column{
-		Name:        "bar",
-		KindDetails: typing.String,
-	})
+	happyPathCols.AddColumn(typing.NewColumn("foo", typing.String))
+	happyPathCols.AddColumn(typing.NewColumn("bar", typing.String))
 
 	happyPathAndJSONCols = happyPathCols
-	happyPathAndJSONCols.AddColumn(typing.Column{
-		Name:        "struct",
-		KindDetails: typing.Struct,
-	})
+	happyPathAndJSONCols.AddColumn(typing.NewColumn("struct", typing.Struct))
 
 	happyPathAndJSONAndArrayCols = happyPathAndJSONCols
-	happyPathAndJSONAndArrayCols.AddColumn(typing.Column{
-		Name:        "array",
-		KindDetails: typing.Array,
-	})
+	happyPathAndJSONAndArrayCols.AddColumn(typing.NewColumn("array", typing.Array))
 
 	testCases := []_testCase{
 		{

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/artie-labs/transfer/lib/typing"
-
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/stretchr/testify/assert"
 )
@@ -74,97 +72,6 @@ func TestToArrayString(t *testing.T) {
 		actualString, actualErr := InterfaceToArrayString(testCase.val)
 		assert.Equal(t, testCase.expectedList, actualString, testCase.name)
 		assert.Equal(t, testCase.expectedErr, actualErr, testCase.name)
-	}
-
-}
-
-func TestColumnsUpdateQuery(t *testing.T) {
-	type testCase struct {
-		name           string
-		columns        []string
-		columnsToTypes typing.Columns
-		expectedString string
-		bigQuery       bool
-	}
-
-	fooBarCols := []string{"foo", "bar"}
-
-	var (
-		happyPathCols      typing.Columns
-		stringAndToastCols typing.Columns
-		lastCaseColTypes   typing.Columns
-	)
-	for _, col := range fooBarCols {
-		happyPathCols.AddColumn(typing.Column{
-			Name:        col,
-			KindDetails: typing.String,
-			ToastColumn: false,
-		})
-	}
-	for _, col := range fooBarCols {
-		var toastCol bool
-		if col == "foo" {
-			toastCol = true
-		}
-
-		stringAndToastCols.AddColumn(typing.Column{
-			Name:        col,
-			KindDetails: typing.String,
-			ToastColumn: toastCol,
-		})
-	}
-
-	lastCaseCols := []string{"a1", "b2", "c3"}
-
-	for _, lastCaseCol := range lastCaseCols {
-		kd := typing.String
-		var toast bool
-		// a1 - struct + toast, b2 - string + toast, c3 = regular string.
-		if lastCaseCol == "a1" {
-			kd = typing.Struct
-			toast = true
-		} else if lastCaseCol == "b2" {
-			toast = true
-		}
-
-		lastCaseColTypes.AddColumn(typing.Column{
-			Name:        lastCaseCol,
-			KindDetails: kd,
-			ToastColumn: toast,
-		})
-	}
-
-	testCases := []testCase{
-		{
-			name:           "happy path",
-			columns:        fooBarCols,
-			columnsToTypes: happyPathCols,
-			expectedString: "foo=cc.foo,bar=cc.bar",
-		},
-		{
-			name:           "string and toast",
-			columns:        fooBarCols,
-			columnsToTypes: stringAndToastCols,
-			expectedString: "foo= CASE WHEN cc.foo != '__debezium_unavailable_value' THEN cc.foo ELSE c.foo END,bar=cc.bar",
-		},
-		{
-			name:           "struct, string and toast string",
-			columns:        lastCaseCols,
-			columnsToTypes: lastCaseColTypes,
-			expectedString: "a1= CASE WHEN cc.a1 != {'key': '__debezium_unavailable_value'} THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3",
-		},
-		{
-			name:           "struct, string and toast string (bigquery)",
-			columns:        lastCaseCols,
-			columnsToTypes: lastCaseColTypes,
-			bigQuery:       true,
-			expectedString: `a1= CASE WHEN TO_JSON_STRING(cc.a1) != '{"key": "__debezium_unavailable_value"}' THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3`,
-		},
-	}
-
-	for _, _testCase := range testCases {
-		actualQuery := ColumnsUpdateQuery(_testCase.columns, _testCase.columnsToTypes, _testCase.bigQuery)
-		assert.Equal(t, _testCase.expectedString, actualQuery, _testCase.name)
 	}
 
 }

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -93,12 +93,9 @@ func (s *SchemaEventPayload) GetColumns() *typing.Columns {
 
 	var cols typing.Columns
 	for _, field := range fieldsObject.Fields {
-		cols.AddColumn(typing.Column{
-			Name: field.FieldName,
-			// We are purposefully doing this to ensure that the correct typing is set
-			// When we invoke event.Save()
-			KindDetails: typing.Invalid,
-		})
+		// We are purposefully doing this to ensure that the correct typing is set
+		// When we invoke event.Save()
+		cols.AddColumn(typing.NewColumn(field.FieldName, typing.Invalid))
 	}
 
 	return &cols

--- a/lib/cdc/mysql/debezium_test.go
+++ b/lib/cdc/mysql/debezium_test.go
@@ -312,6 +312,6 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 
 		col, isOk := cols.GetColumn(key)
 		assert.Equal(m.T(), true, isOk)
-		assert.Equal(m.T(), typing.Invalid, col.KindDetails, fmt.Sprintf("colName: %v, evtData key: %v", col.Name, key))
+		assert.Equal(m.T(), typing.Invalid, col.KindDetails, fmt.Sprintf("colName: %v, evtData key: %v", col.Name(false), key))
 	}
 }

--- a/lib/cdc/mysql/debezium_test.go
+++ b/lib/cdc/mysql/debezium_test.go
@@ -312,6 +312,6 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 
 		col, isOk := cols.GetColumn(key)
 		assert.Equal(m.T(), true, isOk)
-		assert.Equal(m.T(), typing.Invalid, col.KindDetails, fmt.Sprintf("colName: %v, evtData key: %v", col.Name(false), key))
+		assert.Equal(m.T(), typing.Invalid, col.KindDetails, fmt.Sprintf("colName: %v, evtData key: %v", col.Name(nil), key))
 	}
 }

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -44,12 +44,9 @@ func (s *SchemaEventPayload) GetColumns() *typing.Columns {
 
 	var cols typing.Columns
 	for _, field := range fieldsObject.Fields {
-		cols.AddColumn(typing.Column{
-			Name: field.FieldName,
-			// We are purposefully doing this to ensure that the correct typing is set
-			// When we invoke event.Save()
-			KindDetails: typing.Invalid,
-		})
+		// We are purposefully doing this to ensure that the correct typing is set
+		// When we invoke event.Save()
+		cols.AddColumn(typing.NewColumn(field.FieldName, typing.Invalid))
 	}
 
 	return &cols

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -24,6 +24,11 @@ const (
 	BigQueryTempTableTTL = 6 * time.Hour
 )
 
+var ReservedKeywords = []string{
+	"start",
+	"select",
+}
+
 // ExporterKind is used for the Telemetry package
 type ExporterKind string
 

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -90,9 +90,9 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 		mutateCol = append(mutateCol, col)
 		switch args.ColumnOp {
 		case constants.Add:
-			colSQLParts = append(colSQLParts, fmt.Sprintf("%s %s", col.Name, typing.KindToDWHType(col.KindDetails, args.Dwh.Label())))
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name, typing.KindToDWHType(col.KindDetails, args.Dwh.Label())))
 		case constants.Delete:
-			colSQLParts = append(colSQLParts, fmt.Sprintf("%s", col.Name))
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name))
 		}
 	}
 
@@ -121,6 +121,7 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 			sqlQuery = fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", args.FqTableName, strings.Join(colSQLParts, ","))
 		}
 
+		fmt.Println("sqlQuery", sqlQuery)
 		_, err = args.Dwh.Exec(sqlQuery)
 		if ColumnAlreadyExistErr(err, args.Dwh.Label()) {
 			err = nil
@@ -130,6 +131,7 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 	} else {
 		for _, colSQLPart := range colSQLParts {
 			sqlQuery := fmt.Sprintf("ALTER TABLE %s %s COLUMN %s", args.FqTableName, args.ColumnOp, colSQLPart)
+			fmt.Println("sqlQuery", sqlQuery)
 			_, err = args.Dwh.Exec(sqlQuery)
 			if ColumnAlreadyExistErr(err, args.Dwh.Label()) {
 				err = nil

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -127,7 +127,6 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 			sqlQuery = fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", args.FqTableName, strings.Join(colSQLParts, ","))
 		}
 
-		fmt.Println("sqlQuery", sqlQuery)
 		_, err = args.Dwh.Exec(sqlQuery)
 		if ColumnAlreadyExistErr(err, args.Dwh.Label()) {
 			err = nil
@@ -137,7 +136,6 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 	} else {
 		for _, colSQLPart := range colSQLParts {
 			sqlQuery := fmt.Sprintf("ALTER TABLE %s %s COLUMN %s", args.FqTableName, args.ColumnOp, colSQLPart)
-			fmt.Println("sqlQuery", sqlQuery)
 			_, err = args.Dwh.Exec(sqlQuery)
 			if ColumnAlreadyExistErr(err, args.Dwh.Label()) {
 				err = nil

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -82,7 +82,7 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 			continue
 		}
 
-		if args.ColumnOp == constants.Delete && !args.Tc.ShouldDeleteColumn(col.Name, args.CdcTime) {
+		if args.ColumnOp == constants.Delete && !args.Tc.ShouldDeleteColumn(col.Name(false), args.CdcTime) {
 			// Don't delete yet, we can evaluate when we consume more messages.
 			continue
 		}
@@ -90,9 +90,9 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 		mutateCol = append(mutateCol, col)
 		switch args.ColumnOp {
 		case constants.Add:
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name, typing.KindToDWHType(col.KindDetails, args.Dwh.Label())))
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name(true), typing.KindToDWHType(col.KindDetails, args.Dwh.Label())))
 		case constants.Delete:
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name))
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name(true)))
 		}
 	}
 

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -82,7 +82,7 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 			continue
 		}
 
-		if args.ColumnOp == constants.Delete && !args.Tc.ShouldDeleteColumn(col.Name(false), args.CdcTime) {
+		if args.ColumnOp == constants.Delete && !args.Tc.ShouldDeleteColumn(col.Name(nil), args.CdcTime) {
 			// Don't delete yet, we can evaluate when we consume more messages.
 			continue
 		}
@@ -90,9 +90,15 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 		mutateCol = append(mutateCol, col)
 		switch args.ColumnOp {
 		case constants.Add:
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name(true), typing.KindToDWHType(col.KindDetails, args.Dwh.Label())))
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name(&typing.NameArgs{
+				Escape:   true,
+				DestKind: args.Dwh.Label(),
+			}), typing.KindToDWHType(col.KindDetails, args.Dwh.Label())))
 		case constants.Delete:
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name(true)))
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name(&typing.NameArgs{
+				Escape:   true,
+				DestKind: args.Dwh.Label(),
+			})))
 		}
 	}
 

--- a/lib/dwh/ddl/ddl_bq_test.go
+++ b/lib/dwh/ddl/ddl_bq_test.go
@@ -27,8 +27,10 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 	}
 
 	colNameToKindDetailsMap := map[string]typing.KindDetails{
-		"foo": typing.String,
-		"bar": typing.String,
+		"foo":    typing.String,
+		"bar":    typing.String,
+		"select": typing.String,
+		"start":  typing.String,
 	}
 
 	var cols typing.Columns
@@ -103,6 +105,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 		"jacqueline": typing.Integer,
 		"charlie":    typing.Boolean,
 		"robin":      typing.Float,
+		"start":      typing.String,
 	}
 
 	newColsLen := len(newCols)
@@ -128,10 +131,14 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 			ColumnOp:    constants.Add,
 			CdcTime:     ts,
 		}
-		err := ddl.AlterTable(d.bqCtx, alterTableArgs, typing.NewColumn(name, kind))
+
+		col := typing.NewColumn(name, kind)
+
+		err := ddl.AlterTable(d.bqCtx, alterTableArgs, col)
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, name, typing.KindToDWHType(kind, d.bigQueryStore.Label())), query)
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, col.Name(true),
+			typing.KindToDWHType(kind, d.bigQueryStore.Label())), query)
 		callIdx += 1
 	}
 
@@ -154,8 +161,9 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 	fqName := "mock_dataset.add_cols"
 	ts := time.Now()
 	existingColNameToKindDetailsMap := map[string]typing.KindDetails{
-		"foo": typing.String,
-		"bar": typing.String,
+		"foo":   typing.String,
+		"bar":   typing.String,
+		"start": typing.String,
 	}
 
 	existingColsLen := len(existingColNameToKindDetailsMap)
@@ -186,7 +194,8 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(true), typing.KindToDWHType(column.KindDetails, d.bigQueryStore.Label())), query)
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(true),
+			typing.KindToDWHType(column.KindDetails, d.bigQueryStore.Label())), query)
 		callIdx += 1
 	}
 

--- a/lib/dwh/ddl/ddl_create_table_test.go
+++ b/lib/dwh/ddl/ddl_create_table_test.go
@@ -57,7 +57,7 @@ func (d *DDLTestSuite) Test_CreateTable() {
 			ColumnOp:    constants.Add,
 		}
 
-		err := ddl.AlterTable(ctx, alterTableArgs, typing.Column{Name: "name", KindDetails: typing.String})
+		err := ddl.AlterTable(ctx, alterTableArgs, typing.NewColumn("name", typing.String))
 		assert.Equal(d.T(), 1, dwhTc._fakeStore.ExecCallCount())
 
 		query, _ := dwhTc._fakeStore.ExecArgsForCall(0)
@@ -77,38 +77,17 @@ func (d *DDLTestSuite) TestCreateTable() {
 
 	var (
 		happyPathCols = []typing.Column{
-			{
-				Name:        "user_id",
-				KindDetails: typing.String,
-			},
+			typing.NewColumn("user_id", typing.String),
 		}
 		twoCols = []typing.Column{
-			{
-				Name:        "user_id",
-				KindDetails: typing.String,
-			},
-			{
-				Name:        "enabled",
-				KindDetails: typing.Boolean,
-			},
+			typing.NewColumn("user_id", typing.String),
+			typing.NewColumn("enabled", typing.Boolean),
 		}
 		bunchOfCols = []typing.Column{
-			{
-				Name:        "user_id",
-				KindDetails: typing.String,
-			},
-			{
-				Name:        "enabled_boolean",
-				KindDetails: typing.Boolean,
-			},
-			{
-				Name:        "array",
-				KindDetails: typing.Array,
-			},
-			{
-				Name:        "struct",
-				KindDetails: typing.Struct,
-			},
+			typing.NewColumn("user_id", typing.String),
+			typing.NewColumn("enabled_boolean", typing.Boolean),
+			typing.NewColumn("array", typing.Array),
+			typing.NewColumn("struct", typing.Struct),
 		}
 	)
 

--- a/lib/dwh/ddl/ddl_sflk_test.go
+++ b/lib/dwh/ddl/ddl_sflk_test.go
@@ -19,14 +19,8 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 	ctx := context.Background()
 	// Test Structs and Arrays
 	cols := []typing.Column{
-		{
-			Name:        "preferences",
-			KindDetails: typing.Struct,
-		},
-		{
-			Name:        "array_col",
-			KindDetails: typing.Array,
-		},
+		typing.NewColumn("preferences", typing.Struct),
+		typing.NewColumn("array_col", typing.Array),
 	}
 
 	fqTable := "shop.public.complex_columns"
@@ -54,18 +48,9 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 func (d *DDLTestSuite) TestAlterIdempotency() {
 	ctx := context.Background()
 	cols := []typing.Column{
-		{
-			Name:        "created_at",
-			KindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
-		},
-		{
-			Name:        "id",
-			KindDetails: typing.Integer,
-		},
-		{
-			Name:        "order_name",
-			KindDetails: typing.String,
-		},
+		typing.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
+		typing.NewColumn("id", typing.Integer),
+		typing.NewColumn("order_name", typing.String),
 	}
 
 	fqTable := "shop.public.orders"
@@ -94,18 +79,9 @@ func (d *DDLTestSuite) TestAlterIdempotency() {
 func (d *DDLTestSuite) TestAlterTableAdd() {
 	// Test adding a bunch of columns
 	cols := []typing.Column{
-		{
-			Name:        "created_at",
-			KindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
-		},
-		{
-			Name:        "id",
-			KindDetails: typing.Integer,
-		},
-		{
-			Name:        "order_name",
-			KindDetails: typing.String,
-		},
+		typing.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
+		typing.NewColumn("id", typing.Integer),
+		typing.NewColumn("order_name", typing.String),
 	}
 
 	fqTable := "shop.public.orders"
@@ -128,33 +104,24 @@ func (d *DDLTestSuite) TestAlterTableAdd() {
 	for _, column := range tableConfig.Columns().GetColumns() {
 		var found bool
 		for _, expCol := range cols {
-			if found = column.Name == expCol.Name; found {
-				assert.Equal(d.T(), column.KindDetails, expCol.KindDetails, fmt.Sprintf("wrong col kind, col: %s", column.Name))
+			if found = column.Name(false) == expCol.Name(false); found {
+				assert.Equal(d.T(), column.KindDetails, expCol.KindDetails, fmt.Sprintf("wrong col kind, col: %s", column.Name(false)))
 				break
 			}
 		}
 
 		assert.True(d.T(), found,
 			fmt.Sprintf("Col not found: %s, actual list: %v, expected list: %v",
-				column.Name, tableConfig.Columns(), cols))
+				column.Name(false), tableConfig.Columns(), cols))
 	}
 }
 
 func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	// Test adding a bunch of columns
 	cols := []typing.Column{
-		{
-			Name:        "created_at",
-			KindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
-		},
-		{
-			Name:        "id",
-			KindDetails: typing.Integer,
-		},
-		{
-			Name:        "name",
-			KindDetails: typing.String,
-		},
+		typing.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
+		typing.NewColumn("id", typing.Integer),
+		typing.NewColumn("name", typing.String),
 	}
 
 	fqTable := "shop.public.users"
@@ -176,7 +143,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	for col := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, expCol := range cols {
-			if found = col == expCol.Name; found {
+			if found = col == expCol.Name(false); found {
 				break
 			}
 		}
@@ -186,7 +153,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 				col, tableConfig.ReadOnlyColumnsToDelete(), cols))
 	}
 
-	colToActuallyDelete := cols[0].Name
+	colToActuallyDelete := cols[0].Name(false)
 	// Now let's check the timestamp
 	assert.True(d.T(), tableConfig.ReadOnlyColumnsToDelete()[colToActuallyDelete].After(time.Now()))
 	// Now let's actually try to dial the time back, and it should actually try to delete.
@@ -202,26 +169,11 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 func (d *DDLTestSuite) TestAlterTableDelete() {
 	// Test adding a bunch of columns
 	cols := []typing.Column{
-		{
-			Name:        "created_at",
-			KindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
-		},
-		{
-			Name:        "id",
-			KindDetails: typing.Integer,
-		},
-		{
-			Name:        "name",
-			KindDetails: typing.String,
-		},
-		{
-			Name:        "col_to_delete",
-			KindDetails: typing.String,
-		},
-		{
-			Name:        "answers",
-			KindDetails: typing.String,
-		},
+		typing.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
+		typing.NewColumn("id", typing.Integer),
+		typing.NewColumn("name", typing.String),
+		typing.NewColumn("col_to_delete", typing.String),
+		typing.NewColumn("answers", typing.String),
 	}
 
 	fqTable := "shop.public.users1"
@@ -248,7 +200,7 @@ func (d *DDLTestSuite) TestAlterTableDelete() {
 	for col := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, expCol := range cols {
-			if found = col == expCol.Name; found {
+			if found = col == expCol.Name(false); found {
 				break
 			}
 		}

--- a/lib/dwh/ddl/ddl_temp_test.go
+++ b/lib/dwh/ddl/ddl_temp_test.go
@@ -71,7 +71,7 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 		CdcTime:        time.Time{},
 	}
 
-	err := ddl.AlterTable(d.ctx, args, typing.NewColumn("foo", typing.String), typing.NewColumn("bar", typing.Float))
+	err := ddl.AlterTable(d.ctx, args, typing.NewColumn("foo", typing.String), typing.NewColumn("bar", typing.Float), typing.NewColumn("start", typing.String))
 
 	assert.NoError(d.T(), err)
 	assert.Equal(d.T(), 1, d.fakeSnowflakeStagesStore.ExecCallCount())
@@ -79,7 +79,7 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 
 	assert.Contains(d.T(),
 		query,
-		`CREATE TABLE IF NOT EXISTS db.schema.tempTableName (foo string,bar float) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE) COMMENT=`,
+		`CREATE TABLE IF NOT EXISTS db.schema.tempTableName (foo string,bar float,"start" string) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE) COMMENT=`,
 		query)
 
 	// BigQuery
@@ -88,10 +88,10 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 	args.Dwh = d.bigQueryStore
 	args.Tc = bqTc
 
-	err = ddl.AlterTable(d.ctx, args, typing.NewColumn("foo", typing.String), typing.NewColumn("bar", typing.Float))
+	err = ddl.AlterTable(d.ctx, args, typing.NewColumn("foo", typing.String), typing.NewColumn("bar", typing.Float), typing.NewColumn("select", typing.String))
 	assert.NoError(d.T(), err)
 	assert.Equal(d.T(), 1, d.fakeBigQueryStore.ExecCallCount())
 	bqQuery, _ := d.fakeBigQueryStore.ExecArgsForCall(0)
 	// Cutting off the expiration_timestamp since it's time based.
-	assert.Contains(d.T(), bqQuery, `CREATE TABLE IF NOT EXISTS db.schema.tempTableName (foo string,bar float64) OPTIONS (expiration_timestamp =`)
+	assert.Contains(d.T(), bqQuery, `CREATE TABLE IF NOT EXISTS db.schema.tempTableName (foo string,bar float64,"select" string) OPTIONS (expiration_timestamp =`)
 }

--- a/lib/dwh/ddl/ddl_temp_test.go
+++ b/lib/dwh/ddl/ddl_temp_test.go
@@ -93,5 +93,5 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 	assert.Equal(d.T(), 1, d.fakeBigQueryStore.ExecCallCount())
 	bqQuery, _ := d.fakeBigQueryStore.ExecArgsForCall(0)
 	// Cutting off the expiration_timestamp since it's time based.
-	assert.Contains(d.T(), bqQuery, `CREATE TABLE IF NOT EXISTS db.schema.tempTableName (foo string,bar float64,"select" string) OPTIONS (expiration_timestamp =`)
+	assert.Contains(d.T(), bqQuery, "CREATE TABLE IF NOT EXISTS db.schema.tempTableName (foo string,bar float64,`select` string) OPTIONS (expiration_timestamp =")
 }

--- a/lib/dwh/ddl/ddl_temp_test.go
+++ b/lib/dwh/ddl/ddl_temp_test.go
@@ -71,13 +71,7 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 		CdcTime:        time.Time{},
 	}
 
-	err := ddl.AlterTable(d.ctx, args, typing.Column{
-		Name:        "foo",
-		KindDetails: typing.String,
-	}, typing.Column{
-		Name:        "bar",
-		KindDetails: typing.Float,
-	})
+	err := ddl.AlterTable(d.ctx, args, typing.NewColumn("foo", typing.String), typing.NewColumn("bar", typing.Float))
 
 	assert.NoError(d.T(), err)
 	assert.Equal(d.T(), 1, d.fakeSnowflakeStagesStore.ExecCallCount())
@@ -94,13 +88,7 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 	args.Dwh = d.bigQueryStore
 	args.Tc = bqTc
 
-	err = ddl.AlterTable(d.ctx, args, typing.Column{
-		Name:        "foo",
-		KindDetails: typing.String,
-	}, typing.Column{
-		Name:        "bar",
-		KindDetails: typing.Float,
-	})
+	err = ddl.AlterTable(d.ctx, args, typing.NewColumn("foo", typing.String), typing.NewColumn("bar", typing.Float))
 	assert.NoError(d.T(), err)
 	assert.Equal(d.T(), 1, d.fakeBigQueryStore.ExecCallCount())
 	bqQuery, _ := d.fakeBigQueryStore.ExecArgsForCall(0)

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -12,10 +12,13 @@ import (
 )
 
 type MergeArgument struct {
-	FqTableName    string
-	SubQuery       string
-	IdempotentKey  string
-	PrimaryKeys    []string
+	FqTableName   string
+	SubQuery      string
+	IdempotentKey string
+	PrimaryKeys   []string
+
+	// Note columns is already escaped.
+	// ColumnsToTypes also needs to be escaped.
 	Columns        []string
 	ColumnsToTypes typing.Columns
 

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -75,7 +75,7 @@ func MergeStatement(m MergeArgument) (string, error) {
 					);
 		`, m.FqTableName, subQuery, strings.Join(equalitySQLParts, " and "),
 			// Update + Soft Deletion
-			idempotentClause, array.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, m.BigQuery),
+			idempotentClause, typing.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, m.BigQuery),
 			// Insert
 			constants.DeleteColumnMarker, strings.Join(m.Columns, ","),
 			array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
@@ -116,7 +116,7 @@ func MergeStatement(m MergeArgument) (string, error) {
 		// Delete
 		constants.DeleteColumnMarker,
 		// Update
-		constants.DeleteColumnMarker, idempotentClause, array.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, m.BigQuery),
+		constants.DeleteColumnMarker, idempotentClause, typing.ColumnsUpdateQuery(m.Columns, m.ColumnsToTypes, m.BigQuery),
 		// Insert
 		constants.DeleteColumnMarker, strings.Join(m.Columns, ","),
 		array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{

--- a/lib/dwh/dml/merge_bigquery_test.go
+++ b/lib/dwh/dml/merge_bigquery_test.go
@@ -12,18 +12,9 @@ import (
 
 func TestMergeStatement_TempTable(t *testing.T) {
 	var cols typing.Columns
-	cols.AddColumn(typing.Column{
-		Name:        "order_id",
-		KindDetails: typing.Integer,
-	})
-	cols.AddColumn(typing.Column{
-		Name:        "name",
-		KindDetails: typing.String,
-	})
-	cols.AddColumn(typing.Column{
-		Name:        constants.DeleteColumnMarker,
-		KindDetails: typing.Boolean,
-	})
+	cols.AddColumn(typing.NewColumn("order_id", typing.Integer))
+	cols.AddColumn(typing.NewColumn("name", typing.String))
+	cols.AddColumn(typing.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
 	mergeArg := MergeArgument{
 		FqTableName:    "customers.orders",
@@ -43,18 +34,9 @@ func TestMergeStatement_TempTable(t *testing.T) {
 
 func TestMergeStatement_JSONKey(t *testing.T) {
 	var cols typing.Columns
-	cols.AddColumn(typing.Column{
-		Name:        "order_oid",
-		KindDetails: typing.Struct,
-	})
-	cols.AddColumn(typing.Column{
-		Name:        "name",
-		KindDetails: typing.String,
-	})
-	cols.AddColumn(typing.Column{
-		Name:        constants.DeleteColumnMarker,
-		KindDetails: typing.Boolean,
-	})
+	cols.AddColumn(typing.NewColumn("order_oid", typing.Struct))
+	cols.AddColumn(typing.NewColumn("name", typing.String))
+	cols.AddColumn(typing.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
 	mergeArg := MergeArgument{
 		FqTableName:    "customers.orders",

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -83,11 +83,13 @@ func TestMergeStatement(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 	mergeSQL, err := MergeStatement(MergeArgument{
-		FqTableName:    fqTable,
-		SubQuery:       subQuery,
-		IdempotentKey:  "",
-		PrimaryKeys:    []string{"id"},
-		Columns:        _cols.GetColumnsToUpdate(true),
+		FqTableName:   fqTable,
+		SubQuery:      subQuery,
+		IdempotentKey: "",
+		PrimaryKeys:   []string{"id"},
+		Columns: _cols.GetColumnsToUpdate(&typing.NameArgs{
+			Escape: true,
+		}),
 		ColumnsToTypes: _cols,
 		BigQuery:       false,
 		SoftDelete:     false,

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -32,10 +32,7 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
 	var _cols typing.Columns
-	_cols.AddColumn(typing.Column{
-		Name:        "id",
-		KindDetails: typing.String,
-	})
+	_cols.AddColumn(typing.NewColumn("id", typing.String))
 
 	for _, idempotentKey := range []string{"", "updated_at"} {
 		mergeSQL, err := MergeStatement(MergeArgument{
@@ -75,10 +72,7 @@ func TestMergeStatement(t *testing.T) {
 	}
 
 	var _cols typing.Columns
-	_cols.AddColumn(typing.Column{
-		Name:        "id",
-		KindDetails: typing.String,
-	})
+	_cols.AddColumn(typing.NewColumn("id", typing.String))
 
 	// select cc.foo, cc.bar from (values (12, 34), (44, 55)) as cc(foo, bar);
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
@@ -118,10 +112,7 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
 	var _cols typing.Columns
-	_cols.AddColumn(typing.Column{
-		Name:        "id",
-		KindDetails: typing.String,
-	})
+	_cols.AddColumn(typing.NewColumn("id", typing.String))
 
 	mergeSQL, err := MergeStatement(MergeArgument{
 		FqTableName:    fqTable,
@@ -159,14 +150,8 @@ func TestMergeStatementCompositeKey(t *testing.T) {
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
 	var _cols typing.Columns
-	_cols.AddColumn(typing.Column{
-		Name:        "id",
-		KindDetails: typing.String,
-	})
-	_cols.AddColumn(typing.Column{
-		Name:        "another_id",
-		KindDetails: typing.String,
-	})
+	_cols.AddColumn(typing.NewColumn("id", typing.String))
+	_cols.AddColumn(typing.NewColumn("another_id", typing.String))
 
 	mergeSQL, err := MergeStatement(MergeArgument{
 		FqTableName:    fqTable,

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -62,15 +62,15 @@ func (tc *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp const
 		for _, col := range cols {
 			tc.columns.AddColumn(col)
 			// Delete from the permissions table, if exists.
-			delete(tc.columnsToDelete, col.Name(false))
+			delete(tc.columnsToDelete, col.Name(nil))
 		}
 
 		tc.createTable = createTable
 	case constants.Delete:
 		for _, col := range cols {
 			// Delete from the permissions and in-memory table
-			tc.columns.DeleteColumn(col.Name(false))
-			delete(tc.columnsToDelete, col.Name(false))
+			tc.columns.DeleteColumn(col.Name(nil))
+			delete(tc.columnsToDelete, col.Name(nil))
 		}
 	}
 }

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -62,15 +62,15 @@ func (tc *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp const
 		for _, col := range cols {
 			tc.columns.AddColumn(col)
 			// Delete from the permissions table, if exists.
-			delete(tc.columnsToDelete, col.Name)
+			delete(tc.columnsToDelete, col.Name(false))
 		}
 
 		tc.createTable = createTable
 	case constants.Delete:
 		for _, col := range cols {
 			// Delete from the permissions and in-memory table
-			tc.columns.DeleteColumn(col.Name)
-			delete(tc.columnsToDelete, col.Name)
+			tc.columns.DeleteColumn(col.Name(false))
+			delete(tc.columnsToDelete, col.Name(false))
 		}
 	}
 }

--- a/lib/dwh/types/table_config_test.go
+++ b/lib/dwh/types/table_config_test.go
@@ -30,18 +30,9 @@ func TestDwhTableConfig_ShouldDeleteColumn(t *testing.T) {
 // In this test, we spin up 5 parallel Go-routines each making 100 calls to .Columns() and assert the validity of the data.
 func TestDwhTableConfig_ColumnsConcurrency(t *testing.T) {
 	var cols typing.Columns
-	cols.AddColumn(typing.Column{
-		Name:        "foo",
-		KindDetails: typing.Struct,
-	})
-	cols.AddColumn(typing.Column{
-		Name:        "bar",
-		KindDetails: typing.String,
-	})
-	cols.AddColumn(typing.Column{
-		Name:        "boolean",
-		KindDetails: typing.Boolean,
-	})
+	cols.AddColumn(typing.NewColumn("foo", typing.Struct))
+	cols.AddColumn(typing.NewColumn("bar", typing.String))
+	cols.AddColumn(typing.NewColumn("boolean", typing.Boolean))
 
 	dwhTableCfg := NewDwhTableConfig(&cols, nil, false, false)
 
@@ -57,10 +48,7 @@ func TestDwhTableConfig_ColumnsConcurrency(t *testing.T) {
 				if (j % 2) == 0 {
 					kindDetails = typing.Array
 				}
-				tableCfg.Columns().UpdateColumn(typing.Column{
-					Name:        "foo",
-					KindDetails: kindDetails,
-				})
+				tableCfg.Columns().UpdateColumn(typing.NewColumn("foo", kindDetails))
 				assert.Equal(t, 3, len(tableCfg.Columns().GetColumns()), tableCfg.Columns().GetColumns())
 			}
 		}(dwhTableCfg)
@@ -72,7 +60,7 @@ func TestDwhTableConfig_ColumnsConcurrency(t *testing.T) {
 func TestDwhTableConfig_MutateInMemoryColumns(t *testing.T) {
 	tc := NewDwhTableConfig(&typing.Columns{}, nil, false, false)
 	for _, col := range []string{"a", "b", "c", "d", "e"} {
-		tc.MutateInMemoryColumns(false, constants.Add, typing.Column{Name: col, KindDetails: typing.String})
+		tc.MutateInMemoryColumns(false, constants.Add, typing.NewColumn(col, typing.String))
 	}
 
 	assert.Equal(t, 5, len(tc.columns.GetColumns()))
@@ -81,7 +69,7 @@ func TestDwhTableConfig_MutateInMemoryColumns(t *testing.T) {
 		wg.Add(1)
 		go func(colName string) {
 			defer wg.Done()
-			tc.MutateInMemoryColumns(false, constants.Add, typing.Column{Name: colName, KindDetails: typing.String})
+			tc.MutateInMemoryColumns(false, constants.Add, typing.NewColumn(colName, typing.String))
 		}(addCol)
 	}
 
@@ -89,7 +77,7 @@ func TestDwhTableConfig_MutateInMemoryColumns(t *testing.T) {
 		wg.Add(1)
 		go func(colName string) {
 			defer wg.Done()
-			tc.MutateInMemoryColumns(false, constants.Delete, typing.Column{Name: colName})
+			tc.MutateInMemoryColumns(false, constants.Delete, typing.NewColumn(colName, typing.Invalid))
 		}(removeCol)
 	}
 

--- a/lib/dwh/types/types_test.go
+++ b/lib/dwh/types/types_test.go
@@ -20,10 +20,7 @@ func generateDwhTableCfg() *DwhTableConfig {
 	}
 
 	for _, col := range []string{"a", "b", "c", "d"} {
-		cols.AddColumn(typing.Column{
-			Name:        col,
-			KindDetails: typing.String,
-		})
+		cols.AddColumn(typing.NewColumn(col, typing.String))
 	}
 
 	return &DwhTableConfig{

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -165,7 +165,7 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(cols ...typing.Column) 
 		var foundColumn typing.Column
 		var found bool
 		for _, col := range cols {
-			if col.Name(false) == strings.ToLower(inMemoryCol.Name(false)) {
+			if col.Name(nil) == strings.ToLower(inMemoryCol.Name(nil)) {
 				foundColumn = col
 				found = true
 				break

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -165,7 +165,7 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(cols ...typing.Column) 
 		var foundColumn typing.Column
 		var found bool
 		for _, col := range cols {
-			if col.Name == strings.ToLower(inMemoryCol.Name) {
+			if col.Name(false) == strings.ToLower(inMemoryCol.Name(false)) {
 				foundColumn = col
 				found = true
 				break

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -64,17 +64,11 @@ func TestNewTableData_TableName(t *testing.T) {
 func TestTableData_ReadOnlyInMemoryCols(t *testing.T) {
 	// Making sure the columns are actually read only.
 	var cols typing.Columns
-	cols.AddColumn(typing.Column{
-		Name:        "name",
-		KindDetails: typing.String,
-	})
+	cols.AddColumn(typing.NewColumn("name", typing.String))
 
 	td := NewTableData(&cols, nil, kafkalib.TopicConfig{}, "foo")
 	readOnlyCols := td.ReadOnlyInMemoryCols()
-	readOnlyCols.AddColumn(typing.Column{
-		Name:        "last_name",
-		KindDetails: typing.String,
-	})
+	readOnlyCols.AddColumn(typing.NewColumn("last_name", typing.String))
 
 	// Check if last_name actually exists.
 	_, isOk := td.ReadOnlyInMemoryCols().GetColumn("last_name")
@@ -92,10 +86,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 		"CHANGE_me":            typing.String,
 		"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType),
 	} {
-		_cols.AddColumn(typing.Column{
-			Name:        colName,
-			KindDetails: colKind,
-		})
+		_cols.AddColumn(typing.NewColumn(colName, colKind))
 	}
 
 	tableData := &TableData{
@@ -106,10 +97,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	assert.True(t, isOk)
 
 	extCol.KindDetails.ExtendedTimeDetails.Format = time.RFC3339Nano
-	tableData.inMemoryColumns.UpdateColumn(typing.Column{
-		Name:        extCol.Name,
-		KindDetails: extCol.KindDetails,
-	})
+	tableData.inMemoryColumns.UpdateColumn(typing.NewColumn(extCol.Name(false), extCol.KindDetails))
 
 	for name, colKindDetails := range map[string]typing.KindDetails{
 		"foo":                  typing.String,
@@ -117,10 +105,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 		"bar":                  typing.Boolean,
 		"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		tableData.UpdateInMemoryColumnsFromDestination(typing.Column{
-			Name:        name,
-			KindDetails: colKindDetails,
-		})
+		tableData.UpdateInMemoryColumnsFromDestination(typing.NewColumn(name, colKindDetails))
 	}
 
 	// It's saved back in the original format.

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -97,7 +97,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	assert.True(t, isOk)
 
 	extCol.KindDetails.ExtendedTimeDetails.Format = time.RFC3339Nano
-	tableData.inMemoryColumns.UpdateColumn(typing.NewColumn(extCol.Name(false), extCol.KindDetails))
+	tableData.inMemoryColumns.UpdateColumn(typing.NewColumn(extCol.Name(nil), extCol.KindDetails))
 
 	for name, colKindDetails := range map[string]typing.KindDetails{
 		"foo":                  typing.String,

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -31,23 +31,6 @@ func (c *Column) ToLowerName() {
 	return
 }
 
-func (c *Column) NameReplacePrefix(escape bool) string {
-	if escape && array.StringContains(constants.ReservedKeywords, c.name) {
-		return fmt.Sprintf(`%s_%s`, c.name, constants.ArtiePrefix)
-	}
-
-	return c.name
-}
-
-// TODO: document
-func (c *Column) NameEscapePrefix(escape bool) string {
-	if escape && array.StringContains(constants.ReservedKeywords, c.name) {
-		return fmt.Sprintf(`%s_%s as "%s"`, c.name, constants.ArtiePrefix, c.name)
-	}
-
-	return c.name
-}
-
 // Name will give you c.name
 // However, if you pass in escape, we will escape if the column name is part of the reserved words from destinations.
 // If so, it'll change from `start` => `"start"` as suggested by Snowflake.
@@ -115,8 +98,8 @@ func (c *Columns) GetColumn(name string) (Column, bool) {
 }
 
 // GetColumnsToUpdate will filter all the `Invalid` columns so that we do not update it.
+// It also has an option to escape the returned columns or not. This is used mostly for the SQL MERGE queries.
 func (c *Columns) GetColumnsToUpdate(escape bool) []string {
-	// TODO: test & document.
 	if c == nil {
 		return []string{}
 	}

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -31,6 +31,23 @@ func (c *Column) ToLowerName() {
 	return
 }
 
+func (c *Column) NameReplacePrefix(escape bool) string {
+	if escape && array.StringContains(constants.ReservedKeywords, c.name) {
+		return fmt.Sprintf(`%s_%s`, c.name, constants.ArtiePrefix)
+	}
+
+	return c.name
+}
+
+// TODO: document
+func (c *Column) NameEscapePrefix(escape bool) string {
+	if escape && array.StringContains(constants.ReservedKeywords, c.name) {
+		return fmt.Sprintf(`%s_%s as "%s"`, c.name, constants.ArtiePrefix, c.name)
+	}
+
+	return c.name
+}
+
 // Name will give you c.name
 // However, if you pass in escape, we will escape if the column name is part of the reserved words from destinations.
 // If so, it'll change from `start` => `"start"` as suggested by Snowflake.
@@ -98,7 +115,8 @@ func (c *Columns) GetColumn(name string) (Column, bool) {
 }
 
 // GetColumnsToUpdate will filter all the `Invalid` columns so that we do not update it.
-func (c *Columns) GetColumnsToUpdate() []string {
+func (c *Columns) GetColumnsToUpdate(escape bool) []string {
+	// TODO: test & document.
 	if c == nil {
 		return []string{}
 	}
@@ -112,7 +130,7 @@ func (c *Columns) GetColumnsToUpdate() []string {
 			continue
 		}
 
-		cols = append(cols, col.name)
+		cols = append(cols, col.Name(escape))
 	}
 
 	return cols

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -19,7 +19,6 @@ type Column struct {
 }
 
 func UnescapeColumnName(escapedName string, destKind constants.DestinationKind) string {
-	// TODO test
 	if destKind == constants.BigQuery {
 		return strings.ReplaceAll(escapedName, "`", "")
 	} else {

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -1,6 +1,13 @@
 package typing
 
-import "sync"
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/artie-labs/transfer/lib/array"
+	"github.com/artie-labs/transfer/lib/config/constants"
+)
 
 type Column struct {
 	Name        string
@@ -9,6 +16,15 @@ type Column struct {
 	// We have stripped this out.
 	// Whenever we see the same column where there's an opposite value in `toastColumn`, we will trigger a flush
 	ToastColumn bool
+}
+
+// EscapeName will escape specific reserved words from destinations. Change from `start` => `"start"` as suggested by Snowflake.
+func (c *Column) EscapeName() string {
+	if array.StringContains(constants.ReservedKeywords, c.Name) {
+		return fmt.Sprintf(`"%s"`, c.Name)
+	}
+
+	return c.Name
 }
 
 type Columns struct {
@@ -125,4 +141,50 @@ func (c *Columns) DeleteColumn(name string) {
 			return
 		}
 	}
+}
+
+// ColumnsUpdateQuery takes:
+// columns - list of columns to iterate
+// columnsToTypes - given that list, provide the types (separate list because this list may contain invalid columns
+// bigQueryTypeCasting - We'll need to escape the column comparison if the column's a struct.
+// It then returns a list of strings like: cc.first_name=c.first_name,cc.last_name=c.last_name,cc.email=c.email
+func ColumnsUpdateQuery(columns []string, columnsToTypes Columns, bigQueryTypeCasting bool) string {
+	var _columns []string
+	for _, column := range columns {
+		columnType, isOk := columnsToTypes.GetColumn(column)
+		if isOk && columnType.ToastColumn {
+			if columnType.KindDetails == Struct {
+				if bigQueryTypeCasting {
+					_columns = append(_columns,
+						fmt.Sprintf(`%s= CASE WHEN TO_JSON_STRING(cc.%s) != '{"key": "%s"}' THEN cc.%s ELSE c.%s END`,
+							// col CASE when TO_JSON_STRING(cc.col) != { 'key': TOAST_UNAVAILABLE_VALUE }
+							column, column, constants.ToastUnavailableValuePlaceholder,
+							// cc.col ELSE c.col END
+							column, column))
+				} else {
+					_columns = append(_columns,
+						fmt.Sprintf("%s= CASE WHEN cc.%s != {'key': '%s'} THEN cc.%s ELSE c.%s END",
+							// col CASE WHEN cc.col
+							column, column,
+							// { 'key': TOAST_UNAVAILABLE_VALUE } THEN cc.col ELSE c.col END",
+							constants.ToastUnavailableValuePlaceholder, column, column))
+				}
+			} else {
+				// t.column3 = CASE WHEN t.column3 != '__debezium_unavailable_value' THEN t.column3 ELSE s.column3 END
+				_columns = append(_columns,
+					fmt.Sprintf("%s= CASE WHEN cc.%s != '%s' THEN cc.%s ELSE c.%s END",
+						// col = CASE WHEN cc.col != TOAST_UNAVAILABLE_VALUE
+						column, column, constants.ToastUnavailableValuePlaceholder,
+						// THEN cc.col ELSE c.col END
+						column, column))
+			}
+
+		} else {
+			// This is to make it look like: objCol = cc.objCol
+			_columns = append(_columns, fmt.Sprintf("%s=cc.%s", column, column))
+		}
+
+	}
+
+	return strings.Join(_columns, ",")
 }

--- a/lib/typing/columns.go
+++ b/lib/typing/columns.go
@@ -23,8 +23,8 @@ func UnescapeColumnName(escapedName string, destKind constants.DestinationKind) 
 	if destKind == constants.BigQuery {
 		return strings.ReplaceAll(escapedName, "`", "")
 	} else {
-		// TODO not sure if Snowflake needs this.
-		return strings.ReplaceAll(escapedName, `"`, "")
+		// Snowflake does not return escaping.
+		return escapedName
 	}
 }
 

--- a/lib/typing/columns_test.go
+++ b/lib/typing/columns_test.go
@@ -310,7 +310,7 @@ func TestColumnsUpdateQuery(t *testing.T) {
 			columns:        lastCaseCols,
 			columnsToTypes: lastCaseColTypes,
 			bigQuery:       true,
-			expectedString: `a1= CASE WHEN TO_JSON_STRING(cc.a1) != '{"key": "__debezium_unavailable_value"}' THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3`,
+			expectedString: `a1= CASE WHEN TO_JSON_STRING(cc.a1) != '{"key":"__debezium_unavailable_value"}' THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3`,
 		},
 	}
 

--- a/lib/typing/columns_test.go
+++ b/lib/typing/columns_test.go
@@ -45,9 +45,10 @@ func TestColumn_Name(t *testing.T) {
 
 func TestColumns_GetColumnsToUpdate(t *testing.T) {
 	type _testCase struct {
-		name         string
-		cols         []Column
-		expectedCols []string
+		name            string
+		cols            []Column
+		expectedCols    []string
+		expectedColsEsc []string
 	}
 
 	var (
@@ -58,6 +59,10 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 			},
 			{
 				name:        "bye",
+				KindDetails: String,
+			},
+			{
+				name:        "start",
 				KindDetails: String,
 			},
 		}
@@ -73,14 +78,16 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 
 	testCases := []_testCase{
 		{
-			name:         "happy path",
-			cols:         happyPathCols,
-			expectedCols: []string{"hi", "bye"},
+			name:            "happy path",
+			cols:            happyPathCols,
+			expectedCols:    []string{"hi", "bye", "start"},
+			expectedColsEsc: []string{"hi", "bye", `"start"`},
 		},
 		{
-			name:         "happy path + extra col",
-			cols:         extraCols,
-			expectedCols: []string{"hi", "bye"},
+			name:            "happy path + extra col",
+			cols:            extraCols,
+			expectedCols:    []string{"hi", "bye", "start"},
+			expectedColsEsc: []string{"hi", "bye", `"start"`},
 		},
 	}
 
@@ -89,7 +96,8 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 			columns: testCase.cols,
 		}
 
-		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(), testCase.name)
+		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(false), testCase.name)
+		assert.Equal(t, testCase.expectedColsEsc, cols.GetColumnsToUpdate(true), testCase.name)
 	}
 }
 

--- a/lib/typing/columns_test.go
+++ b/lib/typing/columns_test.go
@@ -7,33 +7,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestColumn_EscapeName(t *testing.T) {
+func TestColumn_Name(t *testing.T) {
 	type _testCase struct {
-		colName      string
-		expectedName string
+		colName string
+
+		expectedNameEsc string
+		expectedName    string
 	}
 
 	testCases := []_testCase{
 		{
-			colName:      "start",
-			expectedName: `"start"`, // since this is a reserved word.
+			colName:         "start",
+			expectedName:    "start",
+			expectedNameEsc: `"start"`, // since this is a reserved word.
 		},
 		{
-			colName:      "foo",
-			expectedName: "foo",
+			colName:         "foo",
+			expectedName:    "foo",
+			expectedNameEsc: "foo",
 		},
 		{
-			colName:      "bar",
-			expectedName: "bar",
+			colName:         "bar",
+			expectedName:    "bar",
+			expectedNameEsc: "bar",
 		},
 	}
 
 	for _, testCase := range testCases {
 		c := &Column{
-			Name: testCase.colName,
+			name: testCase.colName,
 		}
 
-		assert.Equal(t, testCase.expectedName, c.EscapeName(), testCase.colName)
+		assert.Equal(t, testCase.expectedName, c.Name(false), testCase.colName)
+		assert.Equal(t, testCase.expectedNameEsc, c.Name(true), testCase.colName)
 	}
 }
 
@@ -47,11 +53,11 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 	var (
 		happyPathCols = []Column{
 			{
-				Name:        "hi",
+				name:        "hi",
 				KindDetails: String,
 			},
 			{
-				Name:        "bye",
+				name:        "bye",
 				KindDetails: String,
 			},
 		}
@@ -60,7 +66,7 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 	extraCols := happyPathCols
 	for i := 0; i < 100; i++ {
 		extraCols = append(extraCols, Column{
-			Name:        fmt.Sprintf("hello_%v", i),
+			name:        fmt.Sprintf("hello_%v", i),
 			KindDetails: Invalid,
 		})
 	}
@@ -92,7 +98,7 @@ func TestColumns_UpsertColumns(t *testing.T) {
 	var cols Columns
 	for _, key := range keys {
 		cols.AddColumn(Column{
-			Name:        key,
+			name:        key,
 			KindDetails: String,
 		})
 	}
@@ -131,7 +137,7 @@ func TestColumns_UpsertColumns(t *testing.T) {
 
 func TestColumns_Add_Duplicate(t *testing.T) {
 	var cols Columns
-	duplicateColumns := []Column{{Name: "foo"}, {Name: "foo"}, {Name: "foo"}, {Name: "foo"}, {Name: "foo"}, {Name: "foo"}}
+	duplicateColumns := []Column{{name: "foo"}, {name: "foo"}, {name: "foo"}, {name: "foo"}, {name: "foo"}, {name: "foo"}}
 	for _, duplicateColumn := range duplicateColumns {
 		cols.AddColumn(duplicateColumn)
 	}
@@ -141,7 +147,7 @@ func TestColumns_Add_Duplicate(t *testing.T) {
 
 func TestColumns_Mutation(t *testing.T) {
 	var cols Columns
-	colsToAdd := []Column{{Name: "foo", KindDetails: String}, {Name: "bar", KindDetails: Struct}}
+	colsToAdd := []Column{{name: "foo", KindDetails: String}, {name: "bar", KindDetails: Struct}}
 	// Insert
 	for _, colToAdd := range colsToAdd {
 		cols.AddColumn(colToAdd)
@@ -158,12 +164,12 @@ func TestColumns_Mutation(t *testing.T) {
 
 	// Update
 	cols.UpdateColumn(Column{
-		Name:        "foo",
+		name:        "foo",
 		KindDetails: Integer,
 	})
 
 	cols.UpdateColumn(Column{
-		Name:        "bar",
+		name:        "bar",
 		KindDetails: Boolean,
 	})
 
@@ -200,7 +206,7 @@ func TestColumnsUpdateQuery(t *testing.T) {
 	)
 	for _, col := range fooBarCols {
 		happyPathCols.AddColumn(Column{
-			Name:        col,
+			name:        col,
 			KindDetails: String,
 			ToastColumn: false,
 		})
@@ -212,7 +218,7 @@ func TestColumnsUpdateQuery(t *testing.T) {
 		}
 
 		stringAndToastCols.AddColumn(Column{
-			Name:        col,
+			name:        col,
 			KindDetails: String,
 			ToastColumn: toastCol,
 		})
@@ -232,7 +238,7 @@ func TestColumnsUpdateQuery(t *testing.T) {
 		}
 
 		lastCaseColTypes.AddColumn(Column{
-			Name:        lastCaseCol,
+			name:        lastCaseCol,
 			KindDetails: kd,
 			ToastColumn: toast,
 		})

--- a/lib/typing/columns_test.go
+++ b/lib/typing/columns_test.go
@@ -296,6 +296,9 @@ func TestColumnsUpdateQuery(t *testing.T) {
 			toast = true
 		} else if lastCaseColEsc == "b2" {
 			toast = true
+		} else if lastCaseColEsc == "`start`" {
+			kd = Struct
+			toast = true
 		}
 
 		name := lastCaseColEsc
@@ -310,6 +313,8 @@ func TestColumnsUpdateQuery(t *testing.T) {
 			ToastColumn: toast,
 		})
 	}
+
+	key := `{"key":"__debezium_unavailable_value"}`
 
 	testCases := []testCase{
 		{
@@ -342,7 +347,8 @@ func TestColumnsUpdateQuery(t *testing.T) {
 			columns:        lastCaseColsEsc,
 			columnsToTypes: lastCaseEscapeTypes,
 			bigQuery:       true,
-			expectedString: fmt.Sprintf(`a1= CASE WHEN TO_JSON_STRING(cc.a1) != '{"key":"__debezium_unavailable_value"}' THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3,%s,%s`, "`start`=cc.`start`", "`select`=cc.`select`"),
+			expectedString: fmt.Sprintf(`a1= CASE WHEN TO_JSON_STRING(cc.a1) != '%s' THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3,%s,%s`,
+				key, fmt.Sprintf("`start`= CASE WHEN TO_JSON_STRING(cc.`start`) != '%s' THEN cc.`start` ELSE c.`start` END", key), "`select`=cc.`select`"),
 		},
 	}
 

--- a/lib/typing/columns_test.go
+++ b/lib/typing/columns_test.go
@@ -47,6 +47,10 @@ func TestColumn_Name(t *testing.T) {
 		}
 
 		assert.Equal(t, testCase.expectedName, c.Name(nil), testCase.colName)
+		assert.Equal(t, testCase.expectedName, c.Name(&NameArgs{
+			Escape: false,
+		}), testCase.colName)
+
 		assert.Equal(t, testCase.expectedNameEsc, c.Name(&NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
@@ -60,10 +64,11 @@ func TestColumn_Name(t *testing.T) {
 
 func TestColumns_GetColumnsToUpdate(t *testing.T) {
 	type _testCase struct {
-		name            string
-		cols            []Column
-		expectedCols    []string
-		expectedColsEsc []string
+		name              string
+		cols              []Column
+		expectedCols      []string
+		expectedColsEsc   []string
+		expectedColsEscBq []string
 	}
 
 	var (
@@ -93,16 +98,18 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 
 	testCases := []_testCase{
 		{
-			name:            "happy path",
-			cols:            happyPathCols,
-			expectedCols:    []string{"hi", "bye", "start"},
-			expectedColsEsc: []string{"hi", "bye", `"start"`},
+			name:              "happy path",
+			cols:              happyPathCols,
+			expectedCols:      []string{"hi", "bye", "start"},
+			expectedColsEsc:   []string{"hi", "bye", `"start"`},
+			expectedColsEscBq: []string{"hi", "bye", "`start`"},
 		},
 		{
-			name:            "happy path + extra col",
-			cols:            extraCols,
-			expectedCols:    []string{"hi", "bye", "start"},
-			expectedColsEsc: []string{"hi", "bye", `"start"`},
+			name:              "happy path + extra col",
+			cols:              extraCols,
+			expectedCols:      []string{"hi", "bye", "start"},
+			expectedColsEsc:   []string{"hi", "bye", `"start"`},
+			expectedColsEscBq: []string{"hi", "bye", "`start`"},
 		},
 	}
 
@@ -112,9 +119,18 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 		}
 
 		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(nil), testCase.name)
+		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(&NameArgs{
+			Escape: false,
+		}), testCase.name)
+
 		assert.Equal(t, testCase.expectedColsEsc, cols.GetColumnsToUpdate(&NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
+		}), testCase.name)
+
+		assert.Equal(t, testCase.expectedColsEscBq, cols.GetColumnsToUpdate(&NameArgs{
+			Escape:   true,
+			DestKind: constants.BigQuery,
 		}), testCase.name)
 	}
 }

--- a/lib/typing/columns_test.go
+++ b/lib/typing/columns_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/config/constants"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,25 +13,31 @@ func TestColumn_Name(t *testing.T) {
 	type _testCase struct {
 		colName string
 
+		expectedName string
+		// Snowflake
 		expectedNameEsc string
-		expectedName    string
+		// BigQuery
+		expectedNameEscBq string
 	}
 
 	testCases := []_testCase{
 		{
-			colName:         "start",
-			expectedName:    "start",
-			expectedNameEsc: `"start"`, // since this is a reserved word.
+			colName:           "start",
+			expectedName:      "start",
+			expectedNameEsc:   `"start"`, // since this is a reserved word.
+			expectedNameEscBq: "`start`", // BQ escapes via backticks.
 		},
 		{
-			colName:         "foo",
-			expectedName:    "foo",
-			expectedNameEsc: "foo",
+			colName:           "foo",
+			expectedName:      "foo",
+			expectedNameEsc:   "foo",
+			expectedNameEscBq: "foo",
 		},
 		{
-			colName:         "bar",
-			expectedName:    "bar",
-			expectedNameEsc: "bar",
+			colName:           "bar",
+			expectedName:      "bar",
+			expectedNameEsc:   "bar",
+			expectedNameEscBq: "bar",
 		},
 	}
 
@@ -38,8 +46,15 @@ func TestColumn_Name(t *testing.T) {
 			name: testCase.colName,
 		}
 
-		assert.Equal(t, testCase.expectedName, c.Name(false), testCase.colName)
-		assert.Equal(t, testCase.expectedNameEsc, c.Name(true), testCase.colName)
+		assert.Equal(t, testCase.expectedName, c.Name(nil), testCase.colName)
+		assert.Equal(t, testCase.expectedNameEsc, c.Name(&NameArgs{
+			Escape:   true,
+			DestKind: constants.Snowflake,
+		}), testCase.colName)
+		assert.Equal(t, testCase.expectedNameEscBq, c.Name(&NameArgs{
+			Escape:   true,
+			DestKind: constants.BigQuery,
+		}), testCase.colName)
 	}
 }
 
@@ -96,8 +111,11 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 			columns: testCase.cols,
 		}
 
-		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(false), testCase.name)
-		assert.Equal(t, testCase.expectedColsEsc, cols.GetColumnsToUpdate(true), testCase.name)
+		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(nil), testCase.name)
+		assert.Equal(t, testCase.expectedColsEsc, cols.GetColumnsToUpdate(&NameArgs{
+			Escape:   true,
+			DestKind: constants.Snowflake,
+		}), testCase.name)
 	}
 }
 

--- a/lib/typing/columns_test.go
+++ b/lib/typing/columns_test.go
@@ -9,10 +9,41 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestUnescapeColumnName(t *testing.T) {
+	type _testCase struct {
+		escapedName           string
+		expectedBigQueryName  string
+		expectedSnowflakeName string
+		expectedOtherName     string
+	}
+
+	testCases := []_testCase{
+		{
+			escapedName:           "foo",
+			expectedBigQueryName:  "foo",
+			expectedSnowflakeName: "foo",
+			expectedOtherName:     "foo",
+		},
+		{
+			escapedName: "`start`",
+			// Should only escape BigQuery
+			expectedBigQueryName:  "start",
+			expectedSnowflakeName: "`start`",
+			expectedOtherName:     "`start`",
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.expectedBigQueryName, UnescapeColumnName(testCase.escapedName, constants.BigQuery))
+		assert.Equal(t, testCase.expectedSnowflakeName, UnescapeColumnName(testCase.escapedName, constants.Snowflake))
+		assert.Equal(t, testCase.expectedSnowflakeName, UnescapeColumnName(testCase.escapedName, constants.SnowflakeStages))
+		assert.Equal(t, testCase.expectedOtherName, UnescapeColumnName(testCase.escapedName, ""))
+	}
+}
+
 func TestColumn_Name(t *testing.T) {
 	type _testCase struct {
-		colName string
-
+		colName      string
 		expectedName string
 		// Snowflake
 		expectedNameEsc string

--- a/lib/typing/diff.go
+++ b/lib/typing/diff.go
@@ -27,7 +27,7 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 	targ := CloneColumns(columnsInDestination)
 	var colsToDelete []Column
 	for _, col := range src.GetColumns() {
-		_, isOk := targ.GetColumn(col.Name(false))
+		_, isOk := targ.GetColumn(col.Name(nil))
 		if isOk {
 			colsToDelete = append(colsToDelete, col)
 
@@ -36,13 +36,13 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 
 	// We cannot delete inside a for-loop that is iterating over src.GetColumns() because we are messing up the array order.
 	for _, colToDelete := range colsToDelete {
-		src.DeleteColumn(colToDelete.Name(false))
-		targ.DeleteColumn(colToDelete.Name(false))
+		src.DeleteColumn(colToDelete.Name(nil))
+		targ.DeleteColumn(colToDelete.Name(nil))
 	}
 
 	var targetColumnsMissing Columns
 	for _, col := range src.GetColumns() {
-		if shouldSkipColumn(col.Name(false), softDelete) {
+		if shouldSkipColumn(col.Name(nil), softDelete) {
 			continue
 		}
 
@@ -51,7 +51,7 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 
 	var sourceColumnsMissing Columns
 	for _, col := range targ.GetColumns() {
-		if shouldSkipColumn(col.Name(false), softDelete) {
+		if shouldSkipColumn(col.Name(nil), softDelete) {
 			continue
 		}
 

--- a/lib/typing/diff.go
+++ b/lib/typing/diff.go
@@ -27,7 +27,7 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 	targ := CloneColumns(columnsInDestination)
 	var colsToDelete []Column
 	for _, col := range src.GetColumns() {
-		_, isOk := targ.GetColumn(col.Name)
+		_, isOk := targ.GetColumn(col.Name(false))
 		if isOk {
 			colsToDelete = append(colsToDelete, col)
 
@@ -36,13 +36,13 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 
 	// We cannot delete inside a for-loop that is iterating over src.GetColumns() because we are messing up the array order.
 	for _, colToDelete := range colsToDelete {
-		src.DeleteColumn(colToDelete.Name)
-		targ.DeleteColumn(colToDelete.Name)
+		src.DeleteColumn(colToDelete.Name(false))
+		targ.DeleteColumn(colToDelete.Name(false))
 	}
 
 	var targetColumnsMissing Columns
 	for _, col := range src.GetColumns() {
-		if shouldSkipColumn(col.Name, softDelete) {
+		if shouldSkipColumn(col.Name(false), softDelete) {
 			continue
 		}
 
@@ -51,7 +51,7 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 
 	var sourceColumnsMissing Columns
 	for _, col := range targ.GetColumns() {
-		if shouldSkipColumn(col.Name, softDelete) {
+		if shouldSkipColumn(col.Name(false), softDelete) {
 			continue
 		}
 
@@ -64,7 +64,7 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 func CloneColumns(cols *Columns) *Columns {
 	var newCols Columns
 	for _, col := range cols.GetColumns() {
-		col.Name = strings.ToLower(col.Name)
+		col.ToLowerName()
 		newCols.AddColumn(col)
 	}
 

--- a/lib/typing/diff_test.go
+++ b/lib/typing/diff_test.go
@@ -166,7 +166,7 @@ func TestDiffDeterministic(t *testing.T) {
 
 		var key string
 		for _, targetKeyMissing := range targetKeysMissing {
-			key += targetKeyMissing.Name(false)
+			key += targetKeyMissing.Name(nil)
 		}
 
 		retMap[key] = false

--- a/lib/typing/diff_test.go
+++ b/lib/typing/diff_test.go
@@ -201,6 +201,13 @@ func TestCloneColumns(t *testing.T) {
 	cols.AddColumn(NewColumn("bar", String))
 	cols.AddColumn(NewColumn("xyz", String))
 	cols.AddColumn(NewColumn("abc", String))
+
+	var mixedCaseCols Columns
+	mixedCaseCols.AddColumn(NewColumn("foo", String))
+	mixedCaseCols.AddColumn(NewColumn("bAr", String))
+	mixedCaseCols.AddColumn(NewColumn("XYZ", String))
+	mixedCaseCols.AddColumn(NewColumn("aBC", String))
+
 	testCases := []_testCase{
 		{
 			name:         "nil col",
@@ -214,6 +221,11 @@ func TestCloneColumns(t *testing.T) {
 		{
 			name:         "copying columns",
 			cols:         &cols,
+			expectedCols: &cols,
+		},
+		{
+			name:         "mixed case cols",
+			cols:         &mixedCaseCols,
 			expectedCols: &cols,
 		},
 	}

--- a/lib/typing/diff_test.go
+++ b/lib/typing/diff_test.go
@@ -40,15 +40,8 @@ func TestDiff_VariousNils(t *testing.T) {
 
 	var sourceColsNotNil Columns
 	var targColsNotNil Columns
-	sourceColsNotNil.AddColumn(Column{
-		Name:        "foo",
-		KindDetails: Invalid,
-	})
-	targColsNotNil.AddColumn(Column{
-		Name:        "foo",
-		KindDetails: Invalid,
-	})
-
+	sourceColsNotNil.AddColumn(NewColumn("foo", Invalid))
+	targColsNotNil.AddColumn(NewColumn("foo", Invalid))
 	testCases := []_testCase{
 		{
 			name:       "both &Columns{}",
@@ -95,10 +88,7 @@ func TestDiff_VariousNils(t *testing.T) {
 
 func TestDiffBasic(t *testing.T) {
 	var source Columns
-	source.AddColumn(Column{
-		Name:        "a",
-		KindDetails: Integer,
-	})
+	source.AddColumn(NewColumn("a", Integer))
 
 	srcKeyMissing, targKeyMissing := Diff(&source, &source, false)
 	assert.Equal(t, len(srcKeyMissing), 0)
@@ -113,10 +103,7 @@ func TestDiffDelta1(t *testing.T) {
 		"b": Boolean,
 		"c": Struct,
 	} {
-		sourceCols.AddColumn(Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		sourceCols.AddColumn(NewColumn(colName, kindDetails))
 	}
 
 	for colName, kindDetails := range map[string]KindDetails{
@@ -124,10 +111,7 @@ func TestDiffDelta1(t *testing.T) {
 		"b":  Boolean,
 		"cc": String,
 	} {
-		targCols.AddColumn(Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		targCols.AddColumn(NewColumn(colName, kindDetails))
 	}
 
 	srcKeyMissing, targKeyMissing := Diff(&sourceCols, &targCols, false)
@@ -149,10 +133,7 @@ func TestDiffDelta2(t *testing.T) {
 		"cC": String,
 		"Cc": String,
 	} {
-		sourceCols.AddColumn(Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		sourceCols.AddColumn(NewColumn(colName, kindDetails))
 	}
 
 	for colName, kindDetails := range map[string]KindDetails{
@@ -162,10 +143,7 @@ func TestDiffDelta2(t *testing.T) {
 		"CC": String,
 		"dd": String,
 	} {
-		targetCols.AddColumn(Column{
-			Name:        colName,
-			KindDetails: kindDetails,
-		})
+		targetCols.AddColumn(NewColumn(colName, kindDetails))
 	}
 
 	srcKeyMissing, targKeyMissing := Diff(&sourceCols, &targetCols, false)
@@ -179,15 +157,8 @@ func TestDiffDeterministic(t *testing.T) {
 	var sourceCols Columns
 	var targCols Columns
 
-	sourceCols.AddColumn(Column{
-		Name:        "id",
-		KindDetails: Integer,
-	})
-
-	sourceCols.AddColumn(Column{
-		Name:        "name",
-		KindDetails: String,
-	})
+	sourceCols.AddColumn(NewColumn("id", Integer))
+	sourceCols.AddColumn(NewColumn("name", String))
 
 	for i := 0; i < 500; i++ {
 		keysMissing, targetKeysMissing := Diff(&sourceCols, &targCols, false)
@@ -195,7 +166,7 @@ func TestDiffDeterministic(t *testing.T) {
 
 		var key string
 		for _, targetKeyMissing := range targetKeysMissing {
-			key += targetKeyMissing.Name
+			key += targetKeyMissing.Name(false)
 		}
 
 		retMap[key] = false
@@ -206,18 +177,9 @@ func TestDiffDeterministic(t *testing.T) {
 
 func TestCopyColMap(t *testing.T) {
 	var cols Columns
-	cols.AddColumn(Column{
-		Name:        "hello",
-		KindDetails: String,
-	})
-	cols.AddColumn(Column{
-		Name:        "created_at",
-		KindDetails: NewKindDetailsFromTemplate(ETime, ext.DateTimeKindType),
-	})
-	cols.AddColumn(Column{
-		Name:        "updated_at",
-		KindDetails: NewKindDetailsFromTemplate(ETime, ext.DateTimeKindType),
-	})
+	cols.AddColumn(NewColumn("hello", String))
+	cols.AddColumn(NewColumn("created_at", NewKindDetailsFromTemplate(ETime, ext.DateTimeKindType)))
+	cols.AddColumn(NewColumn("updated_at", NewKindDetailsFromTemplate(ETime, ext.DateTimeKindType)))
 
 	copiedCols := CloneColumns(&cols)
 	assert.Equal(t, *copiedCols, cols)
@@ -235,10 +197,10 @@ func TestCloneColumns(t *testing.T) {
 	}
 
 	var cols Columns
-	cols.AddColumn(Column{Name: "foo", KindDetails: String})
-	cols.AddColumn(Column{Name: "bar", KindDetails: String})
-	cols.AddColumn(Column{Name: "xyz", KindDetails: String})
-	cols.AddColumn(Column{Name: "abc", KindDetails: String})
+	cols.AddColumn(NewColumn("foo", String))
+	cols.AddColumn(NewColumn("bar", String))
+	cols.AddColumn(NewColumn("xyz", String))
+	cols.AddColumn(NewColumn("abc", String))
 	testCases := []_testCase{
 		{
 			name:         "nil col",

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -143,10 +143,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 			retrievedColumn, isOk := inMemoryColumns.GetColumn(newColName)
 			if !isOk {
 				// This would only happen if the columns did not get passed in initially.
-				inMemoryColumns.AddColumn(typing.Column{
-					Name:        newColName,
-					KindDetails: typing.ParseValue(_col, e.OptionalSchema, val),
-				})
+				inMemoryColumns.AddColumn(typing.NewColumn(newColName, typing.ParseValue(_col, e.OptionalSchema, val)))
 			} else {
 				if retrievedColumn.KindDetails == typing.Invalid {
 					// If colType is Invalid, let's see if we can update it to a better type

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -47,7 +47,7 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	// Check the in-memory DB columns.
 	var found int
 	for _, col := range optimization.ReadOnlyInMemoryCols().GetColumns() {
-		if col.Name(false) == expectedLowerCol || col.Name(false) == anotherLowerCol {
+		if col.Name(nil) == expectedLowerCol || col.Name(nil) == anotherLowerCol {
 			found += 1
 		}
 
@@ -176,16 +176,16 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	td := models.GetMemoryDB(e.ctx).GetOrCreateTableData("non_existent")
 	var prevKey string
 	for _, col := range td.ReadOnlyInMemoryCols().GetColumns() {
-		if col.Name(false) == constants.DeleteColumnMarker {
+		if col.Name(nil) == constants.DeleteColumnMarker {
 			continue
 		}
 
 		if prevKey == "" {
-			prevKey = col.Name(false)
+			prevKey = col.Name(nil)
 			continue
 		}
 
-		currentKeyParsed, err := strconv.Atoi(col.Name(false))
+		currentKeyParsed, err := strconv.Atoi(col.Name(nil))
 		assert.NoError(e.T(), err)
 
 		prevKeyParsed, err := strconv.Atoi(prevKey)
@@ -199,7 +199,7 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	evt.Columns.AddColumn(typing.NewColumn("foo", typing.Invalid))
 	var index int
 	for idx, col := range evt.Columns.GetColumns() {
-		if col.Name(false) == "foo" {
+		if col.Name(nil) == "foo" {
 			index = idx
 		}
 	}

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -47,7 +47,7 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	// Check the in-memory DB columns.
 	var found int
 	for _, col := range optimization.ReadOnlyInMemoryCols().GetColumns() {
-		if col.Name == expectedLowerCol || col.Name == anotherLowerCol {
+		if col.Name(false) == expectedLowerCol || col.Name(false) == anotherLowerCol {
 			found += 1
 		}
 
@@ -155,7 +155,7 @@ func (e *EventsTestSuite) TestEventSaveOptionalSchema() {
 func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	var cols typing.Columns
 	for i := 0; i < 50; i++ {
-		cols.AddColumn(typing.Column{Name: fmt.Sprint(i), KindDetails: typing.Invalid})
+		cols.AddColumn(typing.NewColumn(fmt.Sprint(i), typing.Invalid))
 	}
 
 	evt := Event{
@@ -176,16 +176,16 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	td := models.GetMemoryDB(e.ctx).GetOrCreateTableData("non_existent")
 	var prevKey string
 	for _, col := range td.ReadOnlyInMemoryCols().GetColumns() {
-		if col.Name == constants.DeleteColumnMarker {
+		if col.Name(false) == constants.DeleteColumnMarker {
 			continue
 		}
 
 		if prevKey == "" {
-			prevKey = col.Name
+			prevKey = col.Name(false)
 			continue
 		}
 
-		currentKeyParsed, err := strconv.Atoi(col.Name)
+		currentKeyParsed, err := strconv.Atoi(col.Name(false))
 		assert.NoError(e.T(), err)
 
 		prevKeyParsed, err := strconv.Atoi(prevKey)
@@ -196,10 +196,10 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	}
 
 	// Now let's add more keys.
-	evt.Columns.AddColumn(typing.Column{Name: "foo", KindDetails: typing.Invalid})
+	evt.Columns.AddColumn(typing.NewColumn("foo", typing.Invalid))
 	var index int
 	for idx, col := range evt.Columns.GetColumns() {
-		if col.Name == "foo" {
+		if col.Name(false) == "foo" {
 			index = idx
 		}
 	}
@@ -209,19 +209,9 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 
 func (e *EventsTestSuite) TestEventSaveColumns() {
 	var cols typing.Columns
-	cols.AddColumn(typing.Column{
-		Name:        "randomCol",
-		KindDetails: typing.Invalid,
-	})
-	cols.AddColumn(typing.Column{
-		Name:        "anotherCOL",
-		KindDetails: typing.Invalid,
-	})
-	cols.AddColumn(typing.Column{
-		Name:        "created_at_date_string",
-		KindDetails: typing.Invalid,
-	})
-
+	cols.AddColumn(typing.NewColumn("randomCol", typing.Invalid))
+	cols.AddColumn(typing.NewColumn("anotherCOL", typing.Invalid))
+	cols.AddColumn(typing.NewColumn("created_at_date_string", typing.Invalid))
 	event := Event{
 		Table:   "foo",
 		Columns: &cols,


### PR DESCRIPTION
## TL;DR

We are now escaping column names that are reserved keywords. We are starting with `start` and `select`. We have created an util function since we only need to escape this when making actual calls to Snowflake and BigQuery.

For this, we created `typing.NameArgs` as BigQuery and Snowflake require different types of escaping.

Snowflake wants it to be like: 
```sql
SELECT "start" from table;
```

BigQuery wants it to be like: 
```sql
SELECT `select` from table;
```

This was sprinkled all over the codebase which explains the large diff. This has been tested against JSON, ARRAY and TOASTED columns.