### PR TITLE
Implementing automatic retries 

### DIFF
--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -3,14 +3,59 @@ package db
 import (
 	"context"
 	"database/sql"
+	"time"
 
+	"github.com/artie-labs/transfer/lib/jitter"
 	"github.com/artie-labs/transfer/lib/logger"
+)
+
+const (
+	maxAttempts     = 3
+	sleepIntervalMs = 500
 )
 
 type Store interface {
 	Exec(query string, args ...any) (sql.Result, error)
 	Query(query string, args ...any) (*sql.Rows, error)
 	Begin() (*sql.Tx, error)
+}
+
+type storeWrapper struct {
+	*sql.DB
+	ctx context.Context
+}
+
+func (s *storeWrapper) Exec(query string, args ...any) (sql.Result, error) {
+	var result sql.Result
+	var err error
+	for attempts := 0; attempts < maxAttempts; attempts++ {
+		result, err = s.DB.Exec(query, args...)
+		if err == nil {
+			break
+		}
+
+		if retryableError(err) {
+			sleepDurationMs := jitter.JitterMs(sleepIntervalMs, attempts)
+			logger.FromContext(s.ctx).WithError(err).WithFields(map[string]interface{}{
+				"sleepDurationMs": sleepDurationMs,
+				"attempts":        attempts,
+			}).Warn("failed to execute the query, retrying...")
+
+			time.Sleep(time.Duration(sleepDurationMs) * time.Millisecond)
+			continue
+		}
+
+		break
+	}
+	return result, err
+}
+
+func (s *storeWrapper) Query(query string, args ...any) (*sql.Rows, error) {
+	return s.DB.Query(query, args...)
+}
+
+func (s *storeWrapper) Begin() (*sql.Tx, error) {
+	return s.DB.Begin()
 }
 
 func Open(ctx context.Context, driverName, dsn string) Store {
@@ -32,5 +77,8 @@ func Open(ctx context.Context, driverName, dsn string) Store {
 		}).Fatal("Failed to validate the DB connection")
 	}
 
-	return db
+	return &storeWrapper{
+		DB:  db,
+		ctx: ctx,
+	}
 }

--- a/lib/db/errors.go
+++ b/lib/db/errors.go
@@ -1,0 +1,11 @@
+package db
+
+import "strings"
+
+func retryableError(err error) bool {
+	if err != nil {
+		return strings.Contains(err.Error(), "read: connection reset by peer")
+	}
+
+	return false
+}

--- a/lib/db/errors_test.go
+++ b/lib/db/errors_test.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryable_Errors(t *testing.T) {
+	type _tc struct {
+		name           string
+		err            error
+		expectedResult bool
+	}
+
+	tcs := []_tc{
+		{
+			name:           "nil error",
+			err:            nil,
+			expectedResult: false,
+		},
+		{
+			name:           "irrelevant error",
+			err:            fmt.Errorf("random error"),
+			expectedResult: false,
+		},
+		{
+			name:           "retryable error",
+			err:            fmt.Errorf("error: read tcp 127.0.0.1:40104->127.0.0.1:28889: read: connection reset by peer"),
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		actualErr := retryableError(tc.err)
+		assert.Equal(t, tc.expectedResult, actualErr, tc.name)
+	}
+}


### PR DESCRIPTION
## Motivation

Today, when Transfer is paired with SSH tunnels and there is a remote connection reset (SSH Tunnel and database) - we are emitting a merge error to Datadog (which then pages) and then it will retry.

![image](https://github.com/artie-labs/transfer/assets/4412200/f9485abc-51fb-4f7a-a4fa-4a20a7c9e221)

By adding this SQL wrapper around the SQL engine, we will address the false alarm and also not have to restart the merge process (it will automatically retry from the same merge position on which it encountered the error)