### PR TITLE
[Redshift] SUPER data type for JSON and parsing NUMERIC edge case

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -21,6 +21,11 @@ import (
 // This is necessary because CSV writers require values to in `string`.
 func CastColValStaging(ctx context.Context, colVal interface{}, colKind columns.Column) (string, error) {
 	if colVal == nil {
+		if colKind.KindDetails == typing.Struct {
+			// Returning empty here because if it's a struct, it will go through JSON PARSE and JSON_PARSE("") = null
+			return "", nil
+		}
+
 		// This matches the COPY clause for NULL terminator.
 		return `\N`, nil
 	}

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -54,12 +54,27 @@ func (s *Store) getTableConfig(ctx context.Context, args getTableConfigArgs) (*t
 		FqName:    fmt.Sprintf("%s.%s", args.Schema, args.Table),
 		ConfigMap: s.configMap,
 		// This query is a modified fork from: https://gist.github.com/alexanderlz/7302623
-		Query: fmt.Sprintf(`select c.column_name,c.data_type,d.description 
-from information_schema.columns c 
-left join pg_class c1 on c.table_name=c1.relname 
-left join pg_catalog.pg_namespace n on c.table_schema=n.nspname and c1.relnamespace=n.oid 
-left join pg_catalog.pg_description d on d.objsubid=c.ordinal_position and d.objoid=c1.oid 
-where c.table_name='%s' and c.table_schema='%s'`, args.Table, args.Schema),
+		Query: fmt.Sprintf(`
+SELECT 
+    c.column_name,
+    CASE 
+        WHEN c.data_type = 'numeric' THEN 
+            'numeric(' || COALESCE(CAST(c.numeric_precision AS VARCHAR), '') || ',' || COALESCE(CAST(c.numeric_scale AS VARCHAR), '') || ')'
+        ELSE 
+            c.data_type 
+    END AS data_type,
+    d.description
+FROM 
+    information_schema.columns c 
+LEFT JOIN 
+    pg_class c1 ON c.table_name=c1.relname 
+LEFT JOIN 
+    pg_catalog.pg_namespace n ON c.table_schema=n.nspname AND c1.relnamespace=n.oid 
+LEFT JOIN 
+    pg_catalog.pg_description d ON d.objsubid=c.ordinal_position AND d.objoid=c1.oid 
+WHERE 
+    c.table_name='%s' AND c.table_schema='%s';
+`, args.Table, args.Schema),
 		ColumnNameLabel:    describeNameCol,
 		ColumnTypeLabel:    describeTypeCol,
 		ColumnDescLabel:    describeDescriptionCol,

--- a/clients/utils/table_config.go
+++ b/clients/utils/table_config.go
@@ -116,7 +116,6 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 			return nil, fmt.Errorf("unexpected dwh kind, label: %v", args.Dwh.Label())
 		}
 
-		fmt.Println("kd", kd, "row", row[args.ColumnTypeLabel])
 		col := columns.NewColumn(row[args.ColumnNameLabel], kd)
 		comment, isOk := row[args.ColumnDescLabel]
 		if isOk && args.ShouldParseComment(comment) {

--- a/clients/utils/table_config.go
+++ b/clients/utils/table_config.go
@@ -116,6 +116,7 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 			return nil, fmt.Errorf("unexpected dwh kind, label: %v", args.Dwh.Label())
 		}
 
+		fmt.Println("kd", kd, "row", row[args.ColumnTypeLabel])
 		col := columns.NewColumn(row[args.ColumnNameLabel], kd)
 		comment, isOk := row[args.ColumnDescLabel]
 		if isOk && args.ShouldParseComment(comment) {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/aws/aws-sdk-go-v2 v1.18.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.19
+	github.com/aws/aws-sdk-go-v2/credentials v1.13.18
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.35.0
 	github.com/evalphobia/logrus_sentry v0.8.2
 	github.com/google/uuid v1.3.0
@@ -43,7 +44,6 @@ require (
 	github.com/apache/arrow/go/v12 v12.0.1 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.13.18 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.1 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.59 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.34 // indirect

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -241,7 +241,15 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(ctx context.Context, co
 			// We are not taking primaryKey and defaultValue because DWH does not have this information.
 			// Note: If our in-memory column is `Invalid`, it would get skipped during merge. However, if the column exists in
 			// the destination, we'll copy the type over. This is to make sure we don't miss batch updates where the whole column in the batch is NULL.
-			inMemoryCol.KindDetails.Kind = foundColumn.KindDetails.Kind
+
+			// If the inMemoryColumn is decimal and foundColumn is integer, don't copy it over.
+			// This is because parsing NUMERIC(...) will return an INTEGER if there's no decimal point.
+			// However, this will wipe the precision unit from the INTEGER which may cause integer overflow.
+			shouldSKip := inMemoryCol.KindDetails.Kind == typing.EDecimal.Kind && foundColumn.KindDetails.Kind == typing.Integer.Kind
+			if !shouldSKip {
+				inMemoryCol.KindDetails.Kind = foundColumn.KindDetails.Kind
+			}
+
 			inMemoryCol.SetBackfilled(foundColumn.Backfilled())
 
 			if foundColumn.KindDetails.ExtendedTimeDetails != nil {

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -237,16 +237,15 @@ func (t *TableData) UpdateInMemoryColumnsFromDestination(ctx context.Context, co
 		}
 
 		if found {
-			// We should take `kindDetails.kind` and `backfilled` from foundCol
-			// We are not taking primaryKey and defaultValue because DWH does not have this information.
-			// Note: If our in-memory column is `Invalid`, it would get skipped during merge. However, if the column exists in
-			// the destination, we'll copy the type over. This is to make sure we don't miss batch updates where the whole column in the batch is NULL.
-
 			// If the inMemoryColumn is decimal and foundColumn is integer, don't copy it over.
 			// This is because parsing NUMERIC(...) will return an INTEGER if there's no decimal point.
 			// However, this will wipe the precision unit from the INTEGER which may cause integer overflow.
 			shouldSKip := inMemoryCol.KindDetails.Kind == typing.EDecimal.Kind && foundColumn.KindDetails.Kind == typing.Integer.Kind
 			if !shouldSKip {
+				// We should take `kindDetails.kind` and `backfilled` from foundCol
+				// We are not taking primaryKey and defaultValue because DWH does not have this information.
+				// Note: If our in-memory column is `Invalid`, it would get skipped during merge. However, if the column exists in
+				// the destination, we'll copy the type over. This is to make sure we don't miss batch updates where the whole column in the batch is NULL.
 				inMemoryCol.KindDetails.Kind = foundColumn.KindDetails.Kind
 			}
 

--- a/lib/optimization/event_update_test.go
+++ b/lib/optimization/event_update_test.go
@@ -12,6 +12,7 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 	tableDataCols.AddColumn(columns.NewColumn("name", typing.String))
 	tableDataCols.AddColumn(columns.NewColumn("bool_backfill", typing.Boolean))
 	tableDataCols.AddColumn(columns.NewColumn("prev_invalid", typing.Invalid))
+	tableDataCols.AddColumn(columns.NewColumn("numeric_test", typing.EDecimal))
 
 	// Casting these as STRING so tableColumn via this f(x) will set it correctly.
 	tableDataCols.AddColumn(columns.NewColumn("ext_date", typing.String))
@@ -33,6 +34,12 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 		_, isOk := tableData.inMemoryColumns.GetColumn(nonExistentTableCol)
 		assert.False(o.T(), isOk, nonExistentTableCol)
 	}
+
+	// Making sure it's still numeric
+	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("numeric_test", typing.Integer))
+	numericCol, isOk := tableData.inMemoryColumns.GetColumn("numeric_test")
+	assert.True(o.T(), isOk)
+	assert.Equal(o.T(), typing.EDecimal.Kind, numericCol.KindDetails.Kind, "numeric_test")
 
 	// Testing to make sure we're copying the kindDetails over.
 	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("prev_invalid", typing.String))

--- a/lib/typing/redshift.go
+++ b/lib/typing/redshift.go
@@ -7,6 +7,11 @@ import (
 )
 
 func RedshiftTypeToKind(rawType string) KindDetails {
+	rawType = strings.ToLower(rawType)
+	if strings.HasPrefix(rawType, "numeric") {
+		return ParseNumeric(defaultPrefix, rawType)
+	}
+
 	switch strings.ToLower(rawType) {
 	case "super":
 		return Struct
@@ -24,8 +29,6 @@ func RedshiftTypeToKind(rawType string) KindDetails {
 		return NewKindDetailsFromTemplate(ETime, ext.DateKindType)
 	case "boolean":
 		return Boolean
-	case "numeric":
-		return EDecimal
 	}
 
 	return Invalid

--- a/lib/typing/redshift.go
+++ b/lib/typing/redshift.go
@@ -8,6 +8,8 @@ import (
 
 func RedshiftTypeToKind(rawType string) KindDetails {
 	switch strings.ToLower(rawType) {
+	case "super":
+		return Struct
 	case "integer", "bigint":
 		return Integer
 	case "character varying":
@@ -35,7 +37,9 @@ func kindToRedShift(kd KindDetails) string {
 		// int4 is 2^31, whereas int8 is 2^63.
 		// we're using a larger data type to not have an integer overflow.
 		return "INT8"
-	case String.Kind, Struct.Kind, Array.Kind:
+	case Struct.Kind:
+		return "SUPER"
+	case String.Kind, Array.Kind:
 		// Redshift does not have a built-in JSON type (which means we'll cast STRUCT and ARRAY kinds as TEXT).
 		// As a result, Artie will store this in JSON string and customers will need to extract this data out via SQL.
 		// Columns that are automatically created by Artie are created as VARCHAR(MAX).

--- a/lib/typing/redshift_test.go
+++ b/lib/typing/redshift_test.go
@@ -40,8 +40,8 @@ func TestRedshiftTypeToKind(t *testing.T) {
 			expectedKd: Boolean,
 		},
 		{
-			name:       "Numeric",
-			rawTypes:   []string{"numeric"},
+			name:       "numeric",
+			rawTypes:   []string{"numeric(5,2)", "numeric(5,5)"},
 			expectedKd: EDecimal,
 		},
 	}


### PR DESCRIPTION
## Changes

- [x] Changing the Redshift data type for JSON to be SUPER so that it can exceed the 65k char length limit and have native JSON parsing
- [x] If a data type is NUMERIC(38, 0), this means it's an integer with 38 digits. However, our typing library will output this as just an integer. Our event library will then just override `NUMERIC(38, 0)` to be `INT` and cause us to downcast the column. 

## Converting a column from VARCHAR TO SUPER
```sql
ALTER TABLE mytable ADD COLUMN TEMP_SUPER SUPER;
UPDATE mytable set TEMP_SUPER = json_parse(DETAIL);
ALTER TABLE mytable DROP COLUMN DETAIL;
ALTER TABLE mytable RENAME COLUMN TEMP_SUPER to DETAIL;
```