### PR TITLE
Improving skipDelete

### DIFF
--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -22,32 +22,6 @@ var topicConfig = &kafkalib.TopicConfig{
 	Schema:    "public",
 }
 
-func (e *EventsTestSuite) TestSaveEvent_SkipDelete() {
-	event := Event{
-		Table: "foo",
-		PrimaryKeyMap: map[string]interface{}{
-			"id": "123",
-		},
-		Data: map[string]interface{}{
-			"foo":                        "bar",
-			constants.DeleteColumnMarker: true,
-		},
-		Operation: "d",
-	}
-
-	td := models.GetMemoryDB(e.ctx).GetOrCreateTableData("foo")
-	assert.Equal(e.T(), 0, int(td.Rows()))
-
-	kafkaMsg := kafka.Message{}
-
-	topicConfig.SkipDelete = true
-	_, _, err := event.Save(e.ctx, topicConfig, artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic))
-	assert.Nil(e.T(), err)
-
-	// Inspect the in-memory DB after save (should have no rows).
-	assert.Equal(e.T(), 0, int(td.Rows()))
-}
-
 func (e *EventsTestSuite) TestSaveEvent() {
 	expectedCol := "rOBiN TaNG"
 	expectedLowerCol := "robin__tang"

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/columns"
@@ -140,5 +141,45 @@ func (e *EventsTestSuite) TestPrimaryKeyValueDeterministic() {
 
 	for i := 0; i < 500*1000; i++ {
 		assert.Equal(e.T(), evt.PrimaryKeyValue(), "aa=1bb=5dusty=mini aussiegg=artiezz=ff")
+	}
+}
+
+func (e *EventsTestSuite) TestShouldSkip() {
+	type _tc struct {
+		skipDelete     bool
+		deleted        bool
+		expectedResult bool
+	}
+
+	testCases := []_tc{
+		{
+			skipDelete:     false,
+			deleted:        false,
+			expectedResult: false,
+		},
+		{
+			skipDelete:     false,
+			deleted:        true,
+			expectedResult: false,
+		},
+		{
+			skipDelete:     true,
+			deleted:        false,
+			expectedResult: false,
+		},
+		{
+			skipDelete:     true,
+			deleted:        true,
+			expectedResult: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		evt := &Event{
+			Deleted: testCase.deleted,
+		}
+
+		assert.Equal(e.T(), testCase.expectedResult, evt.ShouldSkip(testCase.skipDelete),
+			fmt.Sprintf("skipDelete: %v, deleted: %v", testCase.skipDelete, testCase.deleted))
 	}
 }

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -61,6 +61,13 @@ func processMessage(ctx context.Context, processArgs ProcessArgs) (string, error
 	// Table name is only available after event has been casted
 	tags["table"] = evt.Table
 
+	// Check to see if we should skip first
+	// This way, we can emit a specific tag to be more clear
+	if evt.ShouldSkip(topicConfig.tc.SkipDelete) {
+		tags["skipped"] = "yes"
+		return evt.Table, nil
+	}
+
 	shouldFlush, flushReason, err := evt.Save(ctx, topicConfig.tc, processArgs.Msg)
 	if err != nil {
 		tags["what"] = "save_fail"

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -212,3 +212,152 @@ func TestProcessMessageFailures(t *testing.T) {
 	assert.Empty(t, tableName)
 	assert.True(t, td.Rows() > 0)
 }
+
+func TestProcessMessageSkip(t *testing.T) {
+	ctx := context.Background()
+	ctx = config.InjectSettingsIntoContext(ctx, &config.Settings{
+		Config: &config.Config{
+			FlushIntervalSeconds: 10,
+			BufferRows:           10,
+			FlushSizeKb:          900,
+		},
+		VerboseLogging: false,
+	})
+
+	ctx = models.LoadMemoryDB(ctx)
+	kafkaMsg := kafka.Message{
+		Topic:         "foo",
+		Partition:     0,
+		Offset:        0,
+		HighWaterMark: 0,
+		Key:           nil,
+		Value:         nil,
+		Headers:       nil,
+		Time:          time.Time{},
+	}
+
+	msg := artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic)
+
+	var mgo mongo.Debezium
+	const (
+		db     = "lemonade"
+		schema = "public"
+		table  = "orders"
+	)
+
+	tcFmtMap := NewTcFmtMap()
+	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
+		tc: &kafkalib.TopicConfig{
+			Database:      db,
+			TableName:     table,
+			Schema:        schema,
+			Topic:         msg.Topic(),
+			IdempotentKey: "",
+			CDCFormat:     "",
+			CDCKeyFormat:  "",
+		},
+		Format: &mgo,
+	})
+
+	processArgs := ProcessArgs{
+		Msg:                    msg,
+		GroupID:                "foo",
+		TopicToConfigFormatMap: tcFmtMap,
+	}
+
+	// Add will just replace the prev setting.
+	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
+		tc: &kafkalib.TopicConfig{
+			Database:      db,
+			TableName:     table,
+			Schema:        schema,
+			Topic:         msg.Topic(),
+			IdempotentKey: "",
+			CDCFormat:     "",
+			CDCKeyFormat:  "org.apache.kafka.connect.storage.StringConverter",
+			SkipDelete:    true,
+		},
+		Format: &mgo,
+	})
+
+	vals := []string{
+		`{
+	"schema": {
+		"type": "struct",
+		"fields": [{
+			"type": "struct",
+			"fields": [{
+				"type": "int32",
+				"optional": false,
+				"default": 0,
+				"field": "id"
+			}, {
+				"type": "string",
+				"optional": false,
+				"field": "first_name"
+			}, {
+				"type": "string",
+				"optional": false,
+				"field": "last_name"
+			}, {
+				"type": "string",
+				"optional": false,
+				"field": "email"
+			}],
+			"optional": true,
+			"name": "dbserver1.inventory.customers.Value",
+			"field": "after"
+		}]
+	},
+	"payload": {
+		"before": "{\"_id\": {\"$numberLong\": \"1004\"},\"first_name\": \"Anne\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}",
+		"after": null,
+		"patch": null,
+		"filter": null,
+		"updateDescription": null,
+		"source": {
+			"version": "2.0.0.Final",
+			"connector": "mongodb",
+			"name": "dbserver1",
+			"ts_ms": 1668753321000,
+			"snapshot": "true",
+			"db": "inventory",
+			"sequence": null,
+			"rs": "rs0",
+			"collection": "customers",
+			"ord": 29,
+			"lsid": null,
+			"txnNumber": null
+		},
+		"op": "d",
+		"ts_ms": 1668753329387,
+		"transaction": null
+	}
+}`,
+	}
+
+	idx := 0
+	memoryDB := models.GetMemoryDB(ctx)
+	for _, val := range vals {
+		idx += 1
+		msg.KafkaMsg.Key = []byte(fmt.Sprintf("Struct{id=%v}", idx))
+		if val != "" {
+			msg.KafkaMsg.Value = []byte(val)
+		}
+
+		processArgs = ProcessArgs{
+			Msg:                    msg,
+			GroupID:                "foo",
+			TopicToConfigFormatMap: tcFmtMap,
+		}
+
+		td := memoryDB.GetOrCreateTableData(table)
+		assert.Equal(t, 0, int(td.Rows()))
+
+		tableName, err := processMessage(ctx, processArgs)
+		assert.NoError(t, err)
+		assert.Equal(t, table, tableName)
+		// Because it got skipped.
+		assert.Equal(t, 0, int(td.Rows()))
+	}
+}


### PR DESCRIPTION
This is an improvement from https://github.com/artie-labs/transfer/pull/205 where we are skipping the message during `processMessage` as opposed to skipping it during `.Save()`.

The benefit of this is that our `process.message.count` will have an additional tag of `skipped=Yes` if `skipDelete = true` and the operation is `delete`.