### PR TITLE
Supporting BigQuery time partition tables

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -229,7 +229,12 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	var additionalEqualityStrings []string
 	if tableData.TopicConfig.BigQueryPartitionSettings != nil {
-		mergeString, err := tableData.TopicConfig.BigQueryPartitionSettings.GenerateMergeString()
+		distinctDates, err := tableData.DistinctDates(tableData.TopicConfig.BigQueryPartitionSettings.PartitionField)
+		if err != nil {
+			return fmt.Errorf("failed to generate distinct dates, err: %v", distinctDates)
+		}
+
+		mergeString, err := tableData.TopicConfig.BigQueryPartitionSettings.GenerateMergeString(distinctDates)
 		if err != nil {
 			log.WithError(err).Warn("failed to generate merge string")
 			return err

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -229,9 +229,9 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	var additionalEqualityStrings []string
 	if tableData.TopicConfig.BigQueryPartitionSettings != nil {
-		distinctDates, err := tableData.DistinctDates(tableData.TopicConfig.BigQueryPartitionSettings.PartitionField)
+		distinctDates, err := tableData.DistinctDates(ctx, tableData.TopicConfig.BigQueryPartitionSettings.PartitionField)
 		if err != nil {
-			return fmt.Errorf("failed to generate distinct dates, err: %v", distinctDates)
+			return fmt.Errorf("failed to generate distinct dates, err: %v", err)
 		}
 
 		mergeString, err := tableData.TopicConfig.BigQueryPartitionSettings.GenerateMergeString(distinctDates)

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -227,10 +227,22 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		return fmt.Errorf("failed to insert into temp table: %s, error: %v", tableName, err)
 	}
 
+	var additionalEqualityStrings []string
+	if tableData.TopicConfig.BigQueryPartitionSettings != nil {
+		mergeString, err := tableData.TopicConfig.BigQueryPartitionSettings.GenerateMergeString()
+		if err != nil {
+			log.WithError(err).Warn("failed to generate merge string")
+			return err
+		}
+
+		additionalEqualityStrings = []string{mergeString}
+	}
+
 	mergeQuery, err := dml.MergeStatement(ctx, &dml.MergeArgument{
-		FqTableName:   tableData.ToFqName(ctx, constants.BigQuery, true),
-		SubQuery:      tempAlterTableArgs.FqTableName,
-		IdempotentKey: tableData.TopicConfig.IdempotentKey,
+		FqTableName:               tableData.ToFqName(ctx, constants.BigQuery, true),
+		AdditionalEqualityStrings: additionalEqualityStrings,
+		SubQuery:                  tempAlterTableArgs.FqTableName,
+		IdempotentKey:             tableData.TopicConfig.IdempotentKey,
 		PrimaryKeys: tableData.PrimaryKeys(ctx, &sql.NameArgs{
 			Escape:   true,
 			DestKind: s.Label(),

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -54,6 +54,15 @@ func InterfaceToArrayString(val interface{}, recastAsArray bool) ([]string, erro
 	return vals, nil
 }
 
+func StringsJoinAddSingleQuotes(values []string) string {
+	var vals []string
+	for _, value := range values {
+		vals = append(vals, fmt.Sprintf(`'%s'`, value))
+	}
+
+	return strings.Join(vals, ",")
+}
+
 type StringsJoinAddPrefixArgs struct {
 	Vals      []string
 	Separator string

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestStringsJoinAddSingleQuotes(t *testing.T) {
+	foo := []string{
+		"abc",
+		"def",
+		"ggg",
+	}
+
+	assert.Equal(t, "'abc','def','ggg'", StringsJoinAddSingleQuotes(foo))
+}
+
 func TestToArrayString(t *testing.T) {
 	type _testCase struct {
 		name          string

--- a/lib/dwh/dml/merge.go
+++ b/lib/dwh/dml/merge.go
@@ -24,6 +24,9 @@ type MergeArgument struct {
 	IdempotentKey string
 	PrimaryKeys   []columns.Wrapper
 
+	// AdditionalEqualityStrings is used for handling BigQuery partitioned table merges
+	AdditionalEqualityStrings []string
+
 	// ColumnsToTypes also needs to be escaped.
 	ColumnsToTypes columns.Columns
 
@@ -210,6 +213,10 @@ func MergeStatement(ctx context.Context, m *MergeArgument) (string, error) {
 	subQuery := fmt.Sprintf("( %s )", m.SubQuery)
 	if m.DestKind == constants.BigQuery {
 		subQuery = m.SubQuery
+
+		if len(m.AdditionalEqualityStrings) > 0 {
+			equalitySQLParts = append(equalitySQLParts, m.AdditionalEqualityStrings...)
+		}
 	}
 
 	cols := m.ColumnsToTypes.GetColumnsToUpdate(ctx, &sql.NameArgs{

--- a/lib/kafkalib/partition/settings.go
+++ b/lib/kafkalib/partition/settings.go
@@ -23,16 +23,20 @@ type BigQuerySettings struct {
 }
 
 // GenerateMergeString this is used as an equality string for the MERGE statement.
-func (b *BigQuerySettings) GenerateMergeString() (string, error) {
+func (b *BigQuerySettings) GenerateMergeString(values []string) (string, error) {
 	if err := b.Valid(); err != nil {
 		return "", fmt.Errorf("failed to validate bigQuerySettings, err: %v", err)
+	}
+
+	if len(values) == 0 {
+		return "", fmt.Errorf("values cannot be empty")
 	}
 
 	switch b.PartitionType {
 	case "time":
 		switch b.PartitionBy {
 		case "daily":
-			return fmt.Sprintf(`DATE(c.%s) = DATE(cc.%s)`, b.PartitionField, b.PartitionField), nil
+			return fmt.Sprintf(`DATE(c.%s) IN (%s)`, b.PartitionField, array.StringsJoinAddSingleQuotes(values)), nil
 		}
 	}
 

--- a/lib/kafkalib/partition/settings.go
+++ b/lib/kafkalib/partition/settings.go
@@ -22,6 +22,22 @@ type BigQuerySettings struct {
 	PartitionBy    string `yaml:"partitionBy"`
 }
 
+func (b *BigQuerySettings) GenerateMergeString() (string, error) {
+	if err := b.Valid(); err != nil {
+		return "", fmt.Errorf("failed to validate bigQuerySettings, err: %v", err)
+	}
+
+	switch b.PartitionType {
+	case "time":
+		switch b.PartitionBy {
+		case "daily":
+			return fmt.Sprintf(`DATE(c.%s) = DATE(cc.%s)`, b.PartitionField, b.PartitionField), nil
+		}
+	}
+
+	return "", fmt.Errorf("unexpected partitionType: %s and/or partitionBy: %s", b.PartitionType, b.PartitionBy)
+}
+
 func (b *BigQuerySettings) Valid() error {
 	if b == nil {
 		return fmt.Errorf("bigQuerySettings is nil")

--- a/lib/kafkalib/partition/settings.go
+++ b/lib/kafkalib/partition/settings.go
@@ -22,6 +22,7 @@ type BigQuerySettings struct {
 	PartitionBy    string `yaml:"partitionBy"`
 }
 
+// GenerateMergeString this is used as an equality string for the MERGE statement.
 func (b *BigQuerySettings) GenerateMergeString() (string, error) {
 	if err := b.Valid(); err != nil {
 		return "", fmt.Errorf("failed to validate bigQuerySettings, err: %v", err)

--- a/lib/kafkalib/partition/settings.go
+++ b/lib/kafkalib/partition/settings.go
@@ -1,0 +1,51 @@
+package partition
+
+import (
+	"fmt"
+
+	"github.com/artie-labs/transfer/lib/array"
+)
+
+var ValidPartitionTypes = []string{
+	"time",
+}
+
+// TODO: We should be able to support different partition by fields in the future.
+// https://cloud.google.com/bigquery/docs/partitioned-tables#partition_decorators
+var ValidPartitionBy = []string{
+	"daily",
+}
+
+type BigQuerySettings struct {
+	PartitionType  string `yaml:"partitionType"`
+	PartitionField string `yaml:"partitionField"`
+	PartitionBy    string `yaml:"partitionBy"`
+}
+
+func (b *BigQuerySettings) Valid() error {
+	if b == nil {
+		return fmt.Errorf("bigQuerySettings is nil")
+	}
+
+	if b.PartitionType == "" {
+		return fmt.Errorf("partitionTypes cannot be empty")
+	}
+
+	if b.PartitionField == "" {
+		return fmt.Errorf("partitionField cannot be empty")
+	}
+
+	if b.PartitionBy == "" {
+		return fmt.Errorf("partitionBy cannot be empty")
+	}
+
+	if array.StringContains(ValidPartitionTypes, b.PartitionType) == false {
+		return fmt.Errorf("partitionType must be one of: %v", ValidPartitionTypes)
+	}
+
+	if array.StringContains(ValidPartitionBy, b.PartitionBy) == false {
+		return fmt.Errorf("partitionBy must be one of: %v", ValidPartitionBy)
+	}
+
+	return nil
+}

--- a/lib/kafkalib/partition/settings_test.go
+++ b/lib/kafkalib/partition/settings_test.go
@@ -1,0 +1,31 @@
+package partition
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBigQuerySettings_Valid(t *testing.T) {
+	type _testCase struct {
+		name             string
+		bigQuerySettings *BigQuerySettings
+		expectError      bool
+	}
+
+	testCases := []_testCase{
+		{
+			name:        "nil",
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualErr := testCase.bigQuerySettings.Valid()
+		if testCase.expectError {
+			assert.Error(t, actualErr, testCase.name)
+		} else {
+			assert.NoError(t, actualErr, testCase.name)
+		}
+	}
+}

--- a/lib/kafkalib/partition/settings_test.go
+++ b/lib/kafkalib/partition/settings_test.go
@@ -18,6 +18,52 @@ func TestBigQuerySettings_Valid(t *testing.T) {
 			name:        "nil",
 			expectError: true,
 		},
+		{
+			name:             "empty partitionType",
+			bigQuerySettings: &BigQuerySettings{},
+			expectError:      true,
+		},
+		{
+			name: "empty partitionField",
+			bigQuerySettings: &BigQuerySettings{
+				PartitionType: "time",
+			},
+			expectError: true,
+		},
+		{
+			name: "empty partitionBy",
+			bigQuerySettings: &BigQuerySettings{
+				PartitionType:  "time",
+				PartitionField: "created_at",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid partitionType",
+			bigQuerySettings: &BigQuerySettings{
+				PartitionType:  "invalid",
+				PartitionField: "created_at",
+				PartitionBy:    "daily",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid partitionBy",
+			bigQuerySettings: &BigQuerySettings{
+				PartitionType:  "time",
+				PartitionField: "created_at",
+				PartitionBy:    "invalid",
+			},
+			expectError: true,
+		},
+		{
+			name: "valid",
+			bigQuerySettings: &BigQuerySettings{
+				PartitionType:  "time",
+				PartitionField: "created_at",
+				PartitionBy:    "daily",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/lib/kafkalib/partition/settings_test.go
+++ b/lib/kafkalib/partition/settings_test.go
@@ -75,3 +75,50 @@ func TestBigQuerySettings_Valid(t *testing.T) {
 		}
 	}
 }
+
+func TestBigQuerySettings_GenerateMergeString(t *testing.T) {
+	type _testCase struct {
+		name           string
+		values         []string
+		expectError    bool
+		expectedString string
+	}
+
+	testCases := []_testCase{
+		{
+			name:        "nil",
+			expectError: true,
+		},
+		{
+			name:        "empty values",
+			values:      []string{},
+			expectError: true,
+		},
+		{
+			name:           "valid",
+			values:         []string{"2020-01-01"},
+			expectedString: "DATE(c.created_at) IN ('2020-01-01')",
+		},
+		{
+			name:           "valid multiple values",
+			values:         []string{"2020-01-01", "2020-01-02"},
+			expectedString: `DATE(c.created_at) IN ('2020-01-01','2020-01-02')`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		bigquery := &BigQuerySettings{
+			PartitionType:  "time",
+			PartitionField: "created_at",
+			PartitionBy:    "daily",
+		}
+
+		actualValue, actualErr := bigquery.GenerateMergeString(testCase.values)
+		if testCase.expectError {
+			assert.Error(t, actualErr, testCase.name)
+		} else {
+			assert.NoError(t, actualErr, testCase.name)
+			assert.Equal(t, testCase.expectedString, actualValue, testCase.name)
+		}
+	}
+}

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -3,6 +3,8 @@ package kafkalib
 import (
 	"fmt"
 
+	"github.com/artie-labs/transfer/lib/kafkalib/partition"
+
 	"github.com/artie-labs/transfer/lib/array"
 )
 
@@ -31,16 +33,17 @@ func GetUniqueDatabaseAndSchema(tcs []*TopicConfig) []DatabaseSchemaPair {
 }
 
 type TopicConfig struct {
-	Database              string `yaml:"db"`
-	TableName             string `yaml:"tableName"`
-	Schema                string `yaml:"schema"`
-	Topic                 string `yaml:"topic"`
-	IdempotentKey         string `yaml:"idempotentKey"`
-	CDCFormat             string `yaml:"cdcFormat"`
-	CDCKeyFormat          string `yaml:"cdcKeyFormat"`
-	DropDeletedColumns    bool   `yaml:"dropDeletedColumns"`
-	SoftDelete            bool   `yaml:"softDelete"`
-	IncludeArtieUpdatedAt bool   `yaml:"includeArtieUpdatedAt"`
+	Database                  string                      `yaml:"db"`
+	TableName                 string                      `yaml:"tableName"`
+	Schema                    string                      `yaml:"schema"`
+	Topic                     string                      `yaml:"topic"`
+	IdempotentKey             string                      `yaml:"idempotentKey"`
+	CDCFormat                 string                      `yaml:"cdcFormat"`
+	CDCKeyFormat              string                      `yaml:"cdcKeyFormat"`
+	DropDeletedColumns        bool                        `yaml:"dropDeletedColumns"`
+	SoftDelete                bool                        `yaml:"softDelete"`
+	IncludeArtieUpdatedAt     bool                        `yaml:"includeArtieUpdatedAt"`
+	BigQueryPartitionSettings *partition.BigQuerySettings `yaml:"bigQueryPartitionSettings"`
 }
 
 const (

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -176,7 +176,7 @@ func (t *TableData) Rows() uint {
 	return uint(len(t.rowsData))
 }
 
-func (t *TableData) DistinctDates(colName string) ([]string, error) {
+func (t *TableData) DistinctDates(ctx context.Context, colName string) ([]string, error) {
 	retMap := make(map[string]bool)
 	for _, row := range t.rowsData {
 		val, isOk := row[colName]
@@ -184,12 +184,12 @@ func (t *TableData) DistinctDates(colName string) ([]string, error) {
 			return nil, fmt.Errorf("col: %v does not exist on row: %v", colName, row)
 		}
 
-		valTime, isOk := val.(*ext.ExtendedTime)
-		if !isOk {
+		extTime, err := ext.ParseFromInterface(ctx, val)
+		if err != nil {
 			return nil, fmt.Errorf("col: %v is not a time column, value: %v", colName, val)
 		}
 
-		retMap[valTime.String(ext.PostgresDateFormat)] = true
+		retMap[extTime.String(ext.PostgresDateFormat)] = true
 	}
 
 	var distinctDates []string

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -104,7 +104,6 @@ func NewTableData(inMemoryColumns *columns.Columns, primaryKeys []string, topicC
 // This is important to avoid concurrent r/w, but also the ability for us to add or decrement row size by keeping a running total
 // With this, we are able to reduce the latency by 500x+ on a 5k row table. See event_bench_test.go vs. size_bench_test.go
 func (t *TableData) InsertRow(pk string, rowData map[string]interface{}, delete bool) {
-
 	var prevRowSize int
 	prevRow, isOk := t.rowsData[pk]
 	if isOk {

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -186,7 +186,7 @@ func (t *TableData) DistinctDates(ctx context.Context, colName string) ([]string
 
 		extTime, err := ext.ParseFromInterface(ctx, val)
 		if err != nil {
-			return nil, fmt.Errorf("col: %v is not a time column, value: %v", colName, val)
+			return nil, fmt.Errorf("col: %v is not a time column, value: %v, err: %v", colName, val, err)
 		}
 
 		retMap[extTime.String(ext.PostgresDateFormat)] = true


### PR DESCRIPTION
## Problem

BigQuery bills you by bytes processed, every time we merge, it will do a full table scan. This then increases bytes processed and incurs additional costs.

When you have lots of data, it's encouraged to use partitions and this PR makes it so that we can support timed partitioned tables when it comes to merging.

We will support daily partitioning for now and will support more in the future. This PR serves to support the minimum recommended partitioning strategy and scaffold to support future ones such as hourly, weekly, monthly and yearly.

## Changes

- [x] We'll be adding `bigQueryPartitionSettings` block inside of `topicConfigs[n]`
- [x] Tests

`bigQueryPartitionSettings` will include:
* `partitionType` (time)
* `partitionField` (ts)
* `partitionBy` (daily)

