### PR TITLE
More guardrails around delete column

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -134,12 +134,13 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	// createTable is set to false because table creation requires a column to be added
 	// Which means, we'll only do it upon Add columns.
 	deleteAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:         s,
-		Tc:          tableConfig,
-		FqTableName: tableData.ToFqName(ctx, s.Label()),
-		CreateTable: false,
-		ColumnOp:    constants.Delete,
-		CdcTime:     tableData.LatestCDCTs,
+		Dwh:                     s,
+		Tc:                      tableConfig,
+		FqTableName:             tableData.ToFqName(ctx, s.Label()),
+		CreateTable:             false,
+		ColumnOp:                constants.Delete,
+		ContainsOtherOperations: tableData.ContainOtherOperations(),
+		CdcTime:                 tableData.LatestCDCTs,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -134,12 +134,13 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	// createTable is set to false because table creation requires a column to be added
 	// Which means, we'll only do it upon Add columns.
 	deleteAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:         s,
-		Tc:          tableConfig,
-		FqTableName: tableData.ToFqName(ctx, s.Label()),
-		CreateTable: false,
-		ColumnOp:    constants.Delete,
-		CdcTime:     tableData.LatestCDCTs,
+		Dwh:                    s,
+		Tc:                     tableConfig,
+		FqTableName:            tableData.ToFqName(ctx, s.Label()),
+		CreateTable:            false,
+		ColumnOp:               constants.Delete,
+		ContainOtherOperations: tableData.ContainOtherOperations(),
+		CdcTime:                tableData.LatestCDCTs,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -134,13 +134,12 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	// createTable is set to false because table creation requires a column to be added
 	// Which means, we'll only do it upon Add columns.
 	deleteAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:                     s,
-		Tc:                      tableConfig,
-		FqTableName:             tableData.ToFqName(ctx, s.Label()),
-		CreateTable:             false,
-		ColumnOp:                constants.Delete,
-		ContainsOtherOperations: tableData.ContainOtherOperations(),
-		CdcTime:                 tableData.LatestCDCTs,
+		Dwh:         s,
+		Tc:          tableConfig,
+		FqTableName: tableData.ToFqName(ctx, s.Label()),
+		CreateTable: false,
+		ColumnOp:    constants.Delete,
+		CdcTime:     tableData.LatestCDCTs,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -41,8 +41,6 @@ func CastColValStaging(colVal interface{}, colKind columns.Column) (string, erro
 		}
 
 	case typing.String.Kind:
-		// TODO: Worth writing a benchmark whether we should check for prefix and suffix of `[ ]`
-		// Check if it's an array.
 		list, err := array.InterfaceToArrayString(colVal)
 		if err == nil {
 			colValString = "[" + strings.Join(list, ",") + "]"

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -53,13 +53,13 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	// createTable is set to false because table creation requires a column to be added
 	// Which means, we'll only do it upon Add columns.
 	deleteAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:                      s,
-		Tc:                       tableConfig,
-		FqTableName:              fqName,
-		CreateTable:              false,
-		ColumnOp:                 constants.Delete,
-		ContainsDeleteEventsOnly: tableData.ContainsDeleteEventsOnly(),
-		CdcTime:                  tableData.LatestCDCTs,
+		Dwh:                    s,
+		Tc:                     tableConfig,
+		FqTableName:            fqName,
+		CreateTable:            false,
+		ColumnOp:               constants.Delete,
+		ContainOtherOperations: tableData.ContainOtherOperations(),
+		CdcTime:                tableData.LatestCDCTs,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -53,12 +53,13 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	// createTable is set to false because table creation requires a column to be added
 	// Which means, we'll only do it upon Add columns.
 	deleteAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:         s,
-		Tc:          tableConfig,
-		FqTableName: fqName,
-		CreateTable: false,
-		ColumnOp:    constants.Delete,
-		CdcTime:     tableData.LatestCDCTs,
+		Dwh:                     s,
+		Tc:                      tableConfig,
+		FqTableName:             fqName,
+		CreateTable:             false,
+		ColumnOp:                constants.Delete,
+		ContainsOtherOperations: tableData.ContainOtherOperations(),
+		CdcTime:                 tableData.LatestCDCTs,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -53,13 +53,13 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	// createTable is set to false because table creation requires a column to be added
 	// Which means, we'll only do it upon Add columns.
 	deleteAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:                     s,
-		Tc:                      tableConfig,
-		FqTableName:             fqName,
-		CreateTable:             false,
-		ColumnOp:                constants.Delete,
-		ContainsOtherOperations: tableData.ContainOtherOperations(),
-		CdcTime:                 tableData.LatestCDCTs,
+		Dwh:                      s,
+		Tc:                       tableConfig,
+		FqTableName:              fqName,
+		CreateTable:              false,
+		ColumnOp:                 constants.Delete,
+		ContainsDeleteEventsOnly: tableData.ContainsDeleteEventsOnly(),
+		CdcTime:                  tableData.LatestCDCTs,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -36,7 +36,7 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 	nameCol := columns.NewColumn("name", typing.String)
 	tc := s.stageStore.configMap.TableConfig(fqName)
 
-	val := tc.ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*6*time.Hour))
+	val := tc.ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*6*time.Hour), true)
 	assert.False(s.T(), val, "should not try to delete this column")
 	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(fqName).ReadOnlyColumnsToDelete()), 1)
 
@@ -46,6 +46,7 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 }
 
 func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
+	// TODO: Extend
 	fqName := "coffee_shop.orders.public"
 
 	var cols columns.Columns
@@ -64,22 +65,22 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 
 	nameCol := columns.NewColumn("name", typing.String)
 	// Let's try to delete name.
-	allowed := s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*(6*time.Hour)))
+	allowed := s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*(6*time.Hour)), true)
 
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete")
 
 	// Process tried to delete, but it's lagged.
-	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*(6*time.Hour)))
+	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil), time.Now().Add(-1*(6*time.Hour)), true)
 
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete")
 
 	// Process now caught up, and is asking if we can delete, should still be no.
-	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil), time.Now())
+	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil), time.Now(), true)
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete still")
 
 	// Process is finally ahead, has permission to delete now.
 	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(nameCol.Name(nil),
-		time.Now().Add(2*constants.DeletionConfidencePadding))
+		time.Now().Add(2*constants.DeletionConfidencePadding), true)
 
 	assert.Equal(s.T(), allowed, true, "should now be allowed to delete")
 }
@@ -101,7 +102,7 @@ func (s *SnowflakeTestSuite) TestManipulateShouldDeleteColumn() {
 	}, false, false)
 
 	assert.Equal(s.T(), len(tc.ReadOnlyColumnsToDelete()), 1)
-	assert.False(s.T(), tc.ShouldDeleteColumn("customer_id", time.Now().Add(24*time.Hour)))
+	assert.False(s.T(), tc.ShouldDeleteColumn("customer_id", time.Now().Add(24*time.Hour), false))
 }
 
 func (s *SnowflakeTestSuite) TestGetTableConfig() {

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -46,9 +46,7 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 }
 
 func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
-	// TODO: Extend
 	fqName := "coffee_shop.orders.public"
