### PR TITLE
Escape primary key comparison for keywords

### DIFF
--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/array"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -12,7 +14,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func CastColVal(colVal interface{}, colKind typing.Column) (interface{}, error) {
+func CastColVal(colVal interface{}, colKind columns.Column) (interface{}, error) {
 	if colVal != nil {
 		switch colKind.KindDetails.Kind {
 		case typing.ETime.Kind:

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
@@ -18,7 +20,7 @@ func TestCastColVal(t *testing.T) {
 	type _testCase struct {
 		name    string
 		colVal  interface{}
-		colKind typing.Column
+		colKind columns.Column
 
 		expectedErr   error
 		expectedValue interface{}
@@ -46,49 +48,49 @@ func TestCastColVal(t *testing.T) {
 		{
 			name:          "escaping string",
 			colVal:        "foo",
-			colKind:       typing.Column{KindDetails: typing.String},
+			colKind:       columns.Column{KindDetails: typing.String},
 			expectedValue: "foo",
 		},
 		{
 			name:          "123 as int",
 			colVal:        123,
-			colKind:       typing.Column{KindDetails: typing.Integer},
+			colKind:       columns.Column{KindDetails: typing.Integer},
 			expectedValue: "123",
 		},
 		{
 			name:          "struct",
 			colVal:        `{"hello": "world"}`,
-			colKind:       typing.Column{KindDetails: typing.Struct},
+			colKind:       columns.Column{KindDetails: typing.Struct},
 			expectedValue: `{"hello": "world"}`,
 		},
 		{
 			name:          "struct w/ toast",
 			colVal:        constants.ToastUnavailableValuePlaceholder,
-			colKind:       typing.Column{KindDetails: typing.Struct},
+			colKind:       columns.Column{KindDetails: typing.Struct},
 			expectedValue: fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder),
 		},
 		{
 			name:          "array",
 			colVal:        []int{1, 2, 3, 4, 5},
-			colKind:       typing.Column{KindDetails: typing.Array},
+			colKind:       columns.Column{KindDetails: typing.Array},
 			expectedValue: []string{"1", "2", "3", "4", "5"},
 		},
 		{
 			name:          "timestamp",
 			colVal:        birthdayTSExt,
-			colKind:       typing.Column{KindDetails: tsKind},
+			colKind:       columns.Column{KindDetails: tsKind},
 			expectedValue: "2022-09-06 03:19:24.942",
 		},
 		{
 			name:          "date",
 			colVal:        birthdayDateExt,
-			colKind:       typing.Column{KindDetails: dateKind},
+			colKind:       columns.Column{KindDetails: dateKind},
 			expectedValue: "2022-09-06",
 		},
 		{
 			name:          "time",
 			colVal:        birthdayTimeExt,
-			colKind:       typing.Column{KindDetails: timeKind},
+			colKind:       columns.Column{KindDetails: timeKind},
 			expectedValue: "03:19:24",
 		},
 	}

--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/dwh/types"
 	"github.com/artie-labs/transfer/lib/optimization"
@@ -51,7 +53,7 @@ func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.Tabl
 // parseSchemaQuery is to parse out the results from this query: https://cloud.google.com/bigquery/docs/information-schema-tables#example_1
 func parseSchemaQuery(row string, createTable, dropDeletedColumns bool) (*types.DwhTableConfig, error) {
 	if createTable {
-		return types.NewDwhTableConfig(&typing.Columns{}, nil, createTable, dropDeletedColumns), nil
+		return types.NewDwhTableConfig(&columns.Columns{}, nil, createTable, dropDeletedColumns), nil
 	}
 
 	// TrimSpace only does the L + R side.
@@ -87,7 +89,7 @@ func parseSchemaQuery(row string, createTable, dropDeletedColumns bool) (*types.
 		return nil, fmt.Errorf("malformed DDL string: missing (, %s", ddlString)
 	}
 
-	var bigQueryColumns typing.Columns
+	var bigQueryColumns columns.Columns
 	ddlString = ddlString[:endOfStatement]
 	columnsToTypes := strings.Split(ddlString, ",")
 	for _, colType := range columnsToTypes {
@@ -104,7 +106,7 @@ func parseSchemaQuery(row string, createTable, dropDeletedColumns bool) (*types.
 			return nil, fmt.Errorf("unexpected colType, colType: %s, parts: %v", colType, parts)
 		}
 
-		bigQueryColumns.AddColumn(typing.NewColumn(typing.UnescapeColumnName(parts[0], constants.BigQuery), typing.BigQueryTypeToKind(strings.Join(parts[1:], " "))))
+		bigQueryColumns.AddColumn(columns.NewColumn(columns.UnescapeColumnName(parts[0], constants.BigQuery), typing.BigQueryTypeToKind(strings.Join(parts[1:], " "))))
 	}
 
 	return types.NewDwhTableConfig(&bigQueryColumns, nil, createTable, dropDeletedColumns), nil

--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/stringutil"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -16,7 +18,7 @@ import (
 
 // CastColValStaging - takes `colVal` interface{} and `colKind` typing.Column and converts the value into a string value
 // This is necessary because CSV writers require values to in `string`.
-func CastColValStaging(colVal interface{}, colKind typing.Column) (string, error) {
+func CastColValStaging(colVal interface{}, colKind columns.Column) (string, error) {
 	if colVal == nil {
 		// \\N needs to match NULL_IF(...) from ddl.go
 		return `\\N`, nil

--- a/clients/snowflake/cast_test.go
+++ b/clients/snowflake/cast_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
@@ -16,7 +18,7 @@ import (
 type _testCase struct {
 	name    string
 	colVal  interface{}
-	colKind typing.Column
+	colKind columns.Column
 
 	expectedString string
 	expectErr      bool
@@ -38,7 +40,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 		{
 			name:   "empty string",
 			colVal: "",
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.String,
 			},
 
@@ -47,7 +49,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 		{
 			name:   "null value (string, not that it matters)",
 			colVal: nil,
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.String,
 			},
 
@@ -56,7 +58,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 		{
 			name:   "string",
 			colVal: "foo",
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.String,
 			},
 
@@ -65,7 +67,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 		{
 			name:   "integer",
 			colVal: 7,
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.Integer,
 			},
 			expectedString: "7",
@@ -73,7 +75,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 		{
 			name:   "boolean",
 			colVal: true,
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.Boolean,
 			},
 			expectedString: "true",
@@ -81,7 +83,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 		{
 			name:   "array",
 			colVal: []string{"hello", "there"},
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.Array,
 			},
 			expectedString: `["hello","there"]`,
@@ -89,7 +91,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 		{
 			name:   "JSON string",
 			colVal: `{"hello": "world"}`,
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.Struct,
 			},
 			expectedString: `{"hello": "world"}`,
@@ -97,7 +99,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 		{
 			name:   "JSON struct",
 			colVal: map[string]string{"hello": "world"},
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.Struct,
 			},
 			expectedString: `{"hello":"world"}`,
@@ -114,14 +116,14 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Array() {
 		{
 			name:   "array w/ numbers",
 			colVal: []int{1, 2, 3, 4, 5},
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.Array,
 			},
 			expectedString: `[1,2,3,4,5]`,
 		},
 		{
 			name: "array w/ nested objects (JSON)",
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.Array,
 			},
 			colVal: []map[string]interface{}{
@@ -139,7 +141,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Array() {
 		},
 		{
 			name: "array w/ bools",
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.Array,
 			},
 			colVal: []bool{
@@ -184,7 +186,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Time() {
 		{
 			name:   "date",
 			colVal: birthdate,
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: dateKind,
 			},
 			expectedString: "2022-09-06",
@@ -192,7 +194,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Time() {
 		{
 			name:   "time",
 			colVal: birthTime,
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: timeKind,
 			},
 			expectedString: "03:19:24.942",
@@ -200,7 +202,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Time() {
 		{
 			name:   "datetime",
 			colVal: birthDateTime,
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: dateTimeKind,
 			},
 			expectedString: "2022-09-06T03:19:24.942Z",
@@ -219,7 +221,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_TOAST() {
 		{
 			name:   "struct with TOAST value",
 			colVal: constants.ToastUnavailableValuePlaceholder,
-			colKind: typing.Column{
+			colKind: columns.Column{
 				KindDetails: typing.Struct,
 			},
 			expectedString: fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder),

--- a/clients/snowflake/ddl.go
+++ b/clients/snowflake/ddl.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/dwh/types"
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -40,11 +42,11 @@ func (s *Store) getTableConfig(ctx context.Context, fqName string, dropDeletedCo
 		}
 	}
 
-	var snowflakeColumns typing.Columns
+	var snowflakeColumns columns.Columns
 	for rows != nil && rows.Next() {
 		// figure out what columns were returned
 		// the column names will be the JSON object field keys
-		columns, err := rows.ColumnTypes()
+		cols, err := rows.ColumnTypes()
 		if err != nil {
 			return nil, err
 		}
@@ -52,8 +54,8 @@ func (s *Store) getTableConfig(ctx context.Context, fqName string, dropDeletedCo
 		var columnNameList []string
 		// Scan needs an array of pointers to the values it is setting
 		// This creates the object and sets the values correctly
-		values := make([]interface{}, len(columns))
-		for idx, column := range columns {
+		values := make([]interface{}, len(cols))
+		for idx, column := range cols {
 			values[idx] = new(interface{})
 			columnNameList = append(columnNameList, strings.ToLower(column.Name()))
 		}
@@ -73,7 +75,7 @@ func (s *Store) getTableConfig(ctx context.Context, fqName string, dropDeletedCo
 			row[columnNameList[idx]] = strings.ToLower(fmt.Sprint(*interfaceVal))
 		}
 
-		snowflakeColumns.AddColumn(typing.NewColumn(row[describeNameCol], typing.SnowflakeTypeToKind(row[describeTypeCol])))
+		snowflakeColumns.AddColumn(columns.NewColumn(row[describeNameCol], typing.SnowflakeTypeToKind(row[describeTypeCol])))
 	}
 
 	sflkTableConfig := types.NewDwhTableConfig(&snowflakeColumns, nil, tableMissing, dropDeletedColumns)

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/dwh/types"
 	"github.com/artie-labs/transfer/lib/typing/ext"
@@ -16,7 +18,7 @@ import (
 func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 	fqName := "coffee_shop.public.orders"
 
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":          typing.Integer,
 		"customer_id": typing.Integer,
@@ -24,14 +26,14 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 		"name":        typing.String,
 		"created_at":  typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		cols.AddColumn(typing.NewColumn(colName, kindDetails))
+		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	config := types.NewDwhTableConfig(&cols, nil, false, true)
 
 	s.store.configMap.AddTableToConfig(fqName, config)
 
-	nameCol := typing.NewColumn("name", typing.String)
+	nameCol := columns.NewColumn("name", typing.String)
 	tc := s.store.configMap.TableConfig(fqName)
 
 	val := tc.ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*6*time.Hour))
@@ -46,7 +48,7 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 	fqName := "coffee_shop.orders.public"
 
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":          typing.Integer,
 		"customer_id": typing.Integer,
@@ -54,13 +56,13 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 		"name":        typing.String,
 		"created_at":  typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		cols.AddColumn(typing.NewColumn(colName, kindDetails))
+		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	config := types.NewDwhTableConfig(&cols, nil, false, true)
 	s.store.configMap.AddTableToConfig(fqName, config)
 
-	nameCol := typing.NewColumn("name", typing.String)
+	nameCol := columns.NewColumn("name", typing.String)
 	// Let's try to delete name.
 	allowed := s.store.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*(6*time.Hour)))
 
@@ -83,7 +85,7 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 }
 
 func (s *SnowflakeTestSuite) TestManipulateShouldDeleteColumn() {
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":          typing.Integer,
 		"customer_id": typing.Integer,
@@ -91,7 +93,7 @@ func (s *SnowflakeTestSuite) TestManipulateShouldDeleteColumn() {
 		"name":        typing.String,
 		"created_at":  typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		cols.AddColumn(typing.NewColumn(colName, kindDetails))
+		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	tc := types.NewDwhTableConfig(&cols, map[string]time.Time{

--- a/clients/snowflake/merge_test.go
+++ b/clients/snowflake/merge_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
@@ -15,29 +17,29 @@ import (
 func (s *SnowflakeTestSuite) TestEscapeCols() {
 	type _testCase struct {
 		name                string
-		cols                []typing.Column
+		cols                []columns.Column
 		expectedCols        []string
 		expectedColsEscaped []string
 	}
 
 	var (
-		happyPathCols                           typing.Columns
-		reservedKeywordsCols                    typing.Columns
-		happyPathStructCols                     typing.Columns
-		reservedKeywordsStructCols              typing.Columns
-		happyPathStructArrayCols                typing.Columns
-		happyPathStructArrayWithToastStructCols typing.Columns
+		happyPathCols                           columns.Columns
+		reservedKeywordsCols                    columns.Columns
+		happyPathStructCols                     columns.Columns
+		reservedKeywordsStructCols              columns.Columns
+		happyPathStructArrayCols                columns.Columns
+		happyPathStructArrayWithToastStructCols columns.Columns
 	)
 
 	for _, col := range []string{"foo", "bar"} {
-		_col := typing.NewColumn(col, typing.String)
+		_col := columns.NewColumn(col, typing.String)
 		_col.ToastColumn = false
 
 		happyPathCols.AddColumn(_col)
 	}
 
 	for _, col := range []string{"foo", "bar", "start", "select"} {
-		_col := typing.NewColumn(col, typing.String)
+		_col := columns.NewColumn(col, typing.String)
 		_col.ToastColumn = false
 
 		reservedKeywordsCols.AddColumn(_col)
@@ -49,7 +51,7 @@ func (s *SnowflakeTestSuite) TestEscapeCols() {
 			kd = typing.Struct
 		}
 
-		_col := typing.NewColumn(col, kd)
+		_col := columns.NewColumn(col, kd)
 		_col.ToastColumn = false
 		happyPathStructCols.AddColumn(_col)
 	}
@@ -60,7 +62,7 @@ func (s *SnowflakeTestSuite) TestEscapeCols() {
 			kd = typing.Struct
 		}
 
-		_col := typing.NewColumn(col, kd)
+		_col := columns.NewColumn(col, kd)
 		_col.ToastColumn = false
 		reservedKeywordsStructCols.AddColumn(_col)
 	}
@@ -75,7 +77,7 @@ func (s *SnowflakeTestSuite) TestEscapeCols() {
 			kd = typing.Array
 		}
 
-		_col := typing.NewColumn(col, kd)
+		_col := columns.NewColumn(col, kd)
 		_col.ToastColumn = false
 
 		happyPathStructArrayCols.AddColumn(_col)
@@ -97,7 +99,7 @@ func (s *SnowflakeTestSuite) TestEscapeCols() {
 			kd = typing.Struct
 		}
 
-		_col := typing.NewColumn(col, kd)
+		_col := columns.NewColumn(col, kd)
 		_col.ToastColumn = toast
 
 		happyPathStructArrayWithToastStructCols.AddColumn(_col)
@@ -151,8 +153,8 @@ func (s *SnowflakeTestSuite) TestEscapeCols() {
 }
 
 func (s *SnowflakeTestSuite) TestMergeNoDeleteFlag() {
-	var cols typing.Columns
-	cols.AddColumn(typing.NewColumn("id", typing.Integer))
+	var cols columns.Columns
+	cols.AddColumn(columns.NewColumn("id", typing.Integer))
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, kafkalib.TopicConfig{}, "")
 	_, err := getMergeStatement(s.ctx, tableData)
@@ -161,13 +163,13 @@ func (s *SnowflakeTestSuite) TestMergeNoDeleteFlag() {
 }
 
 func (s *SnowflakeTestSuite) TestMerge() {
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"NAME":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 	} {
-		cols.AddColumn(typing.NewColumn(colName, kindDetails))
+		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -222,13 +224,13 @@ func (s *SnowflakeTestSuite) TestMerge() {
 }
 
 func (s *SnowflakeTestSuite) TestMergeWithSingleQuote() {
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"NAME":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 	} {
-		cols.AddColumn(typing.NewColumn(colName, kindDetails))
+		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -255,13 +257,13 @@ func (s *SnowflakeTestSuite) TestMergeWithSingleQuote() {
 }
 
 func (s *SnowflakeTestSuite) TestMergeJson() {
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.Integer,
 		"meta":                       typing.Struct,
 		constants.DeleteColumnMarker: typing.Boolean,
 	} {
-		cols.AddColumn(typing.NewColumn(colName, kindDetails))
+		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	rowData := make(map[string]map[string]interface{})
@@ -290,13 +292,13 @@ func (s *SnowflakeTestSuite) TestMergeJson() {
 // TestMergeJSONKey - This test is to confirm that we are changing equality strings for Snowflake
 // Since this is only required for BigQuery.
 func (s *SnowflakeTestSuite) TestMergeJSONKey() {
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":                         typing.Struct,
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 	} {
-		cols.AddColumn(typing.NewColumn(colName, kindDetails))
+		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	rowData := make(map[string]map[string]interface{})

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -3,6 +3,8 @@ package snowflake
 import (
 	"context"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/db"
@@ -10,7 +12,6 @@ import (
 	"github.com/artie-labs/transfer/lib/dwh/types"
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/optimization"
-	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/snowflakedb/gosnowflake"
 )
 
@@ -75,7 +76,7 @@ func (s *Store) merge(ctx context.Context, tableData *optimization.TableData) er
 	log := logger.FromContext(ctx)
 
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(), tableData.TopicConfig.SoftDelete)
+	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(), tableData.TopicConfig.SoftDelete)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,
 		Tc:          tableConfig,

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -27,9 +29,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		constants.DeleteColumnMarker: typing.Boolean,
 	}
 
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, colKind := range colToKindDetailsMap {
-		cols.AddColumn(typing.NewColumn(colName, colKind))
+		cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
 
 	rowsData := map[string]map[string]interface{}{
@@ -57,9 +59,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		constants.DeleteColumnMarker: typing.Boolean,
 	}
 
-	var anotherCols typing.Columns
+	var anotherCols columns.Columns
 	for colName, kindDetails := range anotherColToKindDetailsMap {
-		anotherCols.AddColumn(typing.NewColumn(colName, kindDetails))
+		anotherCols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	s.store.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake),
@@ -81,9 +83,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, colKind := range colToKindDetailsMap {
-		cols.AddColumn(typing.NewColumn(colName, colKind))
+		cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
 
 	rowsData := make(map[string]map[string]interface{})
@@ -129,9 +131,9 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, colKind := range colToKindDetailsMap {
-		cols.AddColumn(typing.NewColumn(colName, colKind))
+		cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
 
 	rowsData := make(map[string]map[string]interface{})
@@ -191,9 +193,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, colKind := range colToKindDetailsMap {
-		cols.AddColumn(typing.NewColumn(colName, colKind))
+		cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
@@ -208,12 +210,12 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		constants.DeleteColumnMarker: typing.Boolean,
 	}
 
-	var sflkCols typing.Columns
+	var sflkCols columns.Columns
 	for colName, colKind := range snowflakeColToKindDetailsMap {
-		sflkCols.AddColumn(typing.NewColumn(colName, colKind))
+		sflkCols.AddColumn(columns.NewColumn(colName, colKind))
 	}
 
-	sflkCols.AddColumn(typing.NewColumn("new", typing.String))
+	sflkCols.AddColumn(columns.NewColumn("new", typing.String))
 	config := types.NewDwhTableConfig(&sflkCols, nil, false, true)
 	s.store.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake), config)
 
@@ -236,7 +238,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 		inMemColumns := tableData.ReadOnlyInMemoryCols()
 		// Since sflkColumns overwrote the format, let's set it correctly again.
-		inMemColumns.UpdateColumn(typing.NewColumn("created_at", typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano))))
+		inMemColumns.UpdateColumn(columns.NewColumn("created_at", typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano))))
 		tableData.SetInMemoryColumns(inMemColumns)
 		break
 	}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -193,7 +193,6 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	})
 
 	log.WithField("query", mergeQuery).Debug("executing...")
-	fmt.Println("mergeQuery", mergeQuery, "err", err)
 	_, err = s.Exec(mergeQuery)
 	if err != nil {
 		return err

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/artie-labs/transfer/lib/dwh/dml"
-	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/dwh/ddl"
+	"github.com/artie-labs/transfer/lib/dwh/dml"
 	"github.com/artie-labs/transfer/lib/dwh/types"
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/optimization"
@@ -48,7 +48,7 @@ func (s *Store) prepareTempTable(ctx context.Context, tableData *optimization.Ta
 
 	_, err = s.Exec(fmt.Sprintf("COPY INTO %s (%s) FROM (SELECT %s FROM @%s)",
 		// Copy into temporary tables (column ...)
-		tempTableName, strings.Join(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(&typing.NameArgs{
+		tempTableName, strings.Join(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(&columns.NameArgs{
 			Escape:   true,
 			DestKind: s.Label(),
 		}), ","),
@@ -117,7 +117,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := typing.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(), tableData.TopicConfig.SoftDelete)
+	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(), tableData.TopicConfig.SoftDelete)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,
 		Tc:          tableConfig,
@@ -180,8 +180,11 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		FqTableName:   tableData.ToFqName(ctx, constants.Snowflake),
 		SubQuery:      temporaryTableName,
 		IdempotentKey: tableData.TopicConfig.IdempotentKey,
-		PrimaryKeys:   tableData.PrimaryKeys,
-		Columns: tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(&typing.NameArgs{
+		PrimaryKeys: tableData.PrimaryKeys(&columns.NameArgs{
+			Escape:   true,
+			DestKind: s.Label(),
+		}),
+		Columns: tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(&columns.NameArgs{
 			Escape:   true,
 			DestKind: s.Label(),
 		}),
@@ -190,6 +193,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	})
 
 	log.WithField("query", mergeQuery).Debug("executing...")
+	fmt.Println("mergeQuery", mergeQuery, "err", err)
 	_, err = s.Exec(mergeQuery)
 	if err != nil {
 		return err

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/dwh/types"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -20,9 +22,9 @@ import (
 // generateTableData - returns tableName and tableData
 func generateTableData(rows int) (string, *optimization.TableData) {
 	randomTableName := fmt.Sprintf("temp_%s_%s", constants.ArtiePrefix, stringutil.Random(10))
-	cols := &typing.Columns{}
+	cols := &columns.Columns{}
 	for _, col := range []string{"user_id", "first_name", "last_name"} {
-		cols.AddColumn(typing.NewColumn(col, typing.String))
+		cols.AddColumn(columns.NewColumn(col, typing.String))
 	}
 
 	td := optimization.NewTableData(cols, []string{"user_id"}, kafkalib.TopicConfig{}, "")
@@ -42,7 +44,7 @@ func generateTableData(rows int) (string, *optimization.TableData) {
 
 func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 	tempTableName, tableData := generateTableData(10)
-	s.stageStore.GetConfigMap().AddTableToConfig(tempTableName, types.NewDwhTableConfig(&typing.Columns{}, nil, true, true))
+	s.stageStore.GetConfigMap().AddTableToConfig(tempTableName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 	sflkTc := s.stageStore.GetConfigMap().TableConfig(tempTableName)
 
 	assert.NoError(s.T(), s.stageStore.prepareTempTable(s.ctx, tableData, sflkTc, tempTableName))

--- a/clients/snowflake/util.go
+++ b/clients/snowflake/util.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
@@ -22,7 +24,7 @@ func addPrefixToTableName(fqTableName string, prefix string) string {
 
 // escapeColumns will take the columns that are passed in, escape them and return them in the ordered received.
 // It'll return like this: $1, $2, $3
-func escapeColumns(columns *typing.Columns, delimiter string) string {
+func escapeColumns(columns *columns.Columns, delimiter string) string {
 	var escapedCols []string
 	for index, col := range columns.GetColumnsToUpdate(nil) {
 		colKind, _ := columns.GetColumn(col)

--- a/clients/snowflake/util_test.go
+++ b/clients/snowflake/util_test.go
@@ -3,6 +3,8 @@ package snowflake
 import (
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/typing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,24 +49,24 @@ func TestAddPrefixToTableName(t *testing.T) {
 func TestEscapeColumns(t *testing.T) {
 	type _testCase struct {
 		name           string
-		cols           *typing.Columns
+		cols           *columns.Columns
 		expectedString string
 	}
 
 	var (
-		happyPathCols                typing.Columns
-		happyPathAndJSONCols         typing.Columns
-		happyPathAndJSONAndArrayCols typing.Columns
+		happyPathCols                columns.Columns
+		happyPathAndJSONCols         columns.Columns
+		happyPathAndJSONAndArrayCols columns.Columns
 	)
 
-	happyPathCols.AddColumn(typing.NewColumn("foo", typing.String))
-	happyPathCols.AddColumn(typing.NewColumn("bar", typing.String))
+	happyPathCols.AddColumn(columns.NewColumn("foo", typing.String))
+	happyPathCols.AddColumn(columns.NewColumn("bar", typing.String))
 
 	happyPathAndJSONCols = happyPathCols
-	happyPathAndJSONCols.AddColumn(typing.NewColumn("struct", typing.Struct))
+	happyPathAndJSONCols.AddColumn(columns.NewColumn("struct", typing.Struct))
 
 	happyPathAndJSONAndArrayCols = happyPathAndJSONCols
-	happyPathAndJSONAndArrayCols.AddColumn(typing.NewColumn("array", typing.Array))
+	happyPathAndJSONAndArrayCols.AddColumn(columns.NewColumn("array", typing.Array))
 
 	testCases := []_testCase{
 		{

--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/typing"
 
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -21,7 +23,7 @@ type Event interface {
 	GetData(ctx context.Context, pkMap map[string]interface{}, config *kafkalib.TopicConfig) map[string]interface{}
 	GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails
 	// GetColumns will inspect the envelope's payload right now and return.
-	GetColumns() *typing.Columns
+	GetColumns() *columns.Columns
 }
 
 // FieldLabelKind is used when the schema is turned on. Each schema object will be labelled.

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/debezium"
 
@@ -84,18 +86,18 @@ func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]t
 	return nil
 }
 
-func (s *SchemaEventPayload) GetColumns() *typing.Columns {
+func (s *SchemaEventPayload) GetColumns() *columns.Columns {
 	fieldsObject := s.Schema.GetSchemaFromLabel(cdc.After)
 	if fieldsObject == nil {
 		// AFTER schema does not exist.
 		return nil
 	}
 
-	var cols typing.Columns
+	var cols columns.Columns
 	for _, field := range fieldsObject.Fields {
 		// We are purposefully doing this to ensure that the correct typing is set
 		// When we invoke event.Save()
-		cols.AddColumn(typing.NewColumn(field.FieldName, typing.Invalid))
+		cols.AddColumn(columns.NewColumn(field.FieldName, typing.Invalid))
 	}
 
 	return &cols

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/debezium"
@@ -35,18 +37,18 @@ type Source struct {
 	Table     string `json:"table"`
 }
 
-func (s *SchemaEventPayload) GetColumns() *typing.Columns {
+func (s *SchemaEventPayload) GetColumns() *columns.Columns {
 	fieldsObject := s.Schema.GetSchemaFromLabel(cdc.After)
 	if fieldsObject == nil {
 		// AFTER schema does not exist.
 		return nil
 	}
 
-	var cols typing.Columns
+	var cols columns.Columns
 	for _, field := range fieldsObject.Fields {
 		// We are purposefully doing this to ensure that the correct typing is set
 		// When we invoke event.Save()
-		cols.AddColumn(typing.NewColumn(field.FieldName, typing.Invalid))
+		cols.AddColumn(columns.NewColumn(field.FieldName, typing.Invalid))
 	}
 
 	return &cols

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/dwh"
 	"github.com/artie-labs/transfer/lib/dwh/types"
@@ -68,12 +70,12 @@ func (a *AlterTableArgs) Validate() error {
 	return nil
 }
 
-func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) error {
+func AlterTable(_ context.Context, args AlterTableArgs, cols ...columns.Column) error {
 	if err := args.Validate(); err != nil {
 		return err
 	}
 
-	var mutateCol []typing.Column
+	var mutateCol []columns.Column
 	// It's okay to combine since args.ColumnOp only takes one of: `Delete` or `Add`
 	var colSQLParts []string
 	for _, col := range cols {
@@ -90,12 +92,12 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...typing.Column) e
 		mutateCol = append(mutateCol, col)
 		switch args.ColumnOp {
 		case constants.Add:
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name(&typing.NameArgs{
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name(&columns.NameArgs{
 				Escape:   true,
 				DestKind: args.Dwh.Label(),
 			}), typing.KindToDWHType(col.KindDetails, args.Dwh.Label())))
 		case constants.Delete:
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name(&typing.NameArgs{
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name(&columns.NameArgs{
 				Escape:   true,
 				DestKind: args.Dwh.Label(),
 			})))

--- a/lib/dwh/ddl/ddl_bq_test.go
+++ b/lib/dwh/ddl/ddl_bq_test.go
@@ -234,20 +234,20 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 		"bar": typing.String,
 	}
 
-	var columns columns.Columns
+	var cols columns.Columns
 	for colName, kindDetails := range columnNameToKindDetailsMap {
-		columns.AddColumn(columns.NewColumn(colName, kindDetails))
+		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	fqName := td.ToFqName(d.bqCtx, constants.BigQuery)
 
 	originalColumnLength := len(columnNameToKindDetailsMap)
-	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns, nil, false, false))
+	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, false))
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)
 
 	// Prior to deletion, there should be no colsToDelete
 	assert.Equal(d.T(), 0, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).ReadOnlyColumnsToDelete()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).ReadOnlyColumnsToDelete())
-	for _, column := range columns.GetColumns() {
+	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
 			Dwh:         d.bigQueryStore,
 			Tc:          tc,
@@ -264,7 +264,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 	assert.Equal(d.T(), originalColumnLength, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns()))
 
 	// Now try to delete again and with an increased TS. It should now be all deleted.
-	for _, column := range columns.GetColumns() {
+	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
 			Dwh:         d.bigQueryStore,
 			Tc:          tc,

--- a/lib/dwh/ddl/ddl_bq_test.go
+++ b/lib/dwh/ddl/ddl_bq_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -33,9 +35,9 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 		"start":  typing.String,
 	}
 
-	var cols typing.Columns
+	var cols columns.Columns
 	for colName, kindDetails := range colNameToKindDetailsMap {
-		cols.AddColumn(typing.NewColumn(colName, kindDetails))
+		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	fqName := td.ToFqName(d.bqCtx, constants.BigQuery)
@@ -80,7 +82,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", fqName, column.Name(&typing.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", fqName, column.Name(&columns.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		})), query)
@@ -113,9 +115,9 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 
 	newColsLen := len(newCols)
 	existingColsLen := len(existingColNameToKindDetailsMap)
-	var existingCols typing.Columns
+	var existingCols columns.Columns
 	for colName, kindDetails := range existingColNameToKindDetailsMap {
-		existingCols.AddColumn(typing.NewColumn(colName, kindDetails))
+		existingCols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&existingCols, nil, false, true))
@@ -135,12 +137,12 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 			CdcTime:     ts,
 		}
 
-		col := typing.NewColumn(name, kind)
+		col := columns.NewColumn(name, kind)
 
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, col)
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, col.Name(&typing.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, col.Name(&columns.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		}),
@@ -173,9 +175,9 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 	}
 
 	existingColsLen := len(existingColNameToKindDetailsMap)
-	var existingCols typing.Columns
+	var existingCols columns.Columns
 	for colName, kindDetails := range existingColNameToKindDetailsMap {
-		existingCols.AddColumn(typing.NewColumn(colName, kindDetails))
+		existingCols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&existingCols, nil, false, true))
@@ -200,7 +202,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(&typing.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(&columns.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		}),
@@ -232,9 +234,9 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 		"bar": typing.String,
 	}
 
-	var columns typing.Columns
+	var columns columns.Columns
 	for colName, kindDetails := range columnNameToKindDetailsMap {
-		columns.AddColumn(typing.NewColumn(colName, kindDetails))
+		columns.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
 	fqName := td.ToFqName(d.bqCtx, constants.BigQuery)

--- a/lib/dwh/ddl/ddl_create_table_test.go
+++ b/lib/dwh/ddl/ddl_create_table_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/dwh"
 	"github.com/artie-labs/transfer/lib/dwh/ddl"
@@ -16,9 +18,9 @@ import (
 
 func (d *DDLTestSuite) Test_CreateTable() {
 	fqName := "mock_dataset.mock_table"
-	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&typing.Columns{}, nil, true, true))
-	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&typing.Columns{}, nil, true, true))
-	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&typing.Columns{}, nil, true, true))
+	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
+	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
+	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 
 	ctx := context.Background()
 
@@ -57,7 +59,7 @@ func (d *DDLTestSuite) Test_CreateTable() {
 			ColumnOp:    constants.Add,
 		}
 
-		err := ddl.AlterTable(ctx, alterTableArgs, typing.NewColumn("name", typing.String))
+		err := ddl.AlterTable(ctx, alterTableArgs, columns.NewColumn("name", typing.String))
 		assert.Equal(d.T(), 1, dwhTc._fakeStore.ExecCallCount())
 
 		query, _ := dwhTc._fakeStore.ExecArgsForCall(0)
@@ -70,24 +72,24 @@ func (d *DDLTestSuite) Test_CreateTable() {
 func (d *DDLTestSuite) TestCreateTable() {
 	type _testCase struct {
 		name string
-		cols []typing.Column
+		cols []columns.Column
 
 		expectedQuery string
 	}
 
 	var (
-		happyPathCols = []typing.Column{
-			typing.NewColumn("user_id", typing.String),
+		happyPathCols = []columns.Column{
+			columns.NewColumn("user_id", typing.String),
 		}
-		twoCols = []typing.Column{
-			typing.NewColumn("user_id", typing.String),
-			typing.NewColumn("enabled", typing.Boolean),
+		twoCols = []columns.Column{
+			columns.NewColumn("user_id", typing.String),
+			columns.NewColumn("enabled", typing.Boolean),
 		}
-		bunchOfCols = []typing.Column{
-			typing.NewColumn("user_id", typing.String),
-			typing.NewColumn("enabled_boolean", typing.Boolean),
-			typing.NewColumn("array", typing.Array),
-			typing.NewColumn("struct", typing.Struct),
+		bunchOfCols = []columns.Column{
+			columns.NewColumn("user_id", typing.String),
+			columns.NewColumn("enabled_boolean", typing.Boolean),
+			columns.NewColumn("array", typing.Array),
+			columns.NewColumn("struct", typing.Struct),
 		}
 	)
 
@@ -112,7 +114,7 @@ func (d *DDLTestSuite) TestCreateTable() {
 	for index, testCase := range testCases {
 		ctx := context.Background()
 		fqTable := "demo.public.experiments"
-		d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&typing.Columns{}, nil, true, true))
+		d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 		tc := d.snowflakeStore.GetConfigMap().TableConfig(fqTable)
 
 		alterTableArgs := ddl.AlterTableArgs{

--- a/lib/dwh/ddl/ddl_sflk_test.go
+++ b/lib/dwh/ddl/ddl_sflk_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -18,14 +20,14 @@ import (
 func (d *DDLTestSuite) TestAlterComplexObjects() {
 	ctx := context.Background()
 	// Test Structs and Arrays
-	cols := []typing.Column{
-		typing.NewColumn("preferences", typing.Struct),
-		typing.NewColumn("array_col", typing.Array),
-		typing.NewColumn("select", typing.String),
+	cols := []columns.Column{
+		columns.NewColumn("preferences", typing.Struct),
+		columns.NewColumn("array_col", typing.Array),
+		columns.NewColumn("select", typing.String),
 	}
 
 	fqTable := "shop.public.complex_columns"
-	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&typing.Columns{}, nil, false, true))
+	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&columns.Columns{}, nil, false, true))
 	tc := d.snowflakeStore.GetConfigMap().TableConfig(fqTable)
 
 	alterTableArgs := ddl.AlterTableArgs{
@@ -40,7 +42,7 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 
 	for i := 0; i < len(cols); i++ {
 		execQuery, _ := d.fakeSnowflakeStore.ExecArgsForCall(i)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s add COLUMN %s %s", fqTable, cols[i].Name(&typing.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s add COLUMN %s %s", fqTable, cols[i].Name(&columns.NameArgs{
 			Escape:   true,
 			DestKind: d.snowflakeStore.Label(),
 		}),
@@ -53,15 +55,15 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 
 func (d *DDLTestSuite) TestAlterIdempotency() {
 	ctx := context.Background()
-	cols := []typing.Column{
-		typing.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
-		typing.NewColumn("id", typing.Integer),
-		typing.NewColumn("order_name", typing.String),
-		typing.NewColumn("start", typing.String),
+	cols := []columns.Column{
+		columns.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
+		columns.NewColumn("id", typing.Integer),
+		columns.NewColumn("order_name", typing.String),
+		columns.NewColumn("start", typing.String),
 	}
 
 	fqTable := "shop.public.orders"
-	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&typing.Columns{}, nil, false, true))
+	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&columns.Columns{}, nil, false, true))
 	tc := d.snowflakeStore.GetConfigMap().TableConfig(fqTable)
 
 	d.fakeSnowflakeStore.ExecReturns(nil, errors.New("column 'order_name' already exists"))
@@ -84,15 +86,15 @@ func (d *DDLTestSuite) TestAlterIdempotency() {
 
 func (d *DDLTestSuite) TestAlterTableAdd() {
 	// Test adding a bunch of columns
-	cols := []typing.Column{
-		typing.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
-		typing.NewColumn("id", typing.Integer),
-		typing.NewColumn("order_name", typing.String),
-		typing.NewColumn("start", typing.String),
+	cols := []columns.Column{
+		columns.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
+		columns.NewColumn("id", typing.Integer),
+		columns.NewColumn("order_name", typing.String),
+		columns.NewColumn("start", typing.String),
 	}
 
 	fqTable := "shop.public.orders"
-	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&typing.Columns{}, nil, false, true))
+	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&columns.Columns{}, nil, false, true))
 	tc := d.snowflakeStore.GetConfigMap().TableConfig(fqTable)
 
 	alterTableArgs := ddl.AlterTableArgs{
@@ -125,15 +127,15 @@ func (d *DDLTestSuite) TestAlterTableAdd() {
 
 func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	// Test adding a bunch of columns
-	cols := []typing.Column{
-		typing.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
-		typing.NewColumn("id", typing.Integer),
-		typing.NewColumn("name", typing.String),
-		typing.NewColumn("start", typing.String),
+	cols := []columns.Column{
+		columns.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
+		columns.NewColumn("id", typing.Integer),
+		columns.NewColumn("name", typing.String),
+		columns.NewColumn("start", typing.String),
 	}
 
 	fqTable := "shop.public.users"
-	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&typing.Columns{}, nil, false, true))
+	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&columns.Columns{}, nil, false, true))
 	tc := d.snowflakeStore.GetConfigMap().TableConfig(fqTable)
 	alterTableArgs := ddl.AlterTableArgs{
 		Dwh:         d.snowflakeStore,
@@ -173,7 +175,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 		assert.Equal(d.T(), i+1, d.fakeSnowflakeStore.ExecCallCount(), "tried to delete one column")
 
 		execArg, _ := d.fakeSnowflakeStore.ExecArgsForCall(i)
-		assert.Equal(d.T(), execArg, fmt.Sprintf("ALTER TABLE %s %s COLUMN %s", fqTable, constants.Delete, cols[i].Name(&typing.NameArgs{
+		assert.Equal(d.T(), execArg, fmt.Sprintf("ALTER TABLE %s %s COLUMN %s", fqTable, constants.Delete, cols[i].Name(&columns.NameArgs{
 			Escape:   true,
 			DestKind: d.snowflakeStore.Label(),
 		})))
@@ -182,18 +184,18 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 
 func (d *DDLTestSuite) TestAlterTableDelete() {
 	// Test adding a bunch of columns
-	cols := []typing.Column{
-		typing.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
-		typing.NewColumn("id", typing.Integer),
-		typing.NewColumn("name", typing.String),
-		typing.NewColumn("col_to_delete", typing.String),
-		typing.NewColumn("answers", typing.String),
-		typing.NewColumn("start", typing.String),
+	cols := []columns.Column{
+		columns.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
+		columns.NewColumn("id", typing.Integer),
+		columns.NewColumn("name", typing.String),
+		columns.NewColumn("col_to_delete", typing.String),
+		columns.NewColumn("answers", typing.String),
+		columns.NewColumn("start", typing.String),
 	}
 
 	fqTable := "shop.public.users1"
 
-	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&typing.Columns{}, map[string]time.Time{
+	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&columns.Columns{}, map[string]time.Time{
 		"col_to_delete": time.Now().Add(-2 * constants.DeletionConfidencePadding),
 		"answers":       time.Now().Add(-2 * constants.DeletionConfidencePadding),
 		"start":         time.Now().Add(-2 * constants.DeletionConfidencePadding),

--- a/lib/dwh/ddl/ddl_temp_test.go
+++ b/lib/dwh/ddl/ddl_temp_test.go
@@ -3,6 +3,8 @@ package ddl_test
 import (
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/dwh/ddl"
 	"github.com/artie-labs/transfer/lib/dwh/types"
@@ -26,7 +28,7 @@ func (d *DDLTestSuite) TestValidate_AlterTableArgs() {
 
 func (d *DDLTestSuite) TestCreateTemporaryTable_Errors() {
 	fqName := "mock_dataset.mock_table"
-	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&typing.Columns{}, nil, true, true))
+	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 	snowflakeTc := d.snowflakeStore.GetConfigMap().TableConfig(fqName)
 	args := ddl.AlterTableArgs{
 		Dwh:            d.snowflakeStore,
@@ -46,7 +48,7 @@ func (d *DDLTestSuite) TestCreateTemporaryTable_Errors() {
 	assert.Contains(d.T(), err.Error(), "incompatible operation - cannot drop columns and create table at the same time")
 
 	// Change it to SFLK + Stage
-	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&typing.Columns{}, nil, true, true))
+	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 	snowflakeStagesTc := d.snowflakeStagesStore.GetConfigMap().TableConfig(fqName)
 	args.Dwh = d.snowflakeStagesStore
 	args.Tc = snowflakeStagesTc
@@ -59,7 +61,7 @@ func (d *DDLTestSuite) TestCreateTemporaryTable_Errors() {
 func (d *DDLTestSuite) TestCreateTemporaryTable() {
 	fqName := "db.schema.tempTableName"
 	// Snowflake Stage
-	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&typing.Columns{}, nil, true, true))
+	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 	sflkStageTc := d.snowflakeStagesStore.GetConfigMap().TableConfig(fqName)
 	args := ddl.AlterTableArgs{
 		Dwh:            d.snowflakeStagesStore,
@@ -71,7 +73,7 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 		CdcTime:        time.Time{},
 	}
 
-	err := ddl.AlterTable(d.ctx, args, typing.NewColumn("foo", typing.String), typing.NewColumn("bar", typing.Float), typing.NewColumn("start", typing.String))
+	err := ddl.AlterTable(d.ctx, args, columns.NewColumn("foo", typing.String), columns.NewColumn("bar", typing.Float), columns.NewColumn("start", typing.String))
 
 	assert.NoError(d.T(), err)
 	assert.Equal(d.T(), 1, d.fakeSnowflakeStagesStore.ExecCallCount())
@@ -83,12 +85,12 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 		query)
 
 	// BigQuery
-	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&typing.Columns{}, nil, true, true))
+	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 	bqTc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)
 	args.Dwh = d.bigQueryStore
 	args.Tc = bqTc
 
-	err = ddl.AlterTable(d.ctx, args, typing.NewColumn("foo", typing.String), typing.NewColumn("bar", typing.Float), typing.NewColumn("select", typing.String))
+	err = ddl.AlterTable(d.ctx, args, columns.NewColumn("foo", typing.String), columns.NewColumn("bar", typing.Float), columns.NewColumn("select", typing.String))
 	assert.NoError(d.T(), err)
 	assert.Equal(d.T(), 1, d.fakeBigQueryStore.ExecCallCount())
 	bqQuery, _ := d.fakeBigQueryStore.ExecArgsForCall(0)

--- a/lib/dwh/dml/merge_bigquery_test.go
+++ b/lib/dwh/dml/merge_bigquery_test.go
@@ -3,6 +3,8 @@ package dml
 import (
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 
 	"github.com/stretchr/testify/assert"
@@ -11,10 +13,10 @@ import (
 )
 
 func TestMergeStatement_TempTable(t *testing.T) {
-	var cols typing.Columns
-	cols.AddColumn(typing.NewColumn("order_id", typing.Integer))
-	cols.AddColumn(typing.NewColumn("name", typing.String))
-	cols.AddColumn(typing.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
+	var cols columns.Columns
+	cols.AddColumn(columns.NewColumn("order_id", typing.Integer))
+	cols.AddColumn(columns.NewColumn("name", typing.String))
+	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
 	mergeArg := MergeArgument{
 		FqTableName:    "customers.orders",
@@ -33,10 +35,10 @@ func TestMergeStatement_TempTable(t *testing.T) {
 }
 
 func TestMergeStatement_JSONKey(t *testing.T) {
-	var cols typing.Columns
-	cols.AddColumn(typing.NewColumn("order_oid", typing.Struct))
-	cols.AddColumn(typing.NewColumn("name", typing.String))
-	cols.AddColumn(typing.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
+	var cols columns.Columns
+	cols.AddColumn(columns.NewColumn("order_oid", typing.Struct))
+	cols.AddColumn(columns.NewColumn("name", typing.String))
+	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
 	mergeArg := MergeArgument{
 		FqTableName:    "customers.orders",

--- a/lib/dwh/dml/merge_bigquery_test.go
+++ b/lib/dwh/dml/merge_bigquery_test.go
@@ -21,7 +21,7 @@ func TestMergeStatement_TempTable(t *testing.T) {
 	mergeArg := MergeArgument{
 		FqTableName:    "customers.orders",
 		SubQuery:       "customers.orders_tmp",
-		PrimaryKeys:    []string{"order_id"},
+		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(columns.NewColumn("order_id", typing.Invalid), nil)},
 		Columns:        []string{"order_id", "name", constants.DeleteColumnMarker},
 		ColumnsToTypes: cols,
 		BigQuery:       true,
@@ -43,7 +43,7 @@ func TestMergeStatement_JSONKey(t *testing.T) {
 	mergeArg := MergeArgument{
 		FqTableName:    "customers.orders",
 		SubQuery:       "customers.orders_tmp",
-		PrimaryKeys:    []string{"order_oid"},
+		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(columns.NewColumn("order_oid", typing.Invalid), nil)},
 		Columns:        []string{"order_oid", "name", constants.DeleteColumnMarker},
 		ColumnsToTypes: cols,
 		BigQuery:       true,

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/stretchr/testify/assert"
@@ -31,8 +33,8 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
-	var _cols typing.Columns
-	_cols.AddColumn(typing.NewColumn("id", typing.String))
+	var _cols columns.Columns
+	_cols.AddColumn(columns.NewColumn("id", typing.String))
 
 	for _, idempotentKey := range []string{"", "updated_at"} {
 		mergeSQL, err := MergeStatement(MergeArgument{
@@ -68,9 +70,9 @@ func TestMergeStatement(t *testing.T) {
 
 	// This feels a bit round about, but this is because iterating over a map is not deterministic.
 	cols := []string{"id", "bar", "updated_at", "start", constants.DeleteColumnMarker}
-	var _cols typing.Columns
+	var _cols columns.Columns
 	for _, col := range cols {
-		_cols.AddColumn(typing.NewColumn(col, colToTypes[col]))
+		_cols.AddColumn(columns.NewColumn(col, colToTypes[col]))
 	}
 
 	tableValues := []string{
@@ -87,7 +89,7 @@ func TestMergeStatement(t *testing.T) {
 		SubQuery:      subQuery,
 		IdempotentKey: "",
 		PrimaryKeys:   []string{"id"},
-		Columns: _cols.GetColumnsToUpdate(&typing.NameArgs{
+		Columns: _cols.GetColumnsToUpdate(&columns.NameArgs{
 			Escape: true,
 		}),
 		ColumnsToTypes: _cols,
@@ -126,8 +128,8 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
-	var _cols typing.Columns
-	_cols.AddColumn(typing.NewColumn("id", typing.String))
+	var _cols columns.Columns
+	_cols.AddColumn(columns.NewColumn("id", typing.String))
 
 	mergeSQL, err := MergeStatement(MergeArgument{
 		FqTableName:    fqTable,
@@ -164,9 +166,9 @@ func TestMergeStatementCompositeKey(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
-	var _cols typing.Columns
-	_cols.AddColumn(typing.NewColumn("id", typing.String))
-	_cols.AddColumn(typing.NewColumn("another_id", typing.String))
+	var _cols columns.Columns
+	_cols.AddColumn(columns.NewColumn("id", typing.String))
+	_cols.AddColumn(columns.NewColumn("another_id", typing.String))
 
 	mergeSQL, err := MergeStatement(MergeArgument{
 		FqTableName:    fqTable,

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -41,7 +41,7 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 			FqTableName:    fqTable,
 			SubQuery:       subQuery,
 			IdempotentKey:  idempotentKey,
-			PrimaryKeys:    []string{"id"},
+			PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(columns.NewColumn("id", typing.Invalid), nil)},
 			Columns:        cols,
 			ColumnsToTypes: _cols,
 			BigQuery:       false,
@@ -88,7 +88,7 @@ func TestMergeStatement(t *testing.T) {
 		FqTableName:   fqTable,
 		SubQuery:      subQuery,
 		IdempotentKey: "",
-		PrimaryKeys:   []string{"id"},
+		PrimaryKeys:   []columns.Wrapper{columns.NewWrapper(columns.NewColumn("id", typing.Invalid), nil)},
 		Columns: _cols.GetColumnsToUpdate(&columns.NameArgs{
 			Escape: true,
 		}),
@@ -135,7 +135,7 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 		FqTableName:    fqTable,
 		SubQuery:       subQuery,
 		IdempotentKey:  "updated_at",
-		PrimaryKeys:    []string{"id"},
+		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(columns.NewColumn("id", typing.Invalid), nil)},
 		Columns:        cols,
 		ColumnsToTypes: _cols,
 		BigQuery:       false,
@@ -171,10 +171,11 @@ func TestMergeStatementCompositeKey(t *testing.T) {
 	_cols.AddColumn(columns.NewColumn("another_id", typing.String))
 
 	mergeSQL, err := MergeStatement(MergeArgument{
-		FqTableName:    fqTable,
-		SubQuery:       subQuery,
-		IdempotentKey:  "updated_at",
-		PrimaryKeys:    []string{"id", "another_id"},
+		FqTableName:   fqTable,
+		SubQuery:      subQuery,
+		IdempotentKey: "updated_at",
+		PrimaryKeys: []columns.Wrapper{columns.NewWrapper(columns.NewColumn("id", typing.Invalid), nil),
+			columns.NewWrapper(columns.NewColumn("another_id", typing.Invalid), nil)},
 		Columns:        cols,
 		ColumnsToTypes: _cols,
 		BigQuery:       false,

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -4,13 +4,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/typing"
 )
 
 type DwhTableConfig struct {
 	// Making these private variables to avoid concurrent R/W panics.
-	columns         *typing.Columns
+	columns         *columns.Columns
 	columnsToDelete map[string]time.Time // column --> when to delete
 	createTable     bool
 
@@ -19,7 +20,7 @@ type DwhTableConfig struct {
 	sync.RWMutex
 }
 
-func NewDwhTableConfig(columns *typing.Columns, colsToDelete map[string]time.Time, createTable, dropDeletedColumns bool) *DwhTableConfig {
+func NewDwhTableConfig(columns *columns.Columns, colsToDelete map[string]time.Time, createTable, dropDeletedColumns bool) *DwhTableConfig {
 	if len(colsToDelete) == 0 {
 		colsToDelete = make(map[string]time.Time)
 	}
@@ -46,7 +47,7 @@ func (tc *DwhTableConfig) DropDeletedColumns() bool {
 	return tc.dropDeletedColumns
 }
 
-func (tc *DwhTableConfig) Columns() *typing.Columns {
+func (tc *DwhTableConfig) Columns() *columns.Columns {
 	if tc == nil {
 		return nil
 	}
@@ -54,7 +55,7 @@ func (tc *DwhTableConfig) Columns() *typing.Columns {
 	return tc.columns
 }
 
-func (tc *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp constants.ColumnOperation, cols ...typing.Column) {
+func (tc *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp constants.ColumnOperation, cols ...columns.Column) {
 	tc.Lock()
 	defer tc.Unlock()
 	switch columnOp {

--- a/lib/dwh/types/table_config_test.go
+++ b/lib/dwh/types/table_config_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/jitter"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -14,7 +16,7 @@ import (
 )
 
 func TestDwhTableConfig_ShouldDeleteColumn(t *testing.T) {
-	dwhTableConfig := NewDwhTableConfig(&typing.Columns{}, nil, false, false)
+	dwhTableConfig := NewDwhTableConfig(&columns.Columns{}, nil, false, false)
 	results := dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC())
 	assert.False(t, results)
 	assert.Equal(t, len(dwhTableConfig.ReadOnlyColumnsToDelete()), 0)
@@ -29,10 +31,10 @@ func TestDwhTableConfig_ShouldDeleteColumn(t *testing.T) {
 // TestDwhTableConfig_ColumnsConcurrency this file is meant to test the concurrency methods of .Columns()
 // In this test, we spin up 5 parallel Go-routines each making 100 calls to .Columns() and assert the validity of the data.
 func TestDwhTableConfig_ColumnsConcurrency(t *testing.T) {
-	var cols typing.Columns
-	cols.AddColumn(typing.NewColumn("foo", typing.Struct))
-	cols.AddColumn(typing.NewColumn("bar", typing.String))
-	cols.AddColumn(typing.NewColumn("boolean", typing.Boolean))
+	var cols columns.Columns
+	cols.AddColumn(columns.NewColumn("foo", typing.Struct))
+	cols.AddColumn(columns.NewColumn("bar", typing.String))
+	cols.AddColumn(columns.NewColumn("boolean", typing.Boolean))
 
 	dwhTableCfg := NewDwhTableConfig(&cols, nil, false, false)
 
@@ -48,7 +50,7 @@ func TestDwhTableConfig_ColumnsConcurrency(t *testing.T) {
 				if (j % 2) == 0 {
 					kindDetails = typing.Array
 				}
-				tableCfg.Columns().UpdateColumn(typing.NewColumn("foo", kindDetails))
+				tableCfg.Columns().UpdateColumn(columns.NewColumn("foo", kindDetails))
 				assert.Equal(t, 3, len(tableCfg.Columns().GetColumns()), tableCfg.Columns().GetColumns())
 			}
 		}(dwhTableCfg)
@@ -58,9 +60,9 @@ func TestDwhTableConfig_ColumnsConcurrency(t *testing.T) {
 }
 
 func TestDwhTableConfig_MutateInMemoryColumns(t *testing.T) {
-	tc := NewDwhTableConfig(&typing.Columns{}, nil, false, false)
+	tc := NewDwhTableConfig(&columns.Columns{}, nil, false, false)
 	for _, col := range []string{"a", "b", "c", "d", "e"} {
-		tc.MutateInMemoryColumns(false, constants.Add, typing.NewColumn(col, typing.String))
+		tc.MutateInMemoryColumns(false, constants.Add, columns.NewColumn(col, typing.String))
 	}
 
 	assert.Equal(t, 5, len(tc.columns.GetColumns()))
@@ -69,7 +71,7 @@ func TestDwhTableConfig_MutateInMemoryColumns(t *testing.T) {
 		wg.Add(1)
 		go func(colName string) {
 			defer wg.Done()
-			tc.MutateInMemoryColumns(false, constants.Add, typing.NewColumn(colName, typing.String))
+			tc.MutateInMemoryColumns(false, constants.Add, columns.NewColumn(colName, typing.String))
 		}(addCol)
 	}
 
@@ -77,7 +79,7 @@ func TestDwhTableConfig_MutateInMemoryColumns(t *testing.T) {
 		wg.Add(1)
 		go func(colName string) {
 			defer wg.Done()
-			tc.MutateInMemoryColumns(false, constants.Delete, typing.NewColumn(colName, typing.Invalid))
+			tc.MutateInMemoryColumns(false, constants.Delete, columns.NewColumn(colName, typing.Invalid))
 		}(removeCol)
 	}
 

--- a/lib/dwh/types/types_test.go
+++ b/lib/dwh/types/types_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/jitter"
 
 	"github.com/stretchr/testify/assert"
@@ -13,14 +15,14 @@ import (
 )
 
 func generateDwhTableCfg() *DwhTableConfig {
-	cols := &typing.Columns{}
+	cols := &columns.Columns{}
 	colsToDelete := make(map[string]time.Time)
 	for _, col := range []string{"foo", "bar", "abc", "xyz"} {
 		colsToDelete[col] = time.Now()
 	}
 
 	for _, col := range []string{"a", "b", "c", "d"} {
-		cols.AddColumn(typing.NewColumn(col, typing.String))
+		cols.AddColumn(columns.NewColumn(col, typing.String))
 	}
 
 	return &DwhTableConfig{

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 
 	"github.com/artie-labs/transfer/lib/config"
@@ -63,12 +65,12 @@ func TestNewTableData_TableName(t *testing.T) {
 
 func TestTableData_ReadOnlyInMemoryCols(t *testing.T) {
 	// Making sure the columns are actually read only.
-	var cols typing.Columns
-	cols.AddColumn(typing.NewColumn("name", typing.String))
+	var cols columns.Columns
+	cols.AddColumn(columns.NewColumn("name", typing.String))
 
 	td := NewTableData(&cols, nil, kafkalib.TopicConfig{}, "foo")
 	readOnlyCols := td.ReadOnlyInMemoryCols()
-	readOnlyCols.AddColumn(typing.NewColumn("last_name", typing.String))
+	readOnlyCols.AddColumn(columns.NewColumn("last_name", typing.String))
 
 	// Check if last_name actually exists.
 	_, isOk := td.ReadOnlyInMemoryCols().GetColumn("last_name")
@@ -79,14 +81,14 @@ func TestTableData_ReadOnlyInMemoryCols(t *testing.T) {
 }
 
 func TestTableData_UpdateInMemoryColumns(t *testing.T) {
-	var _cols typing.Columns
+	var _cols columns.Columns
 	for colName, colKind := range map[string]typing.KindDetails{
 		"FOO":                  typing.String,
 		"bar":                  typing.Invalid,
 		"CHANGE_me":            typing.String,
 		"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType),
 	} {
-		_cols.AddColumn(typing.NewColumn(colName, colKind))
+		_cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
 
 	tableData := &TableData{
@@ -97,7 +99,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	assert.True(t, isOk)
 
 	extCol.KindDetails.ExtendedTimeDetails.Format = time.RFC3339Nano
-	tableData.inMemoryColumns.UpdateColumn(typing.NewColumn(extCol.Name(nil), extCol.KindDetails))
+	tableData.inMemoryColumns.UpdateColumn(columns.NewColumn(extCol.Name(nil), extCol.KindDetails))
 
 	for name, colKindDetails := range map[string]typing.KindDetails{
 		"foo":                  typing.String,
@@ -105,7 +107,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 		"bar":                  typing.Boolean,
 		"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		tableData.UpdateInMemoryColumnsFromDestination(typing.NewColumn(name, colKindDetails))
+		tableData.UpdateInMemoryColumnsFromDestination(columns.NewColumn(name, colKindDetails))
 	}
 
 	// It's saved back in the original format.

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -1,9 +1,11 @@
-package typing
+package columns
 
 import (
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/artie-labs/transfer/lib/typing"
 
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -11,7 +13,7 @@ import (
 
 type Column struct {
 	name        string
-	KindDetails KindDetails
+	KindDetails typing.KindDetails
 	// ToastColumn indicates that the source column is a TOAST column and the value is unavailable
 	// We have stripped this out.
 	// Whenever we see the same column where there's an opposite value in `toastColumn`, we will trigger a flush
@@ -27,7 +29,7 @@ func UnescapeColumnName(escapedName string, destKind constants.DestinationKind) 
 	}
 }
 
-func NewColumn(name string, kd KindDetails) Column {
+func NewColumn(name string, kd typing.KindDetails) Column {
 	return Column{
 		name:        name,
 		KindDetails: kd,
@@ -94,7 +96,7 @@ func (c *Columns) UpsertColumn(colName string, toastColumn bool) {
 
 	c.AddColumn(Column{
 		name:        colName,
-		KindDetails: Invalid,
+		KindDetails: typing.Invalid,
 		ToastColumn: toastColumn,
 	})
 	return
@@ -141,7 +143,7 @@ func (c *Columns) GetColumnsToUpdate(args *NameArgs) []string {
 
 	var cols []string
 	for _, col := range c.columns {
-		if col.KindDetails == Invalid {
+		if col.KindDetails == typing.Invalid {
 			continue
 		}
 
@@ -211,7 +213,7 @@ func ColumnsUpdateQuery(columns []string, columnsToTypes Columns, bigQueryTypeCa
 	for _, column := range columns {
 		columnType, isOk := columnsToTypes.GetColumn(column)
 		if isOk && columnType.ToastColumn {
-			if columnType.KindDetails == Struct {
+			if columnType.KindDetails == typing.Struct {
 				if bigQueryTypeCasting {
 					_columns = append(_columns,
 						fmt.Sprintf(`%s= CASE WHEN TO_JSON_STRING(cc.%s) != '{"key":"%s"}' THEN cc.%s ELSE c.%s END`,

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -1,8 +1,10 @@
-package typing
+package columns
 
 import (
 	"fmt"
 	"testing"
+
+	"github.com/artie-labs/transfer/lib/typing"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 
@@ -106,15 +108,15 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 		happyPathCols = []Column{
 			{
 				name:        "hi",
-				KindDetails: String,
+				KindDetails: typing.String,
 			},
 			{
 				name:        "bye",
-				KindDetails: String,
+				KindDetails: typing.String,
 			},
 			{
 				name:        "start",
-				KindDetails: String,
+				KindDetails: typing.String,
 			},
 		}
 	)
@@ -123,7 +125,7 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		extraCols = append(extraCols, Column{
 			name:        fmt.Sprintf("hello_%v", i),
-			KindDetails: Invalid,
+			KindDetails: typing.Invalid,
 		})
 	}
 
@@ -172,7 +174,7 @@ func TestColumns_UpsertColumns(t *testing.T) {
 	for _, key := range keys {
 		cols.AddColumn(Column{
 			name:        key,
-			KindDetails: String,
+			KindDetails: typing.String,
 		})
 	}
 
@@ -193,12 +195,12 @@ func TestColumns_UpsertColumns(t *testing.T) {
 	cols.UpsertColumn("zzz", false)
 	zzzCol, _ := cols.GetColumn("zzz")
 	assert.False(t, zzzCol.ToastColumn)
-	assert.Equal(t, zzzCol.KindDetails, Invalid)
+	assert.Equal(t, zzzCol.KindDetails, typing.Invalid)
 
 	cols.UpsertColumn("aaa", false)
 	aaaCol, _ := cols.GetColumn("aaa")
 	assert.False(t, aaaCol.ToastColumn)
-	assert.Equal(t, aaaCol.KindDetails, Invalid)
+	assert.Equal(t, aaaCol.KindDetails, typing.Invalid)
 
 	length := len(cols.columns)
 	for i := 0; i < 500; i++ {
@@ -220,7 +222,7 @@ func TestColumns_Add_Duplicate(t *testing.T) {
 
 func TestColumns_Mutation(t *testing.T) {
 	var cols Columns
-	colsToAdd := []Column{{name: "foo", KindDetails: String}, {name: "bar", KindDetails: Struct}}
+	colsToAdd := []Column{{name: "foo", KindDetails: typing.String}, {name: "bar", KindDetails: typing.Struct}}
 	// Insert
 	for _, colToAdd := range colsToAdd {
 		cols.AddColumn(colToAdd)
@@ -229,30 +231,30 @@ func TestColumns_Mutation(t *testing.T) {
 	assert.Equal(t, len(cols.GetColumns()), 2)
 	fooCol, isOk := cols.GetColumn("foo")
 	assert.True(t, isOk)
-	assert.Equal(t, String, fooCol.KindDetails)
+	assert.Equal(t, typing.String, fooCol.KindDetails)
 
 	barCol, isOk := cols.GetColumn("bar")
 	assert.True(t, isOk)
-	assert.Equal(t, Struct, barCol.KindDetails)
+	assert.Equal(t, typing.Struct, barCol.KindDetails)
 
 	// Update
 	cols.UpdateColumn(Column{
 		name:        "foo",
-		KindDetails: Integer,
+		KindDetails: typing.Integer,
 	})
 
 	cols.UpdateColumn(Column{
 		name:        "bar",
-		KindDetails: Boolean,
+		KindDetails: typing.Boolean,
 	})
 
 	fooCol, isOk = cols.GetColumn("foo")
 	assert.True(t, isOk)
-	assert.Equal(t, Integer, fooCol.KindDetails)
+	assert.Equal(t, typing.Integer, fooCol.KindDetails)
 
 	barCol, isOk = cols.GetColumn("bar")
 	assert.True(t, isOk)
-	assert.Equal(t, Boolean, barCol.KindDetails)
+	assert.Equal(t, typing.Boolean, barCol.KindDetails)
 
 	// Delete
 	cols.DeleteColumn("foo")
@@ -281,7 +283,7 @@ func TestColumnsUpdateQuery(t *testing.T) {
 	for _, col := range fooBarCols {
 		happyPathCols.AddColumn(Column{
 			name:        col,
-			KindDetails: String,
+			KindDetails: typing.String,
 			ToastColumn: false,
 		})
 	}
@@ -293,18 +295,18 @@ func TestColumnsUpdateQuery(t *testing.T) {
 
 		stringAndToastCols.AddColumn(Column{
 			name:        col,
-			KindDetails: String,
+			KindDetails: typing.String,
 			ToastColumn: toastCol,
 		})
 	}
 
 	lastCaseCols := []string{"a1", "b2", "c3"}
 	for _, lastCaseCol := range lastCaseCols {
-		kd := String
+		kd := typing.String
 		var toast bool
 		// a1 - struct + toast, b2 - string + toast, c3 = regular string.
 		if lastCaseCol == "a1" {
-			kd = Struct
+			kd = typing.Struct
 			toast = true
 		} else if lastCaseCol == "b2" {
 			toast = true
@@ -319,16 +321,16 @@ func TestColumnsUpdateQuery(t *testing.T) {
 
 	lastCaseColsEsc := []string{"a1", "b2", "c3", "`start`", "`select`"}
 	for _, lastCaseColEsc := range lastCaseColsEsc {
-		kd := String
+		kd := typing.String
 		var toast bool
 		// a1 - struct + toast, b2 - string + toast, c3 = regular string.
 		if lastCaseColEsc == "a1" {
-			kd = Struct
+			kd = typing.Struct
 			toast = true
 		} else if lastCaseColEsc == "b2" {
 			toast = true
 		} else if lastCaseColEsc == "`start`" {
-			kd = Struct
+			kd = typing.Struct
 			toast = true
 		}
 

--- a/lib/typing/columns/diff.go
+++ b/lib/typing/columns/diff.go
@@ -1,4 +1,4 @@
-package typing
+package columns
 
 import (
 	"strings"

--- a/lib/typing/columns/diff_test.go
+++ b/lib/typing/columns/diff_test.go
@@ -1,8 +1,10 @@
-package typing
+package columns
 
 import (
 	"fmt"
 	"testing"
+
+	"github.com/artie-labs/transfer/lib/typing"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/typing/ext"
@@ -40,8 +42,8 @@ func TestDiff_VariousNils(t *testing.T) {
 
 	var sourceColsNotNil Columns
 	var targColsNotNil Columns
-	sourceColsNotNil.AddColumn(NewColumn("foo", Invalid))
-	targColsNotNil.AddColumn(NewColumn("foo", Invalid))
+	sourceColsNotNil.AddColumn(NewColumn("foo", typing.Invalid))
+	targColsNotNil.AddColumn(NewColumn("foo", typing.Invalid))
 	testCases := []_testCase{
 		{
 			name:       "both &Columns{}",
@@ -88,7 +90,7 @@ func TestDiff_VariousNils(t *testing.T) {
 
 func TestDiffBasic(t *testing.T) {
 	var source Columns
-	source.AddColumn(NewColumn("a", Integer))
+	source.AddColumn(NewColumn("a", typing.Integer))
 
 	srcKeyMissing, targKeyMissing := Diff(&source, &source, false)
 	assert.Equal(t, len(srcKeyMissing), 0)
@@ -98,18 +100,18 @@ func TestDiffBasic(t *testing.T) {
 func TestDiffDelta1(t *testing.T) {
 	var sourceCols Columns
 	var targCols Columns
-	for colName, kindDetails := range map[string]KindDetails{
-		"a": String,
-		"b": Boolean,
-		"c": Struct,
+	for colName, kindDetails := range map[string]typing.KindDetails{
+		"a": typing.String,
+		"b": typing.Boolean,
+		"c": typing.Struct,
 	} {
 		sourceCols.AddColumn(NewColumn(colName, kindDetails))
 	}
 
-	for colName, kindDetails := range map[string]KindDetails{
-		"aa": String,
-		"b":  Boolean,
-		"cc": String,
+	for colName, kindDetails := range map[string]typing.KindDetails{
+		"aa": typing.String,
+		"b":  typing.Boolean,
+		"cc": typing.String,
 	} {
 		targCols.AddColumn(NewColumn(colName, kindDetails))
 	}
@@ -123,25 +125,25 @@ func TestDiffDelta2(t *testing.T) {
 	var sourceCols Columns
 	var targetCols Columns
 
-	for colName, kindDetails := range map[string]KindDetails{
-		"a":  String,
-		"aa": String,
-		"b":  Boolean,
-		"c":  Struct,
-		"d":  String,
-		"CC": String,
-		"cC": String,
-		"Cc": String,
+	for colName, kindDetails := range map[string]typing.KindDetails{
+		"a":  typing.String,
+		"aa": typing.String,
+		"b":  typing.Boolean,
+		"c":  typing.Struct,
+		"d":  typing.String,
+		"CC": typing.String,
+		"cC": typing.String,
+		"Cc": typing.String,
 	} {
 		sourceCols.AddColumn(NewColumn(colName, kindDetails))
 	}
 
-	for colName, kindDetails := range map[string]KindDetails{
-		"aa": String,
-		"b":  Boolean,
-		"cc": String,
-		"CC": String,
-		"dd": String,
+	for colName, kindDetails := range map[string]typing.KindDetails{
+		"aa": typing.String,
+		"b":  typing.Boolean,
+		"cc": typing.String,
+		"CC": typing.String,
+		"dd": typing.String,
 	} {
 		targetCols.AddColumn(NewColumn(colName, kindDetails))
 	}
@@ -157,8 +159,8 @@ func TestDiffDeterministic(t *testing.T) {
 	var sourceCols Columns
 	var targCols Columns
 
-	sourceCols.AddColumn(NewColumn("id", Integer))
-	sourceCols.AddColumn(NewColumn("name", String))
+	sourceCols.AddColumn(NewColumn("id", typing.Integer))
+	sourceCols.AddColumn(NewColumn("name", typing.String))
 
 	for i := 0; i < 500; i++ {
 		keysMissing, targetKeysMissing := Diff(&sourceCols, &targCols, false)
@@ -177,9 +179,9 @@ func TestDiffDeterministic(t *testing.T) {
 
 func TestCopyColMap(t *testing.T) {
 	var cols Columns
-	cols.AddColumn(NewColumn("hello", String))
-	cols.AddColumn(NewColumn("created_at", NewKindDetailsFromTemplate(ETime, ext.DateTimeKindType)))
-	cols.AddColumn(NewColumn("updated_at", NewKindDetailsFromTemplate(ETime, ext.DateTimeKindType)))
+	cols.AddColumn(NewColumn("hello", typing.String))
+	cols.AddColumn(NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)))
+	cols.AddColumn(NewColumn("updated_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)))
 
 	copiedCols := CloneColumns(&cols)
 	assert.Equal(t, *copiedCols, cols)
@@ -197,16 +199,16 @@ func TestCloneColumns(t *testing.T) {
 	}
 
 	var cols Columns
-	cols.AddColumn(NewColumn("foo", String))
-	cols.AddColumn(NewColumn("bar", String))
-	cols.AddColumn(NewColumn("xyz", String))
-	cols.AddColumn(NewColumn("abc", String))
+	cols.AddColumn(NewColumn("foo", typing.String))
+	cols.AddColumn(NewColumn("bar", typing.String))
+	cols.AddColumn(NewColumn("xyz", typing.String))
+	cols.AddColumn(NewColumn("abc", typing.String))
 
 	var mixedCaseCols Columns
-	mixedCaseCols.AddColumn(NewColumn("foo", String))
-	mixedCaseCols.AddColumn(NewColumn("bAr", String))
-	mixedCaseCols.AddColumn(NewColumn("XYZ", String))
-	mixedCaseCols.AddColumn(NewColumn("aBC", String))
+	mixedCaseCols.AddColumn(NewColumn("foo", typing.String))
+	mixedCaseCols.AddColumn(NewColumn("bAr", typing.String))
+	mixedCaseCols.AddColumn(NewColumn("XYZ", typing.String))
+	mixedCaseCols.AddColumn(NewColumn("aBC", typing.String))
 
 	testCases := []_testCase{
 		{

--- a/lib/typing/columns/wrapper.go
+++ b/lib/typing/columns/wrapper.go
@@ -1,0 +1,21 @@
+package columns
+
+type Wrapper struct {
+	name        string
+	escapedName string
+}
+
+func NewWrapper(col Column, args *NameArgs) Wrapper {
+	return Wrapper{
+		name:        col.name,
+		escapedName: col.Name(args),
+	}
+}
+
+func (w *Wrapper) EscapedName() string {
+	return w.escapedName
+}
+
+func (w *Wrapper) RawName() string {
+	return w.name
+}

--- a/lib/typing/columns/wrapper_test.go
+++ b/lib/typing/columns/wrapper_test.go
@@ -1,0 +1,62 @@
+package columns
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+
+	"github.com/artie-labs/transfer/lib/typing"
+)
+
+func TestWrapper_Complete(t *testing.T) {
+	type _testCase struct {
+		name                  string
+		args                  *NameArgs
+		expectedRawName       string
+		expectedEscapedName   string
+		expectedEscapedNameBQ string
+	}
+
+	testCases := []_testCase{
+		{},
+	}
+
+	for _, testCase := range testCases {
+		// Snowflake escape
+		w := NewWrapper(NewColumn(testCase.name, typing.Invalid), &NameArgs{
+			Escape:   true,
+			DestKind: constants.SnowflakeStages,
+		})
+
+		assert.Equal(t, testCase.expectedEscapedName, w.EscapedName(), testCase.name)
+		assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
+
+		// BigQuery escape
+		w = NewWrapper(NewColumn(testCase.name, typing.Invalid), &NameArgs{
+			Escape:   true,
+			DestKind: constants.BigQuery,
+		})
+
+		assert.Equal(t, testCase.expectedEscapedNameBQ, w.EscapedName(), testCase.name)
+		assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
+
+		for _, destKind := range []constants.DestinationKind{constants.Snowflake, constants.SnowflakeStages, constants.BigQuery} {
+			w = NewWrapper(NewColumn(testCase.name, typing.Invalid), &NameArgs{
+				Escape:   false,
+				DestKind: destKind,
+			})
+
+			assert.Equal(t, testCase.expectedRawName, w.EscapedName(), testCase.name)
+			assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
+		}
+
+		// Same if nil
+		w = NewWrapper(NewColumn(testCase.name, typing.Invalid), nil)
+
+		assert.Equal(t, testCase.expectedRawName, w.EscapedName(), testCase.name)
+		assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
+
+	}
+}

--- a/lib/typing/columns/wrapper_test.go
+++ b/lib/typing/columns/wrapper_test.go
@@ -13,14 +13,30 @@ import (
 func TestWrapper_Complete(t *testing.T) {
 	type _testCase struct {
 		name                  string
-		args                  *NameArgs
 		expectedRawName       string
 		expectedEscapedName   string
 		expectedEscapedNameBQ string
 	}
 
 	testCases := []_testCase{
-		{},
+		{
+			name:                  "happy",
+			expectedRawName:       "happy",
+			expectedEscapedName:   "happy",
+			expectedEscapedNameBQ: "happy",
+		},
+		{
+			name:                  "user_id",
+			expectedRawName:       "user_id",
+			expectedEscapedName:   "user_id",
+			expectedEscapedNameBQ: "user_id",
+		},
+		{
+			name:                  "group",
+			expectedRawName:       "group",
+			expectedEscapedName:   `"group"`,
+			expectedEscapedNameBQ: "`group`",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/artie"
 	"github.com/artie-labs/transfer/lib/cdc"
@@ -24,7 +26,7 @@ type Event struct {
 	PrimaryKeyMap  map[string]interface{}
 	Data           map[string]interface{} // json serialized column data
 	OptionalSchema map[string]typing.KindDetails
-	Columns        *typing.Columns
+	Columns        *columns.Columns
 	ExecutionTime  time.Time // When the SQL command was executed
 }
 
@@ -104,7 +106,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 	td.Lock()
 	defer td.Unlock()
 	if td.Empty() {
-		columns := &typing.Columns{}
+		columns := &columns.Columns{}
 		if e.Columns != nil {
 			columns = e.Columns
 		}
@@ -143,7 +145,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 			retrievedColumn, isOk := inMemoryColumns.GetColumn(newColName)
 			if !isOk {
 				// This would only happen if the columns did not get passed in initially.
-				inMemoryColumns.AddColumn(typing.NewColumn(newColName, typing.ParseValue(_col, e.OptionalSchema, val)))
+				inMemoryColumns.AddColumn(columns.NewColumn(newColName, typing.ParseValue(_col, e.OptionalSchema, val)))
 			} else {
 				if retrievedColumn.KindDetails == typing.Invalid {
 					// If colType is Invalid, let's see if we can update it to a better type

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/artie"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -153,9 +155,9 @@ func (e *EventsTestSuite) TestEventSaveOptionalSchema() {
 }
 
 func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
-	var cols typing.Columns
+	var cols columns.Columns
 	for i := 0; i < 50; i++ {
-		cols.AddColumn(typing.NewColumn(fmt.Sprint(i), typing.Invalid))
+		cols.AddColumn(columns.NewColumn(fmt.Sprint(i), typing.Invalid))
 	}
 
 	evt := Event{
@@ -196,7 +198,7 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	}
 
 	// Now let's add more keys.
-	evt.Columns.AddColumn(typing.NewColumn("foo", typing.Invalid))
+	evt.Columns.AddColumn(columns.NewColumn("foo", typing.Invalid))
 	var index int
 	for idx, col := range evt.Columns.GetColumns() {
 		if col.Name(nil) == "foo" {
@@ -208,10 +210,10 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 }
 
 func (e *EventsTestSuite) TestEventSaveColumns() {
-	var cols typing.Columns
-	cols.AddColumn(typing.NewColumn("randomCol", typing.Invalid))
-	cols.AddColumn(typing.NewColumn("anotherCOL", typing.Invalid))
-	cols.AddColumn(typing.NewColumn("created_at_date_string", typing.Invalid))
+	var cols columns.Columns
+	cols.AddColumn(columns.NewColumn("randomCol", typing.Invalid))
+	cols.AddColumn(columns.NewColumn("anotherCOL", typing.Invalid))
+	cols.AddColumn(columns.NewColumn("created_at_date_string", typing.Invalid))
 	event := Event{
 		Table:   "foo",
 		Columns: &cols,

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -28,7 +30,7 @@ func (f fakeEvent) GetOptionalSchema(ctx context.Context) map[string]typing.Kind
 	return nil
 }
 
-func (f fakeEvent) GetColumns() *typing.Columns {
+func (f fakeEvent) GetColumns() *columns.Columns {
 	return nil
 }
 


### PR DESCRIPTION
From our previous PR - we were escaping the keyword name from columns for DMLs. 

However, our current MERGE query will error out if the primary key is a reserved keyword. This PR adds that check back in.

We also moved `columns` and their adjacent files into it's own separate directory.