### PR TITLE
Adding GZIP

### DIFF
--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -58,7 +58,7 @@ func (s *Store) prepareTempTable(ctx context.Context, tableData *optimization.Ta
 	// COPY table_name FROM '/path/to/local/file' DELIMITER '\t' NULL '\\N' FORMAT csv;
 	// Note, we need to specify `\\N` here and in `CastColVal(..)` we are only doing `\N`, this is because Redshift treats backslashes as an escape character.
 	// So, it'll convert `\N` => `\\N` during COPY.
-	copyStmt := fmt.Sprintf(`COPY %s FROM '%s' DELIMITER '\t' NULL AS '\\N' GZIP %s dateformat 'auto' timeformat 'auto';`, tempTableName, s3Uri, s.credentialsClause)
+	copyStmt := fmt.Sprintf(`COPY %s FROM '%s' DELIMITER '\t' NULL AS '\\N' GZIP FORMAT CSV %s dateformat 'auto' timeformat 'auto';`, tempTableName, s3Uri, s.credentialsClause)
 	if _, err = s.Exec(copyStmt); err != nil {
 		return fmt.Errorf("failed to run COPY for temporary table, err: %v, copy: %v", err, copyStmt)
 	}


### PR DESCRIPTION
## Motivation

Previously we were writing to a local CSV file and then uploading it to S3. Once there, we then invoke `COPY INTO` for Redshift to load the CSV file into a table.

However, if the diffs are pretty large - this can take a couple of minutes to upload the diffs to S3 and then for Redshift to ingest. 

Instead, we can write this in `csv.gz` format and then upload the compressed file and have Redshift automatically decompress within COPY INTO.

## Preliminary benchmark results
Loading 2M rows into Redshift
```
No GZIP (current) — 337s
W/ GZIP — 286s
```