### PR TITLE
Adding table level skip deletes

### DIFF
--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -129,6 +129,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 			DestKind: s.Label(),
 		}),
 		ColumnsToTypes: *tableData.ReadOnlyInMemoryCols(),
+		SkipDelete:     tableData.TopicConfig.SkipDelete,
 		SoftDelete:     tableData.TopicConfig.SoftDelete,
 		DestKind:       s.Label(),
 	})

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -40,6 +40,7 @@ type MergeArgument struct {
 	*/
 	DestKind   constants.DestinationKind
 	SoftDelete bool
+	// SkipDelete is only used for Redshift and MergeStatementParts
 	SkipDelete bool
 }
 

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -40,6 +40,7 @@ type MergeArgument struct {
 	*/
 	DestKind   constants.DestinationKind
 	SoftDelete bool
+	SkipDelete bool
 }
 
 func (m *MergeArgument) Valid() error {
@@ -140,7 +141,7 @@ func MergeStatementParts(ctx context.Context, m *MergeArgument) ([]string, error
 		pks = append(pks, pk.EscapedName())
 	}
 
-	return []string{
+	parts := []string{
 		// INSERT
 		fmt.Sprintf(`INSERT INTO %s (%s) SELECT %s FROM %s as cc LEFT JOIN %s as c on %s WHERE c.%s IS NULL;`,
 			// insert into target (col1, col2, col3)
@@ -162,18 +163,24 @@ func MergeStatementParts(ctx context.Context, m *MergeArgument) ([]string, error
 			// FROM staging WHERE join on PK(s)
 			m.SubQuery, strings.Join(equalitySQLParts, " and "), idempotentClause, constants.DeleteColumnMarker,
 		),
-		// DELETE
-		fmt.Sprintf(`DELETE FROM %s WHERE (%s) IN (SELECT %s FROM %s as cc WHERE cc.%s = true);`,
-			// DELETE from table where (pk_1, pk_2)
-			m.FqTableName, strings.Join(pks, ","),
-			// IN (cc.pk_1, cc.pk_2) FROM staging
-			array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
-				Vals:      pks,
-				Separator: ",",
-				Prefix:    "cc.",
-			}), m.SubQuery, constants.DeleteColumnMarker,
-		),
-	}, nil
+	}
+
+	if !m.SkipDelete {
+		parts = append(parts,
+			// DELETE
+			fmt.Sprintf(`DELETE FROM %s WHERE (%s) IN (SELECT %s FROM %s as cc WHERE cc.%s = true);`,
+				// DELETE from table where (pk_1, pk_2)
+				m.FqTableName, strings.Join(pks, ","),
+				// IN (cc.pk_1, cc.pk_2) FROM staging
+				array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
+					Vals:      pks,
+					Separator: ",",
+					Prefix:    "cc.",
+				}), m.SubQuery, constants.DeleteColumnMarker,
+			))
+	}
+
+	return parts, nil
 }
 
 func MergeStatement(ctx context.Context, m *MergeArgument) (string, error) {

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -42,6 +42,7 @@ type TopicConfig struct {
 	CDCKeyFormat              string                      `yaml:"cdcKeyFormat"`
 	DropDeletedColumns        bool                        `yaml:"dropDeletedColumns"`
 	SoftDelete                bool                        `yaml:"softDelete"`
+	SkipDelete                bool                        `yaml:"skipDelete"`
 	IncludeArtieUpdatedAt     bool                        `yaml:"includeArtieUpdatedAt"`
 	BigQueryPartitionSettings *partition.BigQuerySettings `yaml:"bigQueryPartitionSettings"`
 }


### PR DESCRIPTION
## Changes

Today, if you wanted to skip table deletes, you'd need to configure this in Debezium. However, Debezium's setting for this is database-wide. Adding this into Transfer creates three benefits:

1. Can toggle this on/off without having to resync
2. Expand this to diff. data sources that DBZ doesn't cover
3. Allow us to move away from database specific to be at the table granularity
