### PR TITLE
Improving Optional Schema

### DIFF
--- a/lib/cdc/mongo/postgres_suite_test.go
+++ b/lib/cdc/mongo/postgres_suite_test.go
@@ -1,18 +1,30 @@
 package mongo
 
 import (
-	"github.com/stretchr/testify/suite"
+	"context"
 	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
+
+	"github.com/artie-labs/transfer/lib/logger"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type MongoTestSuite struct {
 	suite.Suite
 	*Debezium
+	ctx context.Context
 }
 
 func (p *MongoTestSuite) SetupTest() {
 	var debezium Debezium
 	p.Debezium = &debezium
+
+	p.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
+		VerboseLogging: true,
+	})
+	p.ctx = logger.InjectLoggerIntoCtx(p.ctx)
 }
 
 func TestPostgresTestSuite(t *testing.T) {

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -1,7 +1,6 @@
 package postgres
 
 import (
-	"context"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -16,7 +15,7 @@ var validTc = &kafkalib.TopicConfig{
 }
 
 func (p *PostgresTestSuite) TestGetEventFromBytesTombstone() {
-	evt, err := p.GetEventFromBytes(context.Background(), nil)
+	evt, err := p.GetEventFromBytes(p.ctx, nil)
 	assert.NoError(p.T(), err)
 	assert.True(p.T(), evt.DeletePayload())
 	assert.False(p.T(), evt.GetExecutionTime().IsZero())
@@ -24,7 +23,7 @@ func (p *PostgresTestSuite) TestGetEventFromBytesTombstone() {
 
 func (p *PostgresTestSuite) TestGetPrimaryKey() {
 	valString := `{"id": 47}`
-	pkMap, err := p.GetPrimaryKey(context.Background(), []byte(valString), validTc)
+	pkMap, err := p.GetPrimaryKey(p.ctx, []byte(valString), validTc)
 	assert.NoError(p.T(), err)
 
 	val, isOk := pkMap["id"]
@@ -35,7 +34,7 @@ func (p *PostgresTestSuite) TestGetPrimaryKey() {
 
 func (p *PostgresTestSuite) TestGetPrimaryKeyUUID() {
 	valString := `{"uuid": "ca0cefe9-45cf-44fa-a2ab-ec5e7e5522a3"}`
-	pkMap, err := p.GetPrimaryKey(context.Background(), []byte(valString), validTc)
+	pkMap, err := p.GetPrimaryKey(p.ctx, []byte(valString), validTc)
 	val, isOk := pkMap["uuid"]
 	assert.True(p.T(), isOk)
 	assert.Equal(p.T(), val, "ca0cefe9-45cf-44fa-a2ab-ec5e7e5522a3")
@@ -82,11 +81,11 @@ func (p *PostgresTestSuite) TestPostgresEvent() {
 	}
 }
 `
-	evt, err := p.Debezium.GetEventFromBytes(context.Background(), []byte(payload))
+	evt, err := p.Debezium.GetEventFromBytes(p.ctx, []byte(payload))
 	assert.Nil(p.T(), err)
 	assert.False(p.T(), evt.DeletePayload())
 
-	evtData := evt.GetData(context.Background(), map[string]interface{}{"id": 59}, &kafkalib.TopicConfig{})
+	evtData := evt.GetData(p.ctx, map[string]interface{}{"id": 59}, &kafkalib.TopicConfig{})
 	assert.Equal(p.T(), evtData["id"], float64(59))
 
 	assert.Equal(p.T(), evtData["item"], "Barings Participation Investors")
@@ -185,11 +184,11 @@ func (p *PostgresTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 	}
 }
 `
-	evt, err := p.Debezium.GetEventFromBytes(context.Background(), []byte(payload))
+	evt, err := p.Debezium.GetEventFromBytes(p.ctx, []byte(payload))
 	assert.Nil(p.T(), err)
 	assert.False(p.T(), evt.DeletePayload())
 
-	evtData := evt.GetData(context.Background(), map[string]interface{}{"id": 1001}, &kafkalib.TopicConfig{})
+	evtData := evt.GetData(p.ctx, map[string]interface{}{"id": 1001}, &kafkalib.TopicConfig{})
 
 	// Testing typing.
 	assert.Equal(p.T(), evtData["id"], 1001)

--- a/lib/cdc/postgres/postgres_suite_test.go
+++ b/lib/cdc/postgres/postgres_suite_test.go
@@ -2,8 +2,12 @@ package postgres
 
 import (
 	"context"
-	"github.com/stretchr/testify/suite"
 	"testing"
+
+	"github.com/artie-labs/transfer/lib/config"
+
+	"github.com/artie-labs/transfer/lib/logger"
+	"github.com/stretchr/testify/suite"
 )
 
 type PostgresTestSuite struct {
@@ -15,7 +19,10 @@ type PostgresTestSuite struct {
 func (p *PostgresTestSuite) SetupTest() {
 	var debezium Debezium
 	p.Debezium = &debezium
-	p.ctx = context.Background()
+	p.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
+		VerboseLogging: true,
+	})
+	p.ctx = logger.InjectLoggerIntoCtx(p.ctx)
 }
 
 func TestPostgresTestSuite(t *testing.T) {

--- a/lib/cdc/util/optional_schema.go
+++ b/lib/cdc/util/optional_schema.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"context"
+
+	"github.com/artie-labs/transfer/lib/logger"
+
+	"github.com/artie-labs/transfer/lib/cdc"
+	"github.com/artie-labs/transfer/lib/typing"
+)
+
+func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails {
+	fieldsObject := s.Schema.GetSchemaFromLabel(cdc.After)
+	if fieldsObject == nil {
+		// AFTER schema does not exist.
+		return nil
+	}
+
+	schema := make(map[string]typing.KindDetails)
+	for _, field := range fieldsObject.Fields {
+		kd := field.ToKindDetails()
+		if kd == typing.Invalid {
+			logger.FromContext(ctx).WithFields(map[string]interface{}{
+				"field": field.FieldName,
+			}).Warn("skipping field from optional schema b/c we cannot determine the data type")
+			continue
+		}
+
+		schema[field.FieldName] = kd
+	}
+
+	return schema
+}

--- a/lib/cdc/util/optional_schema_test.go
+++ b/lib/cdc/util/optional_schema_test.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/stretchr/testify/assert"
+)
+
+func (u *UtilTestSuite) TestGetOptionalSchema() {
+	type _tc struct {
+		name     string
+		s        *SchemaEventPayload
+		expected map[string]typing.KindDetails
+	}
+
+	tcs := []_tc{
+		{
+			name:     "no schema",
+			s:        &SchemaEventPayload{},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		actualData := tc.s.GetOptionalSchema(u.ctx)
+		assert.Equal(u.T(), tc.expected, actualData, tc.name)
+	}
+}

--- a/lib/cdc/util/parse.go
+++ b/lib/cdc/util/parse.go
@@ -22,7 +22,7 @@ func parseField(ctx context.Context, field debezium.Field, value interface{}) in
 	if valid, supportedType := debezium.RequiresSpecialTypeCasting(field.DebeziumType); valid {
 		switch debezium.SupportedDebeziumType(field.DebeziumType) {
 		case debezium.KafkaDecimalType:
-			decimalVal, err := debezium.DecodeDecimal(fmt.Sprint(value), field.Parameters)
+			decimalVal, err := field.DecodeDecimal(fmt.Sprint(value))
 			if err == nil {
 				return decimalVal
 			} else {
@@ -33,7 +33,7 @@ func parseField(ctx context.Context, field debezium.Field, value interface{}) in
 				}).Debug("skipped casting dbz type due to an error")
 			}
 		case debezium.KafkaVariableNumericType:
-			variableNumericVal, err := debezium.DecodeDebeziumVariableDecimal(value)
+			variableNumericVal, err := field.DecodeDebeziumVariableDecimal(value)
 			if err == nil {
 				return variableNumericVal
 			} else {

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -61,28 +61,6 @@ func (s *SchemaEventPayload) GetColumns(ctx context.Context) *columns.Columns {
 	return &cols
 }
 
-func (s *SchemaEventPayload) GetOptionalSchema(ctx context.Context) map[string]typing.KindDetails {
-	fieldsObject := s.Schema.GetSchemaFromLabel(cdc.After)
-	if fieldsObject == nil {
-		// AFTER schema does not exist.
-		return nil
-	}
-
-	schema := make(map[string]typing.KindDetails)
-	for _, field := range fieldsObject.Fields {
-		// So far, we should only need to add a string type.
-		// (a) All the special Debezium types will be handled by our Debezium library and casted accordingly.
-		// (b) All the ZonedTimestamps where the actual casting is from a string will be handled by our typing library
-		// We are explicitly adding this for string types where the value may be of time/date kind but
-		// the actual column type in the source database is STRING.
-		if field.Type == "string" && field.DebeziumType == "" {
-			schema[field.FieldName] = typing.String
-		}
-	}
-
-	return schema
-}
-
 func (s *SchemaEventPayload) DeletePayload() bool {
 	return s.Payload.Operation == "d"
 }

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -80,10 +80,6 @@ func (u *UtilTestSuite) TestSource_GetOptionalSchema() {
 			assert.Nil(u.T(), defaultVal, _col.Name(u.ctx, nil))
 		}
 	}
-
-	// OptionalColumn does not pick up custom data types.
-	_, isOk = optionalSchema["zoned_timestamp_column"]
-	assert.False(u.T(), isOk)
 }
 
 func TestSource_GetExecutionTime(t *testing.T) {

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -112,6 +112,11 @@ type SharedDestinationConfig struct {
 
 type SharedTransferConfig struct {
 	AdditionalDateFormats []string `yaml:"additionalDateFormats"`
+
+	// CreateAllColumnsIfAvailable - If true, we will create all columns if the metadata is available regardless of
+	// whether we have a value from the column. This will also bypass our Typing library.
+	// This only works for data sources with a schema such as Postgres and MySQL
+	CreateAllColumnsIfAvailable bool `yaml:"createAllColumnsIfAvailable"`
 }
 
 type Snowflake struct {

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -81,23 +81,11 @@ func (f Field) ToKindDetails() typing.KindDetails {
 	// Then, we'll fall back on the actual data types.
 	switch f.DebeziumType {
 	case string(Timestamp), string(MicroTimestamp), string(DateTimeKafkaConnect), string(DateTimeWithTimezone):
-		etime := typing.ETime
-		etime.ExtendedTimeDetails = &ext.NestedKind{
-			Type: ext.DateTimeKindType,
-		}
-		return etime
+		return typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)
 	case string(Date), string(DateKafkaConnect):
-		etime := typing.ETime
-		etime.ExtendedTimeDetails = &ext.NestedKind{
-			Type: ext.DateKindType,
-		}
-		return etime
+		return typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType)
 	case string(Time), string(TimeMicro), string(TimeKafkaConnect), string(TimeWithTimezone):
-		etime := typing.ETime
-		etime.ExtendedTimeDetails = &ext.NestedKind{
-			Type: ext.TimeKindType,
-		}
-		return etime
+		return typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType)
 	case string(JSON):
 		return typing.Struct
 	case string(KafkaDecimalType):

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -2,7 +2,10 @@ package debezium
 
 import (
 	"github.com/artie-labs/transfer/lib/cdc"
+	"github.com/artie-labs/transfer/lib/maputil"
+	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
 type Schema struct {
@@ -45,21 +48,72 @@ func (f Field) IsInteger() (valid bool) {
 	return f.ToKindDetails() == typing.Integer
 }
 
+type ScaleAndPrecisionResults struct {
+	Scale     int
+	Precision *int
+}
+
+func (f Field) GetScaleAndPrecision() (ScaleAndPrecisionResults, error) {
+	scale, scaleErr := maputil.GetIntegerFromMap(f.Parameters, "scale")
+	if scaleErr != nil {
+		return ScaleAndPrecisionResults{}, scaleErr
+	}
+
+	var precisionPtr *int
+	if _, isOk := f.Parameters[KafkaDecimalPrecisionKey]; isOk {
+		precision, precisionErr := maputil.GetIntegerFromMap(f.Parameters, KafkaDecimalPrecisionKey)
+		if precisionErr != nil {
+			return ScaleAndPrecisionResults{}, precisionErr
+		}
+
+		precisionPtr = ptr.ToInt(precision)
+	}
+
+	return ScaleAndPrecisionResults{
+		Scale:     scale,
+		Precision: precisionPtr,
+	}, nil
+}
+
 func (f Field) ToKindDetails() typing.KindDetails {
+	// We'll first cast based on Debezium types
+	// Then, we'll fall back on the actual data types.
+	switch f.DebeziumType {
+	case string(Timestamp), string(MicroTimestamp), string(DateTimeKafkaConnect):
+		etime := typing.ETime
+		etime.ExtendedTimeDetails = &ext.NestedKind{
+			Type: ext.DateTimeKindType,
+		}
+		return etime
+	case string(Date), string(DateKafkaConnect):
+		etime := typing.ETime
+		etime.ExtendedTimeDetails = &ext.NestedKind{
+			Type: ext.DateKindType,
+		}
+		return etime
+	case string(Time), string(TimeMicro), string(TimeKafkaConnect):
+		etime := typing.ETime
+		etime.ExtendedTimeDetails = &ext.NestedKind{
+			Type: ext.TimeKindType,
+		}
+		return etime
+	case string(JSON):
+		return typing.Struct
+	case string(KafkaDecimalType):
+
+	case string(KafkaVariableNumericType):
+		// TODO: make sure KafkaVariableNumericType updates scale
+		// TODO: extract scale and precision out
+		// Then, cast EDECIMAL
+
+	}
+
 	switch f.Type {
 	case "int16", "int32", "int64":
-		if f.DebeziumType == "" {
-			return typing.Integer
-		}
-		// TODO: deal with ts.
-
 		return typing.Integer
 	case "float", "double":
-		// TODO: custom-snapshot is not emitting this yet.
 		return typing.Float
 	case "string":
-		// Within string, now inspect the Debezium type
-		// TODO: Also deal with strings
 		return typing.String
 	case "struct":
 		return typing.Struct

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -80,7 +80,7 @@ func (f Field) ToKindDetails() typing.KindDetails {
 	// We'll first cast based on Debezium types
 	// Then, we'll fall back on the actual data types.
 	switch f.DebeziumType {
-	case string(Timestamp), string(MicroTimestamp), string(DateTimeKafkaConnect):
+	case string(Timestamp), string(MicroTimestamp), string(DateTimeKafkaConnect), string(DateTimeWithTimezone):
 		etime := typing.ETime
 		etime.ExtendedTimeDetails = &ext.NestedKind{
 			Type: ext.DateTimeKindType,
@@ -92,7 +92,7 @@ func (f Field) ToKindDetails() typing.KindDetails {
 			Type: ext.DateKindType,
 		}
 		return etime
-	case string(Time), string(TimeMicro), string(TimeKafkaConnect):
+	case string(Time), string(TimeMicro), string(TimeKafkaConnect), string(TimeWithTimezone):
 		etime := typing.ETime
 		etime.ExtendedTimeDetails = &ext.NestedKind{
 			Type: ext.TimeKindType,

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -4,6 +4,12 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/typing/ext"
+
+	"github.com/artie-labs/transfer/lib/typing/decimal"
+
+	"github.com/artie-labs/transfer/lib/typing"
+
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/ptr"
 
@@ -148,5 +154,179 @@ func TestField_IsInteger(t *testing.T) {
 	for _, key := range foundNonIntKeys {
 		// Make sure these flagged keys are specified within integerKeys.
 		assert.False(t, array.StringContains(integerKeys, key))
+	}
+}
+
+func TestField_ToKindDetails(t *testing.T) {
+	type _tc struct {
+		name                string
+		field               Field
+		expectedKindDetails typing.KindDetails
+	}
+
+	eDecimal := typing.EDecimal
+	eDecimal.ExtendedDecimalDetails = decimal.NewDecimal(decimal.DefaultScale, ptr.ToInt(decimal.PrecisionNotSpecified), nil)
+
+	kafkaDecimalType := typing.EDecimal
+	kafkaDecimalType.ExtendedDecimalDetails = decimal.NewDecimal(5, ptr.ToInt(10), nil)
+
+	tcs := []_tc{
+		{
+			name:                "int16",
+			field:               Field{Type: "int16"},
+			expectedKindDetails: typing.Integer,
+		},
+		{
+			name:                "int32",
+			field:               Field{Type: "int32"},
+			expectedKindDetails: typing.Integer,
+		},
+		{
+			name:                "int64",
+			field:               Field{Type: "int64"},
+			expectedKindDetails: typing.Integer,
+		},
+		{
+			name:                "float",
+			field:               Field{Type: "float"},
+			expectedKindDetails: typing.Float,
+		},
+		{
+			name:                "double",
+			field:               Field{Type: "double"},
+			expectedKindDetails: typing.Float,
+		},
+		{
+			name:                "string",
+			field:               Field{Type: "string"},
+			expectedKindDetails: typing.String,
+		},
+		{
+			name:                "struct",
+			field:               Field{Type: "struct"},
+			expectedKindDetails: typing.Struct,
+		},
+		{
+			name:                "boolean",
+			field:               Field{Type: "boolean"},
+			expectedKindDetails: typing.Boolean,
+		},
+		{
+			name:                "array",
+			field:               Field{Type: "array"},
+			expectedKindDetails: typing.Array,
+		},
+		{
+			name:                "Invalid",
+			field:               Field{Type: "unknown"},
+			expectedKindDetails: typing.Invalid,
+		},
+		// Timestamp fields
+		{
+			name: "Timestamp",
+			field: Field{
+				DebeziumType: string(Timestamp),
+			},
+			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
+		},
+		{
+			name: "Micro Timestamp",
+			field: Field{
+				DebeziumType: string(MicroTimestamp),
+			},
+			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
+		},
+		{
+			name: "Date Time Kafka Connect",
+			field: Field{
+				DebeziumType: string(DateTimeKafkaConnect),
+			},
+			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
+		},
+		{
+			name: "Date Time w/ TZ",
+			field: Field{
+				DebeziumType: string(DateTimeWithTimezone),
+			},
+			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
+		},
+		// Date fields
+		{
+			name: "Date",
+			field: Field{
+				DebeziumType: string(Date),
+			},
+			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType),
+		},
+		{
+			name: "Date Kafka Connect",
+			field: Field{
+				DebeziumType: string(DateKafkaConnect),
+			},
+			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType),
+		},
+		// Time fields
+		{
+			name: "Time",
+			field: Field{
+				DebeziumType: string(Time),
+			},
+			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType),
+		},
+		{
+			name: "Time Micro",
+			field: Field{
+				DebeziumType: string(TimeMicro),
+			},
+			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType),
+		},
+		{
+			name: "Time Kafka Connect",
+			field: Field{
+				DebeziumType: string(TimeKafkaConnect),
+			},
+			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType),
+		},
+		{
+			name: "Time w/ TZ",
+			field: Field{
+				DebeziumType: string(TimeWithTimezone),
+			},
+			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType),
+		},
+		// JSON fields
+		{
+			name: "JSON",
+			field: Field{
+				DebeziumType: string(JSON),
+			},
+			expectedKindDetails: typing.Struct,
+		},
+		// Decimal
+		{
+			name: "KafkaDecimalType",
+			field: Field{
+				DebeziumType: string(KafkaDecimalType),
+				Parameters: map[string]interface{}{
+					"scale":                  5,
+					KafkaDecimalPrecisionKey: 10,
+				},
+			},
+			expectedKindDetails: kafkaDecimalType,
+		},
+		{
+			name: "KafkaVariableNumericType",
+			field: Field{
+				DebeziumType: string(KafkaVariableNumericType),
+				Parameters: map[string]interface{}{
+					"scale": 5,
+				},
+			},
+			expectedKindDetails: eDecimal,
+		},
+	}
+
+	for _, tc := range tcs {
+		assert.Equal(t, tc.expectedKindDetails, tc.field.ToKindDetails(), tc.name)
 	}
 }

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -26,6 +26,8 @@ const (
 	TimeMicro            SupportedDebeziumType = "io.debezium.time.MicroTime"
 	DateKafkaConnect     SupportedDebeziumType = "org.apache.kafka.connect.data.Date"
 	TimeKafkaConnect     SupportedDebeziumType = "org.apache.kafka.connect.data.Time"
+	TimeWithTimezone     SupportedDebeziumType = "io.debezium.time.ZonedTime"
+	DateTimeWithTimezone SupportedDebeziumType = "io.debezium.time.ZonedTimestamp"
 	DateTimeKafkaConnect SupportedDebeziumType = "org.apache.kafka.connect.data.Timestamp"
 
 	KafkaDecimalType         SupportedDebeziumType = "org.apache.kafka.connect.data.Decimal"
@@ -34,7 +36,7 @@ const (
 	KafkaDecimalPrecisionKey = "connect.decimal.precision"
 )
 
-var supportedTypes = []SupportedDebeziumType{
+var typesThatRequireTypeCasting = []SupportedDebeziumType{
 	Timestamp,
 	MicroTimestamp,
 	Date,
@@ -48,7 +50,7 @@ var supportedTypes = []SupportedDebeziumType{
 }
 
 func RequiresSpecialTypeCasting(typeLabel string) (bool, SupportedDebeziumType) {
-	for _, supportedType := range supportedTypes {
+	for _, supportedType := range typesThatRequireTypeCasting {
 		if typeLabel == string(supportedType) {
 			return true, supportedType
 		}

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -6,8 +6,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/ptr"
-
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 
 	"github.com/artie-labs/transfer/lib/maputil"
@@ -18,13 +16,14 @@ import (
 type SupportedDebeziumType string
 
 const (
-	Invalid        SupportedDebeziumType = "invalid"
-	Timestamp      SupportedDebeziumType = "io.debezium.time.Timestamp"
-	MicroTimestamp SupportedDebeziumType = "io.debezium.time.MicroTimestamp"
-	Date           SupportedDebeziumType = "io.debezium.time.Date"
-	Time           SupportedDebeziumType = "io.debezium.time.Time"
-	TimeMicro      SupportedDebeziumType = "io.debezium.time.MicroTime"
+	Invalid SupportedDebeziumType = "invalid"
+	JSON    SupportedDebeziumType = "io.debezium.data.Json"
 
+	Timestamp            SupportedDebeziumType = "io.debezium.time.Timestamp"
+	MicroTimestamp       SupportedDebeziumType = "io.debezium.time.MicroTimestamp"
+	Date                 SupportedDebeziumType = "io.debezium.time.Date"
+	Time                 SupportedDebeziumType = "io.debezium.time.Time"
+	TimeMicro            SupportedDebeziumType = "io.debezium.time.MicroTime"
 	DateKafkaConnect     SupportedDebeziumType = "org.apache.kafka.connect.data.Date"
 	TimeKafkaConnect     SupportedDebeziumType = "org.apache.kafka.connect.data.Time"
 	DateTimeKafkaConnect SupportedDebeziumType = "org.apache.kafka.connect.data.Timestamp"
@@ -88,20 +87,10 @@ func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ex
 // * Parameters - which contains:
 //   - `scale` (number of digits following decimal point)
 //   - `connect.decimal.precision` which is an optional parameter. (If -1, then it's variable and .Value() will be in STRING).
-func DecodeDecimal(encoded string, parameters map[string]interface{}) (*decimal.Decimal, error) {
-	scale, scaleErr := maputil.GetIntegerFromMap(parameters, "scale")
-	if scaleErr != nil {
-		return nil, scaleErr
-	}
-
-	var precPtr *int
-	if _, isOk := parameters[KafkaDecimalPrecisionKey]; isOk {
-		precision, precisionErr := maputil.GetIntegerFromMap(parameters, KafkaDecimalPrecisionKey)
-		if precisionErr != nil {
-			return nil, precisionErr
-		}
-
-		precPtr = ptr.ToInt(precision)
+func (f Field) DecodeDecimal(encoded string) (*decimal.Decimal, error) {
+	results, err := f.GetScaleAndPrecision()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get scale and/or precision, err: %v", err)
 	}
 
 	data, err := base64.StdEncoding.DecodeString(encoded)
@@ -116,17 +105,18 @@ func DecodeDecimal(encoded string, parameters map[string]interface{}) (*decimal.
 	bigFloat := new(big.Float).SetInt(bigInt)
 
 	// Compute divisor as 10^scale with big.Int's Exp, then convert to big.Float
-	scaleInt := big.NewInt(int64(scale))
+	scaleInt := big.NewInt(int64(results.Scale))
 	ten := big.NewInt(10)
 	divisorInt := new(big.Int).Exp(ten, scaleInt, nil)
 	divisorFloat := new(big.Float).SetInt(divisorInt)
 
 	// Perform the division
 	bigFloat.Quo(bigFloat, divisorFloat)
-	return decimal.NewDecimal(scale, precPtr, bigFloat), nil
+	return decimal.NewDecimal(results.Scale, results.Precision, bigFloat), nil
 }
 
-func DecodeDebeziumVariableDecimal(value interface{}) (*decimal.Decimal, error) {
+func (f Field) DecodeDebeziumVariableDecimal(value interface{}) (*decimal.Decimal, error) {
+	// TODO: Test
 	valueStruct, isOk := value.(map[string]interface{})
 	if !isOk {
 		return nil, fmt.Errorf("value is not map[string]interface{} type")
@@ -142,8 +132,10 @@ func DecodeDebeziumVariableDecimal(value interface{}) (*decimal.Decimal, error) 
 		return nil, fmt.Errorf("encoded value does not exist")
 	}
 
-	return DecodeDecimal(fmt.Sprint(val), map[string]interface{}{
-		"scale":                     scale,
-		"connect.decimal.precision": "-1",
-	})
+	f.Parameters = map[string]interface{}{
+		"scale":                  scale,
+		KafkaDecimalPrecisionKey: "-1",
+	}
+
+	return f.DecodeDecimal(fmt.Sprint(val))
 }

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -116,7 +116,6 @@ func (f Field) DecodeDecimal(encoded string) (*decimal.Decimal, error) {
 }
 
 func (f Field) DecodeDebeziumVariableDecimal(value interface{}) (*decimal.Decimal, error) {
-	// TODO: Test
 	valueStruct, isOk := value.(map[string]interface{})
 	if !isOk {
 		return nil, fmt.Errorf("value is not map[string]interface{} type")

--- a/lib/debezium/types_bench_test.go
+++ b/lib/debezium/types_bench_test.go
@@ -13,9 +13,9 @@ func BenchmarkDecodeDecimal_P64_S10(b *testing.B) {
 		"scale":                  10,
 		KafkaDecimalPrecisionKey: 64,
 	}
-
+	field := Field{Parameters: parameters}
 	for i := 0; i < b.N; i++ {
-		dec, err := DecodeDecimal("AwBGAw8m9GLXrCGifrnVP/8jPHrNEtd1r4rS", parameters)
+		dec, err := field.DecodeDecimal("AwBGAw8m9GLXrCGifrnVP/8jPHrNEtd1r4rS")
 		assert.NoError(b, err)
 		assert.Equal(b, "123456789012345678901234567890123456789012345678901234.1234567889", dec.Value())
 		require.NoError(b, err)
@@ -27,9 +27,9 @@ func BenchmarkDecodeDecimal_P38_S2(b *testing.B) {
 		"scale":                  2,
 		KafkaDecimalPrecisionKey: 38,
 	}
-
+	field := Field{Parameters: parameters}
 	for i := 0; i < b.N; i++ {
-		dec, err := DecodeDecimal(`AMCXznvJBxWzS58P/////w==`, parameters)
+		dec, err := field.DecodeDecimal(`AMCXznvJBxWzS58P/////w==`)
 		assert.NoError(b, err)
 		assert.Equal(b, "9999999999999999999999999999999999.99", dec.String())
 	}
@@ -41,8 +41,9 @@ func BenchmarkDecodeDecimal_P5_S2(b *testing.B) {
 		KafkaDecimalPrecisionKey: 5,
 	}
 
+	field := Field{Parameters: parameters}
 	for i := 0; i < b.N; i++ {
-		dec, err := DecodeDecimal(`AOHJ`, parameters)
+		dec, err := field.DecodeDecimal(`AOHJ`)
 		assert.NoError(b, err)
 		assert.Equal(b, "578.01", dec.String())
 	}

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -197,7 +197,11 @@ func TestDecodeDecimal(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		dec, err := DecodeDecimal(testCase.encoded, testCase.params)
+		field := Field{
+			Parameters: testCase.params,
+		}
+
+		dec, err := field.DecodeDecimal(testCase.encoded)
 		if testCase.expectError {
 			assert.Error(t, err, testCase.name)
 			continue
@@ -265,7 +269,8 @@ func TestDecodeDebeziumVariableDecimal(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		dec, err := DecodeDebeziumVariableDecimal(testCase.value)
+		field := Field{}
+		dec, err := field.DecodeDebeziumVariableDecimal(testCase.value)
 		if testCase.expectError {
 			assert.Error(t, err, testCase.name)
 			continue

--- a/lib/maputil/map_test.go
+++ b/lib/maputil/map_test.go
@@ -47,10 +47,46 @@ func TestGetIntegerFromMap(t *testing.T) {
 
 	testCases := []_testCase{
 		{
-			name:          "happy path",
+			name:          "happy path with string value",
 			obj:           object,
 			key:           "abc",
 			expectedValue: 123,
+		},
+		{
+			name:          "happy path with number value",
+			obj:           object,
+			key:           "abc (number)",
+			expectedValue: 123,
+		},
+		{
+			name:        "non-existing key",
+			obj:         object,
+			key:         "xyz",
+			expectError: true,
+		},
+		{
+			name:        "boolean value",
+			obj:         object,
+			key:         "def",
+			expectError: true,
+		},
+		{
+			name:        "non-numeric string value",
+			obj:         object,
+			key:         "ghi",
+			expectError: true,
+		},
+		{
+			name:          "negative number as string",
+			obj:           object,
+			key:           "123",
+			expectedValue: -321,
+		},
+		{
+			name:          "negative number",
+			obj:           object,
+			key:           "123 (number)",
+			expectedValue: -321,
 		},
 	}
 

--- a/lib/typing/decimal/decimal.go
+++ b/lib/typing/decimal/decimal.go
@@ -14,6 +14,11 @@ type Decimal struct {
 	value     *big.Float
 }
 
+const (
+	DefaultScale          = 5
+	PrecisionNotSpecified = -1
+)
+
 // MaxPrecisionBeforeString - if the precision is greater than 38, we'll cast it as a string.
 // This is because Snowflake and BigQuery both do not have NUMERIC data types that go beyond 38.
 const MaxPrecisionBeforeString = 38

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -96,11 +96,18 @@ func ParseValue(ctx context.Context, key string, optionalSchema map[string]KindD
 		return Invalid
 	}
 
-	// OptionalSchema is fetched from the message header
 	if len(optionalSchema) > 0 {
 		// If the column exists in the schema, let's early exit.
 		if kindDetail, isOk := optionalSchema[key]; isOk {
 			// If the schema exists, use it as sot.
+			if val != nil && (kindDetail.Kind == ETime.Kind || kindDetail.Kind == EDecimal.Kind) {
+				// If the data type is either `ETime` or `EDecimal` and the value exists, we will not early exit
+				// We are not skipping so that we are able to get the exact layout specified at the row level to preserve:
+				// 1. Layout for time / date / timestamps
+				// 2. Precision and scale for numeric values
+				return ParseValue(ctx, key, nil, val)
+			}
+
 			return kindDetail
 		}
 	}

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -92,15 +92,14 @@ func IsJSON(str string) bool {
 func ParseValue(ctx context.Context, key string, optionalSchema map[string]KindDetails, val interface{}) KindDetails {
 	cfg := config.FromContext(ctx).Config
 	if val == nil && !cfg.SharedTransferConfig.CreateAllColumnsIfAvailable {
-		// If the value is nil and we do not have `createAllColumnsIfAvailable` turned on, let's return `Invalid`
+		// If the value is nil and `createAllColumnsIfAvailable` = false, then return `Invalid
 		return Invalid
 	}
 
 	// OptionalSchema is fetched from the message header
 	if len(optionalSchema) > 0 {
 		// If the column exists in the schema, let's early exit.
-		kindDetail, isOk := optionalSchema[key]
-		if isOk {
+		if kindDetail, isOk := optionalSchema[key]; isOk {
 			// If the schema exists, use it as sot.
 			return kindDetail
 		}

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -7,9 +7,9 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/artie-labs/transfer/lib/typing/decimal"
-
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
@@ -90,10 +90,13 @@ func IsJSON(str string) bool {
 }
 
 func ParseValue(ctx context.Context, key string, optionalSchema map[string]KindDetails, val interface{}) KindDetails {
-	if val == nil {
+	cfg := config.FromContext(ctx).Config
+	if val == nil && !cfg.SharedTransferConfig.CreateAllColumnsIfAvailable {
+		// If the value is nil and we do not have `createAllColumnsIfAvailable` turned on, let's return `Invalid`
 		return Invalid
 	}
 
+	// OptionalSchema is fetched from the message header
 	if len(optionalSchema) > 0 {
 		// If the column exists in the schema, let's early exit.
 		kindDetail, isOk := optionalSchema[key]


### PR DESCRIPTION
## Motivation

Today, we are reliant on our Typing library inferring the right column to create downstream via inference on the first not null data type.

This works well, however it creates a constraint that the column will only be created if Artie Transfer has seen at least one `not null` value. 

For sources that have schemas such as Postgres and MySQL, we can actually inspect the message header from Debezium and know the exact type. From there, we can map it to our Typing library and create the columns irregardless of whether the value actually is set. 

This will be an opt-in flag that customers can enable.

## Checks

- [x] Test every data type (Debezium)
- [x] Test every data type (Custom snapshot)
- [ ] Add documentation
- [x] Benchmark 
