### PR TITLE
Alleviate periodic panics during initialization

### DIFF
--- a/processes/consumer/configs.go
+++ b/processes/consumer/configs.go
@@ -2,10 +2,37 @@ package consumer
 
 import (
 	"context"
+	"sync"
+
 	"github.com/artie-labs/transfer/lib/artie"
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 )
+
+type TcFmtMap struct {
+	tc map[string]TopicConfigFormatter
+	sync.Mutex
+}
+
+func NewTcFmtMap() *TcFmtMap {
+	return &TcFmtMap{
+		tc: make(map[string]TopicConfigFormatter),
+	}
+}
+
+func (t *TcFmtMap) Add(topic string, fmt TopicConfigFormatter) {
+	t.Lock()
+	defer t.Unlock()
+	t.tc[topic] = fmt
+	return
+}
+
+func (t *TcFmtMap) GetTopicFmt(topic string) (TopicConfigFormatter, bool) {
+	t.Lock()
+	defer t.Unlock()
+	tcFmt, isOk := t.tc[topic]
+	return tcFmt, isOk
+}
 
 type TopicConfigFormatter struct {
 	tc *kafkalib.TopicConfig

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -59,14 +59,14 @@ func StartConsumer(ctx context.Context) {
 		dialer.TLS = &tls.Config{}
 	}
 
-	topicToConfigFmtMap := make(map[string]TopicConfigFormatter)
+	tcFmtMap := NewTcFmtMap()
 	topicToConsumer = make(map[string]kafkalib.Consumer)
 	var topics []string
 	for _, topicConfig := range settings.Config.Kafka.TopicConfigs {
-		topicToConfigFmtMap[topicConfig.Topic] = TopicConfigFormatter{
+		tcFmtMap.Add(topicConfig.Topic, TopicConfigFormatter{
 			tc:     topicConfig,
 			Format: format.GetFormatParser(ctx, topicConfig.CDCFormat, topicConfig.Topic),
-		}
+		})
 		topics = append(topics, topicConfig.Topic)
 	}
 
@@ -108,7 +108,7 @@ func StartConsumer(ctx context.Context) {
 				processErr := processMessage(ctx, ProcessArgs{
 					Msg:                    msg,
 					GroupID:                kafkaConsumer.Config().GroupID,
-					TopicToConfigFormatMap: topicToConfigFmtMap,
+					TopicToConfigFormatMap: tcFmtMap,
 				})
 				if processErr != nil {
 					log.WithError(processErr).WithFields(logFields).Warn("skipping message...")

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -13,7 +13,7 @@ import (
 type ProcessArgs struct {
 	Msg                    artie.Message
 	GroupID                string
-	TopicToConfigFormatMap map[string]TopicConfigFormatter
+	TopicToConfigFormatMap *TcFmtMap
 }
 
 func processMessage(ctx context.Context, processArgs ProcessArgs) error {
@@ -27,7 +27,7 @@ func processMessage(ctx context.Context, processArgs ProcessArgs) error {
 		metrics.FromContext(ctx).Timing("process.message", time.Since(st), tags)
 	}()
 
-	topicConfig, isOk := processArgs.TopicToConfigFormatMap[processArgs.Msg.Topic()]
+	topicConfig, isOk := processArgs.TopicToConfigFormatMap.GetTopicFmt(processArgs.Msg.Topic())
 	if !isOk {
 		tags["what"] = "failed_topic_lookup"
 		return fmt.Errorf("failed to get topic name: %s", processArgs.Msg.Topic())

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -17,6 +17,10 @@ type ProcessArgs struct {
 }
 
 func processMessage(ctx context.Context, processArgs ProcessArgs) error {
+	if processArgs.TopicToConfigFormatMap == nil {
+		return fmt.Errorf("failed to process, topicConfig is nil")
+	}
+
 	tags := map[string]string{
 		"groupID": processArgs.GroupID,
 		"topic":   processArgs.Msg.Topic(),

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -42,12 +42,15 @@ func TestProcessMessageFailures(t *testing.T) {
 
 	msg := artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic)
 	processArgs := ProcessArgs{
-		Msg:                    msg,
-		GroupID:                "foo",
-		TopicToConfigFormatMap: NewTcFmtMap(),
+		Msg:     msg,
+		GroupID: "foo",
 	}
 
 	err := processMessage(ctx, processArgs)
+	assert.True(t, strings.Contains(err.Error(), "failed to process, topicConfig is nil"), err.Error())
+
+	processArgs.TopicToConfigFormatMap = NewTcFmtMap()
+	err = processMessage(ctx, processArgs)
 	assert.True(t, strings.Contains(err.Error(), "failed to get topic"), err.Error())
 	assert.Equal(t, 0, len(models.GetMemoryDB(ctx).TableData()))
 

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -44,7 +44,7 @@ func TestProcessMessageFailures(t *testing.T) {
 	processArgs := ProcessArgs{
 		Msg:                    msg,
 		GroupID:                "foo",
-		TopicToConfigFormatMap: nil,
+		TopicToConfigFormatMap: NewTcFmtMap(),
 	}
 
 	err := processMessage(ctx, processArgs)
@@ -58,34 +58,48 @@ func TestProcessMessageFailures(t *testing.T) {
 		table  = "orders"
 	)
 
-	topicToConfigFmtMap := map[string]TopicConfigFormatter{
-		msg.Topic(): {
-			tc: &kafkalib.TopicConfig{
-				Database:      db,
-				TableName:     table,
-				Schema:        schema,
-				Topic:         msg.Topic(),
-				IdempotentKey: "",
-				CDCFormat:     "",
-				CDCKeyFormat:  "",
-			},
-			Format: &mgo,
+	tcFmtMap := NewTcFmtMap()
+	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
+		tc: &kafkalib.TopicConfig{
+			Database:      db,
+			TableName:     table,
+			Schema:        schema,
+			Topic:         msg.Topic(),
+			IdempotentKey: "",
+			CDCFormat:     "",
+			CDCKeyFormat:  "",
 		},
-	}
+		Format: &mgo,
+	})
 
 	processArgs = ProcessArgs{
 		Msg:                    msg,
 		GroupID:                "foo",
-		TopicToConfigFormatMap: topicToConfigFmtMap,
+		TopicToConfigFormatMap: tcFmtMap,
 	}
+
+	tcFmt, isOk := tcFmtMap.GetTopicFmt(msg.Topic())
+	assert.True(t, isOk)
 
 	err = processMessage(ctx, processArgs)
 	assert.True(t, strings.Contains(err.Error(),
-		fmt.Sprintf("err: format: %s is not supported", topicToConfigFmtMap[msg.Topic()].tc.CDCKeyFormat)), err.Error())
+		fmt.Sprintf("err: format: %s is not supported", tcFmt.tc.CDCKeyFormat)), err.Error())
 	assert.True(t, strings.Contains(err.Error(), "cannot unmarshall key"), err.Error())
 	assert.Equal(t, 0, len(models.GetMemoryDB(ctx).TableData()))
 
-	topicToConfigFmtMap[msg.Topic()].tc.CDCKeyFormat = "org.apache.kafka.connect.storage.StringConverter"
+	// Add will just replace the prev setting.
+	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
+		tc: &kafkalib.TopicConfig{
+			Database:      db,
+			TableName:     table,
+			Schema:        schema,
+			Topic:         msg.Topic(),
+			IdempotentKey: "",
+			CDCFormat:     "",
+			CDCKeyFormat:  "org.apache.kafka.connect.storage.StringConverter",
+		},
+		Format: &mgo,
+	})
 
 	vals := []string{
 		"",
@@ -131,7 +145,7 @@ func TestProcessMessageFailures(t *testing.T) {
 		processArgs = ProcessArgs{
 			Msg:                    msg,
 			GroupID:                "foo",
-			TopicToConfigFormatMap: topicToConfigFmtMap,
+			TopicToConfigFormatMap: tcFmtMap,
 		}
 
 		err = processMessage(ctx, processArgs)
@@ -158,7 +172,7 @@ func TestProcessMessageFailures(t *testing.T) {
 	processArgs = ProcessArgs{
 		Msg:                    msg,
 		GroupID:                "foo",
-		TopicToConfigFormatMap: topicToConfigFmtMap,
+		TopicToConfigFormatMap: tcFmtMap,
 	}
 
 	err = processMessage(ctx, processArgs)

--- a/processes/consumer/pubsub.go
+++ b/processes/consumer/pubsub.go
@@ -64,13 +64,14 @@ func StartSubscriber(ctx context.Context) {
 		log.Fatalf("failed to create a pubsub client, err: %v", clientErr)
 	}
 
-	topicToConfigFmtMap := make(map[string]TopicConfigFormatter)
+	tcFmtMap := NewTcFmtMap()
 	var topics []string
 	for _, topicConfig := range settings.Config.Pubsub.TopicConfigs {
-		topicToConfigFmtMap[topicConfig.Topic] = TopicConfigFormatter{
+		tcFmtMap.Add(topicConfig.Topic, TopicConfigFormatter{
 			tc:     topicConfig,
 			Format: format.GetFormatParser(ctx, topicConfig.CDCFormat, topicConfig.Topic),
-		}
+		})
+
 		topics = append(topics, topicConfig.Topic)
 	}
 
@@ -99,7 +100,7 @@ func StartSubscriber(ctx context.Context) {
 					processErr := processMessage(ctx, ProcessArgs{
 						Msg:                    msg,
 						GroupID:                subName,
-						TopicToConfigFormatMap: topicToConfigFmtMap,
+						TopicToConfigFormatMap: tcFmtMap,
 					})
 					if processErr != nil {
 						log.WithError(processErr).WithFields(logFields).Warn("skipping message...")


### PR DESCRIPTION
Currently, we'll spin up a new go-routine per topic specified within `tableConfig`.

However, if they happen to all run at the same time, we'll run into a concurrent r/w panic for the map, as each topic is trying to find the correct format setting and store it within `tcFmtMap`.

It doesn't happen often, but likelihood increases as there are more topics.

We're coming up with a wrapper object that provides basic `sync.Mutex` safety around reading and writing. 


Previous stacktrace:
```
fatal error: concurrent map writes

goroutine 78 [running]:
github.com/artie-labs/transfer/processes/consumer.StartConsumer.func1({0xc00027dbc0, 0x5d})
	/Users/robintang/code/go/src/github.com/artie-labs/transfer/processes/consumer/kafka.go:91 +0x1f0
created by github.com/artie-labs/transfer/processes/consumer.StartConsumer
	/Users/robintang/code/go/src/github.com/artie-labs/transfer/processes/consumer/kafka.go:76 +0x885

goroutine 1 [semacquire]:
sync.runtime_Semacquire(0xc0010feda0?)
	/usr/local/go/src/runtime/sema.go:62 +0x25
sync.(*WaitGroup).Wait(0xc00023b810?)
	/usr/local/go/src/sync/waitgroup.go:139 +0x52
main.main()
	/Users/robintang/code/go/src/github.com/artie-labs/transfer/main.go:58 +0x47f
```
