### PR TITLE
Add the ability to include __artie_updated_at

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -113,7 +113,8 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in BigQuery
-	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(), tableData.TopicConfig.SoftDelete)
+	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(),
+		tableConfig.Columns(), tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,
 		Tc:          tableConfig,

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -32,7 +32,8 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	log := logger.FromContext(ctx)
 	fqName := tableData.ToFqName(ctx, s.Label())
 	// Check if all the columns exist in Redshift
-	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(), tableData.TopicConfig.SoftDelete)
+	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
+		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,
 		Tc:          tableConfig,

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -121,7 +121,8 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(), tableData.TopicConfig.SoftDelete)
+	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
+		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,
 		Tc:          tableConfig,

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -117,6 +117,7 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 		// the PK. We can explore simplifying this interface in the future by leveraging before.
 		retMap = map[string]interface{}{
 			constants.DeleteColumnMarker: true,
+			constants.UpdateColumnMarker: time.Now().UTC(),
 		}
 
 		for k, v := range pkMap {
@@ -136,6 +137,7 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 		}
 
 		retMap[constants.DeleteColumnMarker] = false
+		retMap[constants.UpdateColumnMarker] = time.Now().UTC()
 	}
 
 	return retMap

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/ext"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -120,7 +122,7 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 		}
 
 		if tc.IncludeArtieUpdatedAt {
-			retMap[constants.UpdateColumnMarker] = time.Now().UTC()
+			retMap[constants.UpdateColumnMarker] = ext.NewUTCTime(ext.ISO8601)
 		}
 
 		for k, v := range pkMap {
@@ -141,7 +143,7 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 
 		retMap[constants.DeleteColumnMarker] = false
 		if tc.IncludeArtieUpdatedAt {
-			retMap[constants.UpdateColumnMarker] = time.Now().UTC()
+			retMap[constants.UpdateColumnMarker] = ext.NewUTCTime(ext.ISO8601)
 		}
 	}
 

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -117,7 +117,10 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 		// the PK. We can explore simplifying this interface in the future by leveraging before.
 		retMap = map[string]interface{}{
 			constants.DeleteColumnMarker: true,
-			constants.UpdateColumnMarker: time.Now().UTC(),
+		}
+
+		if tc.IncludeArtieUpdatedAt {
+			retMap[constants.UpdateColumnMarker] = time.Now().UTC()
 		}
 
 		for k, v := range pkMap {
@@ -137,7 +140,9 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 		}
 
 		retMap[constants.DeleteColumnMarker] = false
