### PR TITLE
Supporting default values

### DIFF
--- a/clients/bigquery/bigquery_suite_test.go
+++ b/clients/bigquery/bigquery_suite_test.go
@@ -2,23 +2,30 @@ package bigquery
 
 import (
 	"context"
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
+
 	"github.com/artie-labs/transfer/lib/db"
 	"github.com/artie-labs/transfer/lib/mocks"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type BigQueryTestSuite struct {
 	suite.Suite
 	fakeStore *mocks.FakeStore
 	store     *Store
+	ctx       context.Context
 }
 
 func (b *BigQueryTestSuite) SetupTest() {
-	ctx := context.Background()
+	b.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
+		VerboseLogging: false,
+	})
+
 	b.fakeStore = &mocks.FakeStore{}
 	store := db.Store(b.fakeStore)
-	b.store = LoadBigQuery(ctx, &store)
+	b.store = LoadBigQuery(b.ctx, &store)
 }
 
 func TestBigQueryTestSuite(t *testing.T) {

--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -92,7 +92,8 @@ func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.Tabl
 
 	var bqColumns columns.Columns
 	for column, columnType := range retMap {
-		bqColumns.AddColumn(columns.NewColumn(column, typing.BigQueryTypeToKind(columnType), nil))
+		// TODO: Find column comment and set shouldBackfill.
+		bqColumns.AddColumn(columns.NewColumn(column, typing.BigQueryTypeToKind(columnType)))
 	}
 
 	// If retMap is empty, it'll create a new table.

--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -92,7 +92,7 @@ func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.Tabl
 
 	var bqColumns columns.Columns
 	for column, columnType := range retMap {
-		bqColumns.AddColumn(columns.NewColumn(column, typing.BigQueryTypeToKind(columnType)))
+		bqColumns.AddColumn(columns.NewColumn(column, typing.BigQueryTypeToKind(columnType), nil))
 	}
 
 	// If retMap is empty, it'll create a new table.

--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -83,8 +83,6 @@ func (s *Store) describeTable(ctx context.Context, tableData *optimization.Table
 			row[columnNameList[idx]] = strings.ToLower(fmt.Sprint(*interfaceVal))
 		}
 
-		fmt.Println("row", row)
-
 		retMap[row[describeNameCol]] = columnMetadata{
 			Type:    row[describeTypeCol],
 			Comment: row[describeCommentCol],

--- a/clients/bigquery/ddl.go
+++ b/clients/bigquery/ddl.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -16,15 +17,25 @@ import (
 )
 
 const (
-	// Column names from SELECT column_name, data_type FROM  `project.INFORMATION_SCHEMA.COLUMNS` WHERE table_name="table";
-	describeNameCol = "column_name"
-	describeTypeCol = "data_type"
+	describeNameCol    = "column_name"
+	describeTypeCol    = "data_type"
+	describeCommentCol = "description"
 )
 
-func (s *Store) describeTable(ctx context.Context, tableData *optimization.TableData) (map[string]string, error) {
+type columnMetadata struct {
+	Type    string
+	Comment string
+}
+
+func (s *Store) describeTable(ctx context.Context, tableData *optimization.TableData) (map[string]columnMetadata, error) {
 	log := logger.FromContext(ctx)
-	rows, err := s.Query(fmt.Sprintf("SELECT column_name, data_type FROM  `%s.INFORMATION_SCHEMA.COLUMNS` WHERE table_name='%s';",
-		tableData.TopicConfig.Database, tableData.Name()))
+
+	// We modified this from COLUMN to COLUMN_FIELD_PATHS, so we can get the column description.
+	// https://cloud.google.com/bigquery/docs/information-schema-column-field-paths
+	query := fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';",
+		tableData.TopicConfig.Database, tableData.Name())
+
+	rows, err := s.Query(query)
 	defer func() {
 		if rows != nil {
 			err = rows.Close()
@@ -37,10 +48,10 @@ func (s *Store) describeTable(ctx context.Context, tableData *optimization.Table
 	if err != nil {
 		// The query will not fail if the table doesn't exist. It will simply return 0 rows.
 		// It WILL fail if the dataset doesn't exist or if it encounters any other forms of error.
-		return nil, err
+		return nil, fmt.Errorf("failed to query, err: %v, query: %v", err, query)
 	}
 
-	retMap := make(map[string]string)
+	retMap := make(map[string]columnMetadata)
 	for rows != nil && rows.Next() {
 		// figure out what columns were returned
 		// the column names will be the JSON object field keys
@@ -72,7 +83,12 @@ func (s *Store) describeTable(ctx context.Context, tableData *optimization.Table
 			row[columnNameList[idx]] = strings.ToLower(fmt.Sprint(*interfaceVal))
 		}
 
-		retMap[row[describeNameCol]] = row[describeTypeCol]
+		fmt.Println("row", row)
+
+		retMap[row[describeNameCol]] = columnMetadata{
+			Type:    row[describeTypeCol],
+			Comment: row[describeCommentCol],
+		}
 	}
 
 	return retMap, nil
@@ -91,9 +107,20 @@ func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.Tabl
 	}
 
 	var bqColumns columns.Columns
-	for column, columnType := range retMap {
-		// TODO: Find column comment and set shouldBackfill.
-		bqColumns.AddColumn(columns.NewColumn(column, typing.BigQueryTypeToKind(columnType)))
+	for column, metadata := range retMap {
+		col := columns.NewColumn(column, typing.BigQueryTypeToKind(metadata.Type))
+		if metadata.Comment != "" {
+			// Try to parse the comment.
+			var _colComment constants.ColComment
+			err = json.Unmarshal([]byte(metadata.Comment), &_colComment)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal comment, err: %v", err)
+			}
+
+			col.SetBackfilled(_colComment.Backfilled)
+		}
+
+		bqColumns.AddColumn(col)
 	}
 
 	// If retMap is empty, it'll create a new table.

--- a/clients/bigquery/errors.go
+++ b/clients/bigquery/errors.go
@@ -10,3 +10,7 @@ func ColumnAlreadyExistErr(err error) bool {
 	// Error ends up looking like something like this: Column already exists: _string at [1:39]
 	return strings.Contains(err.Error(), "Column already exists")
 }
+
+func TableUpdateQuotaErr(err error) bool {
+	return strings.Contains(err.Error(), "Exceeded rate limits: too many table update operations for this table")
+}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -187,7 +187,6 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	for _, col := range tableData.ReadOnlyInMemoryCols().GetColumns() {
 		var attempts int
 		for {
-			// TODO: further optimization available here to not backfill if it's a new table.
 			err = s.backfillColumn(ctx, col, tableData.ToFqName(ctx, s.Label()))
 			if err == nil {
 				break

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/artie-labs/transfer/lib/jitter"
 
 	"github.com/artie-labs/transfer/lib/typing/columns"
@@ -189,6 +191,9 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		for {
 			err = s.backfillColumn(ctx, col, tableData.ToFqName(ctx, s.Label()))
 			if err == nil {
+				tableConfig.Columns().UpsertColumn(col.Name(nil), columns.UpsertColumnArg{
+					Backfilled: ptr.ToBool(true),
+				})
 				break
 			}
 

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -136,6 +136,9 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 	// End temporary table creation
 
+	// Backfill columns if necessary
+
+	// Perform actual merge now
 	rows, err := merge(tableData)
 	if err != nil {
 		log.WithError(err).Warn("failed to generate the merge query")

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -68,12 +68,17 @@ func (s *Store) backfillColumn(ctx context.Context, column columns.Column, fqTab
 		"table":        fqTableName,
 	}).Info("backfilling column")
 
+	defaultVal, err := column.DefaultValue(true)
+	if err != nil {
+		return fmt.Errorf("failed to escape default value, err: %v", err)
+	}
+
 	escapedCol := column.Name(&columns.NameArgs{Escape: true, DestKind: s.Label()})
 	query := fmt.Sprintf(`UPDATE %s SET %s = %v WHERE %s IS NULL;`,
 		// UPDATE table SET col = default_val WHERE col IS NULL
-		fqTableName, escapedCol, column.DefaultValue, escapedCol)
+		fqTableName, escapedCol, defaultVal, escapedCol)
 
-	_, err := s.Exec(query)
+	_, err = s.Exec(query)
 	if err != nil {
 		return fmt.Errorf("failed to backfill, err: %v, query: %v", err, query)
 	}
@@ -174,8 +179,9 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	for _, col := range tableData.ReadOnlyInMemoryCols().GetColumns() {
 		err = s.backfillColumn(ctx, col, tableData.ToFqName(ctx, s.Label()))
 		if err != nil {
+			defaultVal, _ := col.DefaultValue(false)
 			return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v",
-				col.Name(nil), col.DefaultValue, err)
+				col.Name(nil), defaultVal, err)
 		}
 	}
 

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -63,7 +63,9 @@ func (s *Store) backfillColumn(ctx context.Context, column *columns.Column, valu
 
 	fqTableName = strings.ToLower(fqTableName)
 	escapedCol := column.Name(&columns.NameArgs{Escape: true, DestKind: s.Label()})
-	query := fmt.Sprintf(`BEGIN; UPDATE %s SET %s = %v WHERE %s IS NULL; ALTER TABLE %s ALTER COLUMN %s SET OPTIONS (description="%s"); COMMIT;`,
+	query := fmt.Sprintf(`UPDATE %s SET %s = %v WHERE %s IS NULL;
+
+	ALTER TABLE %s ALTER COLUMN %s SET OPTIONS (description="%s"); COMMIT;`,
 		// UPDATE table SET col = default_val WHERE col IS NULL
 		fqTableName, escapedCol, value, escapedCol,
 		// ALTER TABLE table ALTER COLUMN col set OPTIONS (description=...)

--- a/clients/bigquery/merge_test.go
+++ b/clients/bigquery/merge_test.go
@@ -1,0 +1,60 @@
+package bigquery
+
+import (
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/stretchr/testify/assert"
+)
+
+func (b *BigQueryTestSuite) TestBackfillColumn() {
+	fqTableName := "db.public.tableName"
+	type _testCase struct {
+		name        string
+		col         columns.Column
+		expectErr   bool
+		backfillSQL string
+		commentSQL  string
+	}
+
+	backfilledCol := columns.NewColumn("foo", typing.Invalid)
+	backfilledCol.SetDefaultValue(true)
+	backfilledCol.SetBackfilled(true)
+
+	needsBackfillCol := columns.NewColumn("foo", typing.Invalid)
+	needsBackfillCol.SetDefaultValue(true)
+	testCases := []_testCase{
+		{
+			name: "col that doesn't have default val",
+			col:  columns.NewColumn("foo", typing.Invalid),
+		},
+		{
+			name: "col that has default value but already backfilled",
+			col:  backfilledCol,
+		},
+		{
+			name:        "col that has default value that needs to be backfilled",
+			col:         needsBackfillCol,
+			backfillSQL: `UPDATE db.public.tablename SET foo = true WHERE foo IS NULL;`,
+			commentSQL:  "ALTER TABLE db.public.tablename ALTER COLUMN foo SET OPTIONS (description=`{\"backfilled\": true}`);",
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := b.store.backfillColumn(b.ctx, testCase.col, fqTableName)
+		if testCase.expectErr {
+			assert.Error(b.T(), err, testCase.name)
+			continue
+		}
+
+		assert.NoError(b.T(), err, testCase.name)
+		if testCase.backfillSQL != "" && testCase.commentSQL != "" {
+			backfillSQL, _ := b.fakeStore.ExecArgsForCall(0)
+			assert.Equal(b.T(), testCase.backfillSQL, backfillSQL, testCase.name)
+
+			commentSQL, _ := b.fakeStore.ExecArgsForCall(1)
+			assert.Equal(b.T(), testCase.commentSQL, commentSQL, testCase.name)
+		} else {
+			assert.Equal(b.T(), 0, b.fakeStore.ExecCallCount())
+		}
+	}
+}

--- a/clients/snowflake/ddl.go
+++ b/clients/snowflake/ddl.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/config/constants"
+
 	"github.com/artie-labs/transfer/lib/typing"
 
 	"github.com/artie-labs/transfer/lib/typing/columns"
@@ -14,10 +16,6 @@ import (
 	"github.com/artie-labs/transfer/lib/dwh/types"
 	"github.com/artie-labs/transfer/lib/logger"
 )
-
-type colComment struct {
-	Backfilled bool `json:"backfilled"`
-}
 
 func (s *Store) getTableConfig(ctx context.Context, fqName string, dropDeletedColumns bool) (*types.DwhTableConfig, error) {
 	// Check if it already exists in cache
@@ -82,10 +80,9 @@ func (s *Store) getTableConfig(ctx context.Context, fqName string, dropDeletedCo
 		}
 
 		col := columns.NewColumn(row[describeNameCol], typing.SnowflakeTypeToKind(row[describeTypeCol]))
-
 		if comment, isOk := row[describeCommentCol]; isOk && comment != "<nil>" {
 			// Try to parse the comment.
-			var _colComment colComment
+			var _colComment constants.ColComment
 			err = json.Unmarshal([]byte(comment), &_colComment)
 			if err != nil {
 				return nil, fmt.Errorf("failed to unmarshal comment, err: %v", err)
@@ -99,6 +96,5 @@ func (s *Store) getTableConfig(ctx context.Context, fqName string, dropDeletedCo
 
 	sflkTableConfig := types.NewDwhTableConfig(&snowflakeColumns, nil, tableMissing, dropDeletedColumns)
 	s.configMap.AddTableToConfig(fqName, sflkTableConfig)
-
 	return sflkTableConfig, nil
 }

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -25,8 +25,9 @@ type Store struct {
 
 const (
 	// Column names from the output of DESC table;
-	describeNameCol = "name"
-	describeTypeCol = "type"
+	describeNameCol    = "name"
+	describeTypeCol    = "type"
+	describeCommentCol = "comment"
 )
 
 func (s *Store) Label() constants.DestinationKind {

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -216,7 +216,6 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 
 	// Now iterate over all the in-memory cols and see which one requires backfill.
 	for _, col := range tableData.ReadOnlyInMemoryCols().GetColumns() {
-		// TODO: further optimization available here to not backfill if it's a new table.
 		err = s.backfillColumn(ctx, col, tableData.ToFqName(ctx, s.Label()))
 		if err != nil {
 			defaultVal, _ := col.DefaultValue(nil)

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -32,15 +32,12 @@ func (s *Store) backfillColumn(ctx context.Context, column columns.Column, fqTab
 		fqTableName, escapedCol, column.DefaultValue, escapedCol,
 	)
 
-	fmt.Println("query", query)
-
 	_, err := s.Exec(query)
 	if err != nil {
 		return fmt.Errorf("failed to backfill, err: %v", err)
 	}
 
 	query = fmt.Sprintf(`COMMENT ON COLUMN %s.%s IS '%v';`, fqTableName, escapedCol, `{"backfilled": true}`)
-	fmt.Println("query", query)
 	_, err = s.Exec(query)
 	return err
 }

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -222,6 +224,10 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v",
 				col.Name(nil), defaultVal, err)
 		}
+
+		tableConfig.Columns().UpsertColumn(col.Name(nil), columns.UpsertColumnArg{
+			Backfilled: ptr.ToBool(true),
+		})
 	}
 
 	// Prepare merge statement

--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -23,7 +23,7 @@ type Event interface {
 	GetData(ctx context.Context, pkMap map[string]interface{}, config *kafkalib.TopicConfig) map[string]interface{}
 	GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails
 	// GetColumns will inspect the envelope's payload right now and return.
-	GetColumns() *columns.Columns
+	GetColumns(ctx context.Context) *columns.Columns
 }
 
 // FieldLabelKind is used when the schema is turned on. Each schema object will be labelled.

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -86,7 +86,7 @@ func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]t
 	return nil
 }
 
-func (s *SchemaEventPayload) GetColumns() *columns.Columns {
+func (s *SchemaEventPayload) GetColumns(ctx context.Context) *columns.Columns {
 	fieldsObject := s.Schema.GetSchemaFromLabel(cdc.After)
 	if fieldsObject == nil {
 		// AFTER schema does not exist.

--- a/lib/cdc/mysql/debezium_test.go
+++ b/lib/cdc/mysql/debezium_test.go
@@ -290,7 +290,8 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 		"transaction": null
 	}
 }`
-	evt, err := m.Debezium.GetEventFromBytes(context.Background(), []byte(payload))
+	ctx := context.Background()
+	evt, err := m.Debezium.GetEventFromBytes(ctx, []byte(payload))
 	assert.NoError(m.T(), err)
 	assert.Equal(m.T(), time.Date(2023, time.March, 13, 19, 19, 24, 0, time.UTC), evt.GetExecutionTime())
 	assert.Equal(m.T(), "customers", evt.GetTableName())
@@ -298,11 +299,11 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 	kvMap := map[string]interface{}{
 		"id": 1001,
 	}
-	evtData := evt.GetData(context.Background(), kvMap, &kafkalib.TopicConfig{})
+	evtData := evt.GetData(ctx, kvMap, &kafkalib.TopicConfig{})
 	assert.Equal(m.T(), evtData["id"], 1001)
 	assert.Equal(m.T(), evtData["first_name"], "Sally")
 	assert.Equal(m.T(), evtData["bool_test"], false)
-	cols := evt.GetColumns()
+	cols := evt.GetColumns(ctx)
 	assert.NotNil(m.T(), cols)
 
 	for key := range evtData {

--- a/lib/cdc/util/parse.go
+++ b/lib/cdc/util/parse.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/artie-labs/transfer/lib/debezium"
+	"github.com/artie-labs/transfer/lib/logger"
+)
+
+// ParseField returns a `parsedValue` as type interface{}
+func parseField(ctx context.Context, field debezium.Field, value interface{}) interface{} {
+	// Check if the field is an integer and requires us to cast it as such.
+	if field.IsInteger() {
+		valFloat, isOk := value.(float64)
+		if isOk {
+			return int(valFloat)
+		}
+	}
+
+	if valid, supportedType := debezium.RequiresSpecialTypeCasting(field.DebeziumType); valid {
+		switch debezium.SupportedDebeziumType(field.DebeziumType) {
+		case debezium.KafkaDecimalType:
+			decimalVal, err := debezium.DecodeDecimal(fmt.Sprint(value), field.Parameters)
+			if err == nil {
+				return decimalVal
+			} else {
+				logger.FromContext(ctx).WithFields(map[string]interface{}{
+					"err":           err,
+					"supportedType": supportedType,
+					"val":           value,
+				}).Debug("skipped casting dbz type due to an error")
+			}
+		case debezium.KafkaVariableNumericType:
+			variableNumericVal, err := debezium.DecodeDebeziumVariableDecimal(value)
+			if err == nil {
+				return variableNumericVal
+			} else {
+				logger.FromContext(ctx).WithFields(map[string]interface{}{
+					"err":           err,
+					"supportedType": supportedType,
+					"val":           value,
+				}).Debug("skipped casting dbz type due to an error")
+			}
+		default:
+			// Need to cast this as a FLOAT first because the number may come out in scientific notation
+			// ParseFloat is apt to handle it, and ParseInt is not, see: https://github.com/golang/go/issues/19288
+			floatVal, castErr := strconv.ParseFloat(fmt.Sprint(value), 64)
+			if castErr == nil {
+				extendedTime, err := debezium.FromDebeziumTypeToTime(supportedType, int64(floatVal))
+				if err == nil {
+					return extendedTime
+				} else {
+					logger.FromContext(ctx).WithFields(map[string]interface{}{
+						"err":           err,
+						"supportedType": supportedType,
+						"val":           value,
+					}).Debug("skipped casting dbz type due to an error")
+				}
+			} else {
+				logger.FromContext(ctx).WithFields(map[string]interface{}{
+					"err":           castErr,
+					"supportedType": supportedType,
+					"val":           value,
+				}).Debug("skipped casting because we failed to parse the float")
+			}
+		}
+	}
+
+	return value
+}

--- a/lib/cdc/util/parse_test.go
+++ b/lib/cdc/util/parse_test.go
@@ -1,0 +1,98 @@
+package util
+
+import (
+	"github.com/artie-labs/transfer/lib/debezium"
+	"github.com/artie-labs/transfer/lib/typing/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func (u *UtilTestSuite) TestParseField() {
+	type _testCase struct {
+		name          string
+		field         debezium.Field
+		value         interface{}
+		expectedValue interface{}
+
+		expectedDecimal bool
+	}
+
+	testCases := []_testCase{
+		{
+			name:          "string",
+			value:         "robin",
+			expectedValue: "robin",
+		},
+		{
+			name: "integer",
+			field: debezium.Field{
+				Type: "int32",
+			},
+			value:         float64(3),
+			expectedValue: 3,
+		},
+		{
+			name: "decimal",
+			field: debezium.Field{
+				DebeziumType: string(debezium.KafkaDecimalType),
+				Parameters: map[string]interface{}{
+					"scale":                           "0",
+					debezium.KafkaDecimalPrecisionKey: "5",
+				},
+			},
+			value:           "ew==",
+			expectedValue:   "123",
+			expectedDecimal: true,
+		},
+		{
+			name: "numeric",
+			field: debezium.Field{
+				DebeziumType: string(debezium.KafkaDecimalType),
+				Parameters: map[string]interface{}{
+					"scale":                           "2",
+					debezium.KafkaDecimalPrecisionKey: "5",
+				},
+			},
+			value:           "AN3h",
+			expectedValue:   "568.01",
+			expectedDecimal: true,
+		},
+		{
+			name: "money",
+			field: debezium.Field{
+				DebeziumType: string(debezium.KafkaDecimalType),
+				Parameters: map[string]interface{}{
+					"scale": "2",
+				},
+			},
+			value:           "ALxhTg==",
+			expectedValue:   "123456.78",
+			expectedDecimal: true,
+		},
+		{
+			name: "variable decimal",
+			field: debezium.Field{
+				DebeziumType: string(debezium.KafkaVariableNumericType),
+				Parameters: map[string]interface{}{
+					"scale": "2",
+				},
+			},
+			value: map[string]interface{}{
+				"scale": 2,
+				"value": "MDk=",
+			},
+			expectedValue:   "123.45",
+			expectedDecimal: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualField := parseField(u.ctx, testCase.field, testCase.value)
+		if testCase.expectedDecimal {
+			decVal, isOk := actualField.(*decimal.Decimal)
+			assert.True(u.T(), isOk)
+			assert.Equal(u.T(), testCase.expectedValue, decVal.String(), testCase.name)
+		} else {
+			assert.Equal(u.T(), testCase.expectedValue, actualField, testCase.name)
+		}
+	}
+}

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -48,7 +48,7 @@ func (s *SchemaEventPayload) GetColumns() *columns.Columns {
 	for _, field := range fieldsObject.Fields {
 		// We are purposefully doing this to ensure that the correct typing is set
 		// When we invoke event.Save()
-		cols.AddColumn(columns.NewColumn(field.FieldName, typing.Invalid))
+		cols.AddColumn(columns.NewColumn(field.FieldName, typing.Invalid, field.Default))
 	}
 
 	return &cols

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -48,7 +48,9 @@ func (s *SchemaEventPayload) GetColumns() *columns.Columns {
 	for _, field := range fieldsObject.Fields {
 		// We are purposefully doing this to ensure that the correct typing is set
 		// When we invoke event.Save()
-		cols.AddColumn(columns.NewColumn(field.FieldName, typing.Invalid, field.Default))
+		col := columns.NewColumn(field.FieldName, typing.Invalid)
+		col.SetDefaultValue(field.Default)
+		cols.AddColumn(col)
 	}
 
 	return &cols

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -62,6 +62,20 @@ func TestSource_GetOptionalSchema(t *testing.T) {
 	assert.True(t, isOk)
 	assert.Equal(t, value, typing.String)
 
+	cols := schemaEventPayload.GetColumns()
+	assert.Equal(t, 6, len(cols.GetColumns()))
+
+	col, isOk := cols.GetColumn("boolean_column")
+	assert.True(t, isOk)
+	assert.Equal(t, false, col.DefaultValue)
+
+	for _, _col := range cols.GetColumns() {
+		// All the other columns do not have a default value.
+		if _col.Name(nil) != "boolean_column" {
+			assert.Nil(t, _col.DefaultValue, _col.Name(nil))
+		}
+	}
+
 	// OptionalColumn does not pick up custom data types.
 	_, isOk = optionalSchema["zoned_timestamp_column"]
 	assert.False(t, isOk)

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -63,7 +63,7 @@ func TestSource_GetOptionalSchema(t *testing.T) {
 	assert.True(t, isOk)
 	assert.Equal(t, value, typing.String)
 
-	cols := schemaEventPayload.GetColumns()
+	cols := schemaEventPayload.GetColumns(ctx)
 	assert.Equal(t, 6, len(cols.GetColumns()))
 
 	col, isOk := cols.GetColumn("boolean_column")

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -67,12 +68,18 @@ func TestSource_GetOptionalSchema(t *testing.T) {
 
 	col, isOk := cols.GetColumn("boolean_column")
 	assert.True(t, isOk)
-	assert.Equal(t, false, col.DefaultValue)
+
+	defaultVal, err := col.DefaultValue(false)
+	assert.NoError(t, err)
+	assert.Equal(t, false, defaultVal)
 
 	for _, _col := range cols.GetColumns() {
 		// All the other columns do not have a default value.
 		if _col.Name(nil) != "boolean_column" {
-			assert.Nil(t, _col.DefaultValue, _col.Name(nil))
+			defaultVal, err = _col.DefaultValue(false)
+			assert.NoError(t, err)
+			fmt.Println("defaultVal", defaultVal)
+			assert.Nil(t, defaultVal, _col.Name(nil))
 		}
 	}
 

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -69,16 +68,15 @@ func TestSource_GetOptionalSchema(t *testing.T) {
 	col, isOk := cols.GetColumn("boolean_column")
 	assert.True(t, isOk)
 
-	defaultVal, err := col.DefaultValue(false)
+	defaultVal, err := col.DefaultValue(nil)
 	assert.NoError(t, err)
 	assert.Equal(t, false, defaultVal)
 
 	for _, _col := range cols.GetColumns() {
 		// All the other columns do not have a default value.
 		if _col.Name(nil) != "boolean_column" {
-			defaultVal, err = _col.DefaultValue(false)
+			defaultVal, err = _col.DefaultValue(nil)
 			assert.NoError(t, err)
-			fmt.Println("defaultVal", defaultVal)
 			assert.Nil(t, defaultVal, _col.Name(nil))
 		}
 	}

--- a/lib/cdc/util/util_suite_test.go
+++ b/lib/cdc/util/util_suite_test.go
@@ -1,0 +1,25 @@
+package util
+
+import (
+	"context"
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type UtilTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (u *UtilTestSuite) SetupTest() {
+	u.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
+		VerboseLogging: false,
+	})
+}
+
+func TestUtilTestSuite(t *testing.T) {
+	suite.Run(t, new(UtilTestSuite))
+}

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -133,3 +133,7 @@ func IsValidDestination(destination DestinationKind) bool {
 
 	return false
 }
+
+type ColComment struct {
+	Backfilled bool `json:"backfilled"`
+}

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -15,28 +15,6 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-// BackfillColumn will perform a backfill to the destination and also update the comment within a transaction.
-func BackfillColumn(ctx context.Context, dwh dwh.DataWarehouse, column *columns.Column, value interface{}, fqTableName string) error {
-	if !column.ShouldBackfill() {
-		// If we don't need to backfill, don't backfill.
-		return nil
-	}
-
-	fqTableName = strings.ToLower(fqTableName)
-	escapedCol := column.Name(&columns.NameArgs{Escape: true, DestKind: dwh.Label()})
-	query := fmt.Sprintf(`BEGIN; UPDATE %s SET %s = %v WHERE %s IS NULL;ALTER TABLE %s COMMENT = '%v';COMMIT;`,
-		// UPDATE table SET col = default_val
-		fqTableName, escapedCol, value,
-		// WHERE col is NULL;
-		escapedCol,
-		// ALTER TABLE col comment = comment
-		fqTableName, `{"backfilled": true}`,
-	)
-
-	_, err := dwh.Exec(query)
-	return err
-}
-
 // DropTemporaryTable - this will drop the temporary table from Snowflake w/ stages and BigQuery
 // It has a safety check to make sure the tableName contains the `constants.ArtiePrefix` key.
 // Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(10)

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -15,6 +15,28 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
+// BackfillColumn will perform a backfill to the destination and also update the comment within a transaction.
+func BackfillColumn(ctx context.Context, dwh dwh.DataWarehouse, column *columns.Column, value interface{}, fqTableName string) error {
+	if !column.ShouldBackfill() {
+		// If we don't need to backfill, don't backfill.
+		return nil
+	}
+
+	fqTableName = strings.ToLower(fqTableName)
+	escapedCol := column.Name(&columns.NameArgs{Escape: true, DestKind: dwh.Label()})
+	query := fmt.Sprintf(`BEGIN; UPDATE %s SET %s = %v WHERE %s IS NULL;ALTER TABLE %s COMMENT = '%v';COMMIT;`,
+		// UPDATE table SET col = default_val
+		fqTableName, escapedCol, value,
+		// WHERE col is NULL;
+		escapedCol,
+		// ALTER TABLE col comment = comment
+		fqTableName, `{"backfilled": true}`,
+	)
+
+	_, err := dwh.Exec(query)
+	return err
+}
+
 // DropTemporaryTable - this will drop the temporary table from Snowflake w/ stages and BigQuery
 // It has a safety check to make sure the tableName contains the `constants.ArtiePrefix` key.
 // Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(10)

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -186,9 +186,10 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(cols ...columns.Column)
 
 		if found {
 			// We should take `kindDetails.kind`, `defaultValue` and `shouldBackfill` from foundCol
+			// We are not taking primaryKey because DWH does not have this information.
 			inMemoryCol.KindDetails.Kind = foundColumn.KindDetails.Kind
 			inMemoryCol.DefaultValue = foundColumn.DefaultValue
-			inMemoryCol.SetShouldBackfill(foundColumn.ShouldBackfill())
+			inMemoryCol.SetBackfilled(foundColumn.Backfilled())
 
 			if foundColumn.KindDetails.ExtendedTimeDetails != nil {
 				if inMemoryCol.KindDetails.ExtendedTimeDetails == nil {

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -185,7 +185,11 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(cols ...columns.Column)
 		}
 
 		if found {
+			// We should take `kindDetails.kind`, `defaultValue` and `shouldBackfill` from foundCol
 			inMemoryCol.KindDetails.Kind = foundColumn.KindDetails.Kind
+			inMemoryCol.DefaultValue = foundColumn.DefaultValue
+			inMemoryCol.SetShouldBackfill(foundColumn.ShouldBackfill())
+
 			if foundColumn.KindDetails.ExtendedTimeDetails != nil {
 				if inMemoryCol.KindDetails.ExtendedTimeDetails == nil {
 					inMemoryCol.KindDetails.ExtendedTimeDetails = &ext.NestedKind{}

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -185,10 +185,9 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(cols ...columns.Column)
 		}
 
 		if found {
-			// We should take `kindDetails.kind`, `defaultValue` and `shouldBackfill` from foundCol
-			// We are not taking primaryKey because DWH does not have this information.
+			// We should take `kindDetails.kind` and `backfilled` from foundCol
+			// We are not taking primaryKey and defaultValue because DWH does not have this information.
 			inMemoryCol.KindDetails.Kind = foundColumn.KindDetails.Kind
-			inMemoryCol.DefaultValue = foundColumn.DefaultValue
 			inMemoryCol.SetBackfilled(foundColumn.Backfilled())
 
 			if foundColumn.KindDetails.ExtendedTimeDetails != nil {

--- a/lib/ptr/ptr.go
+++ b/lib/ptr/ptr.go
@@ -11,3 +11,7 @@ func ToInt(val int) *int {
 func ToInt64(val int64) *int64 {
 	return &val
 }
+
+func ToBool(val bool) *bool {
+	return &val
+}

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -13,6 +13,7 @@ import (
 
 type Column struct {
 	name        string
+	primaryKey  bool
 	KindDetails typing.KindDetails
 	// ToastColumn indicates that the source column is a TOAST column and the value is unavailable
 	// We have stripped this out.
@@ -47,7 +48,16 @@ func (c *Column) ToLowerName() {
 	return
 }
 
+func (c *Column) SetShouldBackfill(val bool) {
+	c.shouldBackfill = val
+	return
+}
 func (c *Column) ShouldBackfill() bool {
+	if c.primaryKey {
+		// Never need to backfill primary key.
+		return false
+	}
+
 	return c.shouldBackfill
 }
 
@@ -187,6 +197,7 @@ func (c *Columns) UpdateColumn(updateCol Column) {
 
 	for index, col := range c.columns {
 		if col.name == updateCol.name {
+			fmt.Println("name", col.name, "col", col.DefaultValue, "updateCol", updateCol.DefaultValue)
 			if col.DefaultValue != nil && updateCol.DefaultValue == nil {
 				updateCol.DefaultValue = col.DefaultValue
 				updateCol.shouldBackfill = true

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -64,7 +64,7 @@ func (c *Column) ShouldBackfill() bool {
 	}
 
 	// Should backfill if the default value is not null and the column has not been backfilled.
-	return c.DefaultValue != nil && c.backfilled == false
+	return c.defaultValue != nil && c.backfilled == false
 }
 
 type NameArgs struct {

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -17,7 +17,9 @@ type Column struct {
 	// ToastColumn indicates that the source column is a TOAST column and the value is unavailable
 	// We have stripped this out.
 	// Whenever we see the same column where there's an opposite value in `toastColumn`, we will trigger a flush
-	ToastColumn bool
+	ToastColumn    bool
+	DefaultValue   interface{}
+	shouldBackfill bool
 }
 
 func UnescapeColumnName(escapedName string, destKind constants.DestinationKind) string {
@@ -29,10 +31,11 @@ func UnescapeColumnName(escapedName string, destKind constants.DestinationKind) 
 	}
 }
 
-func NewColumn(name string, kd typing.KindDetails) Column {
+func NewColumn(name string, kd typing.KindDetails, defaultValue interface{}) Column {
 	return Column{
-		name:        name,
-		KindDetails: kd,
+		name:         name,
+		KindDetails:  kd,
+		DefaultValue: defaultValue,
 	}
 }
 

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -18,10 +18,9 @@ type Column struct {
 	// ToastColumn indicates that the source column is a TOAST column and the value is unavailable
 	// We have stripped this out.
 	// Whenever we see the same column where there's an opposite value in `toastColumn`, we will trigger a flush
-	ToastColumn    bool
-	DefaultValue   interface{}
-	shouldBackfill bool
-	backfilled     bool
+	ToastColumn  bool
+	DefaultValue interface{}
+	backfilled   bool
 }
 
 func UnescapeColumnName(escapedName string, destKind constants.DestinationKind) string {
@@ -205,7 +204,6 @@ func (c *Columns) GetColumns() []Column {
 
 // UpdateColumn will update the column and also preserve the `defaultValue` from the previous column if the new column does not have one.
 func (c *Columns) UpdateColumn(updateCol Column) {
-	//TODO: Test
 	c.Lock()
 	defer c.Unlock()
 
@@ -213,7 +211,6 @@ func (c *Columns) UpdateColumn(updateCol Column) {
 		if col.name == updateCol.name {
 			if col.DefaultValue != nil && updateCol.DefaultValue == nil {
 				updateCol.DefaultValue = col.DefaultValue
-				updateCol.shouldBackfill = true
 			}
 
 			c.columns[index] = updateCol

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -19,7 +19,7 @@ type Column struct {
 	// We have stripped this out.
 	// Whenever we see the same column where there's an opposite value in `toastColumn`, we will trigger a flush
 	ToastColumn  bool
-	DefaultValue interface{}
+	defaultValue interface{}
 	backfilled   bool
 }
 
@@ -49,7 +49,7 @@ func (c *Column) Backfilled() bool {
 }
 
 func (c *Column) SetDefaultValue(value interface{}) {
-	c.DefaultValue = value
+	c.defaultValue = value
 }
 
 func (c *Column) ToLowerName() {

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -209,10 +209,6 @@ func (c *Columns) UpdateColumn(updateCol Column) {
 
 	for index, col := range c.columns {
 		if col.name == updateCol.name {
-			if col.DefaultValue != nil && updateCol.DefaultValue == nil {
-				updateCol.DefaultValue = col.DefaultValue
-			}
-
 			c.columns[index] = updateCol
 			return
 		}

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -108,8 +108,9 @@ func (c *Columns) EscapeName(args *NameArgs) {
 }
 
 type UpsertColumnArg struct {
-	ToastCol   bool
-	PrimaryKey bool
+	ToastCol   *bool
+	PrimaryKey *bool
+	Backfilled *bool
 }
 
 // UpsertColumn - just a wrapper around UpdateColumn and AddColumn
@@ -120,18 +121,40 @@ func (c *Columns) UpsertColumn(colName string, arg UpsertColumnArg) {
 	}
 
 	if col, isOk := c.GetColumn(colName); isOk {
-		col.ToastColumn = arg.ToastCol
-		col.primaryKey = arg.PrimaryKey
+		if arg.ToastCol != nil {
+			col.ToastColumn = *arg.ToastCol
+		}
+
+		if arg.PrimaryKey != nil {
+			col.primaryKey = *arg.PrimaryKey
+		}
+
+		if arg.Backfilled != nil {
+			col.backfilled = *arg.Backfilled
+		}
+
 		c.UpdateColumn(col)
 		return
 	}
 
-	c.AddColumn(Column{
+	col := Column{
 		name:        colName,
 		KindDetails: typing.Invalid,
-		ToastColumn: arg.ToastCol,
-		primaryKey:  arg.PrimaryKey,
-	})
+	}
+
+	if arg.ToastCol != nil {
+		col.ToastColumn = *arg.ToastCol
+	}
+
+	if arg.PrimaryKey != nil {
+		col.primaryKey = *arg.PrimaryKey
+	}
+
+	if arg.Backfilled != nil {
+		col.backfilled = *arg.Backfilled
+	}
+	
+	c.AddColumn(col)
 	return
 }
 

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -37,14 +37,14 @@ func TestColumn_ShouldBackfill(t *testing.T) {
 			column: &Column{
 				name:         "id",
 				primaryKey:   true,
-				DefaultValue: 123,
+				defaultValue: 123,
 			},
 		},
 		{
 			name: "default value set but backfilled",
 			column: &Column{
 				name:         "id",
-				DefaultValue: "dusty",
+				defaultValue: "dusty",
 				backfilled:   true,
 			},
 		},
@@ -52,7 +52,7 @@ func TestColumn_ShouldBackfill(t *testing.T) {
 			name: "default value set and not backfilled",
 			column: &Column{
 				name:         "id",
-				DefaultValue: "dusty",
+				defaultValue: "dusty",
 			},
 			expectShouldBackfill: true,
 		},
@@ -281,7 +281,7 @@ func TestColumns_Add_Duplicate(t *testing.T) {
 
 func TestColumns_Mutation(t *testing.T) {
 	var cols Columns
-	colsToAdd := []Column{{name: "foo", KindDetails: typing.String, DefaultValue: "bar"}, {name: "bar", KindDetails: typing.Struct}}
+	colsToAdd := []Column{{name: "foo", KindDetails: typing.String, defaultValue: "bar"}, {name: "bar", KindDetails: typing.Struct}}
 	// Insert
 	for _, colToAdd := range colsToAdd {
 		cols.AddColumn(colToAdd)
@@ -305,18 +305,18 @@ func TestColumns_Mutation(t *testing.T) {
 	cols.UpdateColumn(Column{
 		name:         "bar",
 		KindDetails:  typing.Boolean,
-		DefaultValue: "123",
+		defaultValue: "123",
 	})
 
 	fooCol, isOk = cols.GetColumn("foo")
 	assert.True(t, isOk)
 	assert.Equal(t, typing.Integer, fooCol.KindDetails)
-	assert.Equal(t, nil, fooCol.DefaultValue)
+	assert.Equal(t, nil, fooCol.defaultValue)
 
 	barCol, isOk = cols.GetColumn("bar")
 	assert.True(t, isOk)
 	assert.Equal(t, typing.Boolean, barCol.KindDetails)
-	assert.Equal(t, "123", barCol.DefaultValue)
+	assert.Equal(t, "123", barCol.defaultValue)
 
 	// Delete
 	cols.DeleteColumn("foo")

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -311,7 +311,7 @@ func TestColumns_Mutation(t *testing.T) {
 	fooCol, isOk = cols.GetColumn("foo")
 	assert.True(t, isOk)
 	assert.Equal(t, typing.Integer, fooCol.KindDetails)
-	assert.Equal(t, "bar", fooCol.DefaultValue)
+	assert.Equal(t, nil, fooCol.DefaultValue)
 
 	barCol, isOk = cols.GetColumn("bar")
 	assert.True(t, isOk)

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -185,26 +185,28 @@ func TestColumns_UpsertColumns(t *testing.T) {
 
 	// Now selectively update only a, b
 	for _, key := range []string{"a", "b"} {
-		cols.UpsertColumn(key, true)
+		cols.UpsertColumn(key, UpsertColumnArg{
+			ToastCol: true,
+		})
 
 		// Now inspect.
 		col, _ := cols.GetColumn(key)
 		assert.True(t, col.ToastColumn)
 	}
 
-	cols.UpsertColumn("zzz", false)
+	cols.UpsertColumn("zzz", UpsertColumnArg{})
 	zzzCol, _ := cols.GetColumn("zzz")
 	assert.False(t, zzzCol.ToastColumn)
 	assert.Equal(t, zzzCol.KindDetails, typing.Invalid)
 
-	cols.UpsertColumn("aaa", false)
+	cols.UpsertColumn("aaa", UpsertColumnArg{})
 	aaaCol, _ := cols.GetColumn("aaa")
 	assert.False(t, aaaCol.ToastColumn)
 	assert.Equal(t, aaaCol.KindDetails, typing.Invalid)
 
 	length := len(cols.columns)
 	for i := 0; i < 500; i++ {
-		cols.UpsertColumn("", false)
+		cols.UpsertColumn("", UpsertColumnArg{})
 	}
 
 	assert.Equal(t, length, len(cols.columns))

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/artie-labs/transfer/lib/typing"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -238,7 +240,7 @@ func TestColumns_UpsertColumns(t *testing.T) {
 	// Now selectively update only a, b
 	for _, key := range []string{"a", "b"} {
 		cols.UpsertColumn(key, UpsertColumnArg{
-			ToastCol: true,
+			ToastCol: ptr.ToBool(true),
 		})
 
 		// Now inspect.
@@ -253,8 +255,8 @@ func TestColumns_UpsertColumns(t *testing.T) {
 	assert.Equal(t, zzzCol.KindDetails, typing.Invalid)
 
 	cols.UpsertColumn("aaa", UpsertColumnArg{
-		ToastCol:   true,
-		PrimaryKey: true,
+		ToastCol:   ptr.ToBool(true),
+		PrimaryKey: ptr.ToBool(true),
 	})
 	aaaCol, _ := cols.GetColumn("aaa")
 	assert.True(t, aaaCol.ToastColumn)

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -281,7 +281,7 @@ func TestColumns_Add_Duplicate(t *testing.T) {
 
 func TestColumns_Mutation(t *testing.T) {
 	var cols Columns
-	colsToAdd := []Column{{name: "foo", KindDetails: typing.String}, {name: "bar", KindDetails: typing.Struct}}
+	colsToAdd := []Column{{name: "foo", KindDetails: typing.String, DefaultValue: "bar"}, {name: "bar", KindDetails: typing.Struct}}
 	// Insert
 	for _, colToAdd := range colsToAdd {
 		cols.AddColumn(colToAdd)
@@ -303,17 +303,20 @@ func TestColumns_Mutation(t *testing.T) {
 	})
 
 	cols.UpdateColumn(Column{
-		name:        "bar",
-		KindDetails: typing.Boolean,
+		name:         "bar",
+		KindDetails:  typing.Boolean,
+		DefaultValue: "123",
 	})
 
 	fooCol, isOk = cols.GetColumn("foo")
 	assert.True(t, isOk)
 	assert.Equal(t, typing.Integer, fooCol.KindDetails)
+	assert.Equal(t, "bar", fooCol.DefaultValue)
 
 	barCol, isOk = cols.GetColumn("bar")
 	assert.True(t, isOk)
 	assert.Equal(t, typing.Boolean, barCol.KindDetails)
+	assert.Equal(t, "123", barCol.DefaultValue)
 
 	// Delete
 	cols.DeleteColumn("foo")

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -3,13 +3,20 @@ package columns
 import (
 	"fmt"
 
+	"github.com/artie-labs/transfer/lib/typing/ext"
+
 	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 )
 
-func (c *Column) DefaultValue(escape bool) (interface{}, error) {
-	if !escape {
+type DefaultValueArgs struct {
+	Escape   bool
+	BigQuery bool
+}
+
+func (c *Column) DefaultValue(args *DefaultValueArgs) (interface{}, error) {
+	if args == nil {
 		return c.defaultValue, nil
 	}
 
@@ -18,6 +25,22 @@ func (c *Column) DefaultValue(escape bool) (interface{}, error) {
 	}
 
 	switch c.KindDetails.Kind {
+	case typing.Struct.Kind, typing.Array.Kind:
+		if args.BigQuery {
+			return "JSON" + stringutil.Wrap(c.defaultValue, false), nil
+		}
+	case typing.ETime.Kind:
+		extTime, err := ext.ParseFromInterface(c.defaultValue)
+		if err != nil {
+			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", c.defaultValue, err)
+		}
+
+		switch extTime.NestedKind.Type {
+		case ext.TimeKindType:
+			return stringutil.Wrap(extTime.String(ext.PostgresTimeFormatNoTZ), false), nil
+		default:
+			return stringutil.Wrap(extTime.String(""), false), nil
+		}
 	case typing.EDecimal.Kind:
 		val, isOk := c.defaultValue.(*decimal.Decimal)
 		if !isOk {
@@ -27,7 +50,7 @@ func (c *Column) DefaultValue(escape bool) (interface{}, error) {
 		return val.Value(), nil
 	case typing.String.Kind:
 		return stringutil.Wrap(c.defaultValue, false), nil
-	default:
-		return c.defaultValue, nil
 	}
+
+	return c.defaultValue, nil
 }

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -1,0 +1,1 @@
+package columns

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -16,7 +16,8 @@ type DefaultValueArgs struct {
 }
 
 func (c *Column) DefaultValue(args *DefaultValueArgs) (interface{}, error) {
-	if args == nil {
+	if args == nil || !args.Escape {
+		// Either no args, or args.Escape = false
 		return c.defaultValue, nil
 	}
 

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -1,1 +1,33 @@
 package columns
+
+import (
+	"fmt"
+
+	"github.com/artie-labs/transfer/lib/stringutil"
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/decimal"
+)
+
+func (c *Column) DefaultValue(escape bool) (interface{}, error) {
+	if !escape {
+		return c.defaultValue, nil
+	}
+
+	if c.defaultValue == nil {
+		return nil, nil
+	}
+
+	switch c.KindDetails.Kind {
+	case typing.EDecimal.Kind:
+		val, isOk := c.defaultValue.(*decimal.Decimal)
+		if !isOk {
+			return nil, fmt.Errorf("colVal is not type *decimal.Decimal")
+		}
+
+		return val.Value(), nil
+	case typing.String.Kind:
+		return stringutil.Wrap(c.defaultValue, false), nil
+	default:
+		return c.defaultValue, nil
+	}
+}

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -1,0 +1,82 @@
+package columns
+
+import (
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/typing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestColumn_DefaultValue(t *testing.T) {
+	type _testCase struct {
+		name          string
+		col           *Column
+		args          *DefaultValueArgs
+		expectedValue interface{}
+		expectedEr    bool
+	}
+
+	testCases := []_testCase{
+		{
+			name: "escaped args (nil)",
+			col: &Column{
+				KindDetails:  typing.String,
+				defaultValue: "abcdef",
+			},
+			expectedValue: "abcdef",
+		},
+		{
+			name: "escaped args (escaped = false)",
+			col: &Column{
+				KindDetails:  typing.String,
+				defaultValue: "abcdef",
+			},
+			args:          &DefaultValueArgs{},
+			expectedValue: "abcdef",
+		},
+		{
+			name: "string",
+			col: &Column{
+				KindDetails:  typing.String,
+				defaultValue: "abcdef",
+			},
+			args: &DefaultValueArgs{
+				Escape: true,
+			},
+			expectedValue: "'abcdef'",
+		},
+		{
+			name: "json",
+			col: &Column{
+				KindDetails:  typing.Struct,
+				defaultValue: "{}",
+			},
+			args: &DefaultValueArgs{
+				Escape: true,
+			},
+			expectedValue: "{}",
+		},
+		{
+			name: "json (bigquery)",
+			col: &Column{
+				KindDetails:  typing.Struct,
+				defaultValue: "{}",
+			},
+			args: &DefaultValueArgs{
+				Escape:   true,
+				BigQuery: true,
+			},
+			expectedValue: "JSON'{}'",
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualValue, actualErr := testCase.col.DefaultValue(testCase.args)
+		if testCase.expectedEr {
+			assert.Error(t, actualErr, testCase.name)
+		}
+
+		assert.Equal(t, testCase.expectedValue, actualValue, testCase.name)
+	}
+}

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/array"
@@ -36,7 +38,7 @@ func ToMemoryEvent(ctx context.Context, event cdc.Event, pkMap map[string]interf
 	if cols != nil {
 		for primaryKey := range pkMap {
 			cols.UpsertColumn(primaryKey, columns.UpsertColumnArg{
-				PrimaryKey: true,
+				PrimaryKey: ptr.ToBool(true),
 			})
 		}
 	}
@@ -151,7 +153,7 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 
 		if val == constants.ToastUnavailableValuePlaceholder {
 			inMemoryColumns.UpsertColumn(newColName, columns.UpsertColumnArg{
-				ToastCol: true,
+				ToastCol: ptr.ToBool(true),
 			})
 		} else {
 			retrievedColumn, isOk := inMemoryColumns.GetColumn(newColName)

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -31,7 +31,7 @@ type Event struct {
 }
 
 func ToMemoryEvent(ctx context.Context, event cdc.Event, pkMap map[string]interface{}, tc *kafkalib.TopicConfig) Event {
-	cols := event.GetColumns()
+	cols := event.GetColumns(ctx)
 	// Now iterate over pkMap and tag each column that is a primary key
 	if cols != nil {
 		for primaryKey := range pkMap {

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -33,10 +33,12 @@ type Event struct {
 func ToMemoryEvent(ctx context.Context, event cdc.Event, pkMap map[string]interface{}, tc *kafkalib.TopicConfig) Event {
 	cols := event.GetColumns()
 	// Now iterate over pkMap and tag each column that is a primary key
-	for primaryKey := range pkMap {
-		cols.UpsertColumn(primaryKey, columns.UpsertColumnArg{
-			PrimaryKey: true,
-		})
+	if cols != nil {
+		for primaryKey := range pkMap {
+			cols.UpsertColumn(primaryKey, columns.UpsertColumnArg{
+				PrimaryKey: true,
+			})
+		}
 	}
 
 	return Event{

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -30,7 +30,7 @@ func (f fakeEvent) GetOptionalSchema(ctx context.Context) map[string]typing.Kind
 	return nil
 }
 
-func (f fakeEvent) GetColumns() *columns.Columns {
+func (f fakeEvent) GetColumns(ctx context.Context) *columns.Columns {
 	return &columns.Columns{}
 }
 

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -31,7 +31,7 @@ func (f fakeEvent) GetOptionalSchema(ctx context.Context) map[string]typing.Kind
 }
 
 func (f fakeEvent) GetColumns() *columns.Columns {
-	return nil
+	return &columns.Columns{}
 }
 
 func (f fakeEvent) GetData(ctx context.Context, pkMap map[string]interface{}, config *kafkalib.TopicConfig) map[string]interface{} {

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -106,9 +106,34 @@ func TestProcessMessageFailures(t *testing.T) {
 
 	vals := []string{
 		"",
-		`
-{
-	"schema": {},
+		`{
+	"schema": {
+		"type": "struct",
+		"fields": [{
+			"type": "struct",
+			"fields": [{
+				"type": "int32",
+				"optional": false,
+				"default": 0,
+				"field": "id"
+			}, {
+				"type": "string",
+				"optional": false,
+				"field": "first_name"
+			}, {
+				"type": "string",
+				"optional": false,
+				"field": "last_name"
+			}, {
+				"type": "string",
+				"optional": false,
+				"field": "email"
+			}],
+			"optional": true,
+			"name": "dbserver1.inventory.customers.Value",
+			"field": "after"
+		}]
+	},
 	"payload": {
 		"before": null,
 		"after": "{\"_id\": {\"$numberLong\": \"1004\"},\"first_name\": \"Anne\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}",


### PR DESCRIPTION
# Problem
In SQL, any operation related to setting a column default value is considered a DDL operation. This means that it will not be visible to the CDC stream.

# Solution
In order to support this, we'll need to inspect the metadata envelope from Debezium upon a CDC event and see if a column has default values (or not).

If the column indeed has a default value, we will backfill previously values.

_Example: Table `foo` has a column named `bar` and has default value of `false`_

```
UPDATE foo SET bar = FALSE where bar IS NULL;
```

^ This is the simplistic view, however - Transfer is stateless...so how do we not backfill upon every initialization?
We will do so by leveraging column comments (Snowflake) and/or column description (BigQuery).

Upon a successful backfill, we will annotate the column as such:

### Snowflake
![Screenshot 2023-06-17 at 12 47 39 PM](https://github.com/artie-labs/transfer/assets/4412200/20d3a2f7-2c8b-4641-8b99-af88cc3d87a7)

### BigQuery
![image](https://github.com/artie-labs/transfer/assets/4412200/2b6fd675-93f1-4e7b-b16d-1e2a15ad0675)

## Checks remaining
- [x] Test every data type
- [x] Test MySQL