### PR TITLE
[Telemetry] Adding tableName to the Kafka topic ingestion lag

### DIFF
--- a/lib/artie/message.go
+++ b/lib/artie/message.go
@@ -56,10 +56,11 @@ func (m *Message) Kind() Kind {
 	return Invalid
 }
 
-func (m *Message) EmitIngestionLag(ctx context.Context, groupID string) {
+func (m *Message) EmitIngestionLag(ctx context.Context, groupID, table string) {
 	metrics.FromContext(ctx).Timing("ingestion.lag", time.Since(m.PublishTime()), map[string]string{
 		"groupID":   groupID,
 		"topic":     m.Topic(),
+		"table":     table,
 		"partition": m.Partition(),
 	})
 }

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -77,7 +77,6 @@ func Flush(args Args) error {
 				}
 			}
 			metrics.FromContext(args.Context).Timing("flush", time.Since(start), tags)
-
 		}(tableName, tableData)
 	}
 	wg.Wait()

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -93,7 +93,6 @@ func StartConsumer(ctx context.Context) {
 			tc:     topicConfig,
 			Format: format.GetFormatParser(ctx, topicConfig.CDCFormat, topicConfig.Topic),
 		})
-
 		topics = append(topics, topicConfig.Topic)
 	}
 


### PR DESCRIPTION
## Changes

We were previously only emitting the metadata available before processing a message to calculate the ingestion lag, which meant that we had `topic` and `partition`.

This makes it such that we cannot join metrics across all of the metrics we are currently tracking. 

## Notes

This does mean that ingestion lag includes processing time. This will likely increase the overall ingestion lag by a slight margin, however - it should be negligible because when the process locks to merge, we are no longer ingesting.

As a result, the subsequent action of reading from the Kafka topic after merge will incur the merge latency, which makes this negligible. 

## Checks
* [x] Update documentation