### PR TITLE
Merging cooldown

### DIFF
--- a/lib/ptr/ptr.go
+++ b/lib/ptr/ptr.go
@@ -1,5 +1,7 @@
 package ptr
 
+import "time"
+
 func ToString(val string) *string {
 	return &val
 }
@@ -14,4 +16,8 @@ func ToInt64(val int64) *int64 {
 
 func ToBool(val bool) *bool {
 	return &val
+}
+
+func ToDuration(duration time.Duration) *time.Duration {
+	return &duration
 }

--- a/models/memory.go
+++ b/models/memory.go
@@ -2,7 +2,9 @@ package models
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"time"
 
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/optimization"
@@ -15,11 +17,18 @@ const dbKey = "__db"
 // We did this because certain operations require different locking patterns
 type TableData struct {
 	*optimization.TableData
+	lastMergeTime time.Time
 	sync.Mutex
 }
 
 func (t *TableData) Wipe() {
 	t.TableData = nil
+	t.lastMergeTime = time.Now()
+}
+
+func (t *TableData) ShouldSkipMerge(cooldown time.Duration) bool {
+	fmt.Println("coolDown", cooldown)
+	return time.Since(t.lastMergeTime) < cooldown
 }
 
 func (t *TableData) Empty() bool {
@@ -75,7 +84,6 @@ func (d *DatabaseData) GetOrCreateTableData(tableName string) *TableData {
 func (d *DatabaseData) ClearTableConfig(tableName string) {
 	d.Lock()
 	defer d.Unlock()
-
 	d.tableData[tableName].Wipe()
 	return
 }

--- a/models/memory.go
+++ b/models/memory.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -27,7 +26,6 @@ func (t *TableData) Wipe() {
 }
 
 func (t *TableData) ShouldSkipMerge(cooldown time.Duration) bool {
-	fmt.Println("coolDown", cooldown)
 	return time.Since(t.lastMergeTime) < cooldown
 }
 

--- a/models/memory_flush_test.go
+++ b/models/memory_flush_test.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"time"
+
+	"github.com/artie-labs/transfer/lib/optimization"
+	"github.com/stretchr/testify/assert"
+)
+
+func (m *ModelsTestSuite) TestMergeOperations() {
+	coolDown := 5 * time.Second
+	checkInterval := 200 * time.Millisecond
+
+	td := TableData{
+		TableData: &optimization.TableData{},
+	}
+
+	// Before wiping, we should not skip the merge since ts did not get set yet.
+	assert.False(m.T(), td.ShouldSkipMerge(coolDown))
+
+	td.Wipe()
+	for i := 0; i < 10; i++ {
+		assert.True(m.T(), td.ShouldSkipMerge(coolDown))
+		time.Sleep(checkInterval)
+	}
+
+	time.Sleep(3 * time.Second)
+	assert.False(m.T(), td.ShouldSkipMerge(coolDown))
+}

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -2,14 +2,13 @@ package models
 
 import (
 	"context"
-	"testing"
 
 	"github.com/artie-labs/transfer/lib/optimization"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTableData_Complete(t *testing.T) {
+func (m *ModelsTestSuite) TestTableData_Complete() {
 	ctx := context.Background()
 	ctx = LoadMemoryDB(ctx)
 
@@ -18,25 +17,25 @@ func TestTableData_Complete(t *testing.T) {
 
 	// TableData does not exist
 	_, isOk := db.TableData()[tableName]
-	assert.False(t, isOk)
+	assert.False(m.T(), isOk)
 
 	td := db.GetOrCreateTableData(tableName)
-	assert.True(t, td.Empty())
+	assert.True(m.T(), td.Empty())
 	_, isOk = db.TableData()[tableName]
-	assert.True(t, isOk)
+	assert.True(m.T(), isOk)
 
 	// Add the td struct
 	td.SetTableData(&optimization.TableData{})
-	assert.False(t, td.Empty())
+	assert.False(m.T(), td.Empty())
 
 	// Wipe via tableData.Wipe()
 	td.Wipe()
-	assert.True(t, td.Empty())
+	assert.True(m.T(), td.Empty())
 
 	// Wipe via ClearTableConfig(...)
 	td.SetTableData(&optimization.TableData{})
-	assert.False(t, td.Empty())
+	assert.False(m.T(), td.Empty())
 
 	db.ClearTableConfig(tableName)
-	assert.True(t, td.Empty())
+	assert.True(m.T(), td.Empty())
 }

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -12,7 +12,8 @@ import (
 )
 
 type Args struct {
-	Context  context.Context
+	Context context.Context
+	// If cooldown is passed in, we'll skip the merge if the table has been recently merged
 	CoolDown *time.Duration
 	// If specificTable is not passed in, we'll just flush everything.
 	SpecificTable string

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -2,7 +2,6 @@ package consumer
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -68,7 +67,6 @@ func Flush(args Args) error {
 				"schema":   _tableData.TopicConfig.Schema,
 			}
 
-			fmt.Println("rows", _tableData.TableData.Rows())
 			err := utils.FromContext(args.Context).Merge(args.Context, _tableData.TableData)
 			if err != nil {
 				tags["what"] = "merge_fail"

--- a/processes/pool/writes.go
+++ b/processes/pool/writes.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/artie-labs/transfer/processes/consumer"
 
 	"github.com/artie-labs/transfer/lib/logger"
@@ -15,7 +17,8 @@ func StartPool(ctx context.Context, td time.Duration) {
 	ticker := time.NewTicker(td)
 	for range ticker.C {
 		log.WithError(consumer.Flush(consumer.Args{
-			Context: ctx,
+			Context:  ctx,
+			CoolDown: ptr.ToDuration(td),
 		})).Info("Flushing via pool...")
 	}
 }


### PR DESCRIPTION
## Motivation

Right now, there are 3 levers to trigger a merge which are:

a) Time
b) Rows
c) Bytes

How this is implemented is that there is a separate Go-routine following the CPU clock cycle to implement (a). As a result, if we were flushing based on (b) and (c), we may bump into a pre-mature flush based on time.

## Pre-mature flush
Imagine the following scenarios:

(a) t = 30s
(b) rows = 25k
(c) bytes = 25mb

* On t = 28, We just flushed based on (b)
* Now t = 30, we haven't accumulated much changes but now we triggered a flush based on (a) anyway

## Solution
Now, we're adding a concept of merging cooldown for the process that is running (a).

In the same example as above,

* On t = 28, We just flushed based on (b), last merged timestamp is set to t28
* Now t = 30, the time between last merge and now (t = 2) is less than duration, so we will skip it
* t = 60, time between last merge is t = 32, let's flush