### PR TITLE
Remove .ToLower() within backfills

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -3,7 +3,6 @@ package bigquery
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/sql"
@@ -77,7 +76,6 @@ func (s *Store) backfillColumn(ctx context.Context, column columns.Column, fqTab
 		return fmt.Errorf("failed to escape default value, err: %v", err)
 	}
 
-	fqTableName = strings.ToLower(fqTableName)
 	escapedCol := column.Name(ctx, &sql.NameArgs{Escape: true, DestKind: s.Label()})
 	query := fmt.Sprintf(`UPDATE %s SET %s = %v WHERE %s IS NULL;`,
 		// UPDATE table SET col = default_val WHERE col IS NULL

--- a/clients/bigquery/merge_test.go
+++ b/clients/bigquery/merge_test.go
@@ -40,20 +40,20 @@ func (b *BigQueryTestSuite) TestBackfillColumn() {
 		{
 			name:        "col that has default value that needs to be backfilled (boolean)",
 			col:         needsBackfillCol,
-			backfillSQL: `UPDATE db.public.tablename SET foo = true WHERE foo IS NULL;`,
-			commentSQL:  "ALTER TABLE db.public.tablename ALTER COLUMN foo SET OPTIONS (description=`{\"backfilled\": true}`);",
+			backfillSQL: `UPDATE db.public.tableName SET foo = true WHERE foo IS NULL;`,
+			commentSQL:  "ALTER TABLE db.public.tableName ALTER COLUMN foo SET OPTIONS (description=`{\"backfilled\": true}`);",
 		},
 		{
 			name:        "col that has default value that needs to be backfilled (string)",
 			col:         needsBackfillColStr,
-			backfillSQL: `UPDATE db.public.tablename SET foo2 = 'hello there' WHERE foo2 IS NULL;`,
-			commentSQL:  "ALTER TABLE db.public.tablename ALTER COLUMN foo2 SET OPTIONS (description=`{\"backfilled\": true}`);",
+			backfillSQL: `UPDATE db.public.tableName SET foo2 = 'hello there' WHERE foo2 IS NULL;`,
+			commentSQL:  "ALTER TABLE db.public.tableName ALTER COLUMN foo2 SET OPTIONS (description=`{\"backfilled\": true}`);",
 		},
 		{
 			name:        "col that has default value that needs to be backfilled (number)",
 			col:         needsBackfillColNum,
-			backfillSQL: `UPDATE db.public.tablename SET foo3 = 3.5 WHERE foo3 IS NULL;`,
-			commentSQL:  "ALTER TABLE db.public.tablename ALTER COLUMN foo3 SET OPTIONS (description=`{\"backfilled\": true}`);",
+			backfillSQL: `UPDATE db.public.tableName SET foo3 = 3.5 WHERE foo3 IS NULL;`,
+			commentSQL:  "ALTER TABLE db.public.tableName ALTER COLUMN foo3 SET OPTIONS (description=`{\"backfilled\": true}`);",
 		},
 	}
 

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -49,8 +49,8 @@ func (s *SnowflakeTestSuite) TestBackfillColumn() {
 		{
 			name:        "col that has default value that needs to be backfilled",
 			col:         needsBackfillCol,
-			backfillSQL: `UPDATE db.public.tablename SET foo = true WHERE foo IS NULL;`,
-			commentSQL:  `COMMENT ON COLUMN db.public.tablename.foo IS '{"backfilled": true}';`,
+			backfillSQL: `UPDATE db.public.tableName SET foo = true WHERE foo IS NULL;`,
+			commentSQL:  `COMMENT ON COLUMN db.public.tableName.foo IS '{"backfilled": true}';`,
 		},
 	}
 

--- a/clients/utils/utils.go
+++ b/clients/utils/utils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/artie-labs/transfer/lib/sql"
 
@@ -24,7 +23,6 @@ func BackfillColumn(ctx context.Context, dwh dwh.DataWarehouse, column columns.C
 		return nil
 	}
 
-	fqTableName = strings.ToLower(fqTableName)
 	defaultVal, err := column.DefaultValue(&columns.DefaultValueArgs{
 		Escape:   true,
 		DestKind: dwh.Label(),


### PR DESCRIPTION
`.ToLower(...)` is redundant here and also impacts our ability to actually support UPPERCASING table / col name if this is happening.