### PR TITLE
[BigQuery] Mark bad timestamps as NULL value in BigQuery

### DIFF
--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -40,8 +40,16 @@ func CastColVal(ctx context.Context, colVal interface{}, colKind columns.Column)
 			switch colKind.KindDetails.ExtendedTimeDetails.Type {
 			// https://cloud.google.com/bigquery/docs/streaming-data-into-bigquery#sending_datetime_data
 			case ext.DateTimeKindType:
+				if extTime.Year() == 0 {
+					return nil, nil
+				}
+
 				colVal = extTime.StringUTC(ext.BigQueryDateTimeFormat)
 			case ext.DateKindType:
+				if extTime.Year() == 0 {
+					return nil, nil
+				}
+
 				colVal = extTime.String(ext.PostgresDateFormat)
 			case ext.TimeKindType:
 				colVal = extTime.String(typing.StreamingTimeFormat)

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -43,6 +43,10 @@ func (b *BigQueryTestSuite) TestCastColVal() {
 	birthdayTimeExt, err := ext.NewExtendedTime(birthday, timeKind.ExtendedTimeDetails.Type, "")
 	assert.NoError(b.T(), err)
 
+	invalidDate := time.Date(0, time.September, 6, 3, 19, 24, 942000000, time.UTC)
+	invalidDateTsExt, err := ext.NewExtendedTime(invalidDate, tsKind.ExtendedTimeDetails.Type, "")
+	assert.NoError(b.T(), err)
+
 	testCases := []_testCase{
 		{
 			name:          "escaping string",
@@ -109,6 +113,11 @@ func (b *BigQueryTestSuite) TestCastColVal() {
 			colVal:        birthdayTimeExt,
 			colKind:       columns.Column{KindDetails: timeKind},
 			expectedValue: "03:19:24",
+		},
+		{
+			name:    "date (column is a date, but value is invalid)",
+			colVal:  invalidDateTsExt,
+			colKind: columns.Column{KindDetails: dateKind},
 		},
 	}
 

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -119,6 +119,11 @@ func (b *BigQueryTestSuite) TestCastColVal() {
 			colVal:  invalidDateTsExt,
 			colKind: columns.Column{KindDetails: dateKind},
 		},
+		{
+			name:    "datetime (column is a datetime, but value is invalid)",
+			colVal:  invalidDateTsExt,
+			colKind: columns.Column{KindDetails: tsKind},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -1,6 +1,8 @@
 package ext
 
-import "time"
+import (
+	"time"
+)
 
 type ExtendedTimeKindType string
 

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -1,8 +1,6 @@
 package ext
 
-import (
-	"time"
-)
+import "time"
 
 type ExtendedTimeKindType string
 


### PR DESCRIPTION
## Problem

BigQuery is strict on timestamps and does not like bad timestamps such as when the year is `0`.

Today, it's causing a head of line blocking. Let's change this so that marks the value as NULL as opposed to blocking the pipeline.