### PR TITLE
More logging within our DDL library

### DIFF
--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -70,7 +70,7 @@ func (a *AlterTableArgs) Validate() error {
 	return nil
 }
 
-func AlterTable(_ context.Context, args AlterTableArgs, cols ...columns.Column) error {
+func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column) error {
 	if err := args.Validate(); err != nil {
 		return err
 	}
@@ -129,6 +129,7 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...columns.Column) 
 			sqlQuery = fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", args.FqTableName, strings.Join(colSQLParts, ","))
 		}
 
+		logger.FromContext(ctx).WithField("query", sqlQuery).Info("ddl - executing sql")
 		_, err = args.Dwh.Exec(sqlQuery)
 		if ColumnAlreadyExistErr(err, args.Dwh.Label()) {
 			err = nil
@@ -138,6 +139,7 @@ func AlterTable(_ context.Context, args AlterTableArgs, cols ...columns.Column) 
 	} else {
 		for _, colSQLPart := range colSQLParts {
 			sqlQuery := fmt.Sprintf("ALTER TABLE %s %s COLUMN %s", args.FqTableName, args.ColumnOp, colSQLPart)
+			logger.FromContext(ctx).WithField("query", sqlQuery).Info("ddl - executing sql")
 			_, err = args.Dwh.Exec(sqlQuery)
 			if ColumnAlreadyExistErr(err, args.Dwh.Label()) {
 				err = nil

--- a/lib/dwh/ddl/ddl_create_table_test.go
+++ b/lib/dwh/ddl/ddl_create_table_test.go
@@ -1,7 +1,6 @@
 package ddl_test
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -21,8 +20,6 @@ func (d *DDLTestSuite) Test_CreateTable() {
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 	d.snowflakeStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
-
-	ctx := context.Background()
 
 	type dwhToTableConfig struct {
 		_dwh         dwh.DataWarehouse
@@ -59,7 +56,7 @@ func (d *DDLTestSuite) Test_CreateTable() {
 			ColumnOp:    constants.Add,
 		}
 
-		err := ddl.AlterTable(ctx, alterTableArgs, columns.NewColumn("name", typing.String))
+		err := ddl.AlterTable(d.ctx, alterTableArgs, columns.NewColumn("name", typing.String))
 		assert.Equal(d.T(), 1, dwhTc._fakeStore.ExecCallCount())
 
 		query, _ := dwhTc._fakeStore.ExecArgsForCall(0)
@@ -112,7 +109,6 @@ func (d *DDLTestSuite) TestCreateTable() {
 	}
 
 	for index, testCase := range testCases {
-		ctx := context.Background()
 		fqTable := "demo.public.experiments"
 		d.snowflakeStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 		tc := d.snowflakeStore.GetConfigMap().TableConfig(fqTable)
@@ -126,7 +122,7 @@ func (d *DDLTestSuite) TestCreateTable() {
 			CdcTime:     time.Now().UTC(),
 		}
 
-		err := ddl.AlterTable(ctx, alterTableArgs, testCase.cols...)
+		err := ddl.AlterTable(d.ctx, alterTableArgs, testCase.cols...)
 		assert.NoError(d.T(), err, testCase.name)
 
 		execQuery, _ := d.fakeSnowflakeStore.ExecArgsForCall(index)

--- a/lib/dwh/ddl/ddl_sflk_test.go
+++ b/lib/dwh/ddl/ddl_sflk_test.go
@@ -1,7 +1,6 @@
 package ddl_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -18,7 +17,6 @@ import (
 )
 
 func (d *DDLTestSuite) TestAlterComplexObjects() {
-	ctx := context.Background()
 	// Test Structs and Arrays
 	cols := []columns.Column{
 		columns.NewColumn("preferences", typing.Struct),
@@ -38,7 +36,7 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 		CdcTime:     time.Now().UTC(),
 	}
 
-	err := ddl.AlterTable(ctx, alterTableArgs, cols...)
+	err := ddl.AlterTable(d.ctx, alterTableArgs, cols...)
 
 	for i := 0; i < len(cols); i++ {
 		execQuery, _ := d.fakeSnowflakeStore.ExecArgsForCall(i)
@@ -54,7 +52,6 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 }
 
 func (d *DDLTestSuite) TestAlterIdempotency() {
-	ctx := context.Background()
 	cols := []columns.Column{
 		columns.NewColumn("created_at", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)),
 		columns.NewColumn("id", typing.Integer),
@@ -75,12 +72,12 @@ func (d *DDLTestSuite) TestAlterIdempotency() {
 		CdcTime:     time.Now().UTC(),
 	}
 
-	err := ddl.AlterTable(ctx, alterTableArgs, cols...)
+	err := ddl.AlterTable(d.ctx, alterTableArgs, cols...)
 	assert.Equal(d.T(), len(cols), d.fakeSnowflakeStore.ExecCallCount(), "called SFLK the same amt to create cols")
 	assert.NoError(d.T(), err)
 
 	d.fakeSnowflakeStore.ExecReturns(nil, errors.New("table does not exist"))
-	err = ddl.AlterTable(ctx, alterTableArgs, cols...)
+	err = ddl.AlterTable(d.ctx, alterTableArgs, cols...)
 	assert.Error(d.T(), err)
 }
 


### PR DESCRIPTION
This way, we'll see all the temporary staging tables created.

Also, any DDL statements done to the target table such as `ADD COLUMN` and `DROP COLUMN`