### PR TITLE
Adding table guardrail for Redshift

### DIFF
--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -74,7 +74,7 @@ LEFT JOIN
 LEFT JOIN 
     pg_catalog.pg_description d ON d.objsubid=c.ordinal_position AND d.objoid=c1.oid 
 WHERE 
-    c.table_name='%s' AND c.table_schema='%s';
+    LOWER(c.table_name) = LOWER('%s') AND LOWER(c.table_schema) = LOWER('%s');
 `, args.Table, args.Schema),
 		ColumnNameLabel:    describeNameCol,
 		ColumnTypeLabel:    describeTypeCol,

--- a/clients/utils/table_config.go
+++ b/clients/utils/table_config.go
@@ -46,6 +46,7 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 
 	log := logger.FromContext(ctx)
 	rows, err := args.Dwh.Query(args.Query)
+	fmt.Println("query", args.Query)
 	defer func() {
 		if rows != nil {
 			err = rows.Close()
@@ -137,6 +138,8 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 	if len(cols.GetColumns()) == 0 {
 		tableMissing = true
 	}
+
+	fmt.Println("tableMissing", tableMissing, "args.FqName", args.FqName)
 
 	tableCfg := types.NewDwhTableConfig(&cols, nil, tableMissing, args.DropDeletedColumns)
 	args.ConfigMap.AddTableToConfig(args.FqName, tableCfg)

--- a/clients/utils/table_config.go
+++ b/clients/utils/table_config.go
@@ -46,7 +46,6 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 
 	log := logger.FromContext(ctx)
 	rows, err := args.Dwh.Query(args.Query)
-	fmt.Println("query", args.Query)
 	defer func() {
 		if rows != nil {
 			err = rows.Close()
@@ -138,8 +137,6 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 	if len(cols.GetColumns()) == 0 {
 		tableMissing = true
 	}
-
-	fmt.Println("tableMissing", tableMissing, "args.FqName", args.FqName)
 
 	tableCfg := types.NewDwhTableConfig(&cols, nil, tableMissing, args.DropDeletedColumns)
 	args.ConfigMap.AddTableToConfig(args.FqName, tableCfg)


### PR DESCRIPTION
## Problem

We are fetching existing table metadata with Redshift by querying `information_schema`. However, if a table name is capitalized, we are not escaping this correctly.

As a result - we are adding an extra guardrail to lower both key and values for name and schema to avoid this issue.