### PR TITLE
[Redshift Typing bug]

### DIFF
--- a/lib/typing/redshift.go
+++ b/lib/typing/redshift.go
@@ -38,7 +38,9 @@ func kindToRedShift(kd KindDetails) string {
 	case String.Kind, Struct.Kind, Array.Kind:
 		// Redshift does not have a built-in JSON type (which means we'll cast STRUCT and ARRAY kinds as TEXT).
 		// As a result, Artie will store this in JSON string and customers will need to extract this data out via SQL.
-		return "text"
+		// TODO: We should make this more dynamic, especially for Redshift.
+		// This is because TEXT defaults to 256 chars. https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html
+		return "VARCHAR(2048)"
 	case Boolean.Kind:
 		// We need to append `NULL` to let Redshift know that NULL is an acceptable data type.
 		return "BOOLEAN NULL"

--- a/lib/typing/redshift.go
+++ b/lib/typing/redshift.go
@@ -38,9 +38,9 @@ func kindToRedShift(kd KindDetails) string {
 	case String.Kind, Struct.Kind, Array.Kind:
 		// Redshift does not have a built-in JSON type (which means we'll cast STRUCT and ARRAY kinds as TEXT).
 		// As a result, Artie will store this in JSON string and customers will need to extract this data out via SQL.
-		// TODO: We should make this more dynamic, especially for Redshift.
-		// This is because TEXT defaults to 256 chars. https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html
-		return "VARCHAR(2048)"
+		// Columns that are automatically created by Artie are created as VARCHAR(MAX).
+		// Rationale: https://github.com/artie-labs/transfer/pull/173
+		return "VARCHAR(MAX)"
 	case Boolean.Kind:
 		// We need to append `NULL` to let Redshift know that NULL is an acceptable data type.
 		return "BOOLEAN NULL"


### PR DESCRIPTION
## Problem

Redshift TEXT columns default to `256 bytes` which is far too small for JSON or b64-encoded values.

![image](https://github.com/artie-labs/transfer/assets/4412200/e6b1ef3b-e05a-494b-8aae-70cf944dae9b)

URL: https://docs.aws.amazon.com/redshift/latest/dg/r_Character_types.html

## Solution
We will be automatically changing the VARCHAR type to be `VARCHAR(max)`. 

Why?
1. This guarantees that our automatically created columns will not error out based on DDL length.
2. Folks can modify the columns that were created by Transfer to be more efficient.

Such workflow would look something like this:

```sql
ALTER TABLE my_table ADD COLUMN my_column_new VARCHAR(100);
UPDATE my_table SET my_column_new = my_column;
ALTER TABLE my_table DROP COLUMN my_column;
ALTER TABLE my_table RENAME COLUMN my_column_new TO my_column;
```