-
 	var cols columns.Columns
 	for colName, kindDetails := range map[string]typing.KindDetails{
 		"id":          typing.Integer,

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -50,7 +50,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	assert.Equal(s.T(), topicConfig.TableName, tableData.Name(), "override is working")
 
 	for pk, row := range rowsData {
-		tableData.InsertRow(pk, row)
+		tableData.InsertRow(pk, row, false)
 	}
 
 	anotherColToKindDetailsMap := map[string]typing.KindDetails{
@@ -106,7 +106,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
 	for pk, row := range rowsData {
-		tableData.InsertRow(pk, row)
+		tableData.InsertRow(pk, row, false)
 	}
 
 	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake),
@@ -156,7 +156,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
 	for pk, row := range rowsData {
-		tableData.InsertRow(pk, row)
+		tableData.InsertRow(pk, row, false)
 	}
 
 	var idx int
@@ -227,7 +227,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
 	for pk, row := range rowsData {
-		tableData.InsertRow(pk, row)
+		tableData.InsertRow(pk, row, false)
 	}
 
 	snowflakeColToKindDetailsMap := map[string]typing.KindDetails{

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -142,12 +142,13 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	// createTable is set to false because table creation requires a column to be added
 	// Which means, we'll only do it upon Add columns.
 	deleteAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:         s,
-		Tc:          tableConfig,
-		FqTableName: fqName,
-		CreateTable: false,
-		ColumnOp:    constants.Delete,
-		CdcTime:     tableData.LatestCDCTs,
+		Dwh:                     s,
+		Tc:                      tableConfig,
+		FqTableName:             fqName,
+		CreateTable:             false,
+		ColumnOp:                constants.Delete,
+		ContainsOtherOperations: tableData.ContainOtherOperations(),
+		CdcTime:                 tableData.LatestCDCTs,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -142,13 +142,13 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	// createTable is set to false because table creation requires a column to be added
 	// Which means, we'll only do it upon Add columns.
 	deleteAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:                     s,
-		Tc:                      tableConfig,
-		FqTableName:             fqName,
-		CreateTable:             false,
-		ColumnOp:                constants.Delete,
-		ContainsOtherOperations: tableData.ContainOtherOperations(),
-		CdcTime:                 tableData.LatestCDCTs,
+		Dwh:                      s,
+		Tc:                       tableConfig,
+		FqTableName:              fqName,
+		CreateTable:              false,
+		ColumnOp:                 constants.Delete,
+		ContainsDeleteEventsOnly: tableData.ContainsDeleteEventsOnly(),
+		CdcTime:                  tableData.LatestCDCTs,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -142,13 +142,13 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	// createTable is set to false because table creation requires a column to be added
 	// Which means, we'll only do it upon Add columns.
 	deleteAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:                      s,
-		Tc:                       tableConfig,
-		FqTableName:              fqName,
-		CreateTable:              false,
-		ColumnOp:                 constants.Delete,
-		ContainsDeleteEventsOnly: tableData.ContainsDeleteEventsOnly(),
-		CdcTime:                  tableData.LatestCDCTs,
+		Dwh:                    s,
+		Tc:                     tableConfig,
+		FqTableName:            fqName,
+		CreateTable:            false,
+		ColumnOp:               constants.Delete,
+		ContainOtherOperations: tableData.ContainOtherOperations(),
+		CdcTime:                tableData.LatestCDCTs,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -91,7 +91,7 @@ func generateTableData(rows int) (string, *optimization.TableData) {
 			"last_name":  fmt.Sprintf("last_name %d", i),
 		}
 
-		td.InsertRow(key, rowData)
+		td.InsertRow(key, rowData, false)
 	}
 
 	return randomTableName, td

--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -19,6 +19,7 @@ type Format interface {
 
 type Event interface {
 	GetExecutionTime() time.Time
+	DeletePayload() bool
 	GetTableName() string
 	GetData(ctx context.Context, pkMap map[string]interface{}, config *kafkalib.TopicConfig) map[string]interface{}
 	GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -73,6 +73,10 @@ func (d *Debezium) GetPrimaryKey(ctx context.Context, key []byte, tc *kafkalib.T
 	return debezium.ParsePartitionKey(key, tc.CDCKeyFormat)
 }
 
+func (s *SchemaEventPayload) DeletePayload() bool {
+	return s.Payload.Operation == "d"
+}
+
 func (s *SchemaEventPayload) GetExecutionTime() time.Time {
 	return time.UnixMilli(s.Payload.Source.TsMs).UTC()
 }

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -22,6 +22,7 @@ func (d *Debezium) GetEventFromBytes(_ context.Context, bytes []byte) (cdc.Event
 	var schemaEventPayload SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.
+		schemaEventPayload.Payload.Operation = "d"
 		return &schemaEventPayload, nil
 	}
 

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -189,6 +189,13 @@ func (p *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 	assert.Equal(p.T(), evtData[constants.DeleteColumnMarker], true)
 	assert.Equal(p.T(), evt.GetExecutionTime(),
 		time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC))
+	assert.Equal(p.T(), true, evt.DeletePayload())
+}
+
+func (p *MongoTestSuite) TestGetEventFromBytes_Tombstone() {
+	evt, err := p.Debezium.GetEventFromBytes(context.Background(), nil)
+	assert.NoError(p.T(), err)
+	assert.Equal(p.T(), true, evt.DeletePayload())
 }
 
 func (p *MongoTestSuite) TestMongoDBEventWithSchema() {

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -93,6 +93,7 @@ func (p *MongoTestSuite) TestMongoDBEventOrder() {
 	assert.True(p.T(), isOk)
 	assert.Equal(p.T(), time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC), schemaEvt.GetExecutionTime())
 	assert.Equal(p.T(), "orders", schemaEvt.GetTableName())
+	assert.False(p.T(), evt.DeletePayload())
 }
 
 func (p *MongoTestSuite) TestMongoDBEventCustomer() {
@@ -146,6 +147,7 @@ func (p *MongoTestSuite) TestMongoDBEventCustomer() {
 	assert.Equal(p.T(), evt.GetExecutionTime(),
 		time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC))
 	assert.Equal(p.T(), "customers", evt.GetTableName())
+	assert.False(p.T(), evt.DeletePayload())
 }
 
 func (p *MongoTestSuite) TestMongoDBEventCustomerBefore() {
@@ -192,7 +194,7 @@ func (p *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 	assert.Equal(p.T(), true, evt.DeletePayload())
 }
 
-func (p *MongoTestSuite) TestGetEventFromBytes_Tombstone() {
+func (p *MongoTestSuite) TestGetEventFromBytesTombstone() {
 	evt, err := p.Debezium.GetEventFromBytes(context.Background(), nil)
 	assert.NoError(p.T(), err)
 	assert.Equal(p.T(), true, evt.DeletePayload())
@@ -385,10 +387,8 @@ func (p *MongoTestSuite) TestMongoDBEventWithSchema() {
 	}
 }
 `
-
 	evt, err := p.Debezium.GetEventFromBytes(ctx, []byte(payload))
 	assert.NoError(p.T(), err)
-
 	schemaEvt, isOk := evt.(*SchemaEventPayload)
 	assert.True(p.T(), isOk)
 	assert.Equal(p.T(), schemaEvt.Schema.SchemaType, "struct")
@@ -398,5 +398,5 @@ func (p *MongoTestSuite) TestMongoDBEventWithSchema() {
 		DebeziumType: "",
 		Type:         "string",
 	})
-
+	assert.False(p.T(), evt.DeletePayload())
 }

--- a/lib/cdc/mysql/debezium.go
+++ b/lib/cdc/mysql/debezium.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/cdc/util"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -15,6 +16,7 @@ type Debezium string
 func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Event, error) {
 	var event util.SchemaEventPayload
 	if len(bytes) == 0 {
+		event.Payload.Operation = "d"
 		// This is a Kafka Tombstone event.
 		return &event, nil
 	}

--- a/lib/cdc/mysql/debezium_test.go
+++ b/lib/cdc/mysql/debezium_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func (m *MySQLTestSuite) TestGetEventFromBytesTombstone() {
+	evt, err := m.GetEventFromBytes(context.Background(), nil)
+	assert.NoError(m.T(), err)
+	assert.True(m.T(), evt.DeletePayload())
+}
+
 func (m *MySQLTestSuite) TestGetEventFromBytes() {
 	payload := `
 {

--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -17,6 +17,7 @@ func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Eve
 	var event util.SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.
+		event.Payload.Operation = "d"
 		return &event, nil
 	}
 

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -15,10 +15,16 @@ var validTc = &kafkalib.TopicConfig{
 	CDCKeyFormat: "org.apache.kafka.connect.json.JsonConverter",
 }
 
+func (p *PostgresTestSuite) TestGetEventFromBytesTombstone() {
+	evt, err := p.GetEventFromBytes(context.Background(), nil)
+	assert.NoError(p.T(), err)
+	assert.True(p.T(), evt.DeletePayload())
+}
+
 func (p *PostgresTestSuite) TestGetPrimaryKey() {
 	valString := `{"id": 47}`
-
 	pkMap, err := p.GetPrimaryKey(context.Background(), []byte(valString), validTc)
+	assert.NoError(p.T(), err)
 
 	val, isOk := pkMap["id"]
 	assert.True(p.T(), isOk)
@@ -75,9 +81,9 @@ func (p *PostgresTestSuite) TestPostgresEvent() {
 	}
 }
 `
-
 	evt, err := p.Debezium.GetEventFromBytes(context.Background(), []byte(payload))
 	assert.Nil(p.T(), err)
+	assert.False(p.T(), evt.DeletePayload())
 
 	evtData := evt.GetData(context.Background(), map[string]interface{}{"id": 59}, &kafkalib.TopicConfig{})
 	assert.Equal(p.T(), evtData["id"], float64(59))
@@ -87,6 +93,7 @@ func (p *PostgresTestSuite) TestPostgresEvent() {
 	assert.Equal(p.T(), time.Date(2022, time.November, 16,
 		4, 1, 53, 308000000, time.UTC), evt.GetExecutionTime())
 	assert.Equal(p.T(), "orders", evt.GetTableName())
+	assert.False(p.T(), evt.DeletePayload())
 }
 
 func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
@@ -177,9 +184,9 @@ func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 	}
 }
 `
-
 	evt, err := p.Debezium.GetEventFromBytes(context.Background(), []byte(payload))
 	assert.Nil(p.T(), err)
+	assert.False(p.T(), evt.DeletePayload())
 
 	evtData := evt.GetData(context.Background(), map[string]interface{}{"id": 1001}, &kafkalib.TopicConfig{})
 

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -75,6 +75,10 @@ func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]t
 	return schema
 }
 
+func (s *SchemaEventPayload) DeletePayload() bool {
+	return s.Payload.Operation == "d"
+}
+
 func (s *SchemaEventPayload) GetExecutionTime() time.Time {
 	return time.UnixMilli(s.Payload.Source.TsMs).UTC()
 }

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -117,6 +117,8 @@ func TestGetDataTestInsert(t *testing.T) {
 		},
 	}
 
+	assert.False(t, schemaEventPayload.DeletePayload())
+
 	evtData := schemaEventPayload.GetData(context.Background(), map[string]interface{}{"pk": 1}, &tc)
 	assert.Equal(t, len(after), len(evtData), "has deletion flag")
 
@@ -142,6 +144,8 @@ func TestGetDataTestDelete(t *testing.T) {
 			Source:    Source{TsMs: now.UnixMilli()},
 		},
 	}
