### PR TITLE
[Redshift] Replace columns that have exceeded Redshift limits

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -55,7 +55,7 @@ func (s *Store) CastColValStaging(ctx context.Context, colVal interface{}, colKi
 		return `\N`, nil
 	}
 
-	if s.skipLargeColumns {
+	if s.skipLgCols {
 		colVal = replaceExceededValues(colVal, colKind)
 	}
 

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -30,8 +30,8 @@ type _testCase struct {
 	expectErr      bool
 }
 
-func evaluateTestCase(t *testing.T, ctx context.Context, testCase _testCase) {
-	actualString, actualErr := CastColValStaging(ctx, testCase.colVal, testCase.colKind)
+func evaluateTestCase(t *testing.T, ctx context.Context, store *Store, testCase _testCase) {
+	actualString, actualErr := store.CastColValStaging(ctx, testCase.colVal, testCase.colKind)
 	if testCase.expectErr {
 		assert.Error(t, actualErr, testCase.name)
 	} else {
@@ -136,7 +136,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Basic() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.ctx, testCase)
+		evaluateTestCase(r.T(), r.ctx, r.store, testCase)
 	}
 }
 
@@ -185,7 +185,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Array() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.ctx, testCase)
+		evaluateTestCase(r.T(), r.ctx, r.store, testCase)
 	}
 }
 
@@ -247,7 +247,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Time() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.ctx, testCase)
+		evaluateTestCase(r.T(), r.ctx, r.store, testCase)
 	}
 }
 
@@ -266,6 +266,6 @@ func (r *RedshiftTestSuite) TestCastColValStaging_TOAST() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.ctx, testCase)
+		evaluateTestCase(r.T(), r.ctx, r.store, testCase)
 	}
 }

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -21,6 +21,7 @@ type Store struct {
 	bucket            string
 	optionalS3Prefix  string
 	configMap         *types.DwhToTablesConfigMap
+	skipLargeColumns  bool
 	db.Store
 }
 
@@ -101,6 +102,7 @@ func LoadRedshift(ctx context.Context, _store *db.Store) *Store {
 		credentialsClause: settings.Config.Redshift.CredentialsClause,
 		bucket:            settings.Config.Redshift.Bucket,
 		optionalS3Prefix:  settings.Config.Redshift.OptionalS3Prefix,
+		skipLargeColumns:  settings.Config.Redshift.SkipLgCols,
 		Store:             db.Open(ctx, "postgres", connStr),
 		configMap:         &types.DwhToTablesConfigMap{},
 	}

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -21,7 +21,7 @@ type Store struct {
 	bucket            string
 	optionalS3Prefix  string
 	configMap         *types.DwhToTablesConfigMap
-	skipLargeColumns  bool
+	skipLgCols        bool
 	db.Store
 }
 
@@ -85,15 +85,17 @@ WHERE
 }
 
 func LoadRedshift(ctx context.Context, _store *db.Store) *Store {
+	settings := config.FromContext(ctx)
+
 	if _store != nil {
 		// Used for tests.
 		return &Store{
-			Store:     *_store,
-			configMap: &types.DwhToTablesConfigMap{},
+			Store:      *_store,
+			configMap:  &types.DwhToTablesConfigMap{},
+			skipLgCols: settings.Config.Redshift.SkipLgCols,
 		}
 	}
 
-	settings := config.FromContext(ctx)
 	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=require",
 		settings.Config.Redshift.Host, settings.Config.Redshift.Port, settings.Config.Redshift.Username,
 		settings.Config.Redshift.Password, settings.Config.Redshift.Database)
@@ -102,7 +104,7 @@ func LoadRedshift(ctx context.Context, _store *db.Store) *Store {
 		credentialsClause: settings.Config.Redshift.CredentialsClause,
 		bucket:            settings.Config.Redshift.Bucket,
 		optionalS3Prefix:  settings.Config.Redshift.OptionalS3Prefix,
-		skipLargeColumns:  settings.Config.Redshift.SkipLgCols,
+		skipLgCols:        settings.Config.Redshift.SkipLgCols,
 		Store:             db.Open(ctx, "postgres", connStr),
 		configMap:         &types.DwhToTablesConfigMap{},
 	}

--- a/clients/redshift/redshift_suite_test.go
+++ b/clients/redshift/redshift_suite_test.go
@@ -20,6 +20,9 @@ type RedshiftTestSuite struct {
 func (r *RedshiftTestSuite) SetupTest() {
 	r.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
 		VerboseLogging: false,
+		Config: &config.Config{
+			Redshift: &config.Redshift{},
+		},
 	})
 
 	r.fakeStore = &mocks.FakeStore{}

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -88,7 +88,7 @@ func (s *Store) loadTemporaryTable(ctx context.Context, tableData *optimization.
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal := value[col]
 			// Check
-			castedValue, castErr := CastColValStaging(ctx, colVal, colKind)
+			castedValue, castErr := s.CastColValStaging(ctx, colVal, colKind)
 			if castErr != nil {
 				return "", castErr
 			}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -103,6 +103,7 @@ type Redshift struct {
 	OptionalS3Prefix string `yaml:"optionalS3Prefix"`
 	// https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html
 	CredentialsClause string `yaml:"credentialsClause"`
+	SkipLgCols        bool   `yaml:"skipLgCols"`
 }
 
 type SharedDestinationConfig struct {

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -15,8 +15,8 @@ const (
 	ArtiePrefix               = "__artie"
 	DeleteColumnMarker        = ArtiePrefix + "_delete"
 	DeletionConfidencePadding = 4 * time.Hour
-
-	UpdateColumnMarker = ArtiePrefix + "_updated_at"
+	UpdateColumnMarker        = ArtiePrefix + "_updated_at"
+	ExceededValueMarker       = ArtiePrefix + "_exceeded_value"
 
 	// DBZPostgresFormat is the only supported CDC format right now
 	DBZPostgresFormat    = "debezium.postgres"

--- a/lib/destination/ddl/ddl_suite_test.go
+++ b/lib/destination/ddl/ddl_suite_test.go
@@ -33,7 +33,9 @@ type DDLTestSuite struct {
 func (d *DDLTestSuite) SetupTest() {
 	ctx := config.InjectSettingsIntoContext(context.Background(), &config.Settings{
 		VerboseLogging: true,
-		Config:         &config.Config{},
+		Config: &config.Config{
+			Redshift: &config.Redshift{},
+		},
 	})
 
 	bqCtx := config.InjectSettingsIntoContext(context.Background(), &config.Settings{


### PR DESCRIPTION
## Changes

This PR enables customers to turn on column value replacement whenever the column value exceeds Redshift's limits.

Currently, this is implemented such that:
* String values cannot exceed 65k chars
* STRUCT / SUPER values cannot exceed 1 mb


In the case where STRING values exceed, we'll return `__artie_exceeded_value`

For STRUCT / SUPER values, we'll return `{"key":"__artie_exceeded_value"}`

To enable this, update your Redshift configuration and include this:
```yaml
redshift:
    skipLgCols: true
```

## Checks

- [x] Add tests
- [x] Documentation