### PR TITLE
Handling inconsistent source data and weird edge cases

### DIFF
--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -1,6 +1,7 @@
 package bigquery
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -15,7 +16,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func CastColVal(colVal interface{}, colKind columns.Column) (interface{}, error) {
+func CastColVal(ctx context.Context, colVal interface{}, colKind columns.Column) (interface{}, error) {
 	if colVal != nil {
 		switch colKind.KindDetails.Kind {
 		case typing.EDecimal.Kind:
@@ -26,7 +27,7 @@ func CastColVal(colVal interface{}, colKind columns.Column) (interface{}, error)
 
 			return val.Value(), nil
 		case typing.ETime.Kind:
-			extTime, err := ext.ParseFromInterface(colVal)
+			extTime, err := ext.ParseFromInterface(ctx, colVal)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 			}

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -32,9 +32,12 @@ func CastColVal(col string, colVal interface{}, colKind columns.Column) (interfa
 				return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 			}
 
-			fmt.Println("colVal", colVal, "extTime.NestedKind.Type", extTime.NestedKind.Type)
+			if colKind.KindDetails.ExtendedTimeDetails == nil {
+				return nil, fmt.Errorf("column kind details for extended time details is null")
+			}
 
-			switch extTime.NestedKind.Type {
+			// We should be using the colKind here since the data types coming from the source may be inconsistent.
+			switch colKind.KindDetails.ExtendedTimeDetails.Type {
 			// https://cloud.google.com/bigquery/docs/streaming-data-into-bigquery#sending_datetime_data
 			case ext.DateTimeKindType:
 				colVal = extTime.StringUTC(ext.BigQueryDateTimeFormat)
@@ -43,6 +46,8 @@ func CastColVal(col string, colVal interface{}, colKind columns.Column) (interfa
 			case ext.TimeKindType:
 				colVal = extTime.String(typing.StreamingTimeFormat)
 			}
+
+			fmt.Println("### AFTER col", col, "colVal", colVal, "extTime.NestedKind.Type", extTime.NestedKind.Type)
 		case typing.Struct.Kind:
 			if colKind.KindDetails == typing.Struct {
 				if strings.Contains(fmt.Sprint(colVal), constants.ToastUnavailableValuePlaceholder) {

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -53,7 +53,7 @@ func CastColVal(colVal interface{}, colKind columns.Column) (interface{}, error)
 			}
 		case typing.Array.Kind:
 			var err error
-			arrayString, err := array.InterfaceToArrayString(colVal)
+			arrayString, err := array.InterfaceToArrayString(colVal, true)
 			if err != nil {
 				return nil, err
 			}

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"cloud.google.com/go/bigquery"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 
 	"github.com/artie-labs/transfer/lib/typing/columns"
@@ -16,7 +15,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func CastColVal(col string, colVal interface{}, colKind columns.Column) (interface{}, error) {
+func CastColVal(colVal interface{}, colKind columns.Column) (interface{}, error) {
 	if colVal != nil {
 		switch colKind.KindDetails.Kind {
 		case typing.EDecimal.Kind:
@@ -46,8 +45,6 @@ func CastColVal(col string, colVal interface{}, colKind columns.Column) (interfa
 			case ext.TimeKindType:
 				colVal = extTime.String(typing.StreamingTimeFormat)
 			}
-
-			fmt.Println("### AFTER col", col, "colVal", colVal, "extTime.NestedKind.Type", extTime.NestedKind.Type)
 		case typing.Struct.Kind:
 			if colKind.KindDetails == typing.Struct {
 				if strings.Contains(fmt.Sprint(colVal), constants.ToastUnavailableValuePlaceholder) {
@@ -62,7 +59,7 @@ func CastColVal(col string, colVal interface{}, colKind columns.Column) (interfa
 			}
 
 			if len(arrayString) == 0 {
-				return []bigquery.NullString{{Valid: false}}, nil
+				return nil, nil
 			}
 
 			return arrayString, nil

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -76,6 +76,18 @@ func TestCastColVal(t *testing.T) {
 			expectedValue: []string{"1", "2", "3", "4", "5"},
 		},
 		{
+			name:          "empty array",
+			colVal:        []int{},
+			colKind:       columns.Column{KindDetails: typing.Array},
+			expectedValue: nil,
+		},
+		{
+			name:          "null array",
+			colVal:        nil,
+			colKind:       columns.Column{KindDetails: typing.Array},
+			expectedValue: nil,
+		},
+		{
 			name:          "timestamp",
 			colVal:        birthdayTSExt,
 			colKind:       columns.Column{KindDetails: tsKind},
@@ -84,6 +96,12 @@ func TestCastColVal(t *testing.T) {
 		{
 			name:          "date",
 			colVal:        birthdayDateExt,
+			colKind:       columns.Column{KindDetails: dateKind},
+			expectedValue: "2022-09-06",
+		},
+		{
+			name:          "date (column is a date, but value is not)",
+			colVal:        birthdayTSExt,
 			colKind:       columns.Column{KindDetails: dateKind},
 			expectedValue: "2022-09-06",
 		},

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -2,7 +2,6 @@ package bigquery
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/columns"
@@ -16,7 +15,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func TestCastColVal(t *testing.T) {
+func (b *BigQueryTestSuite) TestCastColVal() {
 	type _testCase struct {
 		name    string
 		colVal  interface{}
@@ -114,8 +113,8 @@ func TestCastColVal(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualString, actualErr := CastColVal(testCase.colVal, testCase.colKind)
-		assert.Equal(t, testCase.expectedErr, actualErr, testCase.name)
-		assert.Equal(t, testCase.expectedValue, actualString, testCase.name)
+		actualString, actualErr := CastColVal(b.ctx, testCase.colVal, testCase.colKind)
+		assert.Equal(b.T(), testCase.expectedErr, actualErr, testCase.name)
+		assert.Equal(b.T(), testCase.expectedValue, actualString, testCase.name)
 	}
 }

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -33,15 +33,15 @@ func (b *BigQueryTestSuite) TestCastColVal() {
 
 	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
 	birthdayTSExt, err := ext.NewExtendedTime(birthday, tsKind.ExtendedTimeDetails.Type, "")
-	assert.NoError(t, err)
+	assert.NoError(b.T(), err)
 
 	birthdayDateExt, err := ext.NewExtendedTime(birthday, dateKind.ExtendedTimeDetails.Type, "")
-	assert.NoError(t, err)
+	assert.NoError(b.T(), err)
 
 	timeKind := typing.ETime
 	timeKind.ExtendedTimeDetails = &ext.Time
 	birthdayTimeExt, err := ext.NewExtendedTime(birthday, timeKind.ExtendedTimeDetails.Type, "")
-	assert.NoError(t, err)
+	assert.NoError(b.T(), err)
 
 	testCases := []_testCase{
 		{

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -43,7 +43,7 @@ func merge(ctx context.Context, tableData *optimization.TableData) ([]*Row, erro
 		data := make(map[string]bigquery.Value)
 		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(ctx, nil) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
-			colVal, err := CastColVal(col, value[col], colKind)
+			colVal, err := CastColVal(value[col], colKind)
 			if err != nil {
 				return nil, err
 			}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -43,7 +43,8 @@ func merge(ctx context.Context, tableData *optimization.TableData) ([]*Row, erro
 		data := make(map[string]bigquery.Value)
 		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(ctx, nil) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
-			colVal, err := CastColVal(value[col], colKind)
+			colVal, err := CastColVal(col, value[col], colKind)
+			fmt.Println("value", value[col], "colKind", colKind, "colVal", colVal, "err", err)
 			if err != nil {
 				return nil, err
 			}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -45,7 +45,7 @@ func merge(ctx context.Context, tableData *optimization.TableData) ([]*Row, erro
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal, err := CastColVal(value[col], colKind)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to cast col: %v, err: %v", col, err)
 			}
 
 			if colVal != nil {

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -245,6 +245,8 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	_, err = s.Exec(mergeQuery)
+	// This is above, in the case we have a head of line blocking because of an error
+	// We will not create infinite temporary tables.
 	_ = ddl.DropTemporaryTable(ctx, s, tempAlterTableArgs.FqTableName, false)
 	if err != nil {
 		return err

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -43,7 +43,7 @@ func merge(ctx context.Context, tableData *optimization.TableData) ([]*Row, erro
 		data := make(map[string]bigquery.Value)
 		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(ctx, nil) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
-			colVal, err := CastColVal(value[col], colKind)
+			colVal, err := CastColVal(ctx, value[col], colKind)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast col: %v, err: %v", col, err)
 			}
@@ -67,7 +67,7 @@ func (s *Store) backfillColumn(ctx context.Context, column columns.Column, fqTab
 		return nil
 	}
 
-	defaultVal, err := column.DefaultValue(&columns.DefaultValueArgs{
+	defaultVal, err := column.DefaultValue(ctx, &columns.DefaultValueArgs{
 		Escape:   true,
 		DestKind: s.Label(),
 	})
@@ -206,7 +206,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 				attempts += 1
 				time.Sleep(time.Duration(jitter.JitterMs(1500, attempts)) * time.Millisecond)
 			} else {
-				defaultVal, _ := col.DefaultValue(nil)
+				defaultVal, _ := col.DefaultValue(ctx, nil)
 				return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v",
 					col.Name(ctx, nil), defaultVal, err)
 			}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -245,10 +245,10 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	_, err = s.Exec(mergeQuery)
+	_ = ddl.DropTemporaryTable(ctx, s, tempAlterTableArgs.FqTableName, false)
 	if err != nil {
 		return err
 	}
 
-	_ = ddl.DropTemporaryTable(ctx, s, tempAlterTableArgs.FqTableName, false)
 	return nil
 }

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -44,7 +44,6 @@ func merge(ctx context.Context, tableData *optimization.TableData) ([]*Row, erro
 		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(ctx, nil) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal, err := CastColVal(col, value[col], colKind)
-			fmt.Println("value", value[col], "colKind", colKind, "colVal", colVal, "err", err)
 			if err != nil {
 				return nil, err
 			}

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -33,7 +33,11 @@ func CastColValStaging(colVal interface{}, colKind columns.Column) (string, erro
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 		}
 
-		switch extTime.NestedKind.Type {
+		if colKind.KindDetails.ExtendedTimeDetails == nil {
+			return "", fmt.Errorf("column kind details for extended time details is null")
+		}
+
+		switch colKind.KindDetails.ExtendedTimeDetails.Type {
 		case ext.TimeKindType:
 			colValString = extTime.String(ext.PostgresTimeFormatNoTZ)
 		default:

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -41,7 +41,7 @@ func CastColValStaging(colVal interface{}, colKind columns.Column) (string, erro
 		case ext.TimeKindType:
 			colValString = extTime.String(ext.PostgresTimeFormatNoTZ)
 		default:
-			colValString = extTime.String("")
+			colValString = extTime.String(colKind.KindDetails.ExtendedTimeDetails.Format)
 		}
 
 	case typing.String.Kind:

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -45,7 +45,7 @@ func CastColValStaging(colVal interface{}, colKind columns.Column) (string, erro
 		}
 
 	case typing.String.Kind:
-		list, err := array.InterfaceToArrayString(colVal)
+		list, err := array.InterfaceToArrayString(colVal, false)
 		if err == nil {
 			colValString = "[" + strings.Join(list, ",") + "]"
 		} else {

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -1,6 +1,7 @@
 package redshift
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -18,7 +19,7 @@ import (
 
 // CastColValStaging - takes `colVal` interface{} and `colKind` typing.Column and converts the value into a string value
 // This is necessary because CSV writers require values to in `string`.
-func CastColValStaging(colVal interface{}, colKind columns.Column) (string, error) {
+func CastColValStaging(ctx context.Context, colVal interface{}, colKind columns.Column) (string, error) {
 	if colVal == nil {
 		// This matches the COPY clause for NULL terminator.
 		return `\N`, nil
@@ -28,7 +29,7 @@ func CastColValStaging(colVal interface{}, colKind columns.Column) (string, erro
 	switch colKind.KindDetails.Kind {
 	// All the other types do not need string wrapping.
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(colVal)
+		extTime, err := ext.ParseFromInterface(ctx, colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 		}

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -1,6 +1,7 @@
 package redshift
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"testing"
@@ -29,8 +30,8 @@ type _testCase struct {
 	expectErr      bool
 }
 
-func evaluateTestCase(t *testing.T, testCase _testCase) {
-	actualString, actualErr := CastColValStaging(testCase.colVal, testCase.colKind)
+func evaluateTestCase(t *testing.T, ctx context.Context, testCase _testCase) {
+	actualString, actualErr := CastColValStaging(ctx, testCase.colVal, testCase.colKind)
 	if testCase.expectErr {
 		assert.Error(t, actualErr, testCase.name)
 	} else {
@@ -135,7 +136,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Basic() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), testCase)
+		evaluateTestCase(r.T(), r.ctx, testCase)
 	}
 }
 
@@ -184,7 +185,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Array() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), testCase)
+		evaluateTestCase(r.T(), r.ctx, testCase)
 	}
 }
 
@@ -246,7 +247,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Time() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), testCase)
+		evaluateTestCase(r.T(), r.ctx, testCase)
 	}
 }
 
@@ -265,6 +266,6 @@ func (r *RedshiftTestSuite) TestCastColValStaging_TOAST() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), testCase)
+		evaluateTestCase(r.T(), r.ctx, testCase)
 	}
 }

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -221,6 +221,14 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Time() {
 			expectedString: "2022-09-06",
 		},
 		{
+			name:   "date (but value is datetime)",
+			colVal: birthDateTime,
+			colKind: columns.Column{
+				KindDetails: dateKind,
+			},
+			expectedString: "2022-09-06",
+		},
+		{
 			name:   "time",
 			colVal: birthTime,
 			colKind: columns.Column{

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -47,7 +47,6 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Basic() {
 			colKind: columns.Column{
 				KindDetails: typing.String,
 			},
-
 			expectedString: "",
 		},
 		{

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -107,7 +107,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true))
 		if err != nil {
-			defaultVal, _ := col.DefaultValue(nil)
+			defaultVal, _ := col.DefaultValue(ctx, nil)
 			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v",
 				col.Name(ctx, nil), defaultVal, err)
 		}

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -88,7 +88,7 @@ func (s *Store) loadTemporaryTable(ctx context.Context, tableData *optimization.
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal := value[col]
 			// Check
-			castedValue, castErr := CastColValStaging(colVal, colKind)
+			castedValue, castErr := CastColValStaging(ctx, colVal, colKind)
 			if castErr != nil {
 				return "", castErr
 			}

--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -35,7 +35,11 @@ func CastColValStaging(colVal interface{}, colKind columns.Column) (string, erro
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 		}
 
-		switch extTime.NestedKind.Type {
+		if colKind.KindDetails.ExtendedTimeDetails == nil {
+			return "", fmt.Errorf("column kind details for extended time details is null")
+		}
+
+		switch colKind.KindDetails.ExtendedTimeDetails.Type {
 		case ext.TimeKindType:
 			colValString = extTime.String(ext.PostgresTimeFormatNoTZ)
 		default:

--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -1,6 +1,7 @@
 package snowflake
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -20,7 +21,7 @@ import (
 
 // CastColValStaging - takes `colVal` interface{} and `colKind` typing.Column and converts the value into a string value
 // This is necessary because CSV writers require values to in `string`.
-func CastColValStaging(colVal interface{}, colKind columns.Column) (string, error) {
+func CastColValStaging(ctx context.Context, colVal interface{}, colKind columns.Column) (string, error) {
 	if colVal == nil {
 		// \\N needs to match NULL_IF(...) from ddl.go
 		return `\\N`, nil
@@ -30,7 +31,7 @@ func CastColValStaging(colVal interface{}, colKind columns.Column) (string, erro
 	switch colKind.KindDetails.Kind {
 	// All the other types do not need string wrapping.
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(colVal)
+		extTime, err := ext.ParseFromInterface(ctx, colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 		}

--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -43,7 +43,7 @@ func CastColValStaging(colVal interface{}, colKind columns.Column) (string, erro
 		case ext.TimeKindType:
 			colValString = extTime.String(ext.PostgresTimeFormatNoTZ)
 		default:
-			colValString = extTime.String("")
+			colValString = extTime.String(colKind.KindDetails.ExtendedTimeDetails.Format)
 		}
 
 	case typing.String.Kind:

--- a/clients/snowflake/cast_test.go
+++ b/clients/snowflake/cast_test.go
@@ -213,6 +213,14 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Time() {
 			expectedString: "2022-09-06",
 		},
 		{
+			name:   "date (but value is dateTime)",
+			colVal: birthDateTime,
+			colKind: columns.Column{
+				KindDetails: dateKind,
+			},
+			expectedString: "2022-09-06",
+		},
+		{
 			name:   "time",
 			colVal: birthTime,
 			colKind: columns.Column{

--- a/clients/snowflake/cast_test.go
+++ b/clients/snowflake/cast_test.go
@@ -1,6 +1,7 @@
 package snowflake
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"testing"
@@ -29,8 +30,8 @@ type _testCase struct {
 	expectErr      bool
 }
 
-func evaluateTestCase(t *testing.T, testCase _testCase) {
-	actualString, actualErr := CastColValStaging(testCase.colVal, testCase.colKind)
+func evaluateTestCase(t *testing.T, ctx context.Context, testCase _testCase) {
+	actualString, actualErr := CastColValStaging(ctx, testCase.colVal, testCase.colKind)
 	if testCase.expectErr {
 		assert.Error(t, actualErr, testCase.name)
 	} else {
@@ -128,7 +129,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(s.T(), testCase)
+		evaluateTestCase(s.T(), s.ctx, testCase)
 	}
 }
 
@@ -177,7 +178,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Array() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(s.T(), testCase)
+		evaluateTestCase(s.T(), s.ctx, testCase)
 	}
 }
 
@@ -239,7 +240,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Time() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(s.T(), testCase)
+		evaluateTestCase(s.T(), s.ctx, testCase)
 	}
 }
 
@@ -258,6 +259,6 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_TOAST() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(s.T(), testCase)
+		evaluateTestCase(s.T(), s.ctx, testCase)
 	}
 }

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -80,7 +80,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
-		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
+		"created_at": typing.ParseValue(s.ctx, "", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
 	var cols columns.Columns
@@ -130,7 +130,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
-		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
+		"created_at": typing.ParseValue(s.ctx, "", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
 	var cols columns.Columns
@@ -217,7 +217,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		"name":                       typing.String,
 		constants.DeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
-		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
+		"created_at": typing.ParseValue(s.ctx, "", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
 	var cols columns.Columns
@@ -265,7 +265,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 		inMemColumns := tableData.ReadOnlyInMemoryCols()
 		// Since sflkColumns overwrote the format, let's set it correctly again.
-		inMemColumns.UpdateColumn(columns.NewColumn("created_at", typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano))))
+		inMemColumns.UpdateColumn(columns.NewColumn("created_at", typing.ParseValue(s.ctx, "", nil, time.Now().Format(time.RFC3339Nano))))
 		tableData.SetInMemoryColumns(inMemColumns)
 		break
 	}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -91,7 +91,7 @@ func (s *Store) loadTemporaryTable(ctx context.Context, tableData *optimization.
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal := value[col]
 			// Check
-			castedValue, castErr := CastColValStaging(colVal, colKind)
+			castedValue, castErr := CastColValStaging(ctx, colVal, colKind)
 			if castErr != nil {
 				return "", castErr
 			}
@@ -191,7 +191,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 
 		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true))
 		if err != nil {
-			defaultVal, _ := col.DefaultValue(nil)
+			defaultVal, _ := col.DefaultValue(ctx, nil)
 			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v",
 				col.Name(ctx, nil), defaultVal, err)
 		}

--- a/clients/utils/utils.go
+++ b/clients/utils/utils.go
@@ -23,7 +23,7 @@ func BackfillColumn(ctx context.Context, dwh dwh.DataWarehouse, column columns.C
 		return nil
 	}
 
-	defaultVal, err := column.DefaultValue(&columns.DefaultValueArgs{
+	defaultVal, err := column.DefaultValue(ctx, &columns.DefaultValueArgs{
 		Escape:   true,
 		DestKind: dwh.Label(),
 	})

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -45,10 +45,6 @@ func InterfaceToArrayString(val interface{}) ([]string, error) {
 		}
 	}
 
-	if len(vals) == 0 {
-		return nil, nil
-	}
-
 	return vals, nil
 }
 

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -45,6 +45,10 @@ func InterfaceToArrayString(val interface{}) ([]string, error) {
 		}
 	}
 
+	if len(vals) == 0 {
+		return nil, nil
+	}
+
 	return vals, nil
 }
 

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -2,21 +2,27 @@ package array
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 
 	"github.com/artie-labs/transfer/lib/stringutil"
 )
 
-func InterfaceToArrayString(val interface{}) ([]string, error) {
+func InterfaceToArrayString(val interface{}, recastAsArray bool) ([]string, error) {
 	if val == nil {
 		return nil, nil
 	}
 
 	list := reflect.ValueOf(val)
 	if list.Kind() != reflect.Slice {
-		// Since it's not a slice, let's cast it as a slice and re-enter this function.
-		return InterfaceToArrayString([]interface{}{val})
+		if recastAsArray {
+			// Since it's not a slice, let's cast it as a slice and re-enter this function.
+			return InterfaceToArrayString([]interface{}{val}, recastAsArray)
+		} else {
+			return nil, fmt.Errorf("wrong data type, kind: %v", list.Kind())
+		}
+
 	}
 
 	var vals []string

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -2,7 +2,6 @@ package array
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -16,7 +15,8 @@ func InterfaceToArrayString(val interface{}) ([]string, error) {
 
 	list := reflect.ValueOf(val)
 	if list.Kind() != reflect.Slice {
-		return nil, fmt.Errorf("wrong data type")
+		// Since it's not a slice, let's cast it as a slice and re-enter this function.
+		return InterfaceToArrayString([]interface{}{val})
 	}
 
 	var vals []string

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -10,11 +10,11 @@ import (
 
 func TestToArrayString(t *testing.T) {
 	type _testCase struct {
-		name string
-		val  interface{}
-
-		expectedList []string
-		expectedErr  error
+		name          string
+		val           interface{}
+		recastAsArray bool
+		expectedList  []string
+		expectedErr   error
 	}
 
 	testCases := []_testCase{
@@ -66,10 +66,16 @@ func TestToArrayString(t *testing.T) {
 			},
 			expectedList: []string{"[foo bar]", "[abc def]"},
 		},
+		{
+			name:          "boolean, but recasting as an array",
+			val:           true,
+			expectedList:  []string{"true"},
+			recastAsArray: true,
+		},
 	}
 
 	for _, testCase := range testCases {
-		actualString, actualErr := InterfaceToArrayString(testCase.val, false)
+		actualString, actualErr := InterfaceToArrayString(testCase.val, testCase.recastAsArray)
 		assert.Equal(t, testCase.expectedList, actualString, testCase.name)
 		assert.Equal(t, testCase.expectedErr, actualErr, testCase.name)
 	}

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -25,7 +25,7 @@ func TestToArrayString(t *testing.T) {
 			name:         "wrong data type",
 			val:          true,
 			expectedList: nil,
-			expectedErr:  fmt.Errorf("wrong data type"),
+			expectedErr:  fmt.Errorf("wrong data type, kind: bool"),
 		},
 		{
 			name:         "list of numbers",
@@ -69,7 +69,7 @@ func TestToArrayString(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualString, actualErr := InterfaceToArrayString(testCase.val)
+		actualString, actualErr := InterfaceToArrayString(testCase.val, false)
 		assert.Equal(t, testCase.expectedList, actualString, testCase.name)
 		assert.Equal(t, testCase.expectedErr, actualErr, testCase.name)
 	}

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -21,7 +21,7 @@ import (
 
 type Debezium string
 
-func (d *Debezium) GetEventFromBytes(_ context.Context, bytes []byte) (cdc.Event, error) {
+func (d *Debezium) GetEventFromBytes(ctx context.Context, bytes []byte) (cdc.Event, error) {
 	var schemaEventPayload SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.
@@ -53,7 +53,7 @@ func (d *Debezium) GetEventFromBytes(_ context.Context, bytes []byte) (cdc.Event
 		// Now, we need to iterate over each key and if the value is JSON
 		// We need to parse the JSON into a string format
 		for key, value := range after {
-			if typing.ParseValue(key, nil, value) == typing.Struct {
+			if typing.ParseValue(ctx, key, nil, value) == typing.Struct {
 				valBytes, err := json.Marshal(value)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal, err: %v", err)

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -22,6 +22,7 @@ import (
 type Debezium string
 
 func (d *Debezium) GetEventFromBytes(_ context.Context, bytes []byte) (cdc.Event, error) {
+	//fmt.Println(string(bytes))
 	var schemaEventPayload SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -22,7 +22,6 @@ import (
 type Debezium string
 
 func (d *Debezium) GetEventFromBytes(_ context.Context, bytes []byte) (cdc.Event, error) {
-	//fmt.Println(string(bytes))
 	var schemaEventPayload SchemaEventPayload
 	if len(bytes) == 0 {
 		// This is a Kafka Tombstone event.

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -193,7 +193,7 @@ func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 	// Testing typing.
 	assert.Equal(p.T(), evtData["id"], 1001)
 	assert.Equal(p.T(), evtData["another_id"], 333)
-	assert.Equal(p.T(), typing.ParseValue("another_id", evt.GetOptionalSchema(p.ctx), evtData["another_id"]), typing.Integer)
+	assert.Equal(p.T(), typing.ParseValue(p.ctx, "another_id", evt.GetOptionalSchema(p.ctx), evtData["another_id"]), typing.Integer)
 
 	assert.Equal(p.T(), evtData["email"], "sally.thomas@acme.com")
 

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -68,14 +68,14 @@ func (u *UtilTestSuite) TestSource_GetOptionalSchema() {
 	col, isOk := cols.GetColumn("boolean_column")
 	assert.True(u.T(), isOk)
 
-	defaultVal, err := col.DefaultValue(nil)
+	defaultVal, err := col.DefaultValue(u.ctx, nil)
 	assert.NoError(u.T(), err)
 	assert.Equal(u.T(), false, defaultVal)
 
 	for _, _col := range cols.GetColumns() {
 		// All the other columns do not have a default value.
 		if _col.Name(u.ctx, nil) != "boolean_column" {
-			defaultVal, err = _col.DefaultValue(nil)
+			defaultVal, err = _col.DefaultValue(u.ctx, nil)
 			assert.NoError(u.T(), err)
 			assert.Nil(u.T(), defaultVal, _col.Name(u.ctx, nil))
 		}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -82,7 +82,8 @@ type Redshift struct {
 }
 
 type SharedDestinationConfig struct {
-	UppercaseEscapedNames bool `yaml:"uppercaseEscapedNames"`
+	UppercaseEscapedNames bool     `yaml:"uppercaseEscapedNames"`
+	AdditionalDateFormats []string `yaml:"additionalDateFormats"`
 }
 
 type Snowflake struct {

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -82,7 +82,10 @@ type Redshift struct {
 }
 
 type SharedDestinationConfig struct {
-	UppercaseEscapedNames bool     `yaml:"uppercaseEscapedNames"`
+	UppercaseEscapedNames bool `yaml:"uppercaseEscapedNames"`
+}
+
+type SharedTransferConfig struct {
 	AdditionalDateFormats []string `yaml:"additionalDateFormats"`
 }
 
@@ -132,6 +135,9 @@ type Config struct {
 	// Supported message queues
 	Pubsub *Pubsub
 	Kafka  *Kafka
+
+	// Shared Transfer settings
+	SharedTransferConfig SharedTransferConfig `yaml:"sharedTransferConfig"`
 
 	// Shared destination configuration
 	SharedDestinationConfig SharedDestinationConfig `yaml:"sharedDestinationConfig"`

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -49,7 +49,7 @@ func (c *Column) DefaultValue(args *DefaultValueArgs) (interface{}, error) {
 		case ext.TimeKindType:
 			return stringutil.Wrap(extTime.String(ext.PostgresTimeFormatNoTZ), false), nil
 		default:
-			return stringutil.Wrap(extTime.String(""), false), nil
+			return stringutil.Wrap(extTime.String(c.KindDetails.ExtendedTimeDetails.Format), false), nil
 		}
 	case typing.EDecimal.Kind:
 		val, isOk := c.defaultValue.(*decimal.Decimal)

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -36,12 +36,16 @@ func (c *Column) DefaultValue(args *DefaultValueArgs) (interface{}, error) {
 			return stringutil.Wrap(c.defaultValue, false), nil
 		}
 	case typing.ETime.Kind:
+		if c.KindDetails.ExtendedTimeDetails == nil {
+			return nil, fmt.Errorf("column kind details for extended time is nil")
+		}
+
 		extTime, err := ext.ParseFromInterface(c.defaultValue)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", c.defaultValue, err)
 		}
 
-		switch extTime.NestedKind.Type {
+		switch c.KindDetails.ExtendedTimeDetails.Type {
 		case ext.TimeKindType:
 			return stringutil.Wrap(extTime.String(ext.PostgresTimeFormatNoTZ), false), nil
 		default:

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -1,6 +1,7 @@
 package columns
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -17,7 +18,7 @@ type DefaultValueArgs struct {
 	DestKind constants.DestinationKind
 }
 
-func (c *Column) DefaultValue(args *DefaultValueArgs) (interface{}, error) {
+func (c *Column) DefaultValue(ctx context.Context, args *DefaultValueArgs) (interface{}, error) {
 	if args == nil || !args.Escape {
 		// Either no args, or args.Escape = false
 		return c.defaultValue, nil
@@ -40,7 +41,7 @@ func (c *Column) DefaultValue(args *DefaultValueArgs) (interface{}, error) {
 			return nil, fmt.Errorf("column kind details for extended time is nil")
 		}
 
-		extTime, err := ext.ParseFromInterface(c.defaultValue)
+		extTime, err := ext.ParseFromInterface(ctx, c.defaultValue)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", c.defaultValue, err)
 		}

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -1,7 +1,6 @@
 package columns
 
 import (
-	"testing"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
@@ -13,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestColumn_DefaultValue(t *testing.T) {
+func (c *ColumnsTestSuite) TestColumn_DefaultValue() {
 	type _testCase struct {
 		name          string
 		col           *Column
@@ -23,8 +22,8 @@ func TestColumn_DefaultValue(t *testing.T) {
 	}
 
 	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
-	birthdayExtDateTime, err := ext.ParseExtendedDateTime(birthday.Format(ext.ISO8601))
-	assert.NoError(t, err)
+	birthdayExtDateTime, err := ext.ParseExtendedDateTime(c.ctx, birthday.Format(ext.ISO8601))
+	assert.NoError(c.T(), err)
 
 	// date
 	dateKind := typing.ETime
@@ -136,13 +135,13 @@ func TestColumn_DefaultValue(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualValue, actualErr := testCase.col.DefaultValue(testCase.args)
+		actualValue, actualErr := testCase.col.DefaultValue(c.ctx, testCase.args)
 		if testCase.expectedEr {
-			assert.Error(t, actualErr, testCase.name)
+			assert.Error(c.T(), actualErr, testCase.name)
 		} else {
-			assert.NoError(t, actualErr, testCase.name)
+			assert.NoError(c.T(), actualErr, testCase.name)
 		}
 
-		assert.Equal(t, testCase.expectedValue, actualValue, testCase.name)
+		assert.Equal(c.T(), testCase.expectedValue, actualValue, testCase.name)
 	}
 }

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -2,6 +2,9 @@ package columns
 
 import (
 	"testing"
+	"time"
+
+	"github.com/artie-labs/transfer/lib/typing/ext"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 
@@ -18,6 +21,20 @@ func TestColumn_DefaultValue(t *testing.T) {
 		expectedValue interface{}
 		expectedEr    bool
 	}
+
+	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
+	birthdayExtDateTime, err := ext.ParseExtendedDateTime(birthday.Format(ext.ISO8601))
+	assert.NoError(t, err)
+
+	// date
+	dateKind := typing.ETime
+	dateKind.ExtendedTimeDetails = &ext.Date
+	// time
+	timeKind := typing.ETime
+	timeKind.ExtendedTimeDetails = &ext.Time
+	// date time
+	dateTimeKind := typing.ETime
+	dateTimeKind.ExtendedTimeDetails = &ext.DateTime
 
 	testCases := []_testCase{
 		{
@@ -83,12 +100,47 @@ func TestColumn_DefaultValue(t *testing.T) {
 			},
 			expectedValue: "'{}'",
 		},
+		{
+			name: "date",
+			col: &Column{
+				KindDetails:  dateKind,
+				defaultValue: birthdayExtDateTime,
+			},
+			args: &DefaultValueArgs{
+				Escape: true,
+			},
+			expectedValue: "'2022-09-06'",
+		},
+		{
+			name: "time",
+			col: &Column{
+				KindDetails:  timeKind,
+				defaultValue: birthdayExtDateTime,
+			},
+			args: &DefaultValueArgs{
+				Escape: true,
+			},
+			expectedValue: "'03:19:24'",
+		},
+		{
+			name: "datetime",
+			col: &Column{
+				KindDetails:  dateTimeKind,
+				defaultValue: birthdayExtDateTime,
+			},
+			args: &DefaultValueArgs{
+				Escape: true,
+			},
+			expectedValue: "'2022-09-06T03:19:24Z'",
+		},
 	}
 
 	for _, testCase := range testCases {
 		actualValue, actualErr := testCase.col.DefaultValue(testCase.args)
 		if testCase.expectedEr {
 			assert.Error(t, actualErr, testCase.name)
+		} else {
+			assert.NoError(t, actualErr, testCase.name)
 		}
 
 		assert.Equal(t, testCase.expectedValue, actualValue, testCase.name)

--- a/lib/typing/ext/ext_suite_test.go
+++ b/lib/typing/ext/ext_suite_test.go
@@ -14,12 +14,8 @@ type ExtTestSuite struct {
 }
 
 func (e *ExtTestSuite) SetupTest() {
-	e.ctx = context.Background()
-	e.ctx = config.InjectSettingsIntoContext(e.ctx, &config.Settings{
-		Config: &config.Config{
-			FlushIntervalSeconds: 10,
-			BufferRows:           10,
-		},
+	e.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
+		Config: &config.Config{},
 	})
 }
 

--- a/lib/typing/ext/ext_suite_test.go
+++ b/lib/typing/ext/ext_suite_test.go
@@ -1,0 +1,28 @@
+package ext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
+	"github.com/stretchr/testify/suite"
+)
+
+type ExtTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (e *ExtTestSuite) SetupTest() {
+	e.ctx = context.Background()
+	e.ctx = config.InjectSettingsIntoContext(e.ctx, &config.Settings{
+		Config: &config.Config{
+			FlushIntervalSeconds: 10,
+			BufferRows:           10,
+		},
+	})
+}
+
+func TestExtTestSuite(t *testing.T) {
+	suite.Run(t, new(ExtTestSuite))
+}

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -1,11 +1,12 @@
 package ext
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
 
-func ParseFromInterface(val interface{}) (*ExtendedTime, error) {
+func ParseFromInterface(ctx context.Context, val interface{}) (*ExtendedTime, error) {
 	if val == nil {
 		return nil, fmt.Errorf("val is nil")
 	}
@@ -16,7 +17,7 @@ func ParseFromInterface(val interface{}) (*ExtendedTime, error) {
 	}
 
 	var err error
-	extendedTime, err = ParseExtendedDateTime(fmt.Sprint(val))
+	extendedTime, err = ParseExtendedDateTime(ctx, fmt.Sprint(val))
 	if err != nil {
 		return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", val, err)
 	}
@@ -46,7 +47,7 @@ func ParseTimeExactMatch(layout, potentialDateTimeString string) (time.Time, boo
 // 1) Precision loss in translation
 // 2) Original format preservation (with tz locale).
 // If it cannot find it, then it will give you the next best thing.
-func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
+func ParseExtendedDateTime(ctx context.Context, dtString string) (*ExtendedTime, error) {
 	// Check all the timestamp formats
 	var potentialFormat string
 	var potentialTime time.Time
@@ -64,6 +65,7 @@ func ParseExtendedDateTime(dtString string) (*ExtendedTime, error) {
 	// Now check DATE formats
 	for _, supportedDateFormat := range supportedDateFormats {
 		ts, exactMatch, err := ParseTimeExactMatch(supportedDateFormat, dtString)
+		fmt.Println("ts", ts, "exactMatch", exactMatch, "err", err, "fmt", supportedDateFormat)
 		if err == nil && exactMatch {
 			return NewExtendedTime(ts, DateKindType, supportedDateFormat)
 		}

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/artie-labs/transfer/lib/config"
 )
 
 func ParseFromInterface(ctx context.Context, val interface{}) (*ExtendedTime, error) {
@@ -62,10 +64,14 @@ func ParseExtendedDateTime(ctx context.Context, dtString string) (*ExtendedTime,
 		}
 	}
 
+	allSupportedDateFormats := supportedDateFormats
+	if len(config.FromContext(ctx).Config.SharedTransferConfig.AdditionalDateFormats) > 0 {
+		allSupportedDateFormats = append(allSupportedDateFormats, config.FromContext(ctx).Config.SharedTransferConfig.AdditionalDateFormats...)
+	}
+
 	// Now check DATE formats
-	for _, supportedDateFormat := range supportedDateFormats {
+	for _, supportedDateFormat := range allSupportedDateFormats {
 		ts, exactMatch, err := ParseTimeExactMatch(supportedDateFormat, dtString)
-		fmt.Println("ts", ts, "exactMatch", exactMatch, "err", err, "fmt", supportedDateFormat)
 		if err == nil && exactMatch {
 			return NewExtendedTime(ts, DateKindType, supportedDateFormat)
 		}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -1,8 +1,9 @@
 package ext
 
 import (
-	"testing"
 	"time"
+
+	"github.com/artie-labs/transfer/lib/config"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -79,18 +80,27 @@ func (e *ExtTestSuite) TestParseFromInterfaceDate() {
 	}
 }
 
-func (e *ExtTestSuite) TestParseExtendedDateTime_Timestamp(t *testing.T) {
+func (e *ExtTestSuite) TestParseExtendedDateTime_Timestamp() {
 	tsString := "2023-04-24T17:29:05.69944Z"
 	extTime, err := ParseExtendedDateTime(e.ctx, tsString)
-	assert.NoError(t, err)
-	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.String(""))
+	assert.NoError(e.T(), err)
+	assert.Equal(e.T(), "2023-04-24T17:29:05.69944Z", extTime.String(""))
 }
 
 func (e *ExtTestSuite) TestParseExtendedDateTime() {
+	ctx := config.InjectSettingsIntoContext(e.ctx, &config.Settings{
+		Config: &config.Config{
+			SharedTransferConfig: config.SharedTransferConfig{
+				// DD-MM-YY
+				AdditionalDateFormats: []string{"02/01/06"},
+			},
+		},
+	})
+
 	dateString := "27/12/82"
-	extTime, err := ParseExtendedDateTime(e.ctx, dateString)
+	extTime, err := ParseExtendedDateTime(ctx, dateString)
 	assert.NoError(e.T(), err)
-	assert.Equal(e.T(), "2023-04-24T17:29:05.69944Z", extTime.String(""))
+	assert.Equal(e.T(), "27/12/82", extTime.String(""))
 }
 
 func (e *ExtTestSuite) TestTimeLayout() {

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -1,9 +1,10 @@
 package ext
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseFromInterface(t *testing.T) {
@@ -85,6 +86,13 @@ func TestParseExtendedDateTime_Timestamp(t *testing.T) {
 	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.String(""))
 }
 
+func TestParseExtendedDateTime(t *testing.T) {
+	dateString := "27/12/1992"
+	extTime, err := ParseExtendedDateTime(dateString)
+	assert.NoError(t, err)
+	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.String(""))
+}
+
 func TestTimeLayout(t *testing.T) {
 	ts := time.Now()
 
@@ -94,5 +102,4 @@ func TestTimeLayout(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, parsedTsString, extTime.String(""))
 	}
-
 }

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseFromInterface(t *testing.T) {
+func (e *ExtTestSuite) TestParseFromInterface() {
 	var vals []interface{}
 	vals = append(vals, &ExtendedTime{
 		Time: time.Now().UTC(),
@@ -30,9 +30,9 @@ func TestParseFromInterface(t *testing.T) {
 	})
 
 	for _, val := range vals {
-		extTime, err := ParseFromInterface(val)
-		assert.NoError(t, err)
-		assert.Equal(t, val, extTime)
+		extTime, err := ParseFromInterface(e.ctx, val)
+		assert.NoError(e.T(), err)
+		assert.Equal(e.T(), val, extTime)
 	}
 
 	invalidVals := []interface{}{
@@ -41,65 +41,65 @@ func TestParseFromInterface(t *testing.T) {
 		false,
 	}
 	for _, invalidVal := range invalidVals {
-		_, err := ParseFromInterface(invalidVal)
-		assert.Error(t, err)
+		_, err := ParseFromInterface(e.ctx, invalidVal)
+		assert.Error(e.T(), err)
 	}
 }
 
-func TestParseFromInterfaceDateTime(t *testing.T) {
+func (e *ExtTestSuite) TestParseFromInterfaceDateTime() {
 	now := time.Now().In(time.UTC)
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		et, err := ParseFromInterface(now.Format(supportedDateTimeLayout))
-		assert.NoError(t, err)
-		assert.Equal(t, et.NestedKind.Type, DateTimeKindType)
-		assert.Equal(t, et.String(""), now.Format(supportedDateTimeLayout))
+		et, err := ParseFromInterface(e.ctx, now.Format(supportedDateTimeLayout))
+		assert.NoError(e.T(), err)
+		assert.Equal(e.T(), et.NestedKind.Type, DateTimeKindType)
+		assert.Equal(e.T(), et.String(""), now.Format(supportedDateTimeLayout))
 	}
 }
 
-func TestParseFromInterfaceTime(t *testing.T) {
+func (e *ExtTestSuite) TestParseFromInterfaceTime() {
 	now := time.Now()
 	for _, supportedTimeFormat := range supportedTimeFormats {
-		et, err := ParseFromInterface(now.Format(supportedTimeFormat))
-		assert.NoError(t, err)
-		assert.Equal(t, et.NestedKind.Type, TimeKindType)
+		et, err := ParseFromInterface(e.ctx, now.Format(supportedTimeFormat))
+		assert.NoError(e.T(), err)
+		assert.Equal(e.T(), et.NestedKind.Type, TimeKindType)
 		// Without passing an override format, this should return the same preserved dt format.
-		assert.Equal(t, et.String(""), now.Format(supportedTimeFormat))
+		assert.Equal(e.T(), et.String(""), now.Format(supportedTimeFormat))
 	}
 }
 
-func TestParseFromInterfaceDate(t *testing.T) {
+func (e *ExtTestSuite) TestParseFromInterfaceDate() {
 	now := time.Now()
 	for _, supportedDateFormat := range supportedDateFormats {
-		et, err := ParseFromInterface(now.Format(supportedDateFormat))
-		assert.NoError(t, err)
-		assert.Equal(t, et.NestedKind.Type, DateKindType)
+		et, err := ParseFromInterface(e.ctx, now.Format(supportedDateFormat))
+		assert.NoError(e.T(), err)
+		assert.Equal(e.T(), et.NestedKind.Type, DateKindType)
 
 		// Without passing an override format, this should return the same preserved dt format.
-		assert.Equal(t, et.String(""), now.Format(supportedDateFormat))
+		assert.Equal(e.T(), et.String(""), now.Format(supportedDateFormat))
 	}
 }
 
-func TestParseExtendedDateTime_Timestamp(t *testing.T) {
+func (e *ExtTestSuite) TestParseExtendedDateTime_Timestamp(t *testing.T) {
 	tsString := "2023-04-24T17:29:05.69944Z"
-	extTime, err := ParseExtendedDateTime(tsString)
+	extTime, err := ParseExtendedDateTime(e.ctx, tsString)
 	assert.NoError(t, err)
 	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.String(""))
 }
 
-func TestParseExtendedDateTime(t *testing.T) {
-	dateString := "27/12/1992"
-	extTime, err := ParseExtendedDateTime(dateString)
-	assert.NoError(t, err)
-	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.String(""))
+func (e *ExtTestSuite) TestParseExtendedDateTime() {
+	dateString := "27/12/82"
+	extTime, err := ParseExtendedDateTime(e.ctx, dateString)
+	assert.NoError(e.T(), err)
+	assert.Equal(e.T(), "2023-04-24T17:29:05.69944Z", extTime.String(""))
 }
 
-func TestTimeLayout(t *testing.T) {
+func (e *ExtTestSuite) TestTimeLayout() {
 	ts := time.Now()
 
 	for _, supportedFormat := range supportedTimeFormats {
 		parsedTsString := ts.Format(supportedFormat)
-		extTime, err := ParseExtendedDateTime(parsedTsString)
-		assert.NoError(t, err)
-		assert.Equal(t, parsedTsString, extTime.String(""))
+		extTime, err := ParseExtendedDateTime(e.ctx, parsedTsString)
+		assert.NoError(e.T(), err)
+		assert.Equal(e.T(), parsedTsString, extTime.String(""))
 	}
 }

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -1,6 +1,7 @@
 package typing
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -87,7 +88,7 @@ func IsJSON(str string) bool {
 	return false
 }
 
-func ParseValue(key string, optionalSchema map[string]KindDetails, val interface{}) KindDetails {
+func ParseValue(ctx context.Context, key string, optionalSchema map[string]KindDetails, val interface{}) KindDetails {
 	if val == nil {
 		return Invalid
 	}
@@ -121,7 +122,7 @@ func ParseValue(key string, optionalSchema map[string]KindDetails, val interface
 		// This way, we don't penalize every string into going through this loop
 		// In the future, we can have specific layout RFCs run depending on the char
 		if strings.Contains(valString, ":") || strings.Contains(valString, "-") {
-			extendedKind, err := ext.ParseExtendedDateTime(valString)
+			extendedKind, err := ext.ParseExtendedDateTime(ctx, valString)
 			if err == nil {
 				return KindDetails{
 					Kind:                ETime.Kind,

--- a/lib/typing/typing_bench_test.go
+++ b/lib/typing/typing_bench_test.go
@@ -1,6 +1,7 @@
 package typing
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -36,7 +37,7 @@ func BenchmarkLargeMapLengthQuery_WithMassiveValues(b *testing.B) {
 
 func BenchmarkParseValueIntegerArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ParseValue("", nil, 45456312)
+		ParseValue(context.Background(), "", nil, 45456312)
 	}
 }
 
@@ -48,7 +49,7 @@ func BenchmarkParseValueIntegerGo(b *testing.B) {
 
 func BenchmarkParseValueBooleanArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ParseValue("", nil, true)
+		ParseValue(context.Background(), "", nil, true)
 	}
 }
 
@@ -60,7 +61,7 @@ func BenchmarkParseValueBooleanGo(b *testing.B) {
 
 func BenchmarkParseValueFloatArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ParseValue("", nil, 7.44)
+		ParseValue(context.Background(), "", nil, 7.44)
 	}
 }
 

--- a/lib/typing/typing_suite_test.go
+++ b/lib/typing/typing_suite_test.go
@@ -1,0 +1,24 @@
+package typing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
+	"github.com/stretchr/testify/suite"
+)
+
+type TypingTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (t *TypingTestSuite) SetUpTest() {
+	t.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
+		VerboseLogging: false,
+	})
+}
+
+func TestTypingTestSuite(t *testing.T) {
+	suite.Run(t, new(TypingTestSuite))
+}

--- a/lib/typing/typing_suite_test.go
+++ b/lib/typing/typing_suite_test.go
@@ -13,9 +13,11 @@ type TypingTestSuite struct {
 	ctx context.Context
 }
 
-func (t *TypingTestSuite) SetUpTest() {
-	t.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
+func (t *TypingTestSuite) SetupTest() {
+	t.ctx = context.Background() // Initialize the context
+	t.ctx = config.InjectSettingsIntoContext(t.ctx, &config.Settings{
 		VerboseLogging: false,
+		Config:         &config.Config{},
 	})
 }
 

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -5,22 +5,21 @@ import (
 	"fmt"
 	"math"
 	"strings"
-	"testing"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNil(t *testing.T) {
-	assert.Equal(t, ParseValue("", nil, ""), String)
-	assert.Equal(t, ParseValue("", nil, "nil"), String)
-	assert.Equal(t, ParseValue("", nil, nil), Invalid)
+func (t *TypingTestSuite) TestNil() {
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, ""), String)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, "nil"), String)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, nil), Invalid)
 }
 
-func TestJSONString(t *testing.T) {
-	assert.Equal(t, true, IsJSON(`{"hello": "world"}`))
-	assert.Equal(t, true, IsJSON(`{}`))
-	assert.Equal(t, true, IsJSON(strings.TrimSpace(`
+func (t *TypingTestSuite) TestJSONString() {
+	assert.Equal(t.T(), true, IsJSON(`{"hello": "world"}`))
+	assert.Equal(t.T(), true, IsJSON(`{}`))
+	assert.Equal(t.T(), true, IsJSON(strings.TrimSpace(`
 	{
 		"hello": {
 			"world": {
@@ -33,39 +32,39 @@ func TestJSONString(t *testing.T) {
 	}
 	`)))
 
-	assert.Equal(t, false, IsJSON(`{null`))
-	assert.Equal(t, false, IsJSON(`{null}`))
-	assert.Equal(t, false, IsJSON(`{abc: def}`))
+	assert.Equal(t.T(), false, IsJSON(`{null`))
+	assert.Equal(t.T(), false, IsJSON(`{null}`))
+	assert.Equal(t.T(), false, IsJSON(`{abc: def}`))
 }
 
-func TestParseValueBasic(t *testing.T) {
+func (t *TypingTestSuite) TestParseValueBasic() {
 	// Floats
-	assert.Equal(t, ParseValue("", nil, 7.5), Float)
-	assert.Equal(t, ParseValue("", nil, -7.4999999), Float)
-	assert.Equal(t, ParseValue("", nil, 7.0), Float)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, 7.5), Float)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, -7.4999999), Float)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, 7.0), Float)
 
 	// Integers
-	assert.Equal(t, ParseValue("", nil, 9), Integer)
-	assert.Equal(t, ParseValue("", nil, math.MaxInt), Integer)
-	assert.Equal(t, ParseValue("", nil, -1*math.MaxInt), Integer)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, 9), Integer)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, math.MaxInt), Integer)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, -1*math.MaxInt), Integer)
 
 	// Invalid
-	assert.Equal(t, ParseValue("", nil, nil), Invalid)
-	assert.Equal(t, ParseValue("", nil, errors.New("hello")), Invalid)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, nil), Invalid)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, errors.New("hello")), Invalid)
 
 	// Boolean
-	assert.Equal(t, ParseValue("", nil, true), Boolean)
-	assert.Equal(t, ParseValue("", nil, false), Boolean)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, true), Boolean)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, false), Boolean)
 }
 
-func TestParseValueArrays(t *testing.T) {
-	assert.Equal(t, ParseValue("", nil, []string{"a", "b", "c"}), Array)
-	assert.Equal(t, ParseValue("", nil, []interface{}{"a", 123, "c"}), Array)
-	assert.Equal(t, ParseValue("", nil, []int64{1}), Array)
-	assert.Equal(t, ParseValue("", nil, []bool{false}), Array)
+func (t *TypingTestSuite) TestParseValueArrays() {
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, []string{"a", "b", "c"}), Array)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, []interface{}{"a", 123, "c"}), Array)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, []int64{1}), Array)
+	assert.Equal(t.T(), ParseValue(t.ctx, "", nil, []bool{false}), Array)
 }
 
-func TestParseValueMaps(t *testing.T) {
+func (t *TypingTestSuite) TestParseValueMaps() {
 	randomMaps := []interface{}{
 		map[string]interface{}{
 			"foo":   "bar",
@@ -91,11 +90,11 @@ func TestParseValueMaps(t *testing.T) {
 	}
 
 	for _, randomMap := range randomMaps {
-		assert.Equal(t, ParseValue("", nil, randomMap), Struct, fmt.Sprintf("Failed message is: %v", randomMap))
+		assert.Equal(t.T(), ParseValue(t.ctx, "", nil, randomMap), Struct, fmt.Sprintf("Failed message is: %v", randomMap))
 	}
 }
 
-func TestDateTime(t *testing.T) {
+func (t *TypingTestSuite) TestDateTime() {
 	// Took this list from the Go time library.
 	possibleDates := []interface{}{
 		"01/02 03:04:05PM '06 -0700", // The reference time, in numerical order.
@@ -111,34 +110,34 @@ func TestDateTime(t *testing.T) {
 	}
 
 	for _, possibleDate := range possibleDates {
-		assert.Equal(t, ParseValue("", nil, possibleDate).ExtendedTimeDetails.Type, ext.DateTime.Type, fmt.Sprintf("Failed format, value is: %v", possibleDate))
+		assert.Equal(t.T(), ParseValue(t.ctx, "", nil, possibleDate).ExtendedTimeDetails.Type, ext.DateTime.Type, fmt.Sprintf("Failed format, value is: %v", possibleDate))
 
 		// Test the parseDT function as well.
-		ts, err := ext.ParseExtendedDateTime(fmt.Sprint(possibleDate))
-		assert.NoError(t, err, err)
-		assert.False(t, ts.IsZero(), ts)
+		ts, err := ext.ParseExtendedDateTime(t.ctx, fmt.Sprint(possibleDate))
+		assert.NoError(t.T(), err, err)
+		assert.False(t.T(), ts.IsZero(), ts)
 	}
 
-	ts, err := ext.ParseExtendedDateTime("random")
-	assert.Error(t, err, err)
-	assert.Nil(t, ts)
+	ts, err := ext.ParseExtendedDateTime(t.ctx, "random")
+	assert.Error(t.T(), err, err)
+	assert.Nil(t.T(), ts)
 }
 
-func TestDateTime_Fallback(t *testing.T) {
+func (t *TypingTestSuite) TestDateTime_Fallback() {
 	dtString := "Mon Jan 02 15:04:05.69944 -0700 2006"
-	ts, err := ext.ParseExtendedDateTime(dtString)
-	assert.NoError(t, err)
-	assert.NotEqual(t, ts.String(""), dtString)
+	ts, err := ext.ParseExtendedDateTime(t.ctx, dtString)
+	assert.NoError(t.T(), err)
+	assert.NotEqual(t.T(), ts.String(""), dtString)
 }
 
-func TestTime(t *testing.T) {
-	kindDetails := ParseValue("", nil, "00:18:11.13116+00")
+func (t *TypingTestSuite) TestTime() {
+	kindDetails := ParseValue(t.ctx, "", nil, "00:18:11.13116+00")
 	// 00:42:26.693631Z
-	assert.Equal(t, ETime.Kind, kindDetails.Kind)
-	assert.Equal(t, ext.TimeKindType, kindDetails.ExtendedTimeDetails.Type)
+	assert.Equal(t.T(), ETime.Kind, kindDetails.Kind)
+	assert.Equal(t.T(), ext.TimeKindType, kindDetails.ExtendedTimeDetails.Type)
 }
 
-func TestString(t *testing.T) {
+func (t *TypingTestSuite) TestString() {
 	possibleStrings := []string{
 		"dusty",
 		"robin",
@@ -146,17 +145,17 @@ func TestString(t *testing.T) {
 	}
 
 	for _, possibleString := range possibleStrings {
-		assert.Equal(t, ParseValue("", nil, possibleString), String)
+		assert.Equal(t.T(), ParseValue(t.ctx, "", nil, possibleString), String)
 	}
 }
 
-func TestOptionalSchema(t *testing.T) {
-	kd := ParseValue("", nil, true)
-	assert.Equal(t, kd, Boolean)
+func (t *TypingTestSuite) TestOptionalSchema() {
+	kd := ParseValue(t.ctx, "", nil, true)
+	assert.Equal(t.T(), kd, Boolean)
 
 	// Key in a nil-schema
-	kd = ParseValue("key", nil, true)
-	assert.Equal(t, kd, Boolean)
+	kd = ParseValue(t.ctx, "key", nil, true)
+	assert.Equal(t.T(), kd, Boolean)
 
 	// Non-existent key in the schema.
 	optionalSchema := map[string]KindDetails{
@@ -164,10 +163,10 @@ func TestOptionalSchema(t *testing.T) {
 	}
 
 	// Parse it as a date since it doesn't exist in the optional schema.
-	kd = ParseValue("updated_at", optionalSchema, "2023-01-01")
-	assert.Equal(t, ext.Date.Type, kd.ExtendedTimeDetails.Type)
+	kd = ParseValue(t.ctx, "updated_at", optionalSchema, "2023-01-01")
+	assert.Equal(t.T(), ext.Date.Type, kd.ExtendedTimeDetails.Type)
 
 	// Respecting the optional schema
-	kd = ParseValue("created_at", optionalSchema, "2023-01-01")
-	assert.Equal(t, String, kd)
+	kd = ParseValue(t.ctx, "created_at", optionalSchema, "2023-01-01")
+	assert.Equal(t.T(), String, kd)
 }

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -163,14 +163,14 @@ func (e *Event) Save(ctx context.Context, topicConfig *kafkalib.TopicConfig, mes
 			retrievedColumn, isOk := inMemoryColumns.GetColumn(newColName)
 			if !isOk {
 				// This would only happen if the columns did not get passed in initially.
-				inMemoryColumns.AddColumn(columns.NewColumn(newColName, typing.ParseValue(_col, e.OptionalSchema, val)))
+				inMemoryColumns.AddColumn(columns.NewColumn(newColName, typing.ParseValue(ctx, _col, e.OptionalSchema, val)))
 			} else {
 				if retrievedColumn.KindDetails == typing.Invalid {
 					// If colType is Invalid, let's see if we can update it to a better type
 					// If everything is nil, we don't need to add a column
 					// However, it's important to create a column even if it's nil.
 					// This is because we don't want to think that it's okay to drop a column in DWH
-					if kindDetails := typing.ParseValue(_col, e.OptionalSchema, val); kindDetails.Kind != typing.Invalid.Kind {
+					if kindDetails := typing.ParseValue(ctx, _col, e.OptionalSchema, val); kindDetails.Kind != typing.Invalid.Kind {
 						retrievedColumn.KindDetails = kindDetails
 						inMemoryColumns.UpdateColumn(retrievedColumn)
 					}


### PR DESCRIPTION
## Problem
1. Folks using MongoDB straight and not an application schema layer such as Mongoose can have inconsistent data. 
We are seeing incoming data of `Datetime` and `Date` type being mixed within a flush cycle for the same column. 

Our existing casting library will look at `extTime` which is row specific and try to parse it accordingly. This then leads to a mixed type within our flush cycle.

2. We are returning `[]string{}` within our BigQuery array f(x) instead of `nil` and being skipped. BigQuery does not like empty strings, it prefers to be skipped.

3. Folks that have additional date formats that are not supported within https://github.com/artie-labs/transfer/blob/master/lib/typing/ext/variables.go can now specify additional formats for Artie Transfer to use via `sharedTransferConfig.additionalDateFormats`

## Changes

* Allowing additional date formats to be specified, for example:
```yaml
sharedTransferConfig:
  additionalDateFormats:
    - 02/01/06
```

* For BigQuery, if the column is an array but the value is `STRING`, it will convert the value to be `[]string{"foo"}`.

* If the value for array is empty, return `nil` as opposed to an empty string

* Drop the temporary table regardless of merge outcome, in case if it fails...we do not create infinite tables

## Checks
- [x] BigQuery test
- [x] Redshift test
- [x] Snowflake test