### PR TITLE
[Redshift] Reducing Max VARCHAR length

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	maxRedshiftVarCharLen = 65535
+	maxRedshiftVarCharLen = 65000
 	maxRedshiftSuperLen   = 1 * 1024 * 1024 // 1 MB
 )
 


### PR DESCRIPTION
Redshift has a VARCHAR column that allows up to 2^16. However, it's choking on values that are ~ 65,300 in bytes.

As a result, we are lowering this to 65k as opposed to `65535`