### PR TITLE
We need to lowercase when adding columns in our Debezium envelope

### DIFF
--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -3,6 +3,7 @@ package mongo
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
@@ -102,9 +103,11 @@ func (s *SchemaEventPayload) GetColumns(ctx context.Context) *columns.Columns {
 
 	var cols columns.Columns
 	for _, field := range fieldsObject.Fields {
+		// TODO: lower-case and uppercase should be handled with more robust care. It's too fragile at the moment.
+
 		// We are purposefully doing this to ensure that the correct typing is set
 		// When we invoke event.Save()
-		cols.AddColumn(columns.NewColumn(field.FieldName, typing.Invalid))
+		cols.AddColumn(columns.NewColumn(strings.ToLower(field.FieldName), typing.Invalid))
 	}
 
 	return &cols

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
@@ -45,9 +46,11 @@ func (s *SchemaEventPayload) GetColumns(ctx context.Context) *columns.Columns {
 
 	var cols columns.Columns
 	for _, field := range fieldsObject.Fields {
+		// TODO: lower-case and uppercase should be handled with more robust care. It's too fragile at the moment.
+
 		// We are purposefully doing this to ensure that the correct typing is set
 		// When we invoke event.Save()
-		col := columns.NewColumn(field.FieldName, typing.Invalid)
+		col := columns.NewColumn(strings.ToLower(field.FieldName), typing.Invalid)
 		col.SetDefaultValue(parseField(ctx, field, field.Default))
 		cols.AddColumn(col)
 	}


### PR DESCRIPTION
We are lowercasing and sanitizing the output here: https://github.com/artie-labs/transfer/blob/35fe6193f81bb664d7920da5204786c835b5664d/models/event/event.go#L144-L154

We needed to do the same when we got a field from Debezium's envelope.

What ended up happening is that we ended up adding more columns. As a result, when the `diff` ran, it ran against 2 (one was added by this codepath, the other by `event.go` Save)

As a result, we kept 2 `createdAt` columns and caused column duplication error.