+
+	assert.False(t, schemaEventPayload.DeletePayload())
 
 	kvMap := map[string]interface{}{"pk": 1}
 	evtData := schemaEventPayload.GetData(context.Background(), kvMap, tc)
@@ -187,6 +191,7 @@ func TestGetDataTestUpdate(t *testing.T) {
 		},
 	}
 
+	assert.False(t, schemaEventPayload.DeletePayload())
 	kvMap := map[string]interface{}{"pk": 1}
 
 	evtData := schemaEventPayload.GetData(context.Background(), kvMap, &tc)

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -83,16 +83,10 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 		}
 
 		if args.ColumnOp == constants.Delete {
-			// We should not delete if either conditions are true.
-			// 1. Explicit setting that specifies not to drop columns.
-			// 2. TableData contains only DELETEs
-			if !args.Tc.ShouldDeleteColumn(col.Name(nil), args.CdcTime) {
+			if !args.Tc.ShouldDeleteColumn(col.Name(nil), args.CdcTime, args.ContainsDeleteEventsOnly) {
 				continue
 			}
 
-			if args.ContainsDeleteEventsOnly {
-				continue
-			}
 		}
 
 		mutateCol = append(mutateCol, col)

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -41,13 +41,12 @@ func DropTemporaryTable(ctx context.Context, dwh dwh.DataWarehouse, fqTableName 
 type AlterTableArgs struct {
 	Dwh dwh.DataWarehouse
 	Tc  *types.DwhTableConfig
-	// ContainsOtherOperations - this is tableData `containOtherOperations` complement. We did this so that the default behavior if a new integration or feature is added
-	// It will default to false and skip the DDL to minimize surprise.
-	ContainsDeleteEventsOnly bool
-	FqTableName              string
-	CreateTable              bool
-	TemporaryTable           bool
-	ColumnOp                 constants.ColumnOperation
+	// ContainsOtherOperations - this is sourced from tableData `containOtherOperations`
+	ContainOtherOperations bool
+	FqTableName            string
+	CreateTable            bool
+	TemporaryTable         bool
+	ColumnOp               constants.ColumnOperation
 
 	CdcTime time.Time
 }
@@ -83,7 +82,7 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 		}
 
 		if args.ColumnOp == constants.Delete {
-			if !args.Tc.ShouldDeleteColumn(col.Name(nil), args.CdcTime, args.ContainsDeleteEventsOnly) {
+			if !args.Tc.ShouldDeleteColumn(col.Name(nil), args.CdcTime, args.ContainOtherOperations) {
 				continue
 			}
 

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -41,12 +41,13 @@ func DropTemporaryTable(ctx context.Context, dwh dwh.DataWarehouse, fqTableName 
 type AlterTableArgs struct {
 	Dwh dwh.DataWarehouse
 	Tc  *types.DwhTableConfig
-	// ContainsOtherOperations - this is from tableData's containOtherOperations
-	ContainsOtherOperations bool
-	FqTableName             string
-	CreateTable             bool
-	TemporaryTable          bool
-	ColumnOp                constants.ColumnOperation
+	// ContainsOtherOperations - this is tableData `containOtherOperations` complement. We did this so that the default behavior if a new integration or feature is added
+	// It will default to false and skip the DDL to minimize surprise.
+	ContainsDeleteEventsOnly bool
+	FqTableName              string
+	CreateTable              bool
+	TemporaryTable           bool
+	ColumnOp                 constants.ColumnOperation
 
 	CdcTime time.Time
 }
@@ -83,13 +84,13 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 
 		if args.ColumnOp == constants.Delete {
 			// We should not delete if either conditions are true.
-			// 1. TableData contains only DELETES
-			// 2. Explicit setting that specifies not to drop columns.
+			// 1. Explicit setting that specifies not to drop columns.
+			// 2. TableData contains only DELETEs
 			if !args.Tc.ShouldDeleteColumn(col.Name(nil), args.CdcTime) {
 				continue
 			}
 
-			if !args.ContainsOtherOperations {
+			if args.ContainsDeleteEventsOnly {
 				continue
 			}
 		}

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -85,7 +85,6 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 			if !args.Tc.ShouldDeleteColumn(col.Name(nil), args.CdcTime, args.ContainOtherOperations) {
 				continue
 			}
-
 		}
 
 		mutateCol = append(mutateCol, col)

--- a/lib/dwh/ddl/ddl_alter_delete_test.go
+++ b/lib/dwh/ddl/ddl_alter_delete_test.go
@@ -1,0 +1,352 @@
+package ddl_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/dwh/ddl"
+	"github.com/artie-labs/transfer/lib/dwh/types"
+	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/optimization"
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/stretchr/testify/assert"
+)
+
+func (d *DDLTestSuite) TestAlterDelete_Complete() {
+	ts := time.Now()
+	allCols := []string{"a", "b", "c", "d"}
+	var cols columns.Columns
+	for _, colName := range allCols {
+		cols.AddColumn(columns.NewColumn(colName, typing.String))
+	}
+
+	td := optimization.NewTableData(&cols, nil, kafkalib.TopicConfig{
+		Database:  "db",
+		TableName: "table",
+		Schema:    "public",
+	}, "tableName")
+
+	originalColumnLength := len(cols.GetColumns())
+	bqName := td.ToFqName(d.bqCtx, constants.BigQuery)
+	redshiftName := td.ToFqName(d.ctx, constants.Redshift)
+	snowflakeName := td.ToFqName(d.ctx, constants.Snowflake)
+
+	// Testing 3 scenarios here
+	// 1. DropDeletedColumns = false, ContainOtherOperations = true, don't delete ever.
+	d.bigQueryStore.GetConfigMap().AddTableToConfig(bqName, types.NewDwhTableConfig(&cols, nil, false, false))
+	bqTc := d.bigQueryStore.GetConfigMap().TableConfig(bqName)
+
+	d.redshiftStore.GetConfigMap().AddTableToConfig(redshiftName, types.NewDwhTableConfig(&cols, nil, false, false))
+	redshiftTc := d.redshiftStore.GetConfigMap().TableConfig(redshiftName)
+
+	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(snowflakeName, types.NewDwhTableConfig(&cols, nil, false, false))
+	snowflakeTc := d.snowflakeStagesStore.GetConfigMap().TableConfig(snowflakeName)
+	// Prior to deletion, there should be no colsToDelete
+	assert.Equal(d.T(), 0, len(bqTc.ReadOnlyColumnsToDelete()), bqTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), 0, len(redshiftTc.ReadOnlyColumnsToDelete()), redshiftTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), 0, len(snowflakeTc.ReadOnlyColumnsToDelete()), snowflakeTc.ReadOnlyColumnsToDelete())
+
+	// Snowflake
+	for _, column := range cols.GetColumns() {
+		alterTableArgs := ddl.AlterTableArgs{
+			Dwh:                    d.snowflakeStagesStore,
+			Tc:                     snowflakeTc,
+			FqTableName:            snowflakeName,
+			CreateTable:            snowflakeTc.CreateTable(),
+			ContainOtherOperations: true,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts,
+		}
+
+		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+	}
+
+	// Never actually deleted.
+	assert.Equal(d.T(), 0, len(snowflakeTc.ReadOnlyColumnsToDelete()), snowflakeTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), originalColumnLength, len(snowflakeTc.Columns().GetColumns()), snowflakeTc.Columns().GetColumns())
+
+	// BigQuery
+	for _, column := range cols.GetColumns() {
+		alterTableArgs := ddl.AlterTableArgs{
+			Dwh:                    d.bigQueryStore,
+			Tc:                     bqTc,
+			FqTableName:            bqName,
+			CreateTable:            bqTc.CreateTable(),
+			ContainOtherOperations: true,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts,
+		}
+
+		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+	}
+
+	// Never actually deleted.
+	assert.Equal(d.T(), 0, len(bqTc.ReadOnlyColumnsToDelete()), bqTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), originalColumnLength, len(bqTc.Columns().GetColumns()), bqTc.Columns().GetColumns())
+
+	// Redshift
+	for _, column := range cols.GetColumns() {
+		alterTableArgs := ddl.AlterTableArgs{
+			Dwh:                    d.redshiftStore,
+			Tc:                     redshiftTc,
+			FqTableName:            redshiftName,
+			CreateTable:            redshiftTc.CreateTable(),
+			ContainOtherOperations: true,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts,
+		}
+
+		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+	}
+
+	// Never actually deleted.
+	assert.Equal(d.T(), 0, len(redshiftTc.ReadOnlyColumnsToDelete()), redshiftTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), originalColumnLength, len(redshiftTc.Columns().GetColumns()), redshiftTc.Columns().GetColumns())
+
+	// 2. DropDeletedColumns = true, ContainOtherOperations = false, don't delete ever
+	d.bigQueryStore.GetConfigMap().AddTableToConfig(bqName, types.NewDwhTableConfig(&cols, nil, false, true))
+	bqTc = d.bigQueryStore.GetConfigMap().TableConfig(bqName)
+
+	d.redshiftStore.GetConfigMap().AddTableToConfig(redshiftName, types.NewDwhTableConfig(&cols, nil, false, true))
+	redshiftTc = d.redshiftStore.GetConfigMap().TableConfig(redshiftName)
+
+	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(snowflakeName, types.NewDwhTableConfig(&cols, nil, false, true))
+	snowflakeTc = d.snowflakeStagesStore.GetConfigMap().TableConfig(snowflakeName)
+
+	// Prior to deletion, there should be no colsToDelete
+	assert.Equal(d.T(), 0, len(bqTc.ReadOnlyColumnsToDelete()), bqTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), 0, len(redshiftTc.ReadOnlyColumnsToDelete()), redshiftTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), 0, len(snowflakeTc.ReadOnlyColumnsToDelete()), snowflakeTc.ReadOnlyColumnsToDelete())
+
+	for _, column := range cols.GetColumns() {
+		alterTableArgs := ddl.AlterTableArgs{
+			Dwh:                    d.snowflakeStagesStore,
+			Tc:                     snowflakeTc,
+			FqTableName:            snowflakeName,
+			CreateTable:            snowflakeTc.CreateTable(),
+			ContainOtherOperations: false,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts,
+		}
+
+		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+	}
+
+	// Never actually deleted.
+	assert.Equal(d.T(), 0, len(snowflakeTc.ReadOnlyColumnsToDelete()), snowflakeTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), originalColumnLength, len(snowflakeTc.Columns().GetColumns()), snowflakeTc.Columns().GetColumns())
+
+	// BigQuery
+	for _, column := range cols.GetColumns() {
+		alterTableArgs := ddl.AlterTableArgs{
+			Dwh:                    d.bigQueryStore,
+			Tc:                     bqTc,
+			FqTableName:            bqName,
+			CreateTable:            bqTc.CreateTable(),
+			ContainOtherOperations: false,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts,
+		}
+
+		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+	}
+
+	// Never actually deleted.
+	assert.Equal(d.T(), 0, len(bqTc.ReadOnlyColumnsToDelete()), bqTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), originalColumnLength, len(bqTc.Columns().GetColumns()), bqTc.Columns().GetColumns())
+
+	// Redshift
+	for _, column := range cols.GetColumns() {
+		alterTableArgs := ddl.AlterTableArgs{
+			Dwh:                    d.redshiftStore,
+			Tc:                     redshiftTc,
+			FqTableName:            redshiftName,
+			CreateTable:            redshiftTc.CreateTable(),
+			ContainOtherOperations: false,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts,
+		}
+
+		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+	}
+
+	// Never actually deleted.
+	assert.Equal(d.T(), 0, len(redshiftTc.ReadOnlyColumnsToDelete()), redshiftTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), originalColumnLength, len(redshiftTc.Columns().GetColumns()), redshiftTc.Columns().GetColumns())
+
+	// 3. DropDeletedColumns = true, ContainOtherOperations = true, drop based on timestamp.
+	d.bigQueryStore.GetConfigMap().AddTableToConfig(bqName, types.NewDwhTableConfig(&cols, nil, false, true))
+	bqTc = d.bigQueryStore.GetConfigMap().TableConfig(bqName)
+
+	d.redshiftStore.GetConfigMap().AddTableToConfig(redshiftName, types.NewDwhTableConfig(&cols, nil, false, true))
+	redshiftTc = d.redshiftStore.GetConfigMap().TableConfig(redshiftName)
+
+	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(snowflakeName, types.NewDwhTableConfig(&cols, nil, false, true))
+	snowflakeTc = d.snowflakeStagesStore.GetConfigMap().TableConfig(snowflakeName)
+
+	// Prior to deletion, there should be no colsToDelete
+	assert.Equal(d.T(), 0, len(bqTc.ReadOnlyColumnsToDelete()), bqTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), 0, len(redshiftTc.ReadOnlyColumnsToDelete()), redshiftTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), 0, len(snowflakeTc.ReadOnlyColumnsToDelete()), snowflakeTc.ReadOnlyColumnsToDelete())
+
+	// Now, actually try to delete.
+	// Snowflake
+	for _, column := range cols.GetColumns() {
+		alterTableArgs := ddl.AlterTableArgs{
+			Dwh:                    d.snowflakeStagesStore,
+			Tc:                     snowflakeTc,
+			FqTableName:            snowflakeName,
+			CreateTable:            snowflakeTc.CreateTable(),
+			ContainOtherOperations: true,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts,
+		}
+
+		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+	}
+
+	// BigQuery
+	for _, column := range cols.GetColumns() {
+		alterTableArgs := ddl.AlterTableArgs{
+			Dwh:                    d.bigQueryStore,
+			Tc:                     bqTc,
+			FqTableName:            bqName,
+			CreateTable:            bqTc.CreateTable(),
+			ContainOtherOperations: true,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts,
+		}
+
+		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+	}
+
+	// Redshift
+	for _, column := range cols.GetColumns() {
+		alterTableArgs := ddl.AlterTableArgs{
+			Dwh:                    d.redshiftStore,
+			Tc:                     redshiftTc,
+			FqTableName:            redshiftName,
+			CreateTable:            redshiftTc.CreateTable(),
+			ContainOtherOperations: true,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts,
+		}
+
+		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+	}
+
+	// Nothing has been deleted, but it is all added to the permissions table.
+	assert.Equal(d.T(), originalColumnLength, len(bqTc.Columns().GetColumns()), bqTc.Columns().GetColumns())
+	assert.Equal(d.T(), originalColumnLength, len(redshiftTc.Columns().GetColumns()), redshiftTc.Columns().GetColumns())
+	assert.Equal(d.T(), originalColumnLength, len(snowflakeTc.Columns().GetColumns()), snowflakeTc.Columns().GetColumns())
+
+	assert.Equal(d.T(), originalColumnLength, len(bqTc.ReadOnlyColumnsToDelete()), bqTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), originalColumnLength, len(redshiftTc.ReadOnlyColumnsToDelete()), redshiftTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), originalColumnLength, len(snowflakeTc.ReadOnlyColumnsToDelete()), snowflakeTc.ReadOnlyColumnsToDelete())
+
+	for _, column := range cols.GetColumns() {
+		fmt.Println("snowflake?")
+		alterTableArgs := ddl.AlterTableArgs{
+			Dwh:                    d.snowflakeStagesStore,
+			Tc:                     snowflakeTc,
+			FqTableName:            snowflakeName,
+			CreateTable:            snowflakeTc.CreateTable(),
+			ContainOtherOperations: true,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts.Add(2 * constants.DeletionConfidencePadding),
+		}
+
+		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+
+		// BigQuery
+		fmt.Println("bigquery?")
+		alterTableArgs = ddl.AlterTableArgs{
+			Dwh:                    d.bigQueryStore,
+			Tc:                     bqTc,
+			FqTableName:            bqName,
+			CreateTable:            bqTc.CreateTable(),
+			ContainOtherOperations: true,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts.Add(2 * constants.DeletionConfidencePadding),
+		}
+
+		err = ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+
+		// Redshift
+		alterTableArgs = ddl.AlterTableArgs{
+			Dwh:                    d.redshiftStore,
+			Tc:                     redshiftTc,
+			FqTableName:            redshiftName,
+			CreateTable:            redshiftTc.CreateTable(),
+			ContainOtherOperations: true,
+			ColumnOp:               constants.Delete,
+			CdcTime:                ts.Add(2 * constants.DeletionConfidencePadding),
+		}
+
+		err = ddl.AlterTable(d.ctx, alterTableArgs, column)
+		assert.NoError(d.T(), err)
+	}
+
+	// Everything has been deleted.
+	assert.Equal(d.T(), 0, len(snowflakeTc.Columns().GetColumns()), snowflakeTc.Columns().GetColumns())
+	assert.Equal(d.T(), 0, len(bqTc.Columns().GetColumns()), bqTc.Columns().GetColumns())
+	assert.Equal(d.T(), 0, len(redshiftTc.Columns().GetColumns()), redshiftTc.Columns().GetColumns())
+
+	assert.Equal(d.T(), 0, len(snowflakeTc.ReadOnlyColumnsToDelete()), snowflakeTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), 0, len(bqTc.ReadOnlyColumnsToDelete()), bqTc.ReadOnlyColumnsToDelete())
+	assert.Equal(d.T(), 0, len(redshiftTc.ReadOnlyColumnsToDelete()), redshiftTc.ReadOnlyColumnsToDelete())
+
+	allColsMap := make(map[string]bool, len(allCols))
+	for _, allCol := range allCols {
+		allColsMap[allCol] = true
+	}
+
+	for i := 0; i < d.fakeSnowflakeStagesStore.ExecCallCount(); i++ {
+		execQuery, _ := d.fakeSnowflakeStagesStore.ExecArgsForCall(0)
+		var found bool
+		for key := range allColsMap {
+			if execQuery == fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", snowflakeName, key) {
+				found = true
+			}
+		}
+
+		assert.True(d.T(), found, execQuery)
+	}
+
+	for i := 0; i < d.fakeBigQueryStore.ExecCallCount(); i++ {
+		execQuery, _ := d.fakeBigQueryStore.ExecArgsForCall(0)
+		var found bool
+		for key := range allColsMap {
+			if execQuery == fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", bqName, key) {
+				found = true
+			}
+		}
+
+		assert.True(d.T(), found, execQuery)
+	}
+
+	for i := 0; i < d.fakeRedshiftStore.ExecCallCount(); i++ {
+		execQuery, _ := d.fakeRedshiftStore.ExecArgsForCall(0)
+		var found bool
+		for key := range allColsMap {
+			if execQuery == fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", redshiftName, key) {
+				found = true
+			}
+		}
+
+		assert.True(d.T(), found, execQuery)
+	}
+}

