### PR TITLE
[Redshift] Use string length not byte to calculate DDL overflow

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -10,7 +10,6 @@ import (
 	"github.com/artie-labs/transfer/lib/array"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
@@ -83,10 +82,7 @@ func (s *Store) CastColValStaging(ctx context.Context, colVal interface{}, colKi
 		list, err := array.InterfaceToArrayString(colVal, false)
 		if err == nil {
 			colValString = "[" + strings.Join(list, ",") + "]"
-		} else {
-			colValString = stringutil.Wrap(colVal, true)
 		}
-
 	case typing.Struct.Kind:
 		if colKind.KindDetails == typing.Struct {
 			if strings.Contains(fmt.Sprint(colVal), constants.ToastUnavailableValuePlaceholder) {

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -25,17 +25,16 @@ const (
 // replaceExceededValues - takes `colVal` interface{} and `colKind` columns.Column and replaces the value with an empty string if it exceeds the max length.
 // This currently only works for STRING and SUPER data types.
 func replaceExceededValues(colVal interface{}, colKind columns.Column) interface{} {
-	// TODO: We should try to make this faster. Converting this to `[]rune` from `[]byte` is about 2.5-3x slower
-	colValBytes := len([]rune(fmt.Sprint(colVal)))
+	numOfChars := len(fmt.Sprint(colVal))
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind: // Assuming this corresponds to SUPER type in Redshift
-		if colValBytes > maxRedshiftSuperLen {
+		if numOfChars > maxRedshiftSuperLen {
 			return map[string]interface{}{
 				"key": constants.ExceededValueMarker,
 			}
 		}
 	case typing.String.Kind:
-		if colValBytes > maxRedshiftVarCharLen {
+		if numOfChars > maxRedshiftVarCharLen {
 			return constants.ExceededValueMarker
 		}
 	}

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -25,6 +25,7 @@ const (
 // replaceExceededValues - takes `colVal` interface{} and `colKind` columns.Column and replaces the value with an empty string if it exceeds the max length.
 // This currently only works for STRING and SUPER data types.
 func replaceExceededValues(colVal interface{}, colKind columns.Column) interface{} {
+	// TODO: We should try to make this faster. Converting this to `[]rune` from `[]byte` is about 2.5-3x slower
 	colValBytes := len([]rune(fmt.Sprint(colVal)))
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind: // Assuming this corresponds to SUPER type in Redshift

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -25,7 +25,7 @@ const (
 // replaceExceededValues - takes `colVal` interface{} and `colKind` columns.Column and replaces the value with an empty string if it exceeds the max length.
 // This currently only works for STRING and SUPER data types.
 func replaceExceededValues(colVal interface{}, colKind columns.Column) interface{} {
-	colValBytes := len([]byte(fmt.Sprint(colVal)))
+	colValBytes := len([]rune(fmt.Sprint(colVal)))
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind: // Assuming this corresponds to SUPER type in Redshift
 		if colValBytes > maxRedshiftSuperLen {

--- a/clients/redshift/redshift_bench_test.go
+++ b/clients/redshift/redshift_bench_test.go
@@ -2,7 +2,10 @@ package redshift
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+
+	"github.com/artie-labs/transfer/lib/stringutil"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -10,9 +13,9 @@ import (
 )
 
 func BenchmarkOldMethod(b *testing.B) {
-	colVal := "a string that will be used to benchmark the old method"
+	// Random string between [500, 100000)
+	colVal := stringutil.Random(rand.Intn(100000) + 500)
 	colKind := columns.NewColumn("foo", typing.String)
-
 	for i := 0; i < b.N; i++ {
 		replaceExceededValuesOld(colVal, colKind)
 	}

--- a/clients/redshift/redshift_bench_test.go
+++ b/clients/redshift/redshift_bench_test.go
@@ -47,7 +47,7 @@ func replaceExceededValuesOld(colVal interface{}, colKind columns.Column) interf
 
 func replaceExceededValuesNew(colVal interface{}, colKind columns.Column) interface{} {
 	colValString := fmt.Sprint(colVal)
-	colValBytes := len([]byte(colValString))
+	colValBytes := len([]rune(colValString))
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind:
 		if colValBytes > maxRedshiftSuperLen {

--- a/clients/redshift/redshift_bench_test.go
+++ b/clients/redshift/redshift_bench_test.go
@@ -12,22 +12,22 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
-func BenchmarkOldMethod(b *testing.B) {
-	// Random string between [500, 100000)
-	colVal := stringutil.Random(rand.Intn(100000) + 500)
-	colKind := columns.NewColumn("foo", typing.String)
-	for i := 0; i < b.N; i++ {
-		replaceExceededValuesOld(colVal, colKind)
-	}
-}
+func BenchmarkMethods(b *testing.B) {
+	// Random string of length [500, 100,000)
+	colVal := stringutil.Random(rand.Intn(100000) + 500) // use the same value for both benchmarks
+	colKind := columns.NewColumn("foo", typing.String)   // use the same column kind for both benchmarks
 
-func BenchmarkNewMethod(b *testing.B) {
-	colVal := "a string that will be used to benchmark the new method"
-	colKind := columns.NewColumn("foo", typing.String)
+	b.Run("OldMethod", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			replaceExceededValuesOld(colVal, colKind)
+		}
+	})
 
-	for i := 0; i < b.N; i++ {
-		replaceExceededValuesNew(colVal, colKind)
-	}
+	b.Run("NewMethod", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			replaceExceededValuesNew(colVal, colKind)
+		}
+	})
 }
 
 func replaceExceededValuesOld(colVal interface{}, colKind columns.Column) interface{} {

--- a/clients/redshift/redshift_bench_test.go
+++ b/clients/redshift/redshift_bench_test.go
@@ -50,7 +50,7 @@ func replaceExceededValuesOld(colVal interface{}, colKind columns.Column) interf
 
 func replaceExceededValuesNew(colVal interface{}, colKind columns.Column) interface{} {
 	colValString := fmt.Sprint(colVal)
-	colValBytes := len([]rune(colValString))
+	colValBytes := len(colValString)
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind:
 		if colValBytes > maxRedshiftSuperLen {


### PR DESCRIPTION
## Problem

We are trying to address DDL overflow with the past 2 PRs. However, we are not calculating the overflow correctly since we were using `[]byte` and not just counting the number of characters.

## \ Replacement

In addition to using the wrong metric to count, we were also counting pre-string manipulation. We are currently unnecessarily changing `\` to `\\`, 
