### PR TITLE
Skip backfilling invalid columns

### DIFF
--- a/clients/bigquery/merge_test.go
+++ b/clients/bigquery/merge_test.go
@@ -16,11 +16,11 @@ func (b *BigQueryTestSuite) TestBackfillColumn() {
 		commentSQL  string
 	}
 
-	backfilledCol := columns.NewColumn("foo", typing.Invalid)
+	backfilledCol := columns.NewColumn("foo", typing.Boolean)
 	backfilledCol.SetDefaultValue(true)
 	backfilledCol.SetBackfilled(true)
 
-	needsBackfillCol := columns.NewColumn("foo", typing.Invalid)
+	needsBackfillCol := columns.NewColumn("foo", typing.Boolean)
 	needsBackfillCol.SetDefaultValue(true)
 
 	needsBackfillColStr := columns.NewColumn("foo2", typing.String)

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -29,11 +29,11 @@ func (s *SnowflakeTestSuite) TestBackfillColumn() {
 		commentSQL  string
 	}
 
-	backfilledCol := columns.NewColumn("foo", typing.Invalid)
+	backfilledCol := columns.NewColumn("foo", typing.Boolean)
 	backfilledCol.SetDefaultValue(true)
 	backfilledCol.SetBackfilled(true)
 
-	needsBackfillCol := columns.NewColumn("foo", typing.Invalid)
+	needsBackfillCol := columns.NewColumn("foo", typing.Boolean)
 	needsBackfillCol.SetDefaultValue(true)
 	testCases := []_testCase{
 		{

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -63,6 +63,11 @@ func (c *Column) ShouldBackfill() bool {
 		return false
 	}
 
+	if c.KindDetails.Kind == typing.Invalid.Kind {
+		// Don't backfill if the in-memory data is `INVALID`
+		return false
+	}
+
 	// Should backfill if the default value is not null and the column has not been backfilled.
 	return c.defaultValue != nil && c.backfilled == false
 }
@@ -153,7 +158,7 @@ func (c *Columns) UpsertColumn(colName string, arg UpsertColumnArg) {
 	if arg.Backfilled != nil {
 		col.backfilled = *arg.Backfilled
 	}
-	
+
 	c.AddColumn(col)
 	return
 }

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -43,11 +43,20 @@ func TestColumn_ShouldBackfill(t *testing.T) {
 			},
 		},
 		{
+			name: "default value set but kind = invalid",
+			column: &Column{
+				name:         "id",
+				defaultValue: "dusty",
+				KindDetails:  typing.Invalid,
+			},
+		},
+		{
 			name: "default value set but backfilled",
 			column: &Column{
 				name:         "id",
 				defaultValue: "dusty",
 				backfilled:   true,
+				KindDetails:  typing.String,
 			},
 		},
 		{
@@ -55,6 +64,7 @@ func TestColumn_ShouldBackfill(t *testing.T) {
 			column: &Column{
 				name:         "id",
 				defaultValue: "dusty",
+				KindDetails:  typing.String,
 			},
 			expectShouldBackfill: true,
 		},


### PR DESCRIPTION
This is to patch our most recent PR: https://github.com/artie-labs/transfer/pull/127 which triggers a backfill for any column that has a default value.

However, if the whole pool only contains `DELETE` events, we will not trigger the backfill SQL since we do not have the column metadata from our typing library since `after` is `NULL`.