### PR TITLE
[Redshift] Adding a guardrail around load errors

### DIFF
--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -120,7 +120,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	// Prepare merge statement
 	mergeParts, err := dml.MergeStatementParts(ctx, &dml.MergeArgument{
 		FqTableName:   fqName,
-		SubQuery:      temporaryTableName,
+		SubQuery:      fmt.Sprintf(`( SELECT DISTINCT *  FROM %s )`, temporaryTableName),
 		IdempotentKey: tableData.TopicConfig.IdempotentKey,
 		PrimaryKeys: tableData.PrimaryKeys(ctx, &sql.NameArgs{
 			Escape:   true,

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -119,7 +119,9 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	// Prepare merge statement
 	mergeParts, err := dml.MergeStatementParts(ctx, &dml.MergeArgument{
-		FqTableName:   fqName,
+		FqTableName: fqName,
+		// We are adding SELECT DISTINCT here for the temporary table as an extra guardrail.
+		// Redshift does not enforce any row uniqueness and there could be potential LOAD errors which will cause duplicate rows to arise.
 		SubQuery:      fmt.Sprintf(`( SELECT DISTINCT *  FROM %s )`, temporaryTableName),
 		IdempotentKey: tableData.TopicConfig.IdempotentKey,
 		PrimaryKeys: tableData.PrimaryKeys(ctx, &sql.NameArgs{


### PR DESCRIPTION
## Motivation

We found out last Friday that there was a potential for duplicate rows to arise from loading a temporary table [src](https://saturncloud.io/blog/how-to-prevent-duplicate-data-in-amazon-redshift/#causes-of-duplicate-data-in-amazon-redshift).

This was happening extremely infrequently and happened during a particular timeframe when Redshift was having issues. This change adds an extra guardrail around the temporary table to ensure there are 0 duplicate rows.