-		retMap[constants.UpdateColumnMarker] = time.Now().UTC()
+		if tc.IncludeArtieUpdatedAt {
+			retMap[constants.UpdateColumnMarker] = time.Now().UTC()
+		}
 	}
 
 	return retMap

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -96,6 +96,7 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 		// the PK. We can explore simplifying this interface in the future by leveraging before.
 		retMap = map[string]interface{}{
 			constants.DeleteColumnMarker: true,
+			constants.UpdateColumnMarker: time.Now().UTC(),
 		}
 
 		for k, v := range pkMap {
@@ -109,6 +110,7 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 	} else {
 		retMap = s.Payload.After
 		retMap[constants.DeleteColumnMarker] = false
+		retMap[constants.UpdateColumnMarker] = time.Now().UTC()
 	}
 
 	// Iterate over the schema and identify if there are any fields that require extra care.

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -96,7 +96,10 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 		// the PK. We can explore simplifying this interface in the future by leveraging before.
 		retMap = map[string]interface{}{
 			constants.DeleteColumnMarker: true,
-			constants.UpdateColumnMarker: time.Now().UTC(),
+		}
+
+		if tc.IncludeArtieUpdatedAt {
+			retMap[constants.UpdateColumnMarker] = time.Now().UTC()
 		}
 
 		for k, v := range pkMap {
@@ -110,7 +113,9 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 	} else {
 		retMap = s.Payload.After
 		retMap[constants.DeleteColumnMarker] = false
-		retMap[constants.UpdateColumnMarker] = time.Now().UTC()
+		if tc.IncludeArtieUpdatedAt {
+			retMap[constants.UpdateColumnMarker] = time.Now().UTC()
+		}
 	}
 
 	// Iterate over the schema and identify if there are any fields that require extra care.

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing/ext"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/cdc"
@@ -99,7 +101,7 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 		}
 
 		if tc.IncludeArtieUpdatedAt {
-			retMap[constants.UpdateColumnMarker] = time.Now().UTC()
+			retMap[constants.UpdateColumnMarker] = ext.NewUTCTime(ext.ISO8601)
 		}
 
 		for k, v := range pkMap {
@@ -114,7 +116,7 @@ func (s *SchemaEventPayload) GetData(ctx context.Context, pkMap map[string]inter
 		retMap = s.Payload.After
 		retMap[constants.DeleteColumnMarker] = false
 		if tc.IncludeArtieUpdatedAt {
-			retMap[constants.UpdateColumnMarker] = time.Now().UTC()
+			retMap[constants.UpdateColumnMarker] = ext.NewUTCTime(ext.ISO8601)
 		}
 	}
 

--- a/lib/cdc/util/relational_event_decimal_test.go
+++ b/lib/cdc/util/relational_event_decimal_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/kafkalib"
+
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 
 	"github.com/artie-labs/transfer/lib/config"
@@ -25,7 +27,7 @@ func TestSchemaEventPayload_MiscNumbers_GetData(t *testing.T) {
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
 
-	retMap := schemaEventPayload.GetData(context.Background(), nil, nil)
+	retMap := schemaEventPayload.GetData(context.Background(), nil, &kafkalib.TopicConfig{})
 	assert.Equal(t, retMap["smallint_test"], 1)
 	assert.Equal(t, retMap["smallserial_test"], 2)
 	assert.Equal(t, retMap["int_test"], 3)
@@ -44,7 +46,7 @@ func TestSchemaEventPayload_Numeric_GetData(t *testing.T) {
 	var schemaEventPayload SchemaEventPayload
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
-	retMap := schemaEventPayload.GetData(context.Background(), nil, nil)
+	retMap := schemaEventPayload.GetData(context.Background(), nil, &kafkalib.TopicConfig{})
 
 	assert.Equal(t, "123456.789", retMap["numeric_test"].(*decimal.Decimal).Value())
 	assert.Equal(t, 0, big.NewFloat(1234).Cmp(retMap["numeric_5"].(*decimal.Decimal).Value().(*big.Float)))
@@ -78,7 +80,7 @@ func TestSchemaEventPayload_Decimal_GetData(t *testing.T) {
 	var schemaEventPayload SchemaEventPayload
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
-	retMap := schemaEventPayload.GetData(ctx, nil, nil)
+	retMap := schemaEventPayload.GetData(ctx, nil, &kafkalib.TopicConfig{})
 	assert.Equal(t, "123.45", retMap["decimal_test"].(*decimal.Decimal).Value())
 	decimalWithScaleMap := map[string]string{
 		"decimal_test_5":   "123",
@@ -109,7 +111,7 @@ func TestSchemaEventPayload_Money_GetData(t *testing.T) {
 	var schemaEventPayload SchemaEventPayload
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
-	retMap := schemaEventPayload.GetData(ctx, nil, nil)
+	retMap := schemaEventPayload.GetData(ctx, nil, &kafkalib.TopicConfig{})
 
 	decimalWithScaleMap := map[string]string{
 		"money_test": "123456.78",

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -16,6 +16,8 @@ const (
 	DeleteColumnMarker        = ArtiePrefix + "_delete"
 	DeletionConfidencePadding = 4 * time.Hour
 
+	UpdateColumnMarker = ArtiePrefix + "_updated_at"
+
 	// DBZPostgresFormat is the only supported CDC format right now
 	DBZPostgresFormat    = "debezium.postgres"
 	DBZPostgresAltFormat = "debezium.postgres.wal2json"

--- a/lib/dwh/ddl/ddl_alter_delete_test.go
+++ b/lib/dwh/ddl/ddl_alter_delete_test.go
@@ -256,7 +256,6 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	assert.Equal(d.T(), originalColumnLength, len(snowflakeTc.ReadOnlyColumnsToDelete()), snowflakeTc.ReadOnlyColumnsToDelete())
 
 	for _, column := range cols.GetColumns() {
-		fmt.Println("snowflake?")
 		alterTableArgs := ddl.AlterTableArgs{
 			Dwh:                    d.snowflakeStagesStore,
 			Tc:                     snowflakeTc,
@@ -271,7 +270,6 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 		assert.NoError(d.T(), err)
 
 		// BigQuery
-		fmt.Println("bigquery?")
 		alterTableArgs = ddl.AlterTableArgs{
 			Dwh:                    d.bigQueryStore,
 			Tc:                     bqTc,

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -1,7 +1,6 @@
 package dml
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -32,6 +31,8 @@ type MergeArgument struct {
 	// 1) Using as part of the MergeStatementIndividual
 	Redshift   bool
 	SoftDelete bool
+
+	IncludeArtieUpdatedCol bool
 }
 
 func MergeStatementParts(m MergeArgument) ([]string, error) {
@@ -58,7 +59,6 @@ func MergeStatementParts(m MergeArgument) ([]string, error) {
 		equalitySQLParts = append(equalitySQLParts, equalitySQL)
 	}
 
-	// TODO solve for idempotency
 	if m.SoftDelete {
 		return []string{
 			// INSERT
@@ -85,18 +85,18 @@ func MergeStatementParts(m MergeArgument) ([]string, error) {
 		}, nil
 	}
 
-	// We also need to remove __artie flags since it does not exist in the destination table
-	var removed bool
-	for idx, col := range m.Columns {
-		if col == constants.DeleteColumnMarker {
-			m.Columns = append(m.Columns[:idx], m.Columns[idx+1:]...)
-			removed = true
-			break
-		}
+	colsToStrip := []string{constants.DeleteColumnMarker}
+	if !m.IncludeArtieUpdatedCol {
+		colsToStrip = append(colsToStrip, constants.UpdateColumnMarker)
 	}
 
-	if !removed {
-		return nil, errors.New("artie delete flag doesn't exist")
+	for _, colToStrip := range colsToStrip {
+		// We also need to remove __artie flags since it does not exist in the destination table
+		if !array.StringContains(m.Columns, colToStrip) {
+			return nil, fmt.Errorf("artie %s doesn't exist", colToStrip)
+		}
+
+		m.Columns = array.RemoveElement(m.Columns, colToStrip)
 	}
 
 	var pks []string
@@ -203,18 +203,18 @@ func MergeStatement(m MergeArgument) (string, error) {
 			})), nil
 	}
 
-	// We also need to remove __artie flags since it does not exist in the destination table
-	var removed bool
-	for idx, col := range m.Columns {
-		if col == constants.DeleteColumnMarker {
-			m.Columns = append(m.Columns[:idx], m.Columns[idx+1:]...)
-			removed = true
-			break
-		}
+	colsToStrip := []string{constants.DeleteColumnMarker}
+	if !m.IncludeArtieUpdatedCol {
+		colsToStrip = append(colsToStrip, constants.UpdateColumnMarker)
 	}
 
-	if !removed {
-		return "", errors.New("artie delete flag doesn't exist")
+	for _, colToStrip := range colsToStrip {
+		// We also need to remove __artie flags since it does not exist in the destination table
+		if !array.StringContains(m.Columns, colToStrip) {
+			return "", fmt.Errorf("artie %s doesn't exist", colToStrip)
+		}
+
+		m.Columns = array.RemoveElement(m.Columns, colToStrip)
 	}
 
 	return fmt.Sprintf(`

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -31,15 +31,16 @@ func GetUniqueDatabaseAndSchema(tcs []*TopicConfig) []DatabaseSchemaPair {
 }
 
 type TopicConfig struct {
-	Database           string `yaml:"db"`
-	TableName          string `yaml:"tableName"`
-	Schema             string `yaml:"schema"`
-	Topic              string `yaml:"topic"`
-	IdempotentKey      string `yaml:"idempotentKey"`
-	CDCFormat          string `yaml:"cdcFormat"`
-	CDCKeyFormat       string `yaml:"cdcKeyFormat"`
-	DropDeletedColumns bool   `yaml:"dropDeletedColumns"`
-	SoftDelete         bool   `yaml:"softDelete"`
+	Database              string `yaml:"db"`
+	TableName             string `yaml:"tableName"`
+	Schema                string `yaml:"schema"`
+	Topic                 string `yaml:"topic"`
+	IdempotentKey         string `yaml:"idempotentKey"`
+	CDCFormat             string `yaml:"cdcFormat"`
+	CDCKeyFormat          string `yaml:"cdcKeyFormat"`
+	DropDeletedColumns    bool   `yaml:"dropDeletedColumns"`
+	SoftDelete            bool   `yaml:"softDelete"`
+	IncludeArtieUpdatedAt bool   `yaml:"includeArtieUpdatedAt"`
 }
 
 const (

--- a/lib/typing/columns/diff.go
+++ b/lib/typing/columns/diff.go
@@ -7,9 +7,14 @@ import (
 )
 
 // shouldSkipColumn takes the `colName` and `softDelete` and will return whether we should skip this column when calculating the diff.
-func shouldSkipColumn(colName string, softDelete bool) bool {
+func shouldSkipColumn(colName string, softDelete bool, includeArtieUpdatedAt bool) bool {
 	if colName == constants.DeleteColumnMarker && softDelete {
 		// We need this column to be created if soft deletion is turned on.
+		return false
+	}
+
+	if colName == constants.UpdateColumnMarker && includeArtieUpdatedAt {
+		// We want to keep this column if includeArtieUpdatedAt is turned on
 		return false
 	}
 
@@ -22,7 +27,7 @@ func shouldSkipColumn(colName string, softDelete bool) bool {
 
 // Diff - when given 2 maps, a source and target
 // It will provide a diff in the form of 2 variables
-func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bool) ([]Column, []Column) {
+func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bool, includeArtieUpdatedAt bool) ([]Column, []Column) {
 	src := CloneColumns(columnsInSource)
 	targ := CloneColumns(columnsInDestination)
 	var colsToDelete []Column
@@ -42,7 +47,7 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 
 	var targetColumnsMissing Columns
 	for _, col := range src.GetColumns() {
-		if shouldSkipColumn(col.Name(nil), softDelete) {
+		if shouldSkipColumn(col.Name(nil), softDelete, includeArtieUpdatedAt) {
 			continue
 		}
 
@@ -51,7 +56,7 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 
 	var sourceColumnsMissing Columns
 	for _, col := range targ.GetColumns() {
-		if shouldSkipColumn(col.Name(nil), softDelete) {
+		if shouldSkipColumn(col.Name(nil), softDelete, includeArtieUpdatedAt) {
 			continue
 		}
 

--- a/lib/typing/columns/diff_test.go
+++ b/lib/typing/columns/diff_test.go
@@ -1,33 +1,61 @@
 package columns
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
 
 	"github.com/artie-labs/transfer/lib/typing"
 
-	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestShouldSkipColumn(t *testing.T) {
-	// TODO - fill this out.
-	colsToExpectation := map[string]bool{
-		"id":                         false,
-		"21331":                      false,
-		constants.DeleteColumnMarker: true,
-		fmt.Sprintf("%s_hellooooooo", constants.ArtiePrefix): true,
+	type _testCase struct {
+		name                  string
+		colName               string
+		softDelete            bool
+		includeArtieUpdatedAt bool
+		expectedResult        bool
 	}
 
-	for col, expected := range colsToExpectation {
-		assert.Equal(t, shouldSkipColumn(col, false, false), expected)
+	testCases := []_testCase{
+		{
+			name:       "delete col marker + soft delete",
+			colName:    constants.DeleteColumnMarker,
+			softDelete: true,
+		},
+		{
+			name:           "delete col marker",
+			colName:        constants.DeleteColumnMarker,
+			expectedResult: true,
+		},
+		{
+			name:                  "updated col marker + include updated",
+			colName:               constants.UpdateColumnMarker,
+			includeArtieUpdatedAt: true,
+		},
+		{
+			name:           "updated col marker",
+			colName:        constants.UpdateColumnMarker,
+			expectedResult: true,
+		},
+		{
+			name:    "random col",
+			colName: "firstName",
+		},
+		{
+			name:                  "col with includeArtieUpdatedAt + softDelete",
+			colName:               "email",
+			includeArtieUpdatedAt: true,
+			softDelete:            true,
+		},
 	}
 
-	// When toggling soft deletion on, this column should not be skipped.
-	colsToExpectation[constants.DeleteColumnMarker] = false
-	for col, expected := range colsToExpectation {
-		assert.Equal(t, shouldSkipColumn(col, true, false), expected)
+	for _, testCase := range testCases {
+		actualResult := shouldSkipColumn(testCase.colName, testCase.softDelete, testCase.includeArtieUpdatedAt)
+		assert.Equal(t, testCase.expectedResult, actualResult, testCase.name)
 	}
 }
 

--- a/lib/typing/columns/diff_test.go
+++ b/lib/typing/columns/diff_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestShouldSkipColumn(t *testing.T) {
+	// TODO - fill this out.
 	colsToExpectation := map[string]bool{
 		"id":                         false,
 		"21331":                      false,
@@ -20,13 +21,13 @@ func TestShouldSkipColumn(t *testing.T) {
 	}
 
 	for col, expected := range colsToExpectation {
-		assert.Equal(t, shouldSkipColumn(col, false), expected)
+		assert.Equal(t, shouldSkipColumn(col, false, false), expected)
 	}
 
 	// When toggling soft deletion on, this column should not be skipped.
 	colsToExpectation[constants.DeleteColumnMarker] = false
 	for col, expected := range colsToExpectation {
-		assert.Equal(t, shouldSkipColumn(col, true), expected)
+		assert.Equal(t, shouldSkipColumn(col, true, false), expected)
 	}
 }
 
@@ -82,7 +83,7 @@ func TestDiff_VariousNils(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualSrcKeysMissing, actualTargKeysMissing := Diff(testCase.sourceCols, testCase.targCols, false)
+		actualSrcKeysMissing, actualTargKeysMissing := Diff(testCase.sourceCols, testCase.targCols, false, false)
 		assert.Equal(t, testCase.expectedSrcKeyLength, len(actualSrcKeysMissing), testCase.name)
 		assert.Equal(t, testCase.expectedTargKeyLength, len(actualTargKeysMissing), testCase.name)
 	}
@@ -92,7 +93,7 @@ func TestDiffBasic(t *testing.T) {
 	var source Columns
 	source.AddColumn(NewColumn("a", typing.Integer))
 
-	srcKeyMissing, targKeyMissing := Diff(&source, &source, false)
+	srcKeyMissing, targKeyMissing := Diff(&source, &source, false, false)
 	assert.Equal(t, len(srcKeyMissing), 0)
 	assert.Equal(t, len(targKeyMissing), 0)
 }
@@ -116,7 +117,7 @@ func TestDiffDelta1(t *testing.T) {
 		targCols.AddColumn(NewColumn(colName, kindDetails))
 	}
 
-	srcKeyMissing, targKeyMissing := Diff(&sourceCols, &targCols, false)
+	srcKeyMissing, targKeyMissing := Diff(&sourceCols, &targCols, false, false)
 	assert.Equal(t, len(srcKeyMissing), 2, srcKeyMissing)   // Missing aa, cc
 	assert.Equal(t, len(targKeyMissing), 2, targKeyMissing) // Missing aa, cc
 }
@@ -148,7 +149,7 @@ func TestDiffDelta2(t *testing.T) {
 		targetCols.AddColumn(NewColumn(colName, kindDetails))
 	}
 
-	srcKeyMissing, targKeyMissing := Diff(&sourceCols, &targetCols, false)
+	srcKeyMissing, targKeyMissing := Diff(&sourceCols, &targetCols, false, false)
 	assert.Equal(t, len(srcKeyMissing), 1, srcKeyMissing)   // Missing dd
 	assert.Equal(t, len(targKeyMissing), 3, targKeyMissing) // Missing a, c, d
 }
@@ -163,7 +164,7 @@ func TestDiffDeterministic(t *testing.T) {
 	sourceCols.AddColumn(NewColumn("name", typing.String))
 
 	for i := 0; i < 500; i++ {
-		keysMissing, targetKeysMissing := Diff(&sourceCols, &targCols, false)
+		keysMissing, targetKeysMissing := Diff(&sourceCols, &targCols, false, false)
 		assert.Equal(t, 0, len(keysMissing), keysMissing)
 
 		var key string

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -35,3 +35,7 @@ var supportedTimeFormats = []string{
 	PostgresTimeFormatNoTZ,
 	AdditionalTimeFormat,
 }
+
+func NewUTCTime(layout string) string {
+	return time.Now().UTC().Format(layout)
+}


### PR DESCRIPTION
# Problem

Right now, there is not a canonical way to know when this row was transferred to your destination unless you have a particular ts field. 

Having a consistent timestamp field may be useful if you are setting up `dbt` incremental digest or wanting to query the destination and see Artie's progress (on top of using our telemetry package).

In this PR, we are adding the ability to include `__artie_updated_at` to your destination tables by having this as a configuration option within `tableData`.

## Checks
- [x] Test opting in
- [x] Test opting out
- [ ] Docs

## Result in Snowflake
<img width="1229" alt="image" src="https://github.com/artie-labs/transfer/assets/4412200/b5658b9a-5894-4d1b-aaa0-011f2dd6ca85">
