### PR TITLE
[Typing library] Improving JSON typing

### DIFF
--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -74,13 +74,14 @@ func NewKindDetailsFromTemplate(details KindDetails, extendedType ext.ExtendedTi
 // This is an optimization since JSON string checking is expensive.
 func IsJSON(str string) bool {
 	if len(str) < 2 {
-		// Not LTE 2 because {} is a valid JSON object.
 		return false
 	}
 
-	// Shouldn't need to strings.TrimSpace(...).
-	valStringChars := []rune(str)
-	if string(valStringChars[0]) == "{" && string(valStringChars[len(valStringChars)-1]) == "}" {
+	valStringChars := []rune(strings.TrimSpace(str))
+	firstChar := string(valStringChars[0])
+	lastChar := string(valStringChars[len(valStringChars)-1])
+
+	if (firstChar == "{" && lastChar == "}") || (firstChar == "[" && lastChar == "]") {
 		var js json.RawMessage
 		return json.Unmarshal([]byte(str), &js) == nil
 	}

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strings"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
@@ -17,24 +16,58 @@ func (t *TypingTestSuite) TestNil() {
 }
 
 func (t *TypingTestSuite) TestJSONString() {
-	assert.Equal(t.T(), true, IsJSON(`{"hello": "world"}`))
-	assert.Equal(t.T(), true, IsJSON(`{}`))
-	assert.Equal(t.T(), true, IsJSON(strings.TrimSpace(`
-	{
-		"hello": {
-			"world": {
-				"nested_value": true
-			}
-		},
-		"add_a_list_here": [1, 2, 3, 4],
-		"number": 7.5,
-		"integerNum": 7
+	type _testCase struct {
+		input    string
+		expected bool
 	}
-	`)))
 
-	assert.Equal(t.T(), false, IsJSON(`{null`))
-	assert.Equal(t.T(), false, IsJSON(`{null}`))
-	assert.Equal(t.T(), false, IsJSON(`{abc: def}`))
+	testCases := []_testCase{
+		{
+			input:    "{}",
+			expected: true,
+		},
+		{
+			input:    `{"hello": "world"}`,
+			expected: true,
+		},
+		{
+			input: `{
+				"hello": {
+					"world": {
+						"nested_value": true
+					}
+				},
+				"add_a_list_here": [1, 2, 3, 4],
+				"number": 7.5,
+				"integerNum": 7
+			}`,
+			expected: true,
+		},
+		{
+			input: `{"hello": "world"`,
+		},
+		{
+			input: `{"hello": "world"}}`,
+		},
+		{
+			input: `{null}`,
+		},
+		{
+			input:    `[]`,
+			expected: true,
+		},
+		{
+			input:    `[1, 2, 3, 4]`,
+			expected: true,
+		},
+		{
+			input: `[1, 2, 3, 4`,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t.T(), tc.expected, IsJSON(tc.input), tc.input)
+	}
 }
 
 func (t *TypingTestSuite) TestParseValueBasic() {


### PR DESCRIPTION
Today, we are only considering strings that look like `{"foo": "bar"}` as valid JSON and not strings that look like `["foo", "bar"]`.

However, this is wrong because the latter is valid JSON. By considering this as a string, we are hitting the DDL limit on Redshift of 64k chars.

As a reminder, our typing library looks at data type first and only does special casting for STRING values, which means - if the data type for `[]string{"foo", "bar"}` came in, we would consider this a slice.
