### PR TITLE
Gracefully dealing with MongoDB NaN errors

### DIFF
--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -22,7 +22,6 @@ import (
 type Debezium string
 
 func (d *Debezium) GetEventFromBytes(_ context.Context, bytes []byte) (cdc.Event, error) {
-	//fmt.Println("string", string(bytes))
 	var schemaEventPayload SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -26,10 +26,8 @@ func JSONEToMap(val []byte) (map[string]interface{}, error) {
 	re := regexp.MustCompile(`\bNaN\b|"\bNaN\b"`)
 	val = []byte(re.ReplaceAllStringFunc(string(val), func(match string) string {
 		if strings.Contains(match, "\"") {
-			// if the match has quotes, return as is
 			return match
 		}
-		// if the match doesn't have quotes, replace with null
 		return "null"
 	}))
 

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -19,11 +20,14 @@ import (
 // JSONEToMap will take JSONE data in bytes, parse all the custom types
 // Then from all the custom types,
 func JSONEToMap(val []byte) (map[string]interface{}, error) {
+	re := regexp.MustCompile(`\bNaN\b`)
+	val = []byte(re.ReplaceAllString(string(val), "null"))
+
 	var jsonMap map[string]interface{}
 	var bsonDoc bson.D
 	err := bson.UnmarshalExtJSON(val, false, &bsonDoc)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal ext json, err: %v", err)
 	}
 
 	bytes, err := bson.MarshalExtJSONWithRegistry(createCustomRegistry().Build(),

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -1,8 +1,9 @@
 package mongo
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestMarshal, every single type is listed here: https://github.com/mongodb/specifications/blob/master/source/extended-json.rst#canonical-extended-json-example
@@ -45,7 +46,10 @@ func TestMarshal(t *testing.T) {
 	},
 	"test_timestamp": {
        "$timestamp": { "t": 1678929517, "i": 1 }
-   	}
+   	},
+	"test_nan": NaN,
+	"test_nan_string": "NaN",
+	"test_nan_string33": "NaNaNaNa"
 }
 `)
 	result, err := JSONEToMap(bsonData)
@@ -66,4 +70,7 @@ func TestMarshal(t *testing.T) {
 	assert.Equal(t, result["test_list"], []interface{}{float64(1), float64(2), float64(3), float64(4), "hello"})
 	assert.Equal(t, result["test_nested_object"], map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"c": "hello"}}})
 	assert.Equal(t, "2023-03-16T01:18:37+00:00", result["test_timestamp"])
+	assert.Equal(t, nil, result["test_nan"])
+	assert.Equal(t, "NaN", result["test_nan_string"]) // This should not be escaped.
+	assert.Equal(t, "NaNaNaNa", result["test_nan_string33"])
 }

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -48,6 +48,7 @@ func processMessage(ctx context.Context, processArgs ProcessArgs) error {
 
 	_event, err := topicConfig.GetEventFromBytes(ctx, processArgs.Msg.Value())
 	if err != nil {
+		fmt.Println(string(processArgs.Msg.Value()))
 		tags["what"] = "marshall_value_err"
 		return fmt.Errorf("cannot unmarshall event, err: %v", err)
 	}

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -48,7 +48,6 @@ func processMessage(ctx context.Context, processArgs ProcessArgs) error {
 
 	_event, err := topicConfig.GetEventFromBytes(ctx, processArgs.Msg.Value())
 	if err != nil {
-		fmt.Println(string(processArgs.Msg.Value()))
 		tags["what"] = "marshall_value_err"
 		return fmt.Errorf("cannot unmarshall event, err: %v", err)
 	}


### PR DESCRIPTION
MongoDB allows the value of `NaN` which is not accepted by JSON or JSON extended.
This PR will swap `NaN` values to `NULL` and not touch `"NaN"` or any values that have the `NaN` prefix.