### PR TITLE
Supporting tables named after keywords

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -36,7 +36,7 @@ func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.Tabl
 		Dwh:                s,
 		FqName:             tableData.ToFqName(ctx, constants.BigQuery),
 		ConfigMap:          s.configMap,
-		Query:              fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';", tableData.TopicConfig.Database, tableData.Name()),
+		Query:              fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';", tableData.TopicConfig.Database, tableData.Name(nil)),
 		ColumnNameLabel:    describeNameCol,
 		ColumnTypeLabel:    describeTypeCol,
 		ColumnDescLabel:    describeCommentCol,

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -34,7 +34,7 @@ type Store struct {
 func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.TableData) (*types.DwhTableConfig, error) {
 	return utils.GetTableConfig(ctx, utils.GetTableCfgArgs{
 		Dwh:                s,
-		FqName:             tableData.ToFqName(ctx, constants.BigQuery),
+		FqName:             tableData.ToFqName(ctx, constants.BigQuery, true),
 		ConfigMap:          s.configMap,
 		Query:              fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';", tableData.TopicConfig.Database, tableData.Name(nil)),
 		ColumnNameLabel:    describeNameCol,

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -33,10 +33,11 @@ type Store struct {
 
 func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.TableData) (*types.DwhTableConfig, error) {
 	return utils.GetTableConfig(ctx, utils.GetTableCfgArgs{
-		Dwh:                s,
-		FqName:             tableData.ToFqName(ctx, constants.BigQuery, true),
-		ConfigMap:          s.configMap,
-		Query:              fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';", tableData.TopicConfig.Database, tableData.Name(nil)),
+		Dwh:       s,
+		FqName:    tableData.ToFqName(ctx, constants.BigQuery, true),
+		ConfigMap: s.configMap,
+		Query: fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';",
+			tableData.TopicConfig.Database, tableData.Name(ctx, nil)),
 		ColumnNameLabel:    describeNameCol,
 		ColumnTypeLabel:    describeTypeCol,
 		ColumnDescLabel:    describeCommentCol,

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -35,7 +35,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	log := logger.FromContext(ctx)
-	fqName := tableData.ToFqName(ctx, s.Label())
+	fqName := tableData.ToFqName(ctx, s.Label(), true)
 	// Check if all the columns exist in Redshift
 	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
 		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt)
@@ -94,7 +94,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	tableData.UpdateInMemoryColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 
 	// Temporary tables cannot specify schemas, so we just prefix it instead.
-	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label()), tableData.TempTableSuffix())
+	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false), tableData.TempTableSuffix())
 	if err = s.prepareTempTable(ctx, tableData, tableConfig, temporaryTableName); err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 			continue
 		}
 
-		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label()))
+		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true))
 		if err != nil {
 			defaultVal, _ := col.DefaultValue(nil)
 			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v",

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/artie-labs/transfer/lib/sql"
+
 	"github.com/artie-labs/transfer/clients/utils"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/dwh/ddl"
@@ -21,7 +23,10 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	tableConfig, err := s.getTableConfig(ctx, getTableConfigArgs{
-		Table:              tableData.Name(),
+		Table: tableData.Name(&sql.NameArgs{
+			Escape:   true,
+			DestKind: s.Label(),
+		}),
 		Schema:             tableData.TopicConfig.Schema,
 		DropDeletedColumns: tableData.TopicConfig.DropDeletedColumns,
 	})
@@ -117,7 +122,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		FqTableName:   fqName,
 		SubQuery:      temporaryTableName,
 		IdempotentKey: tableData.TopicConfig.IdempotentKey,
-		PrimaryKeys: tableData.PrimaryKeys(&columns.NameArgs{
+		PrimaryKeys: tableData.PrimaryKeys(&sql.NameArgs{
 			Escape:   true,
 			DestKind: s.Label(),
 		}),

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -38,7 +38,7 @@ func (s *Store) prepareTempTable(ctx context.Context, tableData *optimization.Ta
 		return fmt.Errorf("failed to add comment to table, tableName: %v, err: %v", tempTableName, err)
 	}
 
-	fp, err := s.loadTemporaryTable(tableData, tempTableName)
+	fp, err := s.loadTemporaryTable(ctx, tableData, tempTableName)
 	if err != nil {
 		return fmt.Errorf("failed to load temporary table, err: %v", err)
 	}
@@ -72,7 +72,7 @@ func (s *Store) prepareTempTable(ctx context.Context, tableData *optimization.Ta
 // loadTemporaryTable will write the data into /tmp/newTableName.csv
 // This way, another function can call this and then invoke a Snowflake PUT.
 // Returns the file path and potential error
-func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableName string) (string, error) {
+func (s *Store) loadTemporaryTable(ctx context.Context, tableData *optimization.TableData, newTableName string) (string, error) {
 	filePath := fmt.Sprintf("/tmp/%s.csv", newTableName)
 	file, err := os.Create(filePath)
 	if err != nil {
@@ -84,7 +84,7 @@ func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableNa
 	writer.Comma = '\t'
 	for _, value := range tableData.RowsData() {
 		var row []string
-		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(nil) {
+		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(ctx, nil) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal := value[col]
 			// Check

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -36,12 +36,12 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 	nameCol := columns.NewColumn("name", typing.String)
 	tc := s.stageStore.configMap.TableConfig(fqName)
 
-	val := tc.ShouldDeleteColumn(s.ctx, nameCol.Name(nil), time.Now().Add(-1*6*time.Hour), true)
+	val := tc.ShouldDeleteColumn(s.ctx, nameCol.Name(s.ctx, nil), time.Now().Add(-1*6*time.Hour), true)
 	assert.False(s.T(), val, "should not try to delete this column")
 	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(fqName).ReadOnlyColumnsToDelete()), 1)
 
 	// Now let's try to add this column back, it should delete it from the cache.
-	tc.MutateInMemoryColumns(false, constants.Add, nameCol)
+	tc.MutateInMemoryColumns(s.ctx, false, constants.Add, nameCol)
 	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(fqName).ReadOnlyColumnsToDelete()), 0)
 }
 
@@ -63,23 +63,23 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 
 	nameCol := columns.NewColumn("name", typing.String)
 	// Let's try to delete name.
-	allowed := s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(nil),
+	allowed := s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(s.ctx, nil),
 		time.Now().Add(-1*(6*time.Hour)), true)
 
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete")
 
 	// Process tried to delete, but it's lagged.
-	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(nil),
+	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(s.ctx, nil),
 		time.Now().Add(-1*(6*time.Hour)), true)
 
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete")
 
 	// Process now caught up, and is asking if we can delete, should still be no.
-	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(nil), time.Now(), true)
+	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(s.ctx, nil), time.Now(), true)
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete still")
 
 	// Process is finally ahead, has permission to delete now.
-	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(nil),
+	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(s.ctx, nil),
 		time.Now().Add(2*constants.DeletionConfidencePadding), true)
 
 	assert.Equal(s.T(), allowed, true, "should now be allowed to delete")

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -47,7 +47,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	}
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
-	assert.Equal(s.T(), topicConfig.TableName, tableData.Name(), "override is working")
+	assert.Equal(s.T(), topicConfig.TableName, tableData.Name(nil), "override is working")
 
 	for pk, row := range rowsData {
 		tableData.InsertRow(pk, row, false)

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -64,7 +64,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		anotherCols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake),
+	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true),
 		types.NewDwhTableConfig(&anotherCols, nil, false, true))
 
 	err := s.stageStore.Merge(s.ctx, tableData)
@@ -109,7 +109,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		tableData.InsertRow(pk, row, false)
 	}
 
-	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake),
+	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true),
 		types.NewDwhTableConfig(&cols, nil, false, true))
 
 	s.fakeStageStore.ExecReturnsOnCall(0, nil, fmt.Errorf("390114: Authentication token has expired. The user must authenticate again."))
@@ -161,7 +161,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 
 	var idx int
 	for _, destKind := range []constants.DestinationKind{constants.Snowflake, constants.SnowflakeStages} {
-		fqName := tableData.ToFqName(s.ctx, destKind)
+		fqName := tableData.ToFqName(s.ctx, destKind, true)
 		s.stageStore.configMap.AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, true))
 		err := s.stageStore.Merge(s.ctx, tableData)
 		assert.Nil(s.T(), err)
@@ -244,7 +244,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 	sflkCols.AddColumn(columns.NewColumn("new", typing.String))
 	config := types.NewDwhTableConfig(&sflkCols, nil, false, true)
-	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake), config)
+	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true), config)
 
 	err := s.stageStore.Merge(s.ctx, tableData)
 	assert.Nil(s.T(), err)
@@ -252,10 +252,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	assert.Equal(s.T(), s.fakeStageStore.ExecCallCount(), 5, "called merge")
 
 	// Check the temp deletion table now.
-	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake)).ReadOnlyColumnsToDelete()), 1,
-		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake)).ReadOnlyColumnsToDelete())
+	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true)).ReadOnlyColumnsToDelete()), 1,
+		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true)).ReadOnlyColumnsToDelete())
 
-	_, isOk := s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake)).ReadOnlyColumnsToDelete()["new"]
+	_, isOk := s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true)).ReadOnlyColumnsToDelete()["new"]
 	assert.True(s.T(), isOk)
 
 	// Now try to execute merge where 1 of the rows have the column now
@@ -276,8 +276,8 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	assert.Equal(s.T(), s.fakeStageStore.ExecCallCount(), 10, "called merge again")
 
 	// Caught up now, so columns should be 0.
-	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake)).ReadOnlyColumnsToDelete()), 0,
-		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake)).ReadOnlyColumnsToDelete())
+	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true)).ReadOnlyColumnsToDelete()), 0,
+		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true)).ReadOnlyColumnsToDelete())
 }
 
 func (s *SnowflakeTestSuite) TestExecuteMergeExitEarly() {

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -47,7 +47,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	}
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
-	assert.Equal(s.T(), topicConfig.TableName, tableData.Name(nil), "override is working")
+	assert.Equal(s.T(), topicConfig.TableName, tableData.Name(s.ctx, nil), "override is working")
 
 	for pk, row := range rowsData {
 		tableData.InsertRow(pk, row, false)

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -115,7 +115,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		return nil
 	}
 
-	fqName := tableData.ToFqName(ctx, constants.Snowflake)
+	fqName := tableData.ToFqName(ctx, constants.Snowflake, true)
 	tableConfig, err := s.getTableConfig(ctx, fqName, tableData.TopicConfig.DropDeletedColumns)
 	if err != nil {
 		return err
@@ -178,7 +178,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	}
 
 	tableData.UpdateInMemoryColumnsFromDestination(tableConfig.Columns().GetColumns()...)
-	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label()), tableData.TempTableSuffix())
+	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false), tableData.TempTableSuffix())
 	if err = s.prepareTempTable(ctx, tableData, tableConfig, temporaryTableName); err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 			continue
 		}
 
