### PR TITLE
[Transfer] Hash scientific numbers for in-memory DB

### DIFF
--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/cdc/util"
@@ -15,7 +14,6 @@ import (
 type Debezium string
 
 func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Event, error) {
-	fmt.Println(string(bytes))
 	var event util.SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.

--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/cdc/util"
@@ -14,6 +15,7 @@ import (
 type Debezium string
 
 func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Event, error) {
+	fmt.Println(string(bytes))
 	var event util.SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.

--- a/lib/scientific/scientific.go
+++ b/lib/scientific/scientific.go
@@ -9,7 +9,6 @@ import (
 )
 
 func IsScientificNumber(val interface{}) bool {
-	fmt.Println("val", val)
 	str := fmt.Sprint(val)
 	// Check if there are 'e' within the string.
 	if strings.Contains(str, "e") {

--- a/lib/scientific/scientific.go
+++ b/lib/scientific/scientific.go
@@ -1,0 +1,39 @@
+package scientific
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func IsScientificNumber(val interface{}) bool {
+	fmt.Println("val", val)
+	str := fmt.Sprint(val)
+	// Check if there are 'e' within the string.
+	if strings.Contains(str, "e") {
+		_, err := strconv.ParseFloat(str, 64)
+		return err == nil
+	}
+
+	return false
+}
+
+func ToSha256(val interface{}) (string, error) {
+	if !IsScientificNumber(val) {
+		return "", fmt.Errorf("%v is not a scientific number", val)
+	}
+
+	var str string
+	switch v := val.(type) {
+	case float64:
+		// Print the whole number and up to 6 decimal places for higher precision.
+		str = fmt.Sprintf("%f", v)
+	default:
+		return "", fmt.Errorf("%v data type is not supported", val)
+	}
+
+	hash := sha256.Sum256([]byte(str))
+	return hex.EncodeToString(hash[:]), nil
+}

--- a/lib/scientific/scientific_test.go
+++ b/lib/scientific/scientific_test.go
@@ -1,0 +1,65 @@
+package scientific
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsScientificNumber(t *testing.T) {
+	type _testCase struct {
+		name         string
+		value        interface{}
+		isScientific bool
+		expectError  bool
+	}
+
+	testCases := []_testCase{
+		{
+			name:        "random number",
+			value:       123,
+			expectError: true,
+		},
+		{
+			name:         "actual scientific number #1",
+			value:        float64(58569107296622255421594597096899477504),
+			isScientific: true,
+		},
+		{
+			name:         "actual scientific number #2",
+			value:        float64(58569102859845154622791691858438258688),
+			isScientific: true,
+		},
+		{
+			name:        "boolean",
+			value:       true,
+			expectError: true,
+		},
+		{
+			name:        "array",
+			value:       []int{1, 2, 3, 4},
+			expectError: true,
+		},
+		{
+			name:        "string",
+			value:       "foo",
+			expectError: true,
+		},
+		{
+			name:        "struct",
+			value:       `{"hello": "world"}`,
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.isScientific, IsScientificNumber(testCase.value), testCase.name)
+		sha, err := ToSha256(testCase.value)
+		if testCase.expectError {
+			assert.Error(t, err, testCase.name)
+		} else {
+			assert.NoError(t, err, testCase.name)
+			assert.NotEmpty(t, sha, testCase.name)
+		}
+	}
+}

--- a/lib/scientific/scientific_test.go
+++ b/lib/scientific/scientific_test.go
@@ -62,4 +62,14 @@ func TestIsScientificNumber(t *testing.T) {
 			assert.NotEmpty(t, sha, testCase.name)
 		}
 	}
+
+	// Now iterate over the same thing and make sure it's deterministic.
+	results := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		res, err := ToSha256(float64(58569102859845154622791691858438258688))
+		assert.NoError(t, err)
+		results[res] = true
+	}
+
+	assert.Equal(t, 1, len(results))
 }


### PR DESCRIPTION
Right now, our in-memory database iterates over the primary key and values and stores it as: `pk_1=val_1,pk_2=val_2`.

However, by using a string for a scientific number (e.g. 5e+23), it will create precision loss.

For that, we're coming up with a scientific package that will (a) detect scientific numbers and (b) return the hash back for the in-memory DB to use.

