### PR TITLE
[Redshift] Improvement around DDL inspection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,7 @@ bench_size:
 bench_typing:
 	go test ./lib/typing -bench=Bench -benchtime=20s
 	go test ./lib/debezium -bench=Bench -benchtime=20s
+
+.PHONY: bench_redshift
+bench_redshift:
+	go test ./clients/redshift -bench=Bench -benchtime=20s

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -18,23 +18,23 @@ import (
 )
 
 const (
-	maxRedshiftVarCharLen = 65000
+	maxRedshiftVarCharLen = 65535
 	maxRedshiftSuperLen   = 1 * 1024 * 1024 // 1 MB
 )
 
 // replaceExceededValues - takes `colVal` interface{} and `colKind` columns.Column and replaces the value with an empty string if it exceeds the max length.
 // This currently only works for STRING and SUPER data types.
 func replaceExceededValues(colVal interface{}, colKind columns.Column) interface{} {
-	colValString := fmt.Sprint(colVal)
+	colValBytes := len([]byte(fmt.Sprint(colVal)))
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind: // Assuming this corresponds to SUPER type in Redshift
-		if len(colValString) > maxRedshiftSuperLen {
+		if colValBytes > maxRedshiftSuperLen {
 			return map[string]interface{}{
 				"key": constants.ExceededValueMarker,
 			}
 		}
 	case typing.String.Kind:
-		if len(colValString) > maxRedshiftVarCharLen {
+		if colValBytes > maxRedshiftVarCharLen {
 			return constants.ExceededValueMarker
 		}
 	}

--- a/clients/redshift/redshift_bench_test.go
+++ b/clients/redshift/redshift_bench_test.go
@@ -1,0 +1,65 @@
+package redshift
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
+)
+
+func BenchmarkOldMethod(b *testing.B) {
+	colVal := "a string that will be used to benchmark the old method"
+	colKind := columns.NewColumn("foo", typing.String)
+
+	for i := 0; i < b.N; i++ {
+		replaceExceededValuesOld(colVal, colKind)
+	}
+}
+
+func BenchmarkNewMethod(b *testing.B) {
+	colVal := "a string that will be used to benchmark the new method"
+	colKind := columns.NewColumn("foo", typing.String)
+
+	for i := 0; i < b.N; i++ {
+		replaceExceededValuesNew(colVal, colKind)
+	}
+}
+
+func replaceExceededValuesOld(colVal interface{}, colKind columns.Column) interface{} {
+	colValString := fmt.Sprint(colVal)
+	switch colKind.KindDetails.Kind {
+	case typing.Struct.Kind:
+		if len(colValString) > maxRedshiftSuperLen {
+			return map[string]interface{}{
+				"key": constants.ExceededValueMarker,
+			}
+		}
+	case typing.String.Kind:
+		if len(colValString) > maxRedshiftVarCharLen {
+			return constants.ExceededValueMarker
+		}
+	}
+
+	return colVal
+}
+
+func replaceExceededValuesNew(colVal interface{}, colKind columns.Column) interface{} {
+	colValString := fmt.Sprint(colVal)
+	colValBytes := len([]byte(colValString))
+	switch colKind.KindDetails.Kind {
+	case typing.Struct.Kind:
+		if colValBytes > maxRedshiftSuperLen {
+			return map[string]interface{}{
+				"key": constants.ExceededValueMarker,
+			}
+		}
+	case typing.String.Kind:
+		if colValBytes > maxRedshiftVarCharLen {
+			return constants.ExceededValueMarker
+		}
+	}
+
+	return colVal
+}


### PR DESCRIPTION
## Motivation

The previous PR: https://github.com/artie-labs/transfer/pull/191 was inspecting char length based on `len(valString)` which is not 1:1 with the actual number of bytes.

Instead, we are now casting it into a byte array and inspecting the length.

## Benchmark
The new method is slightly slower, but it's still pretty fast.

```
robins-macbook-pro:transfer robintang$ make bench_redshift
go test ./clients/redshift -bench=Bench -benchtime=20s
goos: darwin
goarch: amd64
pkg: github.com/artie-labs/transfer/clients/redshift
cpu: VirtualApple @ 2.50GHz
BenchmarkOldMethod-12    	280654028	        87.39 ns/op
BenchmarkNewMethod-12    	202929502	       120.2 ns/op
PASS
ok  	github.com/artie-labs/transfer/clients/redshift	70.343s
```