### PR TITLE
Adding JSON encoding to BigQuery Partitions.

### DIFF
--- a/lib/kafkalib/partition/settings.go
+++ b/lib/kafkalib/partition/settings.go
@@ -17,9 +17,9 @@ var ValidPartitionBy = []string{
 }
 
 type BigQuerySettings struct {
-	PartitionType  string `yaml:"partitionType"`
-	PartitionField string `yaml:"partitionField"`
-	PartitionBy    string `yaml:"partitionBy"`
+	PartitionType  string `yaml:"partitionType" json:"partitionType"`
+	PartitionField string `yaml:"partitionField" json:"partitionField"`
+	PartitionBy    string `yaml:"partitionBy" json:"partitionBy"`
 }
 
 // GenerateMergeString this is used as an equality string for the MERGE statement.


### PR DESCRIPTION
As per title. This way, we can marshal and unmarshal this data type in JSON and with YAML.