-		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label()))
+		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true))
 		if err != nil {
 			defaultVal, _ := col.DefaultValue(nil)
 			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v",
@@ -203,7 +203,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 
 	// Prepare merge statement
 	mergeQuery, err := dml.MergeStatement(&dml.MergeArgument{
-		FqTableName:   tableData.ToFqName(ctx, constants.Snowflake),
+		FqTableName:   tableData.ToFqName(ctx, constants.Snowflake, true),
 		SubQuery:      temporaryTableName,
 		IdempotentKey: tableData.TopicConfig.IdempotentKey,
 		PrimaryKeys: tableData.PrimaryKeys(&sql.NameArgs{

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/sql"
+
 	"github.com/artie-labs/transfer/clients/utils"
 
 	"github.com/artie-labs/transfer/lib/ptr"
@@ -52,7 +54,7 @@ func (s *Store) prepareTempTable(ctx context.Context, tableData *optimization.Ta
 
 	_, err = s.Exec(fmt.Sprintf("COPY INTO %s (%s) FROM (SELECT %s FROM @%s)",
 		// Copy into temporary tables (column ...)
-		tempTableName, strings.Join(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(&columns.NameArgs{
+		tempTableName, strings.Join(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(&sql.NameArgs{
 			Escape:   true,
 			DestKind: s.Label(),
 		}), ","),
@@ -204,7 +206,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		FqTableName:   tableData.ToFqName(ctx, constants.Snowflake),
 		SubQuery:      temporaryTableName,
 		IdempotentKey: tableData.TopicConfig.IdempotentKey,
-		PrimaryKeys: tableData.PrimaryKeys(&columns.NameArgs{
+		PrimaryKeys: tableData.PrimaryKeys(&sql.NameArgs{
 			Escape:   true,
 			DestKind: s.Label(),
 		}),

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -126,7 +126,7 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 
 func (s *SnowflakeTestSuite) TestLoadTemporaryTable() {
 	tempTableName, tableData := generateTableData(100)
-	fp, err := s.stageStore.loadTemporaryTable(tableData, tempTableName)
+	fp, err := s.stageStore.loadTemporaryTable(s.ctx, tableData, tempTableName)
 	assert.NoError(s.T(), err)
 	// Read the CSV and confirm.
 	csvfile, err := os.Open(fp)

--- a/clients/snowflake/util.go
+++ b/clients/snowflake/util.go
@@ -1,6 +1,7 @@
 package snowflake
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -24,9 +25,9 @@ func addPrefixToTableName(fqTableName string, prefix string) string {
 
 // escapeColumns will take the columns that are passed in, escape them and return them in the ordered received.
 // It'll return like this: $1, $2, $3
-func escapeColumns(columns *columns.Columns, delimiter string) string {
+func escapeColumns(ctx context.Context, columns *columns.Columns, delimiter string) string {
 	var escapedCols []string
-	for index, col := range columns.GetColumnsToUpdate(nil) {
+	for index, col := range columns.GetColumnsToUpdate(ctx, nil) {
 		colKind, _ := columns.GetColumn(col)
 		escapedCol := fmt.Sprintf("$%d", index+1)
 		switch colKind.KindDetails {

--- a/clients/snowflake/util_test.go
+++ b/clients/snowflake/util_test.go
@@ -46,7 +46,7 @@ func TestAddPrefixToTableName(t *testing.T) {
 	}
 }
 
-func TestEscapeColumns(t *testing.T) {
+func (s *SnowflakeTestSuite) TestEscapeColumns() {
 	type _testCase struct {
 		name           string
 		cols           *columns.Columns
@@ -87,7 +87,7 @@ func TestEscapeColumns(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualString := escapeColumns(testCase.cols, ",")
-		assert.Equal(t, testCase.expectedString, actualString, testCase.name)
+		actualString := escapeColumns(s.ctx, testCase.cols, ",")
+		assert.Equal(s.T(), testCase.expectedString, actualString, testCase.name)
 	}
 }

--- a/clients/utils/table_config.go
+++ b/clients/utils/table_config.go
@@ -64,7 +64,7 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 				tableMissing = true
 				err = nil
 			} else {
-				return nil, fmt.Errorf("failed to query %v, err: %v", args.Dwh.Label(), err)
+				return nil, fmt.Errorf("failed to query %v, err: %v, query: %v", args.Dwh.Label(), err, args.Query)
 			}
 		default:
 			return nil, fmt.Errorf("failed to query %v, err: %v", args.Dwh.Label(), err)

--- a/clients/utils/utils.go
+++ b/clients/utils/utils.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/sql"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 
 	"github.com/artie-labs/transfer/lib/dwh"
@@ -31,7 +33,7 @@ func BackfillColumn(ctx context.Context, dwh dwh.DataWarehouse, column columns.C
 		return fmt.Errorf("failed to escape default value, err: %v", err)
 	}
 
-	escapedCol := column.Name(&columns.NameArgs{Escape: true, DestKind: dwh.Label()})
+	escapedCol := column.Name(&sql.NameArgs{Escape: true, DestKind: dwh.Label()})
 	query := fmt.Sprintf(`UPDATE %s SET %s = %v WHERE %s IS NULL;`,
 		// UPDATE table SET col = default_val WHERE col IS NULL
 		fqTableName, escapedCol, defaultVal, escapedCol,

--- a/clients/utils/utils.go
+++ b/clients/utils/utils.go
@@ -33,13 +33,13 @@ func BackfillColumn(ctx context.Context, dwh dwh.DataWarehouse, column columns.C
 		return fmt.Errorf("failed to escape default value, err: %v", err)
 	}
 
-	escapedCol := column.Name(&sql.NameArgs{Escape: true, DestKind: dwh.Label()})
+	escapedCol := column.Name(ctx, &sql.NameArgs{Escape: true, DestKind: dwh.Label()})
 	query := fmt.Sprintf(`UPDATE %s SET %s = %v WHERE %s IS NULL;`,
 		// UPDATE table SET col = default_val WHERE col IS NULL
 		fqTableName, escapedCol, defaultVal, escapedCol,
 	)
 	logger.FromContext(ctx).WithFields(map[string]interface{}{
-		"colName": column.Name(nil),
+		"colName": column.Name(ctx, nil),
 		"query":   query,
 		"table":   fqTableName,
 	}).Info("backfilling column")

--- a/lib/cdc/mysql/debezium_test.go
+++ b/lib/cdc/mysql/debezium_test.go
@@ -319,7 +319,7 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 
 	col, isOk := cols.GetColumn("abcdef")
 	assert.True(m.T(), isOk)
-	assert.Equal(m.T(), "abcdef", col.Name(nil))
+	assert.Equal(m.T(), "abcdef", col.Name(m.ctx, nil))
 	for key := range evtData {
 		if strings.Contains(key, constants.ArtiePrefix) {
 			continue
@@ -327,6 +327,6 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 
 		col, isOk := cols.GetColumn(strings.ToLower(key))
 		assert.Equal(m.T(), true, isOk, key)
-		assert.Equal(m.T(), typing.Invalid, col.KindDetails, fmt.Sprintf("colName: %v, evtData key: %v", col.Name(nil), key))
+		assert.Equal(m.T(), typing.Invalid, col.KindDetails, fmt.Sprintf("colName: %v, evtData key: %v", col.Name(m.ctx, nil), key))
 	}
 }

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSource_GetOptionalSchema(t *testing.T) {
+func (u *UtilTestSuite) TestSource_GetOptionalSchema() {
 	ctx := context.Background()
 	var schemaEventPayload SchemaEventPayload
 	err := json.Unmarshal([]byte(`{
@@ -56,34 +56,34 @@ func TestSource_GetOptionalSchema(t *testing.T) {
 	"payload": {}
 }`), &schemaEventPayload)
 
-	assert.NoError(t, err)
+	assert.NoError(u.T(), err)
 	optionalSchema := schemaEventPayload.GetOptionalSchema(ctx)
 	value, isOk := optionalSchema["last_modified"]
-	assert.True(t, isOk)
-	assert.Equal(t, value, typing.String)
+	assert.True(u.T(), isOk)
+	assert.Equal(u.T(), value, typing.String)
 
 	cols := schemaEventPayload.GetColumns(ctx)
-	assert.Equal(t, 6, len(cols.GetColumns()))
+	assert.Equal(u.T(), 6, len(cols.GetColumns()))
 
 	col, isOk := cols.GetColumn("boolean_column")
-	assert.True(t, isOk)
+	assert.True(u.T(), isOk)
 
 	defaultVal, err := col.DefaultValue(nil)
-	assert.NoError(t, err)
-	assert.Equal(t, false, defaultVal)
+	assert.NoError(u.T(), err)
+	assert.Equal(u.T(), false, defaultVal)
 
 	for _, _col := range cols.GetColumns() {
 		// All the other columns do not have a default value.
-		if _col.Name(nil) != "boolean_column" {
+		if _col.Name(u.ctx, nil) != "boolean_column" {
 			defaultVal, err = _col.DefaultValue(nil)
-			assert.NoError(t, err)
-			assert.Nil(t, defaultVal, _col.Name(nil))
+			assert.NoError(u.T(), err)
+			assert.Nil(u.T(), defaultVal, _col.Name(u.ctx, nil))
 		}
 	}
 
 	// OptionalColumn does not pick up custom data types.
 	_, isOk = optionalSchema["zoned_timestamp_column"]
-	assert.False(t, isOk)
+	assert.False(u.T(), isOk)
 }
 
 func TestSource_GetExecutionTime(t *testing.T) {

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -81,6 +81,10 @@ type Redshift struct {
 	CredentialsClause string `yaml:"credentialsClause"`
 }
 
+type SharedDestinationConfig struct {
+	UppercaseEscapedNames bool `yaml:"uppercaseEscapedNames"`
+}
+
 type Snowflake struct {
 	AccountID string `yaml:"account"`
 	Username  string `yaml:"username"`
@@ -127,6 +131,9 @@ type Config struct {
 	// Supported message queues
 	Pubsub *Pubsub
 	Kafka  *Kafka
+
+	// Shared destination configuration
+	SharedDestinationConfig SharedDestinationConfig `yaml:"sharedDestinationConfig"`
 
 	// Supported destinations
 	BigQuery  *BigQuery  `yaml:"bigquery"`

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/sql"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -90,12 +92,12 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 		mutateCol = append(mutateCol, col)
 		switch args.ColumnOp {
 		case constants.Add:
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name(&columns.NameArgs{
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name(&sql.NameArgs{
 				Escape:   true,
 				DestKind: args.Dwh.Label(),
 			}), typing.KindToDWHType(col.KindDetails, args.Dwh.Label())))
 		case constants.Delete:
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name(&columns.NameArgs{
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name(&sql.NameArgs{
 				Escape:   true,
 				DestKind: args.Dwh.Label(),
 			})))

--- a/lib/dwh/ddl/ddl.go
+++ b/lib/dwh/ddl/ddl.go
@@ -84,7 +84,7 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 		}
 
 		if args.ColumnOp == constants.Delete {
-			if !args.Tc.ShouldDeleteColumn(ctx, col.Name(nil), args.CdcTime, args.ContainOtherOperations) {
+			if !args.Tc.ShouldDeleteColumn(ctx, col.Name(ctx, nil), args.CdcTime, args.ContainOtherOperations) {
 				continue
 			}
 		}
@@ -92,12 +92,12 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 		mutateCol = append(mutateCol, col)
 		switch args.ColumnOp {
 		case constants.Add:
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name(&sql.NameArgs{
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, col.Name(ctx, &sql.NameArgs{
 				Escape:   true,
 				DestKind: args.Dwh.Label(),
 			}), typing.KindToDWHType(col.KindDetails, args.Dwh.Label())))
 		case constants.Delete:
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name(&sql.NameArgs{
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s`, col.Name(ctx, &sql.NameArgs{
 				Escape:   true,
 				DestKind: args.Dwh.Label(),
 			})))
@@ -154,7 +154,7 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 
 	if err == nil {
 		// createTable = false since it all successfully updated.
-		args.Tc.MutateInMemoryColumns(false, args.ColumnOp, mutateCol...)
+		args.Tc.MutateInMemoryColumns(ctx, false, args.ColumnOp, mutateCol...)
 	}
 
 	return nil

--- a/lib/dwh/ddl/ddl_alter_delete_test.go
+++ b/lib/dwh/ddl/ddl_alter_delete_test.go
@@ -29,9 +29,9 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	}, "tableName")
 
 	originalColumnLength := len(cols.GetColumns())
-	bqName := td.ToFqName(d.bqCtx, constants.BigQuery)
-	redshiftName := td.ToFqName(d.ctx, constants.Redshift)
-	snowflakeName := td.ToFqName(d.ctx, constants.Snowflake)
+	bqName := td.ToFqName(d.bqCtx, constants.BigQuery, true)
+	redshiftName := td.ToFqName(d.ctx, constants.Redshift, true)
+	snowflakeName := td.ToFqName(d.ctx, constants.Snowflake, true)
 
 	// Testing 3 scenarios here
 	// 1. DropDeletedColumns = false, ContainOtherOperations = true, don't delete ever.

--- a/lib/dwh/ddl/ddl_bq_test.go
+++ b/lib/dwh/ddl/ddl_bq_test.go
@@ -85,7 +85,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", fqName, column.Name(&artieSQL.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", fqName, column.Name(d.ctx, &artieSQL.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		})), query)
@@ -145,7 +145,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, col)
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, col.Name(&artieSQL.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, col.Name(d.ctx, &artieSQL.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		}),
@@ -157,10 +157,10 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 	assert.Equal(d.T(), newColsLen+existingColsLen, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns())
 	// Check by iterating over the columns
 	for _, column := range d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns() {
-		existingCol, isOk := existingCols.GetColumn(column.Name(nil))
+		existingCol, isOk := existingCols.GetColumn(column.Name(d.ctx, nil))
 		if !isOk {
 			// Check new cols?
-			existingCol.KindDetails, isOk = newCols[column.Name(nil)]
+			existingCol.KindDetails, isOk = newCols[column.Name(d.ctx, nil)]
 		}
 
 		assert.True(d.T(), isOk)
@@ -205,7 +205,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(&artieSQL.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(d.ctx, &artieSQL.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		}),
@@ -217,7 +217,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 	assert.Equal(d.T(), existingColsLen, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns())
 	// Check by iterating over the columns
 	for _, column := range d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns() {
-		existingCol, isOk := existingCols.GetColumn(column.Name(nil))
+		existingCol, isOk := existingCols.GetColumn(column.Name(d.ctx, nil))
 		assert.True(d.T(), isOk)
 		assert.Equal(d.T(), column.KindDetails, existingCol.KindDetails)
 	}

--- a/lib/dwh/ddl/ddl_bq_test.go
+++ b/lib/dwh/ddl/ddl_bq_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	artieSQL "github.com/artie-labs/transfer/lib/sql"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/stretchr/testify/assert"
@@ -84,7 +86,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", fqName, column.Name(&columns.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", fqName, column.Name(&artieSQL.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		})), query)
@@ -144,7 +146,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, col)
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, col.Name(&columns.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, col.Name(&artieSQL.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		}),
@@ -204,7 +206,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(&columns.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(&artieSQL.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		}),

--- a/lib/dwh/ddl/ddl_bq_test.go
+++ b/lib/dwh/ddl/ddl_bq_test.go
@@ -42,8 +42,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	fqName := td.ToFqName(d.bqCtx, constants.BigQuery)
-
+	fqName := td.ToFqName(d.bqCtx, constants.BigQuery, true)
 	originalColumnLength := len(cols.GetColumns())
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, true))
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)
@@ -243,8 +242,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	fqName := td.ToFqName(d.bqCtx, constants.BigQuery)
-
+	fqName := td.ToFqName(d.bqCtx, constants.BigQuery, true)
 	originalColumnLength := len(columnNameToKindDetailsMap)
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, false))
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)

--- a/lib/dwh/ddl/ddl_sflk_test.go
+++ b/lib/dwh/ddl/ddl_sflk_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/sql"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +42,7 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 
 	for i := 0; i < len(cols); i++ {
 		execQuery, _ := d.fakeSnowflakeStagesStore.ExecArgsForCall(i)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s add COLUMN %s %s", fqTable, cols[i].Name(&columns.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s add COLUMN %s %s", fqTable, cols[i].Name(&sql.NameArgs{
 			Escape:   true,
 			DestKind: d.snowflakeStagesStore.Label(),
 		}),
@@ -173,7 +175,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 		assert.Equal(d.T(), i+1, d.fakeSnowflakeStagesStore.ExecCallCount(), "tried to delete one column")
 
 		execArg, _ := d.fakeSnowflakeStagesStore.ExecArgsForCall(i)
-		assert.Equal(d.T(), execArg, fmt.Sprintf("ALTER TABLE %s %s COLUMN %s", fqTable, constants.Delete, cols[i].Name(&columns.NameArgs{
+		assert.Equal(d.T(), execArg, fmt.Sprintf("ALTER TABLE %s %s COLUMN %s", fqTable, constants.Delete, cols[i].Name(&sql.NameArgs{
 			Escape:   true,
 			DestKind: d.snowflakeStagesStore.Label(),
 		})))

--- a/lib/dwh/ddl/ddl_sflk_test.go
+++ b/lib/dwh/ddl/ddl_sflk_test.go
@@ -42,7 +42,7 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 
 	for i := 0; i < len(cols); i++ {
 		execQuery, _ := d.fakeSnowflakeStagesStore.ExecArgsForCall(i)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s add COLUMN %s %s", fqTable, cols[i].Name(&sql.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s add COLUMN %s %s", fqTable, cols[i].Name(d.ctx, &sql.NameArgs{
 			Escape:   true,
 			DestKind: d.snowflakeStagesStore.Label(),
 		}),
@@ -112,15 +112,15 @@ func (d *DDLTestSuite) TestAlterTableAdd() {
 	for _, column := range tableConfig.Columns().GetColumns() {
 		var found bool
 		for _, expCol := range cols {
-			if found = column.Name(nil) == expCol.Name(nil); found {
-				assert.Equal(d.T(), column.KindDetails, expCol.KindDetails, fmt.Sprintf("wrong col kind, col: %s", column.Name(nil)))
+			if found = column.Name(d.ctx, nil) == expCol.Name(d.ctx, nil); found {
+				assert.Equal(d.T(), column.KindDetails, expCol.KindDetails, fmt.Sprintf("wrong col kind, col: %s", column.Name(d.ctx, nil)))
 				break
 			}
 		}
 
 		assert.True(d.T(), found,
 			fmt.Sprintf("Col not found: %s, actual list: %v, expected list: %v",
-				column.Name(nil), tableConfig.Columns(), cols))
+				column.Name(d.ctx, nil), tableConfig.Columns(), cols))
 	}
 }
 
@@ -153,7 +153,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	for col := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, expCol := range cols {
-			if found = col == expCol.Name(nil); found {
+			if found = col == expCol.Name(d.ctx, nil); found {
 				break
 			}
 		}
@@ -164,7 +164,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	}
 
 	for i := 0; i < len(cols); i++ {
-		colToActuallyDelete := cols[i].Name(nil)
+		colToActuallyDelete := cols[i].Name(d.ctx, nil)
 		// Now let's check the timestamp
 		assert.True(d.T(), tableConfig.ReadOnlyColumnsToDelete()[colToActuallyDelete].After(time.Now()))
 		// Now let's actually try to dial the time back, and it should actually try to delete.
@@ -175,10 +175,11 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 		assert.Equal(d.T(), i+1, d.fakeSnowflakeStagesStore.ExecCallCount(), "tried to delete one column")
 
 		execArg, _ := d.fakeSnowflakeStagesStore.ExecArgsForCall(i)
-		assert.Equal(d.T(), execArg, fmt.Sprintf("ALTER TABLE %s %s COLUMN %s", fqTable, constants.Delete, cols[i].Name(&sql.NameArgs{
-			Escape:   true,
-			DestKind: d.snowflakeStagesStore.Label(),
-		})))
+		assert.Equal(d.T(), execArg, fmt.Sprintf("ALTER TABLE %s %s COLUMN %s", fqTable, constants.Delete, cols[i].Name(d.ctx,
+			&sql.NameArgs{
+				Escape:   true,
+				DestKind: d.snowflakeStagesStore.Label(),
+			})))
 	}
 }
 
@@ -219,7 +220,7 @@ func (d *DDLTestSuite) TestAlterTableDelete() {
 	for col := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, expCol := range cols {
-			if found = col == expCol.Name(nil); found {
+			if found = col == expCol.Name(d.ctx, nil); found {
 				break
 			}
 		}

--- a/lib/dwh/ddl/ddl_suite_test.go
+++ b/lib/dwh/ddl/ddl_suite_test.go
@@ -33,6 +33,7 @@ type DDLTestSuite struct {
 func (d *DDLTestSuite) SetupTest() {
 	ctx := config.InjectSettingsIntoContext(context.Background(), &config.Settings{
 		VerboseLogging: true,
+		Config:         &config.Config{},
 	})
 
 	bqCtx := config.InjectSettingsIntoContext(context.Background(), &config.Settings{

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/sql"
+
 	"github.com/artie-labs/transfer/lib/stringutil"
 
 	"github.com/artie-labs/transfer/lib/typing/columns"
@@ -84,7 +86,7 @@ func MergeStatementParts(m *MergeArgument) ([]string, error) {
 		equalitySQLParts = append(equalitySQLParts, equalitySQL)
 	}
 
-	cols := m.ColumnsToTypes.GetColumnsToUpdate(&columns.NameArgs{
+	cols := m.ColumnsToTypes.GetColumnsToUpdate(&sql.NameArgs{
 		Escape:   true,
 		DestKind: m.DestKind,
 	})
@@ -209,7 +211,7 @@ func MergeStatement(m *MergeArgument) (string, error) {
 		subQuery = m.SubQuery
 	}
 
-	cols := m.ColumnsToTypes.GetColumnsToUpdate(&columns.NameArgs{
+	cols := m.ColumnsToTypes.GetColumnsToUpdate(&sql.NameArgs{
 		Escape:   true,
 		DestKind: m.DestKind,
 	})

--- a/lib/dwh/dml/merge_bigquery_test.go
+++ b/lib/dwh/dml/merge_bigquery_test.go
@@ -1,18 +1,13 @@
 package dml
 
 import (
-	"testing"
-
-	"github.com/artie-labs/transfer/lib/typing/columns"
-
 	"github.com/artie-labs/transfer/lib/config/constants"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestMergeStatement_TempTable(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatement_TempTable() {
 	var cols columns.Columns
 	cols.AddColumn(columns.NewColumn("order_id", typing.Integer))
 	cols.AddColumn(columns.NewColumn("name", typing.String))
@@ -21,19 +16,19 @@ func TestMergeStatement_TempTable(t *testing.T) {
 	mergeArg := &MergeArgument{
 		FqTableName:    "customers.orders",
 		SubQuery:       "customers.orders_tmp",
-		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(columns.NewColumn("order_id", typing.Invalid), nil)},
+		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(m.ctx, columns.NewColumn("order_id", typing.Invalid), nil)},
 		ColumnsToTypes: cols,
 		DestKind:       constants.BigQuery,
 		SoftDelete:     false,
 	}
 
-	mergeSQL, err := MergeStatement(mergeArg)
-	assert.NoError(t, err)
+	mergeSQL, err := MergeStatement(m.ctx, mergeArg)
+	assert.NoError(m.T(), err)
 
-	assert.Contains(t, mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp as cc on c.order_id = cc.order_id", mergeSQL)
+	assert.Contains(m.T(), mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp as cc on c.order_id = cc.order_id", mergeSQL)
 }
 
-func TestMergeStatement_JSONKey(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatement_JSONKey() {
 	var cols columns.Columns
 	cols.AddColumn(columns.NewColumn("order_oid", typing.Struct))
 	cols.AddColumn(columns.NewColumn("name", typing.String))
@@ -42,13 +37,13 @@ func TestMergeStatement_JSONKey(t *testing.T) {
 	mergeArg := &MergeArgument{
 		FqTableName:    "customers.orders",
 		SubQuery:       "customers.orders_tmp",
-		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(columns.NewColumn("order_oid", typing.Invalid), nil)},
+		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(m.ctx, columns.NewColumn("order_oid", typing.Invalid), nil)},
 		ColumnsToTypes: cols,
 		DestKind:       constants.BigQuery,
 		SoftDelete:     false,
 	}
 
-	mergeSQL, err := MergeStatement(mergeArg)
-	assert.NoError(t, err)
-	assert.Contains(t, mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp as cc on TO_JSON_STRING(c.order_oid) = TO_JSON_STRING(cc.order_oid)", mergeSQL)
+	mergeSQL, err := MergeStatement(m.ctx, mergeArg)
+	assert.NoError(m.T(), err)
+	assert.Contains(m.T(), mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp as cc on TO_JSON_STRING(c.order_oid) = TO_JSON_STRING(cc.order_oid)", mergeSQL)
 }

--- a/lib/dwh/dml/merge_parts_test.go
+++ b/lib/dwh/dml/merge_parts_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/sql"
 
 	"github.com/artie-labs/transfer/lib/typing"
 
@@ -47,13 +48,13 @@ func getBasicColumnsForTest(compositeKey bool) result {
 	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
 	var pks []columns.Wrapper
-	pks = append(pks, columns.NewWrapper(idCol, &columns.NameArgs{
+	pks = append(pks, columns.NewWrapper(idCol, &sql.NameArgs{
 		Escape:   true,
 		DestKind: constants.Redshift,
 	}))
 
 	if compositeKey {
-		pks = append(pks, columns.NewWrapper(emailCol, &columns.NameArgs{
+		pks = append(pks, columns.NewWrapper(emailCol, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Redshift,
 		}))

--- a/lib/dwh/dml/merge_parts_test.go
+++ b/lib/dwh/dml/merge_parts_test.go
@@ -1,7 +1,7 @@
 package dml
 
 import (
-	"testing"
+	"context"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/sql"
@@ -12,15 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMergeStatementPartsValidation(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatementPartsValidation() {
 	for _, arg := range []*MergeArgument{
 		{DestKind: constants.Snowflake},
 		{DestKind: constants.SnowflakeStages},
 		{DestKind: constants.BigQuery},
 	} {
-		parts, err := MergeStatementParts(arg)
-		assert.Error(t, err)
-		assert.Nil(t, parts)
+		parts, err := MergeStatementParts(m.ctx, arg)
+		assert.Error(m.T(), err)
+		assert.Nil(m.T(), parts)
 	}
 }
 
@@ -32,7 +32,7 @@ type result struct {
 // getBasicColumnsForTest - will return you all the columns within `result` that are needed for tests.
 // * In here, we'll return if compositeKey=false - id (pk), email, first_name, last_name, created_at, toast_text (TOAST-able)
 // * Else if compositeKey=true - id(pk), email (pk), first_name, last_name, created_at, toast_text (TOAST-able)
-func getBasicColumnsForTest(compositeKey bool) result {
+func getBasicColumnsForTest(ctx context.Context, compositeKey bool) result {
 	idCol := columns.NewColumn("id", typing.Float)
 	emailCol := columns.NewColumn("email", typing.String)
 	textToastCol := columns.NewColumn("toast_text", typing.String)
@@ -48,13 +48,13 @@ func getBasicColumnsForTest(compositeKey bool) result {
 	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
 	var pks []columns.Wrapper
-	pks = append(pks, columns.NewWrapper(idCol, &sql.NameArgs{
+	pks = append(pks, columns.NewWrapper(ctx, idCol, &sql.NameArgs{
 		Escape:   true,
 		DestKind: constants.Redshift,
 	}))
 
 	if compositeKey {
-		pks = append(pks, columns.NewWrapper(emailCol, &sql.NameArgs{
+		pks = append(pks, columns.NewWrapper(ctx, emailCol, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Redshift,
 		}))
@@ -66,11 +66,11 @@ func getBasicColumnsForTest(compositeKey bool) result {
 	}
 }
 
-func TestMergeStatementPartsSoftDelete(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatementPartsSoftDelete() {
 	fqTableName := "public.tableName"
 	tempTableName := "public.tableName__temp"
-	res := getBasicColumnsForTest(false)
-	m := &MergeArgument{
+	res := getBasicColumnsForTest(m.ctx, false)
+	mergeArg := &MergeArgument{
 		FqTableName:    fqTableName,
 		SubQuery:       tempTableName,
 		PrimaryKeys:    res.PrimaryKeys,
@@ -78,35 +78,34 @@ func TestMergeStatementPartsSoftDelete(t *testing.T) {
 		DestKind:       constants.Redshift,
 		SoftDelete:     true,
 	}
+	parts, err := MergeStatementParts(m.ctx, mergeArg)
+	assert.NoError(m.T(), err)
+	assert.Equal(m.T(), 2, len(parts))
 
-	parts, err := MergeStatementParts(m)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(parts))
-
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`INSERT INTO public.tableName (id,email,first_name,last_name,created_at,toast_text,__artie_delete) SELECT cc.id,cc.email,cc.first_name,cc.last_name,cc.created_at,cc.toast_text,cc.__artie_delete FROM public.tableName__temp as cc LEFT JOIN public.tableName as c on c.id = cc.id WHERE c.id IS NULL;`,
 		parts[0])
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`UPDATE public.tableName as c SET id=cc.id,email=cc.email,first_name=cc.first_name,last_name=cc.last_name,created_at=cc.created_at,toast_text= CASE WHEN cc.toast_text != '__debezium_unavailable_value' THEN cc.toast_text ELSE c.toast_text END,__artie_delete=cc.__artie_delete FROM public.tableName__temp as cc WHERE c.id = cc.id;`,
 		parts[1])
 
-	m.IdempotentKey = "created_at"
-	parts, err = MergeStatementParts(m)
+	mergeArg.IdempotentKey = "created_at"
+	parts, err = MergeStatementParts(m.ctx, mergeArg)
 	// Parts[0] for insertion should be identical
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`INSERT INTO public.tableName (id,email,first_name,last_name,created_at,toast_text,__artie_delete) SELECT cc.id,cc.email,cc.first_name,cc.last_name,cc.created_at,cc.toast_text,cc.__artie_delete FROM public.tableName__temp as cc LEFT JOIN public.tableName as c on c.id = cc.id WHERE c.id IS NULL;`,
 		parts[0])
 	// Parts[1] where we're doing UPDATES will have idempotency key.
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`UPDATE public.tableName as c SET id=cc.id,email=cc.email,first_name=cc.first_name,last_name=cc.last_name,created_at=cc.created_at,toast_text= CASE WHEN cc.toast_text != '__debezium_unavailable_value' THEN cc.toast_text ELSE c.toast_text END,__artie_delete=cc.__artie_delete FROM public.tableName__temp as cc WHERE c.id = cc.id AND cc.created_at >= c.created_at;`,
 		parts[1])
 }
 
-func TestMergeStatementPartsSoftDeleteComposite(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatementPartsSoftDeleteComposite() {
 	fqTableName := "public.tableName"
 	tempTableName := "public.tableName__temp"
-	res := getBasicColumnsForTest(true)
-	m := &MergeArgument{
+	res := getBasicColumnsForTest(m.ctx, true)
+	mergeArg := &MergeArgument{
 		FqTableName:    fqTableName,
 		SubQuery:       tempTableName,
 		PrimaryKeys:    res.PrimaryKeys,
@@ -115,37 +114,37 @@ func TestMergeStatementPartsSoftDeleteComposite(t *testing.T) {
 		SoftDelete:     true,
 	}
 
-	parts, err := MergeStatementParts(m)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(parts))
+	parts, err := MergeStatementParts(m.ctx, mergeArg)
+	assert.NoError(m.T(), err)
+	assert.Equal(m.T(), 2, len(parts))
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`INSERT INTO public.tableName (id,email,first_name,last_name,created_at,toast_text,__artie_delete) SELECT cc.id,cc.email,cc.first_name,cc.last_name,cc.created_at,cc.toast_text,cc.__artie_delete FROM public.tableName__temp as cc LEFT JOIN public.tableName as c on c.id = cc.id and c.email = cc.email WHERE c.id IS NULL;`,
 		parts[0])
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`UPDATE public.tableName as c SET id=cc.id,email=cc.email,first_name=cc.first_name,last_name=cc.last_name,created_at=cc.created_at,toast_text= CASE WHEN cc.toast_text != '__debezium_unavailable_value' THEN cc.toast_text ELSE c.toast_text END,__artie_delete=cc.__artie_delete FROM public.tableName__temp as cc WHERE c.id = cc.id and c.email = cc.email;`,
 		parts[1])
 
-	m.IdempotentKey = "created_at"
-	parts, err = MergeStatementParts(m)
+	mergeArg.IdempotentKey = "created_at"
+	parts, err = MergeStatementParts(m.ctx, mergeArg)
 	// Parts[0] for insertion should be identical
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`INSERT INTO public.tableName (id,email,first_name,last_name,created_at,toast_text,__artie_delete) SELECT cc.id,cc.email,cc.first_name,cc.last_name,cc.created_at,cc.toast_text,cc.__artie_delete FROM public.tableName__temp as cc LEFT JOIN public.tableName as c on c.id = cc.id and c.email = cc.email WHERE c.id IS NULL;`,
 		parts[0])
 	// Parts[1] where we're doing UPDATES will have idempotency key.
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`UPDATE public.tableName as c SET id=cc.id,email=cc.email,first_name=cc.first_name,last_name=cc.last_name,created_at=cc.created_at,toast_text= CASE WHEN cc.toast_text != '__debezium_unavailable_value' THEN cc.toast_text ELSE c.toast_text END,__artie_delete=cc.__artie_delete FROM public.tableName__temp as cc WHERE c.id = cc.id and c.email = cc.email AND cc.created_at >= c.created_at;`,
 		parts[1])
 }
 
-func TestMergeStatementParts(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatementParts() {
 	// Biggest difference with this test are:
 	// 1. We are not saving `__artie_deleted` column
 	// 2. There are 3 SQL queries (INSERT, UPDATE and DELETE)
 	fqTableName := "public.tableName"
 	tempTableName := "public.tableName__temp"
-	res := getBasicColumnsForTest(false)
-	m := &MergeArgument{
+	res := getBasicColumnsForTest(m.ctx, false)
+	mergeArg := &MergeArgument{
 		FqTableName:    fqTableName,
 		SubQuery:       tempTableName,
 		PrimaryKeys:    res.PrimaryKeys,
@@ -153,23 +152,23 @@ func TestMergeStatementParts(t *testing.T) {
 		DestKind:       constants.Redshift,
 	}
 
-	parts, err := MergeStatementParts(m)
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(parts))
+	parts, err := MergeStatementParts(m.ctx, mergeArg)
+	assert.NoError(m.T(), err)
+	assert.Equal(m.T(), 3, len(parts))
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`INSERT INTO public.tableName (id,email,first_name,last_name,created_at,toast_text) SELECT cc.id,cc.email,cc.first_name,cc.last_name,cc.created_at,cc.toast_text FROM public.tableName__temp as cc LEFT JOIN public.tableName as c on c.id = cc.id WHERE c.id IS NULL;`,
 		parts[0])
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`UPDATE public.tableName as c SET id=cc.id,email=cc.email,first_name=cc.first_name,last_name=cc.last_name,created_at=cc.created_at,toast_text= CASE WHEN cc.toast_text != '__debezium_unavailable_value' THEN cc.toast_text ELSE c.toast_text END FROM public.tableName__temp as cc WHERE c.id = cc.id AND COALESCE(cc.__artie_delete, false) = false;`,
 		parts[1])
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`DELETE FROM public.tableName WHERE (id) IN (SELECT cc.id FROM public.tableName__temp as cc WHERE cc.__artie_delete = true);`,
 		parts[2])
 
-	m = &MergeArgument{
+	mergeArg = &MergeArgument{
 		FqTableName:    fqTableName,
 		SubQuery:       tempTableName,
 		PrimaryKeys:    res.PrimaryKeys,
@@ -178,28 +177,28 @@ func TestMergeStatementParts(t *testing.T) {
 		IdempotentKey:  "created_at",
 	}
 
-	parts, err = MergeStatementParts(m)
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(parts))
+	parts, err = MergeStatementParts(m.ctx, mergeArg)
+	assert.NoError(m.T(), err)
+	assert.Equal(m.T(), 3, len(parts))
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`INSERT INTO public.tableName (id,email,first_name,last_name,created_at,toast_text) SELECT cc.id,cc.email,cc.first_name,cc.last_name,cc.created_at,cc.toast_text FROM public.tableName__temp as cc LEFT JOIN public.tableName as c on c.id = cc.id WHERE c.id IS NULL;`,
 		parts[0])
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`UPDATE public.tableName as c SET id=cc.id,email=cc.email,first_name=cc.first_name,last_name=cc.last_name,created_at=cc.created_at,toast_text= CASE WHEN cc.toast_text != '__debezium_unavailable_value' THEN cc.toast_text ELSE c.toast_text END FROM public.tableName__temp as cc WHERE c.id = cc.id AND cc.created_at >= c.created_at AND COALESCE(cc.__artie_delete, false) = false;`,
 		parts[1])
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`DELETE FROM public.tableName WHERE (id) IN (SELECT cc.id FROM public.tableName__temp as cc WHERE cc.__artie_delete = true);`,
 		parts[2])
 }
 
-func TestMergeStatementPartsCompositeKey(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatementPartsCompositeKey() {
 	fqTableName := "public.tableName"
 	tempTableName := "public.tableName__temp"
-	res := getBasicColumnsForTest(true)
-	m := &MergeArgument{
+	res := getBasicColumnsForTest(m.ctx, true)
+	mergeArg := &MergeArgument{
 		FqTableName:    fqTableName,
 		SubQuery:       tempTableName,
 		PrimaryKeys:    res.PrimaryKeys,
@@ -207,23 +206,23 @@ func TestMergeStatementPartsCompositeKey(t *testing.T) {
 		DestKind:       constants.Redshift,
 	}
 
-	parts, err := MergeStatementParts(m)
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(parts))
+	parts, err := MergeStatementParts(m.ctx, mergeArg)
+	assert.NoError(m.T(), err)
+	assert.Equal(m.T(), 3, len(parts))
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`INSERT INTO public.tableName (id,email,first_name,last_name,created_at,toast_text) SELECT cc.id,cc.email,cc.first_name,cc.last_name,cc.created_at,cc.toast_text FROM public.tableName__temp as cc LEFT JOIN public.tableName as c on c.id = cc.id and c.email = cc.email WHERE c.id IS NULL;`,
 		parts[0])
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`UPDATE public.tableName as c SET id=cc.id,email=cc.email,first_name=cc.first_name,last_name=cc.last_name,created_at=cc.created_at,toast_text= CASE WHEN cc.toast_text != '__debezium_unavailable_value' THEN cc.toast_text ELSE c.toast_text END FROM public.tableName__temp as cc WHERE c.id = cc.id and c.email = cc.email AND COALESCE(cc.__artie_delete, false) = false;`,
 		parts[1])
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`DELETE FROM public.tableName WHERE (id,email) IN (SELECT cc.id,cc.email FROM public.tableName__temp as cc WHERE cc.__artie_delete = true);`,
 		parts[2])
 
-	m = &MergeArgument{
+	mergeArg = &MergeArgument{
 		FqTableName:    fqTableName,
 		SubQuery:       tempTableName,
 		PrimaryKeys:    res.PrimaryKeys,
@@ -232,19 +231,19 @@ func TestMergeStatementPartsCompositeKey(t *testing.T) {
 		IdempotentKey:  "created_at",
 	}
 
-	parts, err = MergeStatementParts(m)
-	assert.NoError(t, err)
-	assert.Equal(t, 3, len(parts))
+	parts, err = MergeStatementParts(m.ctx, mergeArg)
+	assert.NoError(m.T(), err)
+	assert.Equal(m.T(), 3, len(parts))
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`INSERT INTO public.tableName (id,email,first_name,last_name,created_at,toast_text) SELECT cc.id,cc.email,cc.first_name,cc.last_name,cc.created_at,cc.toast_text FROM public.tableName__temp as cc LEFT JOIN public.tableName as c on c.id = cc.id and c.email = cc.email WHERE c.id IS NULL;`,
 		parts[0])
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`UPDATE public.tableName as c SET id=cc.id,email=cc.email,first_name=cc.first_name,last_name=cc.last_name,created_at=cc.created_at,toast_text= CASE WHEN cc.toast_text != '__debezium_unavailable_value' THEN cc.toast_text ELSE c.toast_text END FROM public.tableName__temp as cc WHERE c.id = cc.id and c.email = cc.email AND cc.created_at >= c.created_at AND COALESCE(cc.__artie_delete, false) = false;`,
 		parts[1])
 
-	assert.Equal(t,
+	assert.Equal(m.T(),
 		`DELETE FROM public.tableName WHERE (id,email) IN (SELECT cc.id,cc.email FROM public.tableName__temp as cc WHERE cc.__artie_delete = true);`,
 		parts[2])
 }

--- a/lib/dwh/dml/merge_suite_test.go
+++ b/lib/dwh/dml/merge_suite_test.go
@@ -1,27 +1,23 @@
-package mysql
+package dml
 
 import (
 	"context"
 	"testing"
 
 	"github.com/artie-labs/transfer/lib/config"
-
 	"github.com/stretchr/testify/suite"
 )
 
-type MySQLTestSuite struct {
+type MergeTestSuite struct {
 	suite.Suite
-	*Debezium
 	ctx context.Context
 }
 
-func (m *MySQLTestSuite) SetupTest() {
-	var debezium Debezium
-	m.Debezium = &debezium
+func (m *MergeTestSuite) SetupTest() {
 	m.ctx = context.Background()
 	m.ctx = config.InjectSettingsIntoContext(m.ctx, &config.Settings{Config: &config.Config{}})
 }
 
-func TestPostgresTestSuite(t *testing.T) {
-	suite.Run(t, new(MySQLTestSuite))
+func TestMergeTestSuite(t *testing.T) {
+	suite.Run(t, new(MergeTestSuite))
 }

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/sql"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -217,11 +219,11 @@ func TestMergeStatementEscapePrimaryKeys(t *testing.T) {
 		SubQuery:      subQuery,
 		IdempotentKey: "",
 		PrimaryKeys: []columns.Wrapper{
-			columns.NewWrapper(columns.NewColumn("id", typing.Invalid), &columns.NameArgs{
+			columns.NewWrapper(columns.NewColumn("id", typing.Invalid), &sql.NameArgs{
 				Escape:   true,
 				DestKind: constants.Snowflake,
 			}),
-			columns.NewWrapper(columns.NewColumn("group", typing.Invalid), &columns.NameArgs{
+			columns.NewWrapper(columns.NewColumn("group", typing.Invalid), &sql.NameArgs{
 				Escape:   true,
 				DestKind: constants.Snowflake,
 			}),

--- a/lib/dwh/dml/merge_test.go
+++ b/lib/dwh/dml/merge_test.go
@@ -3,7 +3,6 @@ package dml
 import (
 	"fmt"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/sql"
@@ -15,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMergeStatementSoftDelete(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatementSoftDelete() {
 	// No idempotent key
 	fqTable := "database.schema.table"
 	cols := []string{
@@ -40,26 +39,26 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 	_cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
 	for _, idempotentKey := range []string{"", "updated_at"} {
-		mergeSQL, err := MergeStatement(&MergeArgument{
+		mergeSQL, err := MergeStatement(m.ctx, &MergeArgument{
 			FqTableName:    fqTable,
 			SubQuery:       subQuery,
 			IdempotentKey:  idempotentKey,
-			PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(columns.NewColumn("id", typing.Invalid), nil)},
+			PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(m.ctx, columns.NewColumn("id", typing.Invalid), nil)},
 			ColumnsToTypes: _cols,
 			DestKind:       constants.Snowflake,
 			SoftDelete:     true,
 		})
-		assert.NoError(t, err)
-		assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
+		assert.NoError(m.T(), err)
+		assert.True(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
 		// Soft deletion flag being passed.
-		assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("%s=cc.%s", constants.DeleteColumnMarker, constants.DeleteColumnMarker)), mergeSQL)
+		assert.True(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("%s=cc.%s", constants.DeleteColumnMarker, constants.DeleteColumnMarker)), mergeSQL)
 
-		assert.Equal(t, len(idempotentKey) > 0, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")))
+		assert.Equal(m.T(), len(idempotentKey) > 0, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")))
 	}
 
 }
 
-func TestMergeStatement(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatement() {
 	// No idempotent key
 	fqTable := "database.schema.table"
 	colToTypes := map[string]typing.KindDetails{
@@ -86,29 +85,29 @@ func TestMergeStatement(t *testing.T) {
 	// select cc.foo, cc.bar from (values (12, 34), (44, 55)) as cc(foo, bar);
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
-	mergeSQL, err := MergeStatement(&MergeArgument{
+	mergeSQL, err := MergeStatement(m.ctx, &MergeArgument{
 		FqTableName:    fqTable,
 		SubQuery:       subQuery,
 		IdempotentKey:  "",
-		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(columns.NewColumn("id", typing.Invalid), nil)},
+		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(m.ctx, columns.NewColumn("id", typing.Invalid), nil)},
 		ColumnsToTypes: _cols,
 		DestKind:       constants.Snowflake,
 		SoftDelete:     false,
 	})
-	assert.NoError(t, err)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
-	assert.False(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
+	assert.NoError(m.T(), err)
+	assert.True(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
+	assert.False(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
 	// Check primary keys clause
-	assert.True(t, strings.Contains(mergeSQL, "as cc on c.id = cc.id"), mergeSQL)
+	assert.True(m.T(), strings.Contains(mergeSQL, "as cc on c.id = cc.id"), mergeSQL)
 
 	// Check setting for update
-	assert.True(t, strings.Contains(mergeSQL, `SET id=cc.id,bar=cc.bar,updated_at=cc.updated_at,"start"=cc."start"`), mergeSQL)
+	assert.True(m.T(), strings.Contains(mergeSQL, `SET id=cc.id,bar=cc.bar,updated_at=cc.updated_at,"start"=cc."start"`), mergeSQL)
 	// Check for INSERT
-	assert.True(t, strings.Contains(mergeSQL, `id,bar,updated_at,"start"`), mergeSQL)
-	assert.True(t, strings.Contains(mergeSQL, `cc.id,cc.bar,cc.updated_at,cc."start"`), mergeSQL)
+	assert.True(m.T(), strings.Contains(mergeSQL, `id,bar,updated_at,"start"`), mergeSQL)
+	assert.True(m.T(), strings.Contains(mergeSQL, `cc.id,cc.bar,cc.updated_at,cc."start"`), mergeSQL)
 }
 
-func TestMergeStatementIdempotentKey(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatementIdempotentKey() {
 	fqTable := "database.schema.table"
 	cols := []string{
 		"id",
@@ -131,21 +130,21 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 	_cols.AddColumn(columns.NewColumn("id", typing.String))
 	_cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
-	mergeSQL, err := MergeStatement(&MergeArgument{
+	mergeSQL, err := MergeStatement(m.ctx, &MergeArgument{
 		FqTableName:    fqTable,
 		SubQuery:       subQuery,
 		IdempotentKey:  "updated_at",
-		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(columns.NewColumn("id", typing.Invalid), nil)},
+		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(m.ctx, columns.NewColumn("id", typing.Invalid), nil)},
 		ColumnsToTypes: _cols,
 		DestKind:       constants.Snowflake,
 		SoftDelete:     false,
 	})
-	assert.NoError(t, err)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
+	assert.NoError(m.T(), err)
+	assert.True(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
+	assert.True(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
 }
 
-func TestMergeStatementCompositeKey(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatementCompositeKey() {
 	fqTable := "database.schema.table"
 	cols := []string{
 		"id",
@@ -170,24 +169,23 @@ func TestMergeStatementCompositeKey(t *testing.T) {
 	_cols.AddColumn(columns.NewColumn("another_id", typing.String))
 	_cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
-	mergeSQL, err := MergeStatement(&MergeArgument{
+	mergeSQL, err := MergeStatement(m.ctx, &MergeArgument{
 		FqTableName:   fqTable,
 		SubQuery:      subQuery,
 		IdempotentKey: "updated_at",
-		PrimaryKeys: []columns.Wrapper{columns.NewWrapper(columns.NewColumn("id", typing.Invalid), nil),
-			columns.NewWrapper(columns.NewColumn("another_id", typing.Invalid), nil)},
+		PrimaryKeys: []columns.Wrapper{columns.NewWrapper(m.ctx, columns.NewColumn("id", typing.Invalid), nil),
+			columns.NewWrapper(m.ctx, columns.NewColumn("another_id", typing.Invalid), nil)},
 		ColumnsToTypes: _cols,
 		DestKind:       constants.Snowflake,
 		SoftDelete:     false,
 	})
-	assert.NoError(t, err)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
-
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("cc on c.id = cc.id and c.another_id = cc.another_id")))
+	assert.NoError(m.T(), err)
+	assert.True(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
+	assert.True(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
+	assert.True(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("cc on c.id = cc.id and c.another_id = cc.another_id")))
 }
 
-func TestMergeStatementEscapePrimaryKeys(t *testing.T) {
+func (m *MergeTestSuite) TestMergeStatementEscapePrimaryKeys() {
 	// No idempotent key
 	fqTable := "database.schema.table"
 	colToTypes := map[string]typing.KindDetails{
@@ -214,16 +212,16 @@ func TestMergeStatementEscapePrimaryKeys(t *testing.T) {
 	// select cc.foo, cc.bar from (values (12, 34), (44, 55)) as cc(foo, bar);
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
-	mergeSQL, err := MergeStatement(&MergeArgument{
+	mergeSQL, err := MergeStatement(m.ctx, &MergeArgument{
 		FqTableName:   fqTable,
 		SubQuery:      subQuery,
 		IdempotentKey: "",
 		PrimaryKeys: []columns.Wrapper{
-			columns.NewWrapper(columns.NewColumn("id", typing.Invalid), &sql.NameArgs{
+			columns.NewWrapper(m.ctx, columns.NewColumn("id", typing.Invalid), &sql.NameArgs{
 				Escape:   true,
 				DestKind: constants.Snowflake,
 			}),
-			columns.NewWrapper(columns.NewColumn("group", typing.Invalid), &sql.NameArgs{
+			columns.NewWrapper(m.ctx, columns.NewColumn("group", typing.Invalid), &sql.NameArgs{
 				Escape:   true,
 				DestKind: constants.Snowflake,
 			}),
@@ -232,15 +230,15 @@ func TestMergeStatementEscapePrimaryKeys(t *testing.T) {
 		DestKind:       constants.Snowflake,
 		SoftDelete:     false,
 	})
-	assert.NoError(t, err)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
-	assert.False(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
+	assert.NoError(m.T(), err)
+	assert.True(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
+	assert.False(m.T(), strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
 	// Check primary keys clause
-	assert.True(t, strings.Contains(mergeSQL, `as cc on c.id = cc.id and c."group" = cc."group"`), mergeSQL)
+	assert.True(m.T(), strings.Contains(mergeSQL, `as cc on c.id = cc.id and c."group" = cc."group"`), mergeSQL)
 
 	// Check setting for update
-	assert.True(t, strings.Contains(mergeSQL, `SET id=cc.id,"group"=cc."group",updated_at=cc.updated_at,"start"=cc."start"`), mergeSQL)
+	assert.True(m.T(), strings.Contains(mergeSQL, `SET id=cc.id,"group"=cc."group",updated_at=cc.updated_at,"start"=cc."start"`), mergeSQL)
 	// Check for INSERT
-	assert.True(t, strings.Contains(mergeSQL, `id,"group",updated_at,"start"`), mergeSQL)
-	assert.True(t, strings.Contains(mergeSQL, `cc.id,cc."group",cc.updated_at,cc."start"`), mergeSQL)
+	assert.True(m.T(), strings.Contains(mergeSQL, `id,"group",updated_at,"start"`), mergeSQL)
+	assert.True(m.T(), strings.Contains(mergeSQL, `cc.id,cc."group",cc.updated_at,cc."start"`), mergeSQL)
 }

--- a/lib/dwh/dml/merge_valid_test.go
+++ b/lib/dwh/dml/merge_valid_test.go
@@ -1,15 +1,13 @@
 package dml
 
 import (
-	"testing"
-
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMergeArgument_Valid(t *testing.T) {
+func (m *MergeTestSuite) TestMergeArgument_Valid() {
 	type _testCase struct {
 		name               string
 		mergeArg           *MergeArgument
@@ -18,7 +16,7 @@ func TestMergeArgument_Valid(t *testing.T) {
 	}
 
 	primaryKeys := []columns.Wrapper{
-		columns.NewWrapper(columns.NewColumn("id", typing.Integer), nil),
+		columns.NewWrapper(m.ctx, columns.NewColumn("id", typing.Integer), nil),
 	}
 
 	var cols columns.Columns
@@ -89,10 +87,10 @@ func TestMergeArgument_Valid(t *testing.T) {
 	for _, testCase := range testCases {
 		actualErr := testCase.mergeArg.Valid()
 		if testCase.expectedError {
-			assert.Error(t, actualErr, testCase.name)
-			assert.Equal(t, testCase.expectErrorMessage, actualErr.Error(), testCase.name)
+			assert.Error(m.T(), actualErr, testCase.name)
+			assert.Equal(m.T(), testCase.expectErrorMessage, actualErr.Error(), testCase.name)
 		} else {
-			assert.NoError(t, actualErr, testCase.name)
+			assert.NoError(m.T(), actualErr, testCase.name)
 		}
 	}
 }

--- a/lib/dwh/types/table_config.go
+++ b/lib/dwh/types/table_config.go
@@ -56,7 +56,7 @@ func (d *DwhTableConfig) Columns() *columns.Columns {
 	return d.columns
 }
 
-func (d *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp constants.ColumnOperation, cols ...columns.Column) {
+func (d *DwhTableConfig) MutateInMemoryColumns(ctx context.Context, createTable bool, columnOp constants.ColumnOperation, cols ...columns.Column) {
 	d.Lock()
 	defer d.Unlock()
 	switch columnOp {
@@ -64,15 +64,15 @@ func (d *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp consta
 		for _, col := range cols {
 			d.columns.AddColumn(col)
 			// Delete from the permissions table, if exists.
-			delete(d.columnsToDelete, col.Name(nil))
+			delete(d.columnsToDelete, col.Name(ctx, nil))
 		}
 
 		d.createTable = createTable
 	case constants.Delete:
 		for _, col := range cols {
 			// Delete from the permissions and in-memory table
-			d.columns.DeleteColumn(col.Name(nil))
-			delete(d.columnsToDelete, col.Name(nil))
+			d.columns.DeleteColumn(col.Name(ctx, nil))
+			delete(d.columnsToDelete, col.Name(ctx, nil))
 		}
 	}
 }

--- a/lib/dwh/types/types_suite_test.go
+++ b/lib/dwh/types/types_suite_test.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	"context"
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TypesTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (t *TypesTestSuite) SetupTest() {
+	t.ctx = context.Background()
+	t.ctx = config.InjectSettingsIntoContext(t.ctx, &config.Settings{Config: &config.Config{}})
+}
+
+func TestTypesTestSuite(t *testing.T) {
+	suite.Run(t, new(TypesTestSuite))
+}

--- a/lib/dwh/types/types_test.go
+++ b/lib/dwh/types/types_test.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/columns"
@@ -31,17 +30,17 @@ func generateDwhTableCfg() *DwhTableConfig {
 	}
 }
 
-func TestDwhToTablesConfigMap_TableConfigBasic(t *testing.T) {
+func (t *TypesTestSuite) TestDwhToTablesConfigMap_TableConfigBasic() {
 	dwh := &DwhToTablesConfigMap{}
 	dwhTableConfig := generateDwhTableCfg()
 
 	fqName := "database.schema.tableName"
 	dwh.AddTableToConfig(fqName, dwhTableConfig)
-	assert.Equal(t, *dwhTableConfig, *dwh.TableConfig(fqName))
+	assert.Equal(t.T(), *dwhTableConfig, *dwh.TableConfig(fqName))
 }
 
 // TestDwhToTablesConfigMap_Concurrency - has a bunch of concurrent go-routines that are rapidly adding and reading from the tableConfig.
-func TestDwhToTablesConfigMap_Concurrency(t *testing.T) {
+func (t *TypesTestSuite) TestDwhToTablesConfigMap_Concurrency() {
 	dwh := &DwhToTablesConfigMap{}
 	fqName := "db.schema.table"
 	dwhTableCfg := generateDwhTableCfg()
@@ -63,7 +62,7 @@ func TestDwhToTablesConfigMap_Concurrency(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < 1000; i++ {
 			time.Sleep(time.Duration(jitter.JitterMs(5, 1)) * time.Millisecond)
-			assert.Equal(t, *dwhTableCfg, *dwh.TableConfig(fqName))
+			assert.Equal(t.T(), *dwhTableCfg, *dwh.TableConfig(fqName))
 		}
 
 	}()

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -144,24 +144,24 @@ func (t *TableData) RowsData() map[string]map[string]interface{} {
 	return _rowsData
 }
 
-func (t *TableData) ToFqName(ctx context.Context, kind constants.DestinationKind) string {
+func (t *TableData) ToFqName(ctx context.Context, kind constants.DestinationKind, escape bool) string {
 	switch kind {
 	case constants.Redshift:
 		// Redshift is Postgres compatible, so when establishing a connection, we'll specify a database.
 		// Thus, we only need to specify schema and table name here.
 		return fmt.Sprintf("%s.%s", t.TopicConfig.Schema, t.Name(&sql.NameArgs{
-			Escape:   true,
+			Escape:   escape,
 			DestKind: kind,
 		}))
 	case constants.BigQuery:
 		// The fully qualified name for BigQuery is: project_id.dataset.tableName.
 		return fmt.Sprintf("%s.%s.%s", config.FromContext(ctx).Config.BigQuery.ProjectID, t.TopicConfig.Database, t.Name(&sql.NameArgs{
-			Escape:   true,
+			Escape:   escape,
 			DestKind: kind,
 		}))
 	default:
 		return fmt.Sprintf("%s.%s.%s", t.TopicConfig.Database, t.TopicConfig.Schema, t.Name(&sql.NameArgs{
-			Escape:   true,
+			Escape:   escape,
 			DestKind: kind,
 		}))
 	}

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -71,7 +71,7 @@ func TestNewTableData_TableName(t *testing.T) {
 			TableName: testCase.overrideName,
 			Schema:    testCase.schema,
 		}, testCase.tableName)
-		assert.Equal(t, testCase.expectedName, td.Name(), testCase.name)
+		assert.Equal(t, testCase.expectedName, td.Name(nil), testCase.name)
 		assert.Equal(t, testCase.expectedName, td.name, testCase.name)
 		assert.Equal(t, testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.SnowflakeStages))
 		assert.Equal(t, testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.Snowflake))

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -73,10 +73,10 @@ func TestNewTableData_TableName(t *testing.T) {
 		}, testCase.tableName)
 		assert.Equal(t, testCase.expectedName, td.Name(nil), testCase.name)
 		assert.Equal(t, testCase.expectedName, td.name, testCase.name)
-		assert.Equal(t, testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.SnowflakeStages))
-		assert.Equal(t, testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.Snowflake))
-		assert.Equal(t, testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery))
-		assert.Equal(t, testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery))
+		assert.Equal(t, testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.SnowflakeStages, true))
+		assert.Equal(t, testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.Snowflake, true))
+		assert.Equal(t, testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true))
+		assert.Equal(t, testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true))
 	}
 }
 

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewTableData_TableName(t *testing.T) {
+func (o *OptimizationTestSuite) TestNewTableData_TableName() {
 	type _testCase struct {
 		name         string
 		tableName    string
@@ -71,16 +71,16 @@ func TestNewTableData_TableName(t *testing.T) {
 			TableName: testCase.overrideName,
 			Schema:    testCase.schema,
 		}, testCase.tableName)
-		assert.Equal(t, testCase.expectedName, td.Name(nil), testCase.name)
-		assert.Equal(t, testCase.expectedName, td.name, testCase.name)
-		assert.Equal(t, testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.SnowflakeStages, true))
-		assert.Equal(t, testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.Snowflake, true))
-		assert.Equal(t, testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true))
-		assert.Equal(t, testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true))
+		assert.Equal(o.T(), testCase.expectedName, td.Name(o.ctx, nil), testCase.name)
+		assert.Equal(o.T(), testCase.expectedName, td.name, testCase.name)
+		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.SnowflakeStages, true))
+		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.Snowflake, true))
+		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true))
+		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true))
 	}
 }
 
-func TestTableData_ReadOnlyInMemoryCols(t *testing.T) {
+func (o *OptimizationTestSuite) TestTableData_ReadOnlyInMemoryCols() {
 	// Making sure the columns are actually read only.
 	var cols columns.Columns
 	cols.AddColumn(columns.NewColumn("name", typing.String))
@@ -91,13 +91,13 @@ func TestTableData_ReadOnlyInMemoryCols(t *testing.T) {
 
 	// Check if last_name actually exists.
 	_, isOk := td.ReadOnlyInMemoryCols().GetColumn("last_name")
-	assert.False(t, isOk)
+	assert.False(o.T(), isOk)
 
 	// Check length is 1.
-	assert.Equal(t, 1, len(td.ReadOnlyInMemoryCols().GetColumns()))
+	assert.Equal(o.T(), 1, len(td.ReadOnlyInMemoryCols().GetColumns()))
 }
 
-func TestTableData_UpdateInMemoryColumns(t *testing.T) {
+func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumns() {
 	var _cols columns.Columns
 	for colName, colKind := range map[string]typing.KindDetails{
 		"FOO":                  typing.String,
@@ -113,10 +113,10 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 	}
 
 	extCol, isOk := tableData.ReadOnlyInMemoryCols().GetColumn("do_not_change_format")
-	assert.True(t, isOk)
+	assert.True(o.T(), isOk)
 
 	extCol.KindDetails.ExtendedTimeDetails.Format = time.RFC3339Nano
-	tableData.inMemoryColumns.UpdateColumn(columns.NewColumn(extCol.Name(nil), extCol.KindDetails))
+	tableData.inMemoryColumns.UpdateColumn(columns.NewColumn(extCol.Name(o.ctx, nil), extCol.KindDetails))
 
 	for name, colKindDetails := range map[string]typing.KindDetails{
 		"foo":                  typing.String,
@@ -124,30 +124,30 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 		"bar":                  typing.Boolean,
 		"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		tableData.UpdateInMemoryColumnsFromDestination(columns.NewColumn(name, colKindDetails))
+		tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn(name, colKindDetails))
 	}
 
 	// It's saved back in the original format.
 	_, isOk = tableData.ReadOnlyInMemoryCols().GetColumn("foo")
-	assert.False(t, isOk)
+	assert.False(o.T(), isOk)
 
 	_, isOk = tableData.ReadOnlyInMemoryCols().GetColumn("FOO")
-	assert.True(t, isOk)
+	assert.True(o.T(), isOk)
 
 	col, isOk := tableData.ReadOnlyInMemoryCols().GetColumn("CHANGE_me")
-	assert.True(t, isOk)
-	assert.Equal(t, ext.DateTime.Type, col.KindDetails.ExtendedTimeDetails.Type)
+	assert.True(o.T(), isOk)
+	assert.Equal(o.T(), ext.DateTime.Type, col.KindDetails.ExtendedTimeDetails.Type)
 
 	// It went from invalid to boolean.
 	col, isOk = tableData.ReadOnlyInMemoryCols().GetColumn("bar")
-	assert.True(t, isOk)
-	assert.Equal(t, typing.Boolean, col.KindDetails)
+	assert.True(o.T(), isOk)
+	assert.Equal(o.T(), typing.Boolean, col.KindDetails)
 
 	col, isOk = tableData.ReadOnlyInMemoryCols().GetColumn("do_not_change_format")
-	assert.True(t, isOk)
-	assert.Equal(t, col.KindDetails.Kind, typing.ETime.Kind)
-	assert.Equal(t, col.KindDetails.ExtendedTimeDetails.Type, ext.DateTimeKindType, "correctly mapped type")
-	assert.Equal(t, col.KindDetails.ExtendedTimeDetails.Format, time.RFC3339Nano, "format has been preserved")
+	assert.True(o.T(), isOk)
+	assert.Equal(o.T(), col.KindDetails.Kind, typing.ETime.Kind)
+	assert.Equal(o.T(), col.KindDetails.ExtendedTimeDetails.Type, ext.DateTimeKindType, "correctly mapped type")
+	assert.Equal(o.T(), col.KindDetails.ExtendedTimeDetails.Format, time.RFC3339Nano, "format has been preserved")
 }
 
 func TestTableData_ShouldFlushRowLength(t *testing.T) {

--- a/lib/optimization/event_update_test.go
+++ b/lib/optimization/event_update_test.go
@@ -1,15 +1,13 @@
 package optimization
 
 import (
-	"testing"
-
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
+func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestination() {
 	tableDataCols := &columns.Columns{}
 	tableDataCols.AddColumn(columns.NewColumn("name", typing.String))
 	tableDataCols.AddColumn(columns.NewColumn("bool_backfill", typing.Boolean))
@@ -30,57 +28,57 @@ func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 	}
 
 	// Testing to make sure we don't copy over non-existent columns
-	tableData.UpdateInMemoryColumnsFromDestination(nonExistentCols...)
+	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, nonExistentCols...)
 	for _, nonExistentTableCol := range nonExistentTableCols {
 		_, isOk := tableData.inMemoryColumns.GetColumn(nonExistentTableCol)
-		assert.False(t, isOk, nonExistentTableCol)
+		assert.False(o.T(), isOk, nonExistentTableCol)
 	}
 
 	// Testing to make sure we're copying the kindDetails over.
-	tableData.UpdateInMemoryColumnsFromDestination(columns.NewColumn("prev_invalid", typing.String))
+	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("prev_invalid", typing.String))
 	prevInvalidCol, isOk := tableData.inMemoryColumns.GetColumn("prev_invalid")
-	assert.True(t, isOk)
-	assert.Equal(t, typing.String, prevInvalidCol.KindDetails)
+	assert.True(o.T(), isOk)
+	assert.Equal(o.T(), typing.String, prevInvalidCol.KindDetails)
 
 	// Testing backfill
 	for _, inMemoryCol := range tableData.inMemoryColumns.GetColumns() {
-		assert.False(t, inMemoryCol.Backfilled(), inMemoryCol.Name(nil))
+		assert.False(o.T(), inMemoryCol.Backfilled(), inMemoryCol.Name(o.ctx, nil))
 	}
 	backfilledCol := columns.NewColumn("bool_backfill", typing.Boolean)
 	backfilledCol.SetBackfilled(true)
-	tableData.UpdateInMemoryColumnsFromDestination(backfilledCol)
+	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, backfilledCol)
 	for _, inMemoryCol := range tableData.inMemoryColumns.GetColumns() {
-		if inMemoryCol.Name(nil) == backfilledCol.Name(nil) {
-			assert.True(t, inMemoryCol.Backfilled(), inMemoryCol.Name(nil))
+		if inMemoryCol.Name(o.ctx, nil) == backfilledCol.Name(o.ctx, nil) {
+			assert.True(o.T(), inMemoryCol.Backfilled(), inMemoryCol.Name(o.ctx, nil))
 		} else {
-			assert.False(t, inMemoryCol.Backfilled(), inMemoryCol.Name(nil))
+			assert.False(o.T(), inMemoryCol.Backfilled(), inMemoryCol.Name(o.ctx, nil))
 		}
 	}
 
 	// Testing extTimeDetails
 	for _, extTimeDetailsCol := range []string{"ext_date", "ext_time", "ext_datetime"} {
 		col, isOk := tableData.inMemoryColumns.GetColumn(extTimeDetailsCol)
-		assert.True(t, isOk, extTimeDetailsCol)
-		assert.Equal(t, typing.String, col.KindDetails, extTimeDetailsCol)
-		assert.Nil(t, col.KindDetails.ExtendedTimeDetails, extTimeDetailsCol)
+		assert.True(o.T(), isOk, extTimeDetailsCol)
+		assert.Equal(o.T(), typing.String, col.KindDetails, extTimeDetailsCol)
+		assert.Nil(o.T(), col.KindDetails.ExtendedTimeDetails, extTimeDetailsCol)
 	}
 
-	tableData.UpdateInMemoryColumnsFromDestination(columns.NewColumn("ext_date", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType)))
-	tableData.UpdateInMemoryColumnsFromDestination(columns.NewColumn("ext_time", typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType)))
-	tableData.UpdateInMemoryColumnsFromDestination(columns.NewColumn("ext_datetime", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)))
+	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("ext_date", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType)))
+	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("ext_time", typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType)))
+	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("ext_datetime", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)))
 
 	dateCol, isOk := tableData.inMemoryColumns.GetColumn("ext_date")
-	assert.True(t, isOk)
-	assert.NotNil(t, dateCol.KindDetails.ExtendedTimeDetails)
-	assert.Equal(t, ext.DateKindType, dateCol.KindDetails.ExtendedTimeDetails.Type)
+	assert.True(o.T(), isOk)
+	assert.NotNil(o.T(), dateCol.KindDetails.ExtendedTimeDetails)
+	assert.Equal(o.T(), ext.DateKindType, dateCol.KindDetails.ExtendedTimeDetails.Type)
 
 	timeCol, isOk := tableData.inMemoryColumns.GetColumn("ext_time")
-	assert.True(t, isOk)
-	assert.NotNil(t, timeCol.KindDetails.ExtendedTimeDetails)
-	assert.Equal(t, ext.TimeKindType, timeCol.KindDetails.ExtendedTimeDetails.Type)
+	assert.True(o.T(), isOk)
+	assert.NotNil(o.T(), timeCol.KindDetails.ExtendedTimeDetails)
+	assert.Equal(o.T(), ext.TimeKindType, timeCol.KindDetails.ExtendedTimeDetails.Type)
 
 	dateTimeCol, isOk := tableData.inMemoryColumns.GetColumn("ext_datetime")
-	assert.True(t, isOk)
-	assert.NotNil(t, dateTimeCol.KindDetails.ExtendedTimeDetails)
-	assert.Equal(t, ext.DateTimeKindType, dateTimeCol.KindDetails.ExtendedTimeDetails.Type)
+	assert.True(o.T(), isOk)
+	assert.NotNil(o.T(), dateTimeCol.KindDetails.ExtendedTimeDetails)
+	assert.Equal(o.T(), ext.DateTimeKindType, dateTimeCol.KindDetails.ExtendedTimeDetails.Type)
 }

--- a/lib/optimization/optimization_suite_test.go
+++ b/lib/optimization/optimization_suite_test.go
@@ -1,0 +1,24 @@
+package optimization
+
+import (
+	"context"
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type OptimizationTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (o *OptimizationTestSuite) SetupTest() {
+	o.ctx = context.Background()
+	o.ctx = config.InjectSettingsIntoContext(o.ctx, &config.Settings{Config: &config.Config{}})
+}
+
+func TestOptimizationTestSuite(t *testing.T) {
+	suite.Run(t, new(OptimizationTestSuite))
+}

--- a/lib/sql/escape.go
+++ b/lib/sql/escape.go
@@ -1,0 +1,32 @@
+package sql
+
+import (
+	"fmt"
+
+	"github.com/artie-labs/transfer/lib/array"
+	"github.com/artie-labs/transfer/lib/config/constants"
+)
+
+type NameArgs struct {
+	Escape   bool
+	DestKind constants.DestinationKind
+}
+
+func EscapeName(name string, args *NameArgs) string {
+	var escape bool
+	if args != nil {
+		escape = args.Escape
+	}
+
+	if escape && array.StringContains(constants.ReservedKeywords, name) {
+		if args != nil && args.DestKind == constants.BigQuery {
+			// BigQuery needs backticks to escape.
+			return fmt.Sprintf("`%s`", name)
+		} else {
+			// Snowflake uses quotes.
+			return fmt.Sprintf(`"%s"`, name)
+		}
+	}
+
+	return name
+}

--- a/lib/sql/escape.go
+++ b/lib/sql/escape.go
@@ -1,7 +1,11 @@
 package sql
 
 import (
+	"context"
 	"fmt"
+	"strings"
+
+	"github.com/artie-labs/transfer/lib/config"
 
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -12,13 +16,17 @@ type NameArgs struct {
 	DestKind constants.DestinationKind
 }
 
-func EscapeName(name string, args *NameArgs) string {
+func EscapeName(ctx context.Context, name string, args *NameArgs) string {
 	var escape bool
 	if args != nil {
 		escape = args.Escape
 	}
 
 	if escape && array.StringContains(constants.ReservedKeywords, name) {
+		if config.FromContext(ctx).Config.SharedDestinationConfig.UppercaseEscapedNames {
+			name = strings.ToUpper(name)
+		}
+
 		if args != nil && args.DestKind == constants.BigQuery {
 			// BigQuery needs backticks to escape.
 			return fmt.Sprintf("`%s`", name)

--- a/lib/sql/escape_test.go
+++ b/lib/sql/escape_test.go
@@ -1,0 +1,91 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeName(t *testing.T) {
+	type _testCase struct {
+		name         string
+		nameToEscape string
+		args         *NameArgs
+		expectedName string
+	}
+
+	testCases := []_testCase{
+		{
+			name:         "args = nil",
+			nameToEscape: "order",
+			expectedName: "order",
+		},
+		{
+			name:         "escape = false",
+			args:         &NameArgs{},
+			nameToEscape: "order",
+			expectedName: "order",
+		},
+		{
+			name: "escape = true, snowflake",
+			args: &NameArgs{
+				Escape:   true,
+				DestKind: constants.Snowflake,
+			},
+			nameToEscape: "order",
+			expectedName: `"order"`,
+		},
+		{
+			name: "escape = true, snowflake #2",
+			args: &NameArgs{
+				Escape:   true,
+				DestKind: constants.Snowflake,
+			},
+			nameToEscape: "hello",
+			expectedName: `hello`,
+		},
+		{
+			name: "escape = true, redshift",
+			args: &NameArgs{
+				Escape:   true,
+				DestKind: constants.Redshift,
+			},
+			nameToEscape: "order",
+			expectedName: `"order"`,
+		},
+		{
+			name: "escape = true, redshift #2",
+			args: &NameArgs{
+				Escape:   true,
+				DestKind: constants.Redshift,
+			},
+			nameToEscape: "hello",
+			expectedName: `hello`,
+		},
+		{
+			name: "escape = true, bigquery",
+			args: &NameArgs{
+				Escape:   true,
+				DestKind: constants.BigQuery,
+			},
+			nameToEscape: "order",
+			expectedName: "`order`",
+		},
+		{
+			name: "escape = true, bigquery, #2",
+			args: &NameArgs{
+				Escape:   true,
+				DestKind: constants.BigQuery,
+			},
+			nameToEscape: "hello",
+			expectedName: "hello",
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualName := EscapeName(testCase.nameToEscape, testCase.args)
+		assert.Equal(t, testCase.expectedName, actualName, testCase.name)
+	}
+}

--- a/lib/sql/escape_test.go
+++ b/lib/sql/escape_test.go
@@ -1,14 +1,11 @@
 package sql
 
 import (
-	"testing"
-
 	"github.com/artie-labs/transfer/lib/config/constants"
-
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEscapeName(t *testing.T) {
+func (s *SqlTestSuite) TestEscapeName() {
 	type _testCase struct {
 		name         string
 		nameToEscape string
@@ -85,7 +82,7 @@ func TestEscapeName(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualName := EscapeName(testCase.nameToEscape, testCase.args)
-		assert.Equal(t, testCase.expectedName, actualName, testCase.name)
+		actualName := EscapeName(s.ctx, testCase.nameToEscape, testCase.args)
+		assert.Equal(s.T(), testCase.expectedName, actualName, testCase.name)
 	}
 }

--- a/lib/sql/sql_suite_test.go
+++ b/lib/sql/sql_suite_test.go
@@ -1,0 +1,24 @@
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SqlTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (s *SqlTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.ctx = config.InjectSettingsIntoContext(s.ctx, &config.Settings{Config: &config.Config{}})
+}
+
+func TestSqlTestSuite(t *testing.T) {
+	suite.Run(t, new(SqlTestSuite))
+}

--- a/lib/typing/columns/columns_suite_test.go
+++ b/lib/typing/columns/columns_suite_test.go
@@ -1,0 +1,25 @@
+package columns
+
+import (
+	"context"
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
+	"github.com/stretchr/testify/suite"
+)
+
+type ColumnsTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (c *ColumnsTestSuite) SetupTest() {
+	c.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
+		VerboseLogging: false,
+		Config:         &config.Config{},
+	})
+}
+
+func TestColumnsTestSuite(t *testing.T) {
+	suite.Run(t, new(ColumnsTestSuite))
+}

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/artie-labs/transfer/lib/ptr"
-
-	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/sql"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
-
+	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -203,15 +202,15 @@ func TestColumn_Name(t *testing.T) {
 		}
 
 		assert.Equal(t, testCase.expectedName, c.Name(nil), testCase.colName)
-		assert.Equal(t, testCase.expectedName, c.Name(&NameArgs{
+		assert.Equal(t, testCase.expectedName, c.Name(&sql.NameArgs{
 			Escape: false,
 		}), testCase.colName)
 
-		assert.Equal(t, testCase.expectedNameEsc, c.Name(&NameArgs{
+		assert.Equal(t, testCase.expectedNameEsc, c.Name(&sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
 		}), testCase.colName)
-		assert.Equal(t, testCase.expectedNameEscBq, c.Name(&NameArgs{
+		assert.Equal(t, testCase.expectedNameEscBq, c.Name(&sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.BigQuery,
 		}), testCase.colName)
@@ -275,16 +274,16 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 		}
 
 		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(nil), testCase.name)
-		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(&NameArgs{
+		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(&sql.NameArgs{
 			Escape: false,
 		}), testCase.name)
 
-		assert.Equal(t, testCase.expectedColsEsc, cols.GetColumnsToUpdate(&NameArgs{
+		assert.Equal(t, testCase.expectedColsEsc, cols.GetColumnsToUpdate(&sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
 		}), testCase.name)
 
-		assert.Equal(t, testCase.expectedColsEscBq, cols.GetColumnsToUpdate(&NameArgs{
+		assert.Equal(t, testCase.expectedColsEscBq, cols.GetColumnsToUpdate(&sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.BigQuery,
 		}), testCase.name)

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -2,7 +2,6 @@ package columns
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/artie-labs/transfer/lib/sql"
 
@@ -12,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEscapeName(t *testing.T) {
+func (c *ColumnsTestSuite) TestEscapeName() {
 	type _testCase struct {
 		name         string
 		expectedName string
@@ -35,11 +34,11 @@ func TestEscapeName(t *testing.T) {
 
 	for _, testCase := range testCases {
 		actualName := EscapeName(testCase.name)
-		assert.Equal(t, testCase.expectedName, actualName, testCase.name)
+		assert.Equal(c.T(), testCase.expectedName, actualName, testCase.name)
 	}
 }
 
-func TestColumn_ShouldSkip(t *testing.T) {
+func (c *ColumnsTestSuite) TestColumn_ShouldSkip() {
 	type _testCase struct {
 		name           string
 		col            *Column
@@ -67,11 +66,11 @@ func TestColumn_ShouldSkip(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.expectedResult, testCase.col.ShouldSkip(), testCase.name)
+		assert.Equal(c.T(), testCase.expectedResult, testCase.col.ShouldSkip(), testCase.name)
 	}
 }
 
-func TestColumn_ShouldBackfill(t *testing.T) {
+func (c *ColumnsTestSuite) TestColumn_ShouldBackfill() {
 	type _testCase struct {
 		name                 string
 		column               *Column
@@ -129,11 +128,11 @@ func TestColumn_ShouldBackfill(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.expectShouldBackfill, testCase.column.ShouldBackfill(), testCase.name)
+		assert.Equal(c.T(), testCase.expectShouldBackfill, testCase.column.ShouldBackfill(), testCase.name)
 	}
 }
 
-func TestUnescapeColumnName(t *testing.T) {
+func (c *ColumnsTestSuite) TestUnescapeColumnName() {
 	type _testCase struct {
 		escapedName           string
 		expectedBigQueryName  string
@@ -158,14 +157,14 @@ func TestUnescapeColumnName(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		assert.Equal(t, testCase.expectedBigQueryName, UnescapeColumnName(testCase.escapedName, constants.BigQuery))
-		assert.Equal(t, testCase.expectedSnowflakeName, UnescapeColumnName(testCase.escapedName, constants.Snowflake))
-		assert.Equal(t, testCase.expectedSnowflakeName, UnescapeColumnName(testCase.escapedName, constants.SnowflakeStages))
-		assert.Equal(t, testCase.expectedOtherName, UnescapeColumnName(testCase.escapedName, ""))
+		assert.Equal(c.T(), testCase.expectedBigQueryName, UnescapeColumnName(testCase.escapedName, constants.BigQuery))
+		assert.Equal(c.T(), testCase.expectedSnowflakeName, UnescapeColumnName(testCase.escapedName, constants.Snowflake))
+		assert.Equal(c.T(), testCase.expectedSnowflakeName, UnescapeColumnName(testCase.escapedName, constants.SnowflakeStages))
+		assert.Equal(c.T(), testCase.expectedOtherName, UnescapeColumnName(testCase.escapedName, ""))
 	}
 }
 
-func TestColumn_Name(t *testing.T) {
+func (c *ColumnsTestSuite) TestColumn_Name() {
 	type _testCase struct {
 		colName      string
 		expectedName string
@@ -197,27 +196,27 @@ func TestColumn_Name(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		c := &Column{
+		col := &Column{
 			name: testCase.colName,
 		}
 
-		assert.Equal(t, testCase.expectedName, c.Name(nil), testCase.colName)
-		assert.Equal(t, testCase.expectedName, c.Name(&sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedName, col.Name(c.ctx, nil), testCase.colName)
+		assert.Equal(c.T(), testCase.expectedName, col.Name(c.ctx, &sql.NameArgs{
 			Escape: false,
 		}), testCase.colName)
 
-		assert.Equal(t, testCase.expectedNameEsc, c.Name(&sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedNameEsc, col.Name(c.ctx, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
 		}), testCase.colName)
-		assert.Equal(t, testCase.expectedNameEscBq, c.Name(&sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedNameEscBq, col.Name(c.ctx, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.BigQuery,
 		}), testCase.colName)
 	}
 }
 
-func TestColumns_GetColumnsToUpdate(t *testing.T) {
+func (c *ColumnsTestSuite) TestColumns_GetColumnsToUpdate() {
 	type _testCase struct {
 		name              string
 		cols              []Column
@@ -273,24 +272,24 @@ func TestColumns_GetColumnsToUpdate(t *testing.T) {
 			columns: testCase.cols,
 		}
 
-		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(nil), testCase.name)
-		assert.Equal(t, testCase.expectedCols, cols.GetColumnsToUpdate(&sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedCols, cols.GetColumnsToUpdate(c.ctx, nil), testCase.name)
+		assert.Equal(c.T(), testCase.expectedCols, cols.GetColumnsToUpdate(c.ctx, &sql.NameArgs{
 			Escape: false,
 		}), testCase.name)
 
-		assert.Equal(t, testCase.expectedColsEsc, cols.GetColumnsToUpdate(&sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedColsEsc, cols.GetColumnsToUpdate(c.ctx, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
 		}), testCase.name)
 
-		assert.Equal(t, testCase.expectedColsEscBq, cols.GetColumnsToUpdate(&sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedColsEscBq, cols.GetColumnsToUpdate(c.ctx, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.BigQuery,
 		}), testCase.name)
 	}
 }
 
-func TestColumns_UpsertColumns(t *testing.T) {
+func (c *ColumnsTestSuite) TestColumns_UpsertColumns() {
 	keys := []string{"a", "b", "c", "d", "e"}
 	var cols Columns
 	for _, key := range keys {
@@ -302,7 +301,7 @@ func TestColumns_UpsertColumns(t *testing.T) {
 
 	// Now inspect prior to change.
 	for _, col := range cols.GetColumns() {
-		assert.False(t, col.ToastColumn)
+		assert.False(c.T(), col.ToastColumn)
 	}
 
 	// Now selectively update only a, b
@@ -313,43 +312,43 @@ func TestColumns_UpsertColumns(t *testing.T) {
 
 		// Now inspect.
 		col, _ := cols.GetColumn(key)
-		assert.True(t, col.ToastColumn)
+		assert.True(c.T(), col.ToastColumn)
 	}
 
 	cols.UpsertColumn("zzz", UpsertColumnArg{})
 	zzzCol, _ := cols.GetColumn("zzz")
-	assert.False(t, zzzCol.ToastColumn)
-	assert.False(t, zzzCol.primaryKey)
-	assert.Equal(t, zzzCol.KindDetails, typing.Invalid)
+	assert.False(c.T(), zzzCol.ToastColumn)
+	assert.False(c.T(), zzzCol.primaryKey)
+	assert.Equal(c.T(), zzzCol.KindDetails, typing.Invalid)
 
 	cols.UpsertColumn("aaa", UpsertColumnArg{
 		ToastCol:   ptr.ToBool(true),
 		PrimaryKey: ptr.ToBool(true),
 	})
 	aaaCol, _ := cols.GetColumn("aaa")
-	assert.True(t, aaaCol.ToastColumn)
-	assert.True(t, aaaCol.primaryKey)
-	assert.Equal(t, aaaCol.KindDetails, typing.Invalid)
+	assert.True(c.T(), aaaCol.ToastColumn)
+	assert.True(c.T(), aaaCol.primaryKey)
+	assert.Equal(c.T(), aaaCol.KindDetails, typing.Invalid)
 
 	length := len(cols.columns)
 	for i := 0; i < 500; i++ {
 		cols.UpsertColumn("", UpsertColumnArg{})
 	}
 
-	assert.Equal(t, length, len(cols.columns))
+	assert.Equal(c.T(), length, len(cols.columns))
 }
 
-func TestColumns_Add_Duplicate(t *testing.T) {
+func (c *ColumnsTestSuite) TestColumns_Add_Duplicate() {
 	var cols Columns
 	duplicateColumns := []Column{{name: "foo"}, {name: "foo"}, {name: "foo"}, {name: "foo"}, {name: "foo"}, {name: "foo"}}
 	for _, duplicateColumn := range duplicateColumns {
 		cols.AddColumn(duplicateColumn)
 	}
 
-	assert.Equal(t, len(cols.GetColumns()), 1, "AddColumn() de-duplicates")
+	assert.Equal(c.T(), len(cols.GetColumns()), 1, "AddColumn() de-duplicates")
 }
 
-func TestColumns_Mutation(t *testing.T) {
+func (c *ColumnsTestSuite) TestColumns_Mutation() {
 	var cols Columns
 	colsToAdd := []Column{{name: "foo", KindDetails: typing.String, defaultValue: "bar"}, {name: "bar", KindDetails: typing.Struct}}
 	// Insert
@@ -357,14 +356,14 @@ func TestColumns_Mutation(t *testing.T) {
 		cols.AddColumn(colToAdd)
 	}
 
-	assert.Equal(t, len(cols.GetColumns()), 2)
+	assert.Equal(c.T(), len(cols.GetColumns()), 2)
 	fooCol, isOk := cols.GetColumn("foo")
-	assert.True(t, isOk)
-	assert.Equal(t, typing.String, fooCol.KindDetails)
+	assert.True(c.T(), isOk)
+	assert.Equal(c.T(), typing.String, fooCol.KindDetails)
 
 	barCol, isOk := cols.GetColumn("bar")
-	assert.True(t, isOk)
-	assert.Equal(t, typing.Struct, barCol.KindDetails)
+	assert.True(c.T(), isOk)
+	assert.Equal(c.T(), typing.Struct, barCol.KindDetails)
 
 	// Update
 	cols.UpdateColumn(Column{
@@ -379,23 +378,23 @@ func TestColumns_Mutation(t *testing.T) {
 	})
 
 	fooCol, isOk = cols.GetColumn("foo")
-	assert.True(t, isOk)
-	assert.Equal(t, typing.Integer, fooCol.KindDetails)
-	assert.Equal(t, nil, fooCol.defaultValue)
+	assert.True(c.T(), isOk)
+	assert.Equal(c.T(), typing.Integer, fooCol.KindDetails)
+	assert.Equal(c.T(), nil, fooCol.defaultValue)
 
 	barCol, isOk = cols.GetColumn("bar")
-	assert.True(t, isOk)
-	assert.Equal(t, typing.Boolean, barCol.KindDetails)
-	assert.Equal(t, "123", barCol.defaultValue)
+	assert.True(c.T(), isOk)
+	assert.Equal(c.T(), typing.Boolean, barCol.KindDetails)
+	assert.Equal(c.T(), "123", barCol.defaultValue)
 
 	// Delete
 	cols.DeleteColumn("foo")
-	assert.Equal(t, len(cols.GetColumns()), 1)
+	assert.Equal(c.T(), len(cols.GetColumns()), 1)
 	cols.DeleteColumn("bar")
-	assert.Equal(t, len(cols.GetColumns()), 0)
+	assert.Equal(c.T(), len(cols.GetColumns()), 0)
 }
 
-func TestColumnsUpdateQuery(t *testing.T) {
+func (c *ColumnsTestSuite) TestColumnsUpdateQuery() {
 	type testCase struct {
 		name           string
 		columns        []string
@@ -521,7 +520,7 @@ func TestColumnsUpdateQuery(t *testing.T) {
 	}
 
 	for _, _testCase := range testCases {
-		actualQuery := ColumnsUpdateQuery(_testCase.columns, _testCase.columnsToTypes, _testCase.destKind)
-		assert.Equal(t, _testCase.expectedString, actualQuery, _testCase.name)
+		actualQuery := ColumnsUpdateQuery(c.ctx, _testCase.columns, _testCase.columnsToTypes, _testCase.destKind)
+		assert.Equal(c.T(), _testCase.expectedString, actualQuery, _testCase.name)
 	}
 }

--- a/lib/typing/columns/diff.go
+++ b/lib/typing/columns/diff.go
@@ -1,6 +1,7 @@
 package columns
 
 import (
+	"context"
 	"strings"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -27,12 +28,12 @@ func shouldSkipColumn(colName string, softDelete bool, includeArtieUpdatedAt boo
 
 // Diff - when given 2 maps, a source and target
 // It will provide a diff in the form of 2 variables
-func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bool, includeArtieUpdatedAt bool) ([]Column, []Column) {
+func Diff(ctx context.Context, columnsInSource *Columns, columnsInDestination *Columns, softDelete bool, includeArtieUpdatedAt bool) ([]Column, []Column) {
 	src := CloneColumns(columnsInSource)
 	targ := CloneColumns(columnsInDestination)
 	var colsToDelete []Column
 	for _, col := range src.GetColumns() {
-		_, isOk := targ.GetColumn(col.Name(nil))
+		_, isOk := targ.GetColumn(col.Name(ctx, nil))
 		if isOk {
 			colsToDelete = append(colsToDelete, col)
 
@@ -41,13 +42,13 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 
 	// We cannot delete inside a for-loop that is iterating over src.GetColumns() because we are messing up the array order.
 	for _, colToDelete := range colsToDelete {
-		src.DeleteColumn(colToDelete.Name(nil))
-		targ.DeleteColumn(colToDelete.Name(nil))
+		src.DeleteColumn(colToDelete.Name(ctx, nil))
+		targ.DeleteColumn(colToDelete.Name(ctx, nil))
 	}
 
 	var targetColumnsMissing Columns
 	for _, col := range src.GetColumns() {
-		if shouldSkipColumn(col.Name(nil), softDelete, includeArtieUpdatedAt) {
+		if shouldSkipColumn(col.Name(ctx, nil), softDelete, includeArtieUpdatedAt) {
 			continue
 		}
 
@@ -56,7 +57,7 @@ func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bo
 
 	var sourceColumnsMissing Columns
 	for _, col := range targ.GetColumns() {
-		if shouldSkipColumn(col.Name(nil), softDelete, includeArtieUpdatedAt) {
+		if shouldSkipColumn(col.Name(ctx, nil), softDelete, includeArtieUpdatedAt) {
 			continue
 		}
 

--- a/lib/typing/columns/wrapper.go
+++ b/lib/typing/columns/wrapper.go
@@ -1,11 +1,13 @@
 package columns
 
+import "github.com/artie-labs/transfer/lib/sql"
+
 type Wrapper struct {
 	name        string
 	escapedName string
 }
 
-func NewWrapper(col Column, args *NameArgs) Wrapper {
+func NewWrapper(col Column, args *sql.NameArgs) Wrapper {
 	return Wrapper{
 		name:        col.name,
 		escapedName: col.Name(args),

--- a/lib/typing/columns/wrapper.go
+++ b/lib/typing/columns/wrapper.go
@@ -1,16 +1,20 @@
 package columns
 
-import "github.com/artie-labs/transfer/lib/sql"
+import (
+	"context"
+
+	"github.com/artie-labs/transfer/lib/sql"
+)
 
 type Wrapper struct {
 	name        string
 	escapedName string
 }
 
-func NewWrapper(col Column, args *sql.NameArgs) Wrapper {
+func NewWrapper(ctx context.Context, col Column, args *sql.NameArgs) Wrapper {
 	return Wrapper{
 		name:        col.name,
-		escapedName: col.Name(args),
+		escapedName: col.Name(ctx, args),
 	}
 }
 

--- a/lib/typing/columns/wrapper_test.go
+++ b/lib/typing/columns/wrapper_test.go
@@ -1,8 +1,6 @@
 package columns
 
 import (
-	"testing"
-
 	"github.com/artie-labs/transfer/lib/sql"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +10,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func TestWrapper_Complete(t *testing.T) {
+func (c *ColumnsTestSuite) TestWrapper_Complete() {
 	type _testCase struct {
 		name                  string
 		expectedRawName       string
@@ -43,38 +41,38 @@ func TestWrapper_Complete(t *testing.T) {
 
 	for _, testCase := range testCases {
 		// Snowflake escape
-		w := NewWrapper(NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
+		w := NewWrapper(c.ctx, NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
 		})
 
-		assert.Equal(t, testCase.expectedEscapedName, w.EscapedName(), testCase.name)
-		assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
+		assert.Equal(c.T(), testCase.expectedEscapedName, w.EscapedName(), testCase.name)
+		assert.Equal(c.T(), testCase.expectedRawName, w.RawName(), testCase.name)
 
 		// BigQuery escape
-		w = NewWrapper(NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
+		w = NewWrapper(c.ctx, NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.BigQuery,
 		})
 
-		assert.Equal(t, testCase.expectedEscapedNameBQ, w.EscapedName(), testCase.name)
-		assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
+		assert.Equal(c.T(), testCase.expectedEscapedNameBQ, w.EscapedName(), testCase.name)
+		assert.Equal(c.T(), testCase.expectedRawName, w.RawName(), testCase.name)
 
 		for _, destKind := range []constants.DestinationKind{constants.Snowflake, constants.SnowflakeStages, constants.BigQuery} {
-			w = NewWrapper(NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
+			w = NewWrapper(c.ctx, NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
 				Escape:   false,
 				DestKind: destKind,
 			})
 
-			assert.Equal(t, testCase.expectedRawName, w.EscapedName(), testCase.name)
-			assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
+			assert.Equal(c.T(), testCase.expectedRawName, w.EscapedName(), testCase.name)
+			assert.Equal(c.T(), testCase.expectedRawName, w.RawName(), testCase.name)
 		}
 
 		// Same if nil
-		w = NewWrapper(NewColumn(testCase.name, typing.Invalid), nil)
+		w = NewWrapper(c.ctx, NewColumn(testCase.name, typing.Invalid), nil)
 
-		assert.Equal(t, testCase.expectedRawName, w.EscapedName(), testCase.name)
-		assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
+		assert.Equal(c.T(), testCase.expectedRawName, w.EscapedName(), testCase.name)
+		assert.Equal(c.T(), testCase.expectedRawName, w.RawName(), testCase.name)
 
 	}
 }

--- a/lib/typing/columns/wrapper_test.go
+++ b/lib/typing/columns/wrapper_test.go
@@ -3,6 +3,8 @@ package columns
 import (
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/sql"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -41,7 +43,7 @@ func TestWrapper_Complete(t *testing.T) {
 
 	for _, testCase := range testCases {
 		// Snowflake escape
-		w := NewWrapper(NewColumn(testCase.name, typing.Invalid), &NameArgs{
+		w := NewWrapper(NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
 		})
@@ -50,7 +52,7 @@ func TestWrapper_Complete(t *testing.T) {
 		assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
 
 		// BigQuery escape
-		w = NewWrapper(NewColumn(testCase.name, typing.Invalid), &NameArgs{
+		w = NewWrapper(NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.BigQuery,
 		})
@@ -59,7 +61,7 @@ func TestWrapper_Complete(t *testing.T) {
 		assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
 
 		for _, destKind := range []constants.DestinationKind{constants.Snowflake, constants.SnowflakeStages, constants.BigQuery} {
-			w = NewWrapper(NewColumn(testCase.name, typing.Invalid), &NameArgs{
+			w = NewWrapper(NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
 				Escape:   false,
 				DestKind: destKind,
 			})

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -49,7 +49,7 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	// Check the in-memory DB columns.
 	var found int
 	for _, col := range optimization.ReadOnlyInMemoryCols().GetColumns() {
-		if col.Name(nil) == expectedLowerCol || col.Name(nil) == anotherLowerCol {
+		if col.Name(e.ctx, nil) == expectedLowerCol || col.Name(e.ctx, nil) == anotherLowerCol {
 			found += 1
 		}
 
@@ -178,16 +178,16 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	td := models.GetMemoryDB(e.ctx).GetOrCreateTableData("non_existent")
 	var prevKey string
 	for _, col := range td.ReadOnlyInMemoryCols().GetColumns() {
-		if col.Name(nil) == constants.DeleteColumnMarker {
+		if col.Name(e.ctx, nil) == constants.DeleteColumnMarker {
 			continue
 		}
 
 		if prevKey == "" {
-			prevKey = col.Name(nil)
+			prevKey = col.Name(e.ctx, nil)
 			continue
 		}
 
-		currentKeyParsed, err := strconv.Atoi(col.Name(nil))
+		currentKeyParsed, err := strconv.Atoi(col.Name(e.ctx, nil))
 		assert.NoError(e.T(), err)
 
 		prevKeyParsed, err := strconv.Atoi(prevKey)
@@ -201,7 +201,7 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	evt.Columns.AddColumn(columns.NewColumn("foo", typing.Invalid))
 	var index int
 	for idx, col := range evt.Columns.GetColumns() {
-		if col.Name(nil) == "foo" {
+		if col.Name(e.ctx, nil) == "foo" {
 			index = idx
 		}
 	}


### PR DESCRIPTION
## Changes
* Table names such as `order` is a reserved SQL keyword. However, we were previously not escaping it. 
* Escape table and column names have been centralized
* Users now have an ability to specify whether the escaped name should be all UPPER or not. (Default is all lower), this is done under `sharedDestinationConfig`

## Checks
- [x] Tests
- [ ] Add documentation
- [x] Checked against Snowflake
- [x] Checked against Redshift
- [x] Checked against BigQuery