### PR TITLE
Working past the 10 mb limit of BigQuery

### DIFF
--- a/clients/bigquery/batch.go
+++ b/clients/bigquery/batch.go
@@ -1,0 +1,56 @@
+package bigquery
+
+import (
+	"fmt"
+)
+
+var BatchEmptyErr = fmt.Errorf("batch is empty")
+
+type Batch struct {
+	rows        []*Row
+	chunkSize   int
+	iteratorIdx int
+}
+
+func (b *Batch) IsValid() error {
+	if len(b.rows) == 0 {
+		return BatchEmptyErr
+	}
+
+	if b.chunkSize < 1 {
+		return fmt.Errorf("chunk size is too small")
+	}
+
+	if b.iteratorIdx < 0 {
+		return fmt.Errorf("iterator cannot be less than 0")
+	}
+
+	return nil
+}
+
+func NewBatch(rows []*Row, chunkSize int) *Batch {
+	return &Batch{
+		rows:      rows,
+		chunkSize: chunkSize,
+	}
+}
+
+func (b *Batch) HasNext() bool {
+	return len(b.rows) > b.iteratorIdx
+}
+
+func (b *Batch) NextChunk() []*Row {
+	start := b.iteratorIdx
+	b.iteratorIdx += b.chunkSize
+	end := b.iteratorIdx
+
+	if end > len(b.rows) {
+		end = len(b.rows)
+	}
+
+	if start > end {
+		return nil
+	}
+
+	return b.rows[start:end]
+}

