### PR TITLE
[Redshift] Modify escaping TOAST columns for SUPER data types

### DIFF
--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -273,6 +273,13 @@ func ColumnsUpdateQuery(ctx context.Context, columns []string, columnsToTypes Co
 							column, column, constants.ToastUnavailableValuePlaceholder,
 							// cc.col ELSE c.col END
 							column, column))
+				} else if destKind == constants.Redshift {
+					_columns = append(_columns,
+						fmt.Sprintf(`%s= CASE WHEN cc.%s != JSON_PARSE('{"key":"%s"}') THEN cc.%s ELSE c.%s END`,
+							// col CASE when TO_JSON_STRING(cc.col) != { 'key': TOAST_UNAVAILABLE_VALUE }
+							column, column, constants.ToastUnavailableValuePlaceholder,
+							// cc.col ELSE c.col END
+							column, column))
 				} else {
 					_columns = append(_columns,
 						fmt.Sprintf("%s= CASE WHEN cc.%s != {'key': '%s'} THEN cc.%s ELSE c.%s END",

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -500,7 +500,7 @@ func (c *ColumnsTestSuite) TestColumnsUpdateQuery() {
 			columns:        lastCaseCols,
 			columnsToTypes: lastCaseColTypes,
 			destKind:       constants.Redshift,
-			expectedString: "a1= CASE WHEN cc.a1 != {'key': '__debezium_unavailable_value'} THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3",
+			expectedString: `a1= CASE WHEN cc.a1 != JSON_PARSE('{"key":"__debezium_unavailable_value"}') THEN cc.a1 ELSE c.a1 END,b2= CASE WHEN cc.b2 != '__debezium_unavailable_value' THEN cc.b2 ELSE c.b2 END,c3=cc.c3`,
 		},
 		{
 			name:           "struct, string and toast string (bigquery)",


### PR DESCRIPTION
In the previous PRs, we made JSON data types into a SUPER data type. We now need to escape the TOAST columns correctly.