### PR TITLE
[Redshift] Adding DDL idempotency

### DIFF
--- a/lib/destination/ddl/errors.go
+++ b/lib/destination/ddl/errors.go
@@ -16,8 +16,9 @@ func ColumnAlreadyExistErr(err error, kind constants.DestinationKind) bool {
 		// Error ends up looking like something like this: Column already exists: _string at [1:39]
 		return strings.Contains(err.Error(), "Column already exists")
 
-	case constants.Snowflake, constants.SnowflakeStages:
+	case constants.Snowflake, constants.SnowflakeStages, constants.Redshift:
 		// Snowflake doesn't have column mutations (IF NOT EXISTS)
+		// Redshift's error: ERROR: column "foo" of relation "statement" already exists
 		return strings.Contains(err.Error(), "already exists")
 	}
 

--- a/lib/destination/ddl/errors_test.go
+++ b/lib/destination/ddl/errors_test.go
@@ -1,0 +1,38 @@
+package ddl_test
+
+import (
+	"fmt"
+
+	"github.com/artie-labs/transfer/lib/destination/ddl"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+)
+
+func (d *DDLTestSuite) TestColumnAlreadyExistErr() {
+	type _testCase struct {
+		name           string
+		err            error
+		kind           constants.DestinationKind
+		expectedResult bool
+	}
+
+	testCases := []_testCase{
+		{
+			name:           "Redshift actual error",
+			err:            fmt.Errorf(`ERROR: column "foo" of relation "statement" already exists [ErrorId: 1-64da9ea9]`),
+			kind:           constants.Redshift,
+			expectedResult: true,
+		},
+		{
+			name: "Redshift error, but irrelevant",
+			err:  fmt.Errorf("foo"),
+			kind: constants.Redshift,
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := ddl.ColumnAlreadyExistErr(tc.err, tc.kind)
+		assert.Equal(d.T(), tc.expectedResult, actual, tc.name)
+	}
+}


### PR DESCRIPTION
Making it so that we don't hard fail if the column doesn't exist, following the same pattern as BigQuery and Snowflake.