--- a/lib/dwh/ddl/ddl_bq_test.go
+++ b/lib/dwh/ddl/ddl_bq_test.go
@@ -50,12 +50,13 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 	assert.Equal(d.T(), 0, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).ReadOnlyColumnsToDelete()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).ReadOnlyColumnsToDelete())
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:         d.bigQueryStore,
-			Tc:          tc,
-			FqTableName: fqName,
-			CreateTable: tc.CreateTable(),
-			ColumnOp:    constants.Delete,
-			CdcTime:     ts,
+			Dwh:                    d.bigQueryStore,
+			Tc:                     tc,
+			FqTableName:            fqName,
+			CreateTable:            tc.CreateTable(),
+			ColumnOp:               constants.Delete,
+			ContainOtherOperations: true,
+			CdcTime:                ts,
 		}
 
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
@@ -71,12 +72,13 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 	var callIdx int
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:         d.bigQueryStore,
-			Tc:          tc,
-			FqTableName: fqName,
-			CreateTable: tc.CreateTable(),
-			ColumnOp:    constants.Delete,
-			CdcTime:     ts.Add(2 * constants.DeletionConfidencePadding),
+			Dwh:                    d.bigQueryStore,
+			Tc:                     tc,
+			FqTableName:            fqName,
+			CreateTable:            tc.CreateTable(),
+			ColumnOp:               constants.Delete,
+			ContainOtherOperations: true,
+			CdcTime:                ts.Add(2 * constants.DeletionConfidencePadding),
 		}
 
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)

--- a/lib/dwh/ddl/ddl_sflk_test.go
+++ b/lib/dwh/ddl/ddl_sflk_test.go
@@ -135,11 +135,12 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(fqTable, types.NewDwhTableConfig(&columns.Columns{}, nil, false, true))
 	tc := d.snowflakeStagesStore.GetConfigMap().TableConfig(fqTable)
 	alterTableArgs := ddl.AlterTableArgs{
-		Dwh:         d.snowflakeStagesStore,
-		Tc:          tc,
-		FqTableName: fqTable,
-		ColumnOp:    constants.Delete,
-		CdcTime:     time.Now().UTC(),
+		Dwh:                    d.snowflakeStagesStore,
+		Tc:                     tc,
+		FqTableName:            fqTable,
+		ContainOtherOperations: true,
+		ColumnOp:               constants.Delete,
+		CdcTime:                time.Now().UTC(),
 	}
 	err := ddl.AlterTable(d.ctx, alterTableArgs, cols...)
 	assert.Equal(d.T(), 0, d.fakeSnowflakeStagesStore.ExecCallCount(), "tried to delete, but not yet.")
@@ -200,11 +201,12 @@ func (d *DDLTestSuite) TestAlterTableDelete() {
 
 	tc := d.snowflakeStagesStore.GetConfigMap().TableConfig(fqTable)
 	alterTableArgs := ddl.AlterTableArgs{
-		Dwh:         d.snowflakeStagesStore,
-		Tc:          tc,
-		FqTableName: fqTable,
-		ColumnOp:    constants.Delete,
-		CdcTime:     time.Now(),
+		Dwh:                    d.snowflakeStagesStore,
+		Tc:                     tc,
+		FqTableName:            fqTable,
+		ColumnOp:               constants.Delete,
+		ContainOtherOperations: true,
+		CdcTime:                time.Now(),
 	}
 	err := ddl.AlterTable(d.ctx, alterTableArgs, cols...)
 	assert.Equal(d.T(), 3, d.fakeSnowflakeStagesStore.ExecCallCount(), "tried to delete, but not yet.")

--- a/lib/dwh/ddl/ddl_suite_test.go
+++ b/lib/dwh/ddl/ddl_suite_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/artie-labs/transfer/clients/redshift"
+
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/logger"
 
@@ -23,6 +25,9 @@ type DDLTestSuite struct {
 
 	fakeSnowflakeStagesStore *mocks.FakeStore
 	snowflakeStagesStore     *snowflake.Store
+
+	fakeRedshiftStore *mocks.FakeStore
+	redshiftStore     *redshift.Store
 }
 
 func (d *DDLTestSuite) SetupTest() {
@@ -51,6 +56,10 @@ func (d *DDLTestSuite) SetupTest() {
 	d.fakeSnowflakeStagesStore = &mocks.FakeStore{}
 	snowflakeStagesStore := db.Store(d.fakeSnowflakeStagesStore)
 	d.snowflakeStagesStore = snowflake.LoadSnowflake(ctx, &snowflakeStagesStore)
+
+	d.fakeRedshiftStore = &mocks.FakeStore{}
+	redshiftStore := db.Store(d.fakeRedshiftStore)
+	d.redshiftStore = redshift.LoadRedshift(ctx, &redshiftStore)
 }
 
 func TestDDLTestSuite(t *testing.T) {

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -33,63 +33,63 @@ func NewDwhTableConfig(columns *columns.Columns, colsToDelete map[string]time.Ti
 	}
 }
 
-func (tc *DwhTableConfig) CreateTable() bool {
-	tc.RLock()
-	defer tc.RUnlock()
+func (d *DwhTableConfig) CreateTable() bool {
+	d.RLock()
+	defer d.RUnlock()
 
-	return tc.createTable
+	return d.createTable
 }
 
-func (tc *DwhTableConfig) DropDeletedColumns() bool {
-	tc.RLock()
-	defer tc.RUnlock()
+func (d *DwhTableConfig) DropDeletedColumns() bool {
+	d.RLock()
+	defer d.RUnlock()
 
-	return tc.dropDeletedColumns
+	return d.dropDeletedColumns
 }
 
-func (tc *DwhTableConfig) Columns() *columns.Columns {
-	if tc == nil {
+func (d *DwhTableConfig) Columns() *columns.Columns {
+	if d == nil {
 		return nil
 	}
 
-	return tc.columns
+	return d.columns
 }
 
-func (tc *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp constants.ColumnOperation, cols ...columns.Column) {
-	tc.Lock()
-	defer tc.Unlock()
+func (d *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp constants.ColumnOperation, cols ...columns.Column) {
+	d.Lock()
+	defer d.Unlock()
 	switch columnOp {
 	case constants.Add:
 		for _, col := range cols {
-			tc.columns.AddColumn(col)
+			d.columns.AddColumn(col)
 			// Delete from the permissions table, if exists.
-			delete(tc.columnsToDelete, col.Name(nil))
+			delete(d.columnsToDelete, col.Name(nil))
 		}
 
-		tc.createTable = createTable
+		d.createTable = createTable
 	case constants.Delete:
 		for _, col := range cols {
 			// Delete from the permissions and in-memory table
-			tc.columns.DeleteColumn(col.Name(nil))
-			delete(tc.columnsToDelete, col.Name(nil))
+			d.columns.DeleteColumn(col.Name(nil))
+			delete(d.columnsToDelete, col.Name(nil))
 		}
 	}
 }
 
 // ReadOnlyColumnsToDelete returns a read only version of the columns that need to be deleted.
-func (tc *DwhTableConfig) ReadOnlyColumnsToDelete() map[string]time.Time {
-	tc.RLock()
-	defer tc.RUnlock()
+func (d *DwhTableConfig) ReadOnlyColumnsToDelete() map[string]time.Time {
+	d.RLock()
+	defer d.RUnlock()
 	colsToDelete := make(map[string]time.Time)
-	for k, v := range tc.columnsToDelete {
+	for k, v := range d.columnsToDelete {
 		colsToDelete[k] = v
 	}
 
 	return colsToDelete
 }
 
-func (tc *DwhTableConfig) ShouldDeleteColumn(colName string, cdcTime time.Time, containOtherOperations bool) bool {
-	if tc == nil {
+func (d *DwhTableConfig) ShouldDeleteColumn(colName string, cdcTime time.Time, containOtherOperations bool) bool {
+	if d == nil {
 		// Avoid a panic and default to FALSE.
 		return false
 	}
@@ -102,37 +102,37 @@ func (tc *DwhTableConfig) ShouldDeleteColumn(colName string, cdcTime time.Time, 
 		return false
 	}
 
-	if tc.dropDeletedColumns == false {
+	if d.dropDeletedColumns == false {
 		// Never delete
 		return false
 	}
 
-	colsToDelete := tc.ReadOnlyColumnsToDelete()
+	colsToDelete := d.ReadOnlyColumnsToDelete()
 	ts, isOk := colsToDelete[colName]
 	if isOk {
 		// If the CDC time is greater than this timestamp, then we should delete it.
 		return cdcTime.After(ts)
 	}
 
-	tc.AddColumnsToDelete(colName, time.Now().UTC().Add(constants.DeletionConfidencePadding))
+	d.AddColumnsToDelete(colName, time.Now().UTC().Add(constants.DeletionConfidencePadding))
 	return false
 }
 
-func (tc *DwhTableConfig) AddColumnsToDelete(colName string, ts time.Time) {
-	tc.Lock()
-	defer tc.Unlock()
+func (d *DwhTableConfig) AddColumnsToDelete(colName string, ts time.Time) {
+	d.Lock()
+	defer d.Unlock()
 
-	if tc.columnsToDelete == nil {
-		tc.columnsToDelete = make(map[string]time.Time)
+	if d.columnsToDelete == nil {
+		d.columnsToDelete = make(map[string]time.Time)
 	}
 
-	tc.columnsToDelete[colName] = ts
+	d.columnsToDelete[colName] = ts
 	return
 }
 
-func (tc *DwhTableConfig) ClearColumnsToDeleteByColName(colName string) {
-	tc.Lock()
-	defer tc.Unlock()
+func (d *DwhTableConfig) ClearColumnsToDeleteByColName(colName string) {
+	d.Lock()
+	defer d.Unlock()
 
-	delete(tc.columnsToDelete, colName)
+	delete(d.columnsToDelete, colName)
 }

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -88,9 +88,17 @@ func (tc *DwhTableConfig) ReadOnlyColumnsToDelete() map[string]time.Time {
 	return colsToDelete
 }
 
-func (tc *DwhTableConfig) ShouldDeleteColumn(colName string, cdcTime time.Time) bool {
+func (tc *DwhTableConfig) ShouldDeleteColumn(colName string, cdcTime time.Time, containsDeleteEventsOnly bool) bool {
 	if tc == nil {
 		// Avoid a panic and default to FALSE.
+		return false
+	}
+
+	// We should not delete if either conditions are true.
+	// 1. TableData contains only DELETES
+	// 2. Explicit setting that specifies not to drop columns
+	if containsDeleteEventsOnly {
+		// never delete
 		return false
 	}
 

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -88,7 +88,7 @@ func (tc *DwhTableConfig) ReadOnlyColumnsToDelete() map[string]time.Time {
 	return colsToDelete
 }
 
-func (tc *DwhTableConfig) ShouldDeleteColumn(colName string, cdcTime time.Time, containsDeleteEventsOnly bool) bool {
+func (tc *DwhTableConfig) ShouldDeleteColumn(colName string, cdcTime time.Time, containOtherOperations bool) bool {
 	if tc == nil {
 		// Avoid a panic and default to FALSE.
 		return false
@@ -97,7 +97,7 @@ func (tc *DwhTableConfig) ShouldDeleteColumn(colName string, cdcTime time.Time, 
 	// We should not delete if either conditions are true.
 	// 1. TableData contains only DELETES
 	// 2. Explicit setting that specifies not to drop columns
-	if containsDeleteEventsOnly {
+	if !containOtherOperations {
 		// never delete
 		return false
 	}

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -98,12 +98,10 @@ func (d *DwhTableConfig) ShouldDeleteColumn(colName string, cdcTime time.Time, c
 	// 1. TableData contains only DELETES
 	// 2. Explicit setting that specifies not to drop columns
 	if !containOtherOperations {
-		// never delete
 		return false
 	}
 
 	if d.dropDeletedColumns == false {
-		// Never delete
 		return false
 	}
 

--- a/lib/dwh/types/table_config_test.go
+++ b/lib/dwh/types/table_config_test.go
@@ -16,17 +16,32 @@ import (
 )
 
 func TestDwhTableConfig_ShouldDeleteColumn(t *testing.T) {
-	// TODO: Extend
+	// Test 3 different possibilities:
+	// 1. DropDeletedColumns = false, so don't delete.
 	dwhTableConfig := NewDwhTableConfig(&columns.Columns{}, nil, false, false)
-	results := dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC(), true)
-	assert.False(t, results)
-	assert.Equal(t, len(dwhTableConfig.ReadOnlyColumnsToDelete()), 0)
+	for i := 0; i < 100; i++ {
+		results := dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC(), true)
+		assert.False(t, results)
+		assert.Equal(t, len(dwhTableConfig.ReadOnlyColumnsToDelete()), 0)
+	}
 
-	// Once the flag is turned on.
-	dwhTableConfig.dropDeletedColumns = true
-	results = dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC(), true)
-	assert.False(t, results)
-	assert.Equal(t, len(dwhTableConfig.ReadOnlyColumnsToDelete()), 1)
+	// 2. DropDeletedColumns = true and ContainsOtherOperations = false, so don't delete
+	dwhTableConfig = NewDwhTableConfig(&columns.Columns{}, nil, false, true)
+	for i := 0; i < 100; i++ {
+		results := dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC(), false)
+		assert.False(t, results)
+		assert.Equal(t, len(dwhTableConfig.ReadOnlyColumnsToDelete()), 0)
+	}
+
+	// 3. DropDeletedColumns = true and ContainsOtherOperations = true, now check CDC time to delete.
+	dwhTableConfig = NewDwhTableConfig(&columns.Columns{}, nil, false, true)
+	for i := 0; i < 100; i++ {
+		results := dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC(), true)
+		assert.False(t, results)
+		assert.Equal(t, len(dwhTableConfig.ReadOnlyColumnsToDelete()), 1)
+	}
+
+	assert.True(t, dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC().Add(2*constants.DeletionConfidencePadding), true))
 }
 
 // TestDwhTableConfig_ColumnsConcurrency this file is meant to test the concurrency methods of .Columns()

--- a/lib/dwh/types/table_config_test.go
+++ b/lib/dwh/types/table_config_test.go
@@ -16,14 +16,15 @@ import (
 )
 
 func TestDwhTableConfig_ShouldDeleteColumn(t *testing.T) {
+	// TODO: Extend
 	dwhTableConfig := NewDwhTableConfig(&columns.Columns{}, nil, false, false)
-	results := dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC())
+	results := dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC(), true)
 	assert.False(t, results)
 	assert.Equal(t, len(dwhTableConfig.ReadOnlyColumnsToDelete()), 0)
 
 	// Once the flag is turned on.
 	dwhTableConfig.dropDeletedColumns = true
-	results = dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC())
+	results = dwhTableConfig.ShouldDeleteColumn("hello", time.Now().UTC(), true)
 	assert.False(t, results)
 	assert.Equal(t, len(dwhTableConfig.ReadOnlyColumnsToDelete()), 1)
 }

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -45,6 +45,10 @@ type TableData struct {
 	name string
 }
 
+func (t *TableData) ContainOtherOperations() bool {
+	return t.containOtherOperations
+}
+
 func (t *TableData) PrimaryKeys(args *columns.NameArgs) []columns.Wrapper {
 	var primaryKeysEscaped []columns.Wrapper
 	for _, pk := range t.primaryKeys {

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -45,8 +45,10 @@ type TableData struct {
 	name string
 }
 
-func (t *TableData) ContainOtherOperations() bool {
-	return t.containOtherOperations
+// ContainsDeleteEventsOnly is the complement version of `containOtherOperations` to minimize surprises
+// Since `ContainsDeleteEventsonly` if true, we will skip column deletion in the destination.
+func (t *TableData) ContainsDeleteEventsOnly() bool {
+	return !t.containOtherOperations
 }
 
 func (t *TableData) PrimaryKeys(args *columns.NameArgs) []columns.Wrapper {

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -45,10 +45,8 @@ type TableData struct {
 	name string
 }
 
-// ContainsDeleteEventsOnly is the complement version of `containOtherOperations` to minimize surprises
-// Since `ContainsDeleteEventsonly` if true, we will skip column deletion in the destination.
-func (t *TableData) ContainsDeleteEventsOnly() bool {
-	return !t.containOtherOperations
+func (t *TableData) ContainOtherOperations() bool {
+	return t.containOtherOperations
 }
 
 func (t *TableData) PrimaryKeys(args *columns.NameArgs) []columns.Wrapper {

--- a/lib/optimization/event_bench_test.go
+++ b/lib/optimization/event_bench_test.go
@@ -15,7 +15,7 @@ func BenchmarkTableData_ApproxSize_TallTable(b *testing.B) {
 			"id":   n,
 			"name": "Robin",
 			"dog":  "dusty the mini aussie",
-		})
+		}, false)
 	}
 }
 
@@ -52,6 +52,6 @@ func BenchmarkTableData_ApproxSize_WideTable(b *testing.B) {
 			"is_deleted":   false,
 			"lorem_ipsum":  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec elementum aliquet mi at efficitur. Praesent at erat ac elit faucibus convallis. Donec fermentum tellus eu nunc ornare, non convallis justo facilisis. In hac habitasse platea dictumst. Praesent eu ante vitae erat semper finibus eget ac mauris. Duis gravida cursus enim, nec sagittis arcu placerat sed. Integer semper orci justo, nec rhoncus libero convallis sed.",
 			"lorem_ipsum2": "Fusce vitae elementum tortor. Vestibulum consectetur ante id nibh ullamcorper, quis sodales turpis tempor. Duis pellentesque suscipit nibh porta posuere. In libero massa, efficitur at ultricies sit amet, vulputate ac ante. In euismod erat eget nulla blandit pretium. Ut tempor ante vel congue venenatis. Vestibulum at metus nec nibh iaculis consequat suscipit ac leo. Maecenas vitae rutrum nulla, quis ultrices justo. Aliquam ipsum ex, luctus ac diam eget, tempor tempor risus.",
-		})
+		}, false)
 	}
 }

--- a/lib/optimization/event_insert_test.go
+++ b/lib/optimization/event_insert_test.go
@@ -103,7 +103,7 @@ func TestInsertRow_Toast(t *testing.T) {
 		// Wipe the table data per test run.
 		td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
 		for _, rowData := range testCase.rowsDataToUpdate {
-			td.InsertRow(testCase.primaryKey, rowData)
+			td.InsertRow(testCase.primaryKey, rowData, false)
 		}
 
 		var actualSize int
@@ -130,7 +130,7 @@ func TestTableData_InsertRow(t *testing.T) {
 	// Now insert the right way.
 	td.InsertRow("foo", map[string]interface{}{
 		"foo": "bar",
-	})
+	}, false)
 
 	assert.Equal(t, 1, int(td.Rows()))
 }
@@ -155,7 +155,7 @@ func TestTableData_InsertRowApproxSize(t *testing.T) {
 					"true": false,
 				},
 			},
-		})
+		}, false)
 	}
 
 	var updateCount int
@@ -164,7 +164,7 @@ func TestTableData_InsertRowApproxSize(t *testing.T) {
 		td.InsertRow(updateKey, map[string]interface{}{
 			"foo": "foo",
 			"bar": "bar",
-		})
+		}, false)
 
 		if updateCount > numUpdateRows {
 			break
@@ -176,7 +176,7 @@ func TestTableData_InsertRowApproxSize(t *testing.T) {
 		deleteCount += 1
 		td.InsertRow(deleteKey, map[string]interface{}{
 			"__artie_deleted": true,
-		})
+		}, true)
 
 		if deleteCount > numDeleteRows {
 			break

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -163,7 +163,7 @@ func TestTableData_ShouldFlushRowLength(t *testing.T) {
 		assert.False(t, td.ShouldFlush(ctx))
 		td.InsertRow(fmt.Sprint(i), map[string]interface{}{
 			"foo": "bar",
-		})
+		}, false)
 	}
 
 	assert.True(t, td.ShouldFlush(ctx))
@@ -188,7 +188,7 @@ func TestTableData_ShouldFlushRowSize(t *testing.T) {
 			"nested": map[string]interface{}{
 				"foo": "bar",
 			},
-		})
+		}, false)
 	}
 
 	td.InsertRow("33333", map[string]interface{}{
@@ -199,7 +199,7 @@ func TestTableData_ShouldFlushRowSize(t *testing.T) {
 		"nested": map[string]interface{}{
 			"foo": "bar",
 		},
-	})
+	}, false)
 
 	assert.True(t, td.ShouldFlush(ctx))
 }

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -213,15 +213,15 @@ func TestTableData_InsertRowIntegrity(t *testing.T) {
 
 	td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
 	assert.Equal(t, 0, int(td.Rows()))
-	assert.False(t, td.containOtherOperations)
+	assert.False(t, td.ContainOtherOperations())
 
 	for i := 0; i < 100; i++ {
 		td.InsertRow("123", nil, true)
-		assert.False(t, td.containOtherOperations)
+		assert.False(t, td.ContainOtherOperations())
 	}
 
 	for i := 0; i < 100; i++ {
 		td.InsertRow("123", nil, false)
-		assert.True(t, td.containOtherOperations)
+		assert.True(t, td.ContainOtherOperations())
 	}
 }

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -120,12 +120,12 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 	td.Lock()
 	defer td.Unlock()
 	if td.Empty() {
-		columns := &columns.Columns{}
+		cols := &columns.Columns{}
 		if e.Columns != nil {
-			columns = e.Columns
+			cols = e.Columns
 		}
 
-		td.SetTableData(optimization.NewTableData(columns, e.PrimaryKeys(), *topicConfig, e.Table))
+		td.SetTableData(optimization.NewTableData(cols, e.PrimaryKeys(), *topicConfig, e.Table))
 	} else {
 		if e.Columns != nil {
 			// Iterate over this again just in case.

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -18,6 +18,10 @@ var idMap = map[string]interface{}{
 	"id": 123,
 }
 
+func (f fakeEvent) DeletePayload() bool {
+	return false
+}
+
 func (f fakeEvent) GetExecutionTime() time.Time {
 	return time.Now()
 }

--- a/processes/pool/writes.go
+++ b/processes/pool/writes.go
@@ -2,7 +2,6 @@ package pool
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/artie-labs/transfer/processes/consumer"
@@ -11,23 +10,12 @@ import (
 )
 
 func StartPool(ctx context.Context, td time.Duration) {
-	// To start pool, we will have 2 go routines running.
-	// Go Routine #1 - running with the Ticker.
-	// Go Routine #2 - running with a blocking channel such that we can act on signals (like pool size has exceeded flush threshold)
-
-	var wg sync.WaitGroup
 	log := logger.FromContext(ctx)
-	wg.Add(1)
-	go func() {
-		log.Info("Starting pool timer...")
-		defer wg.Done()
-		ticker := time.NewTicker(td)
-		for range ticker.C {
-			log.WithError(consumer.Flush(consumer.Args{
-				Context: ctx,
-			})).Info("Flushing via pool...")
-		}
-	}()
-
-	// TODO - we're not doing anything with the wait?
+	log.Info("Starting pool timer...")
+	ticker := time.NewTicker(td)
+	for range ticker.C {
+		log.WithError(consumer.Flush(consumer.Args{
+			Context: ctx,
+		})).Info("Flushing via pool...")
+	}
 }


### PR DESCRIPTION
# Problem

Right now, an edge case may arise with column dropping:

* t = 0, whole batch has only deletes and Artie does not see any columns apart from the primary key(s). Artie then will add these columns to a map, `colsToDelete` which the key is `colName` and value is `permissionToDropTime` (NOW + 4h)
* t = 4, whole batch is deletes again and Artie then proceeds to drop the column.


This is pretty unlikely due to the fact that the whole time between t0 and t4 must be only deletes. However, it's still possible.
The fix here is to avoid dropping altogether if the whole batch is filled with DELETES.

## Checks

- [x] Tests
- [x] Tests against edge case
- [x] Manual checks against Snowflake
- [x] Manual checks against Redshift
- [x] Manual checks against BigQuery