--- a/clients/bigquery/batch_test.go
+++ b/clients/bigquery/batch_test.go
@@ -1,0 +1,83 @@
+package bigquery
+
+import (
+	"cloud.google.com/go/bigquery"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (b *BigQueryTestSuite) TestBatch_IsValid() {
+	type _testCase struct {
+		name        string
+		msgs        []*Row
+		chunkSize   int
+		expectError bool
+	}
+
+	testCases := []_testCase{
+		{
+			name: "happy path",
+			msgs: []*Row{
+				NewRow(map[string]bigquery.Value{"col1": "message1"}),
+				NewRow(map[string]bigquery.Value{"col1": "message2"}),
+			},
+			chunkSize: 2,
+		},
+		{
+			name: "happy path (chunkSize = 0)",
+			msgs: []*Row{
+				NewRow(map[string]bigquery.Value{"col1": "message1"}),
+				NewRow(map[string]bigquery.Value{"col1": "message2"}),
+			},
+			expectError: true,
+		},
+		{
+			name: "happy path (chunkSize = -5)",
+			msgs: []*Row{
+				NewRow(map[string]bigquery.Value{"col1": "message1"}),
+				NewRow(map[string]bigquery.Value{"col1": "message2"}),
+			},
+			chunkSize:   -5,
+			expectError: true,
+		},
+		{
+			name:        "batch is empty",
+			chunkSize:   2,
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		batch := NewBatch(testCase.msgs, testCase.chunkSize)
+		actualErr := batch.IsValid()
+		if testCase.expectError {
+			assert.Error(b.T(), actualErr, testCase.name)
+		} else {
+			assert.NoError(b.T(), actualErr, testCase.name)
+		}
+	}
+}
+
+func (b *BigQueryTestSuite) TestBatch_NextChunk() {
+	messages := []*Row{
+		NewRow(map[string]bigquery.Value{"col1": "message1"}),
+		NewRow(map[string]bigquery.Value{"col1": "message2"}),
+		NewRow(map[string]bigquery.Value{"col1": "message3"}),
+	}
+
+	batch := NewBatch(messages, 2)
+	// First call to NextChunk
+	chunk := batch.NextChunk()
+	assert.Equal(b.T(), 2, len(chunk), "Expected chunk size to be 2")
+	assert.Equal(b.T(), map[string]bigquery.Value{"col1": "message1"}, chunk[0].data, "Expected first message in chunk to be message1")
+	assert.Equal(b.T(), map[string]bigquery.Value{"col1": "message2"}, chunk[1].data, "Expected second message in chunk to be message2")
+
+	// Second call to NextChunk
+	chunk = batch.NextChunk()
+	assert.Equal(b.T(), 1, len(chunk), "Expected chunk size to be 1 for the remaining messages")
+	assert.Equal(b.T(), map[string]bigquery.Value{"col1": "message3"}, chunk[0].data, "Expected the last message in chunk to be message3")
+
+	// Third call to NextChunk should return an empty chunk as there are no more messages
+	chunk = batch.NextChunk()
+	assert.Empty(b.T(), chunk, "Expected an empty chunk when there are no more messages")
+}

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -28,6 +28,7 @@ const (
 
 type Store struct {
 	configMap *types.DwhToTablesConfigMap
+	batchSize int
 	db.Store
 }
 
@@ -72,8 +73,15 @@ func (s *Store) PutTable(ctx context.Context, dataset, tableName string, rows []
 	client := s.GetClient(ctx)
 	defer client.Close()
 
+	batch := NewBatch(rows, s.batchSize)
 	inserter := client.Dataset(dataset).Table(tableName).Inserter()
-	return inserter.Put(ctx, rows)
+	for batch.HasNext() {
+		if err := inserter.Put(ctx, batch.NextChunk()); err != nil {
+			return fmt.Errorf("failed to insert rows, err: %v", err
+		}
+	}
+
+	return nil
 }
 
 func LoadBigQuery(ctx context.Context, _store *db.Store) *Store {
@@ -86,6 +94,7 @@ func LoadBigQuery(ctx context.Context, _store *db.Store) *Store {
 	}
 
 	settings := config.FromContext(ctx)
+	settings.Config.BigQuery.LoadDefaultValues()
 	if credPath := settings.Config.BigQuery.PathToCredentials; credPath != "" {
 		// If the credPath is set, let's set it into the env var.
 		logger.FromContext(ctx).Debug("writing the path to BQ credentials to env var for google auth")
@@ -98,5 +107,6 @@ func LoadBigQuery(ctx context.Context, _store *db.Store) *Store {
 	return &Store{
 		Store:     db.Open(ctx, "bigquery", settings.Config.BigQuery.DSN()),
 		configMap: &types.DwhToTablesConfigMap{},
+		batchSize: settings.Config.BigQuery.BatchSize,
 	}
 }

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -77,7 +77,7 @@ func (s *Store) PutTable(ctx context.Context, dataset, tableName string, rows []
 	inserter := client.Dataset(dataset).Table(tableName).Inserter()
 	for batch.HasNext() {
 		if err := inserter.Put(ctx, batch.NextChunk()); err != nil {
-			return fmt.Errorf("failed to insert rows, err: %v", err
+			return fmt.Errorf("failed to insert rows, err: %v", err)
 		}
 	}
 

--- a/lib/config/bigquery.go
+++ b/lib/config/bigquery.go
@@ -1,0 +1,31 @@
+package config
+
+import "fmt"
+
+type BigQuery struct {
+	// PathToCredentials is _optional_ if you have GOOGLE_APPLICATION_CREDENTIALS set as an env var
+	// Links to credentials: https://cloud.google.com/docs/authentication/application-default-credentials#GAC
+	PathToCredentials string `yaml:"pathToCredentials"`
+	DefaultDataset    string `yaml:"defaultDataset"`
+	ProjectID         string `yaml:"projectID"`
+	Location          string `yaml:"location"`
+	BatchSize         int    `yaml:"batchSize"`
+}
+
+func (b *BigQuery) LoadDefaultValues() {
+	if b.BatchSize == 0 {
+		b.BatchSize = 1000
+	}
+}
+
+// DSN - returns the notation for BigQuery following this format: bigquery://projectID/[location/]datasetID?queryString
+// If location is passed in, we'll specify it. Else, it'll default to empty and our library will set it to US.
+func (b *BigQuery) DSN() string {
+	dsn := fmt.Sprintf("bigquery://%s/%s", b.ProjectID, b.DefaultDataset)
+
+	if b.Location != "" {
+		dsn = fmt.Sprintf("bigquery://%s/%s/%s", b.ProjectID, b.Location, b.DefaultDataset)
+	}
+
+	return dsn
+}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -48,27 +48,6 @@ type Kafka struct {
 	TopicConfigs    []*kafkalib.TopicConfig `yaml:"topicConfigs"`
 }
 
-type BigQuery struct {
-	// PathToCredentials is _optional_ if you have GOOGLE_APPLICATION_CREDENTIALS set as an env var
-	// Links to credentials: https://cloud.google.com/docs/authentication/application-default-credentials#GAC
-	PathToCredentials string `yaml:"pathToCredentials"`
-	DefaultDataset    string `yaml:"defaultDataset"`
-	ProjectID         string `yaml:"projectID"`
-	Location          string `yaml:"location"`
-}
-
-// DSN - returns the notation for BigQuery following this format: bigquery://projectID/[location/]datasetID?queryString
-// If location is passed in, we'll specify it. Else, it'll default to empty and our library will set it to US.
-func (b *BigQuery) DSN() string {
-	dsn := fmt.Sprintf("bigquery://%s/%s", b.ProjectID, b.DefaultDataset)
-
-	if b.Location != "" {
-		dsn = fmt.Sprintf("bigquery://%s/%s/%s", b.ProjectID, b.Location, b.DefaultDataset)
-	}
-
-	return dsn
-}
-
 type S3Settings struct {
 	OptionalPrefix     string                   `yaml:"optionalPrefix"`
 	Bucket             string                   `yaml:"bucket"`


### PR DESCRIPTION
Addresses: https://github.com/artie-labs/transfer/issues/183

## Motivation
See linked issue for the reason why we are doing this.

## Changes
We are adding a new optional parameter called `bigQuery.batchSize` (int) which defaults to 1k if not passed in.

This is used to iterate over the in-memory database to incrementally call the Streaming API to insert data with the size specified by `batchSize`. Once this is done, it will then invoke a MERGE.

This now allows us to have a larger in-memory database pool