### PR TITLE
[Optional Schema] Recognizing bytea

### DIFF
--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -111,7 +111,7 @@ func (f Field) ToKindDetails() typing.KindDetails {
 		return typing.Integer
 	case "float", "double":
 		return typing.Float
-	case "string":
+	case "string", "bytes":
 		return typing.String
 	case "struct":
 		return typing.Struct

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -202,6 +202,11 @@ func TestField_ToKindDetails(t *testing.T) {
 			expectedKindDetails: typing.String,
 		},
 		{
+			name:                "bytes",
+			field:               Field{Type: "bytes"},
+			expectedKindDetails: typing.String,
+		},
+		{
 			name:                "struct",
 			field:               Field{Type: "struct"},
 			expectedKindDetails: typing.Struct,


### PR DESCRIPTION
* We are currently storing all bytes data as TEXT and allowing customers to coerce it out at the DWH level. 
* This PR formally recognizes that in the optional schema such that we are not storing it as `typing.Invalid`