### PR TITLE
Fix NULL edgecase

### DIFF
--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -173,10 +173,10 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(cols ...columns.Column)
 	}
 
 	for _, inMemoryCol := range t.inMemoryColumns.GetColumns() {
-		if inMemoryCol.KindDetails.Kind == typing.Invalid.Kind {
-			// Don't copy this over because tableData has the wrong colVal
-			continue
-		}
+		//if inMemoryCol.KindDetails.Kind == typing.Invalid.Kind {
+		//	// Don't copy this over because tableData has the wrong colVal
+		//	continue
+		//}
 
 		var foundColumn columns.Column
 		var found bool

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -173,11 +173,6 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(cols ...columns.Column)
 	}
 
 	for _, inMemoryCol := range t.inMemoryColumns.GetColumns() {
-		//if inMemoryCol.KindDetails.Kind == typing.Invalid.Kind {
-		//	// Don't copy this over because tableData has the wrong colVal
-		//	continue
-		//}
-
 		var foundColumn columns.Column
 		var found bool
 		for _, col := range cols {
@@ -191,6 +186,8 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(cols ...columns.Column)
 		if found {
 			// We should take `kindDetails.kind` and `backfilled` from foundCol
 			// We are not taking primaryKey and defaultValue because DWH does not have this information.
+			// Note: If our in-memory column is `Invalid`, it would get skipped during merge. However, if the column exists in
+			// the destination, we'll copy the type over. This is to make sure we don't miss batch updates where the whole column in the batch is NULL.
 			inMemoryCol.KindDetails.Kind = foundColumn.KindDetails.Kind
 			inMemoryCol.SetBackfilled(foundColumn.Backfilled())
 

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -138,9 +138,10 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	assert.True(t, isOk)
 	assert.Equal(t, ext.DateTime.Type, col.KindDetails.ExtendedTimeDetails.Type)
 
+	// It went from invalid to boolean.
 	col, isOk = tableData.ReadOnlyInMemoryCols().GetColumn("bar")
 	assert.True(t, isOk)
-	assert.Equal(t, typing.Invalid, col.KindDetails)
+	assert.Equal(t, typing.Boolean, col.KindDetails)
 
 	col, isOk = tableData.ReadOnlyInMemoryCols().GetColumn("do_not_change_format")
 	assert.True(t, isOk)

--- a/lib/optimization/event_update_test.go
+++ b/lib/optimization/event_update_test.go
@@ -1,0 +1,11 @@
+package optimization
+
+import "testing"
+
+func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
+	// Test the following scenarios:
+	// 1. col does not exist.
+	// 2. test backfill (true and false)
+	// 3. test copying the col type over
+	// 4. Test copying `extendedTimeDetails`
+}

--- a/lib/optimization/event_update_test.go
+++ b/lib/optimization/event_update_test.go
@@ -1,11 +1,57 @@
 package optimization
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/artie-labs/transfer/lib/typing"
+
+	"github.com/artie-labs/transfer/lib/typing/columns"
+)
 
 func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 	// Test the following scenarios:
-	// 1. col does not exist.
-	// 2. test backfill (true and false)
-	// 3. test copying the col type over
 	// 4. Test copying `extendedTimeDetails`
+	tableDataCols := &columns.Columns{}
+	tableDataCols.AddColumn(columns.NewColumn("name", typing.String))
+	tableDataCols.AddColumn(columns.NewColumn("bool_backfill", typing.Boolean))
+	tableDataCols.AddColumn(columns.NewColumn("prev_invalid", typing.Invalid))
+	tableData := &TableData{
+		inMemoryColumns: tableDataCols,
+	}
+
+	nonExistentTableCols := []string{"dusty", "the", "mini", "aussie"}
+	var nonExistentCols []columns.Column
+	for _, nonExistentTableCol := range nonExistentTableCols {
+		nonExistentCols = append(nonExistentCols, columns.NewColumn(nonExistentTableCol, typing.String))
+	}
+
+	// Testing to make sure we don't copy over non-existent columns
+	tableData.UpdateInMemoryColumnsFromDestination(nonExistentCols...)
+	for _, nonExistentTableCol := range nonExistentTableCols {
+		_, isOk := tableData.inMemoryColumns.GetColumn(nonExistentTableCol)
+		assert.False(t, isOk, nonExistentTableCol)
+	}
+
+	// Testing to make sure we're copying the kindDetails over.
+	tableData.UpdateInMemoryColumnsFromDestination(columns.NewColumn("prev_invalid", typing.String))
+	prevInvalidCol, isOk := tableData.inMemoryColumns.GetColumn("prev_invalid")
+	assert.True(t, isOk)
+	assert.Equal(t, typing.String, prevInvalidCol.KindDetails)
+
+	// Testing backfill
+	for _, inMemoryCol := range tableData.inMemoryColumns.GetColumns() {
+		assert.False(t, inMemoryCol.Backfilled(), inMemoryCol.Name(nil))
+	}
+	backfilledCol := columns.NewColumn("bool_backfill", typing.Boolean)
+	backfilledCol.SetBackfilled(true)
+	tableData.UpdateInMemoryColumnsFromDestination(backfilledCol)
+	for _, inMemoryCol := range tableData.inMemoryColumns.GetColumns() {
+		if inMemoryCol.Name(nil) == backfilledCol.Name(nil) {
+			assert.True(t, inMemoryCol.Backfilled(), inMemoryCol.Name(nil))
+		} else {
+			assert.False(t, inMemoryCol.Backfilled(), inMemoryCol.Name(nil))
+		}
+	}
 }


### PR DESCRIPTION
# Problem

Right now, we are filtering out any columns that are entirely labelled as `typing.Invalid` for 2 primary reasons.

1. We are not able to infer the data type from the value which limits our ability to create the column downstream
2. We have an optimization to skip updating that column altogether.

However, what if the column exists in the destination and either the batch consists of updates coming from:
* `UPDATE TABLE set col = NULL;` or 
* `UPDATE TABLE set col = NULL where id = 1;` on a low traffic table?

If any of these edge cases arise, we'll then skip this column update on the destination. This PR aims to fix that entirely and only skip column creation if column type = `typing.Invalid`.

## Checks
- [x] Toast
- [x] Regular DML and DDL are not impacted
- [x] Still skipping based on reason 1