### PR TITLE
BigQuery DSN to specify location

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -85,7 +85,6 @@ func LoadBigQuery(ctx context.Context, _store *db.Store) *Store {
 	}
 
 	settings := config.FromContext(ctx)
-
 	if credPath := settings.Config.BigQuery.PathToCredentials; credPath != "" {
 		// If the credPath is set, let's set it into the env var.
 		logger.FromContext(ctx).Debug("writing the path to BQ credentials to env var for google auth")
@@ -96,8 +95,7 @@ func LoadBigQuery(ctx context.Context, _store *db.Store) *Store {
 	}
 
 	return &Store{
-		Store: db.Open(ctx, "bigquery", fmt.Sprintf("bigquery://%s/%s",
-			settings.Config.BigQuery.ProjectID, settings.Config.BigQuery.DefaultDataset)),
+		Store:     db.Open(ctx, "bigquery", settings.Config.BigQuery.DSN()),
 		configMap: &types.DwhToTablesConfigMap{},
 	}
 }

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -54,6 +54,19 @@ type BigQuery struct {
 	PathToCredentials string `yaml:"pathToCredentials"`
 	DefaultDataset    string `yaml:"defaultDataset"`
 	ProjectID         string `yaml:"projectID"`
+	Location          string `yaml:"location"`
+}
+
+// DSN - returns the notation for BigQuery following this format: bigquery://projectID/[location/]datasetID?queryString
+// If location is passed in, we'll specify it. Else, it'll default to empty and our library will set it to US.
+func (b *BigQuery) DSN() string {
+	dsn := fmt.Sprintf("bigquery://%s/%s", b.ProjectID, b.DefaultDataset)
+
+	if b.Location != "" {
+		dsn = fmt.Sprintf("bigquery://%s/%s/%s", b.ProjectID, b.Location, b.DefaultDataset)
+	}
+
+	return dsn
 }
 
 type Redshift struct {

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -27,6 +27,17 @@ kafka:
 `
 )
 
+func TestBigQuery_DSN(t *testing.T) {
+	b := BigQuery{
+		DefaultDataset: "dataset",
+		ProjectID:      "project",
+	}
+
+	assert.Equal(t, "bigquery://project/dataset", b.DSN())
+	b.Location = "eu"
+	assert.Equal(t, "bigquery://project/eu/dataset", b.DSN())
+}
+
 func TestKafka_String(t *testing.T) {
 	k := Kafka{
 		BootstrapServer: "server",


### PR DESCRIPTION
If we don't allow location to be specified, it will default to the US, as per our library: https://github.com/viant/bigquery/blob/8f5b6fd4770f9a2206f1096bf4db9d1a28f8e2f0/dsn.go#L155-L157

This PR adds the ability to specify an optional location.