### PR TITLE
[BigQuery] Better support of NUMERIC and BIGNUMERIC

### DIFF
--- a/clients/bigquery/errors.go
+++ b/clients/bigquery/errors.go
@@ -2,15 +2,6 @@ package bigquery
 
 import "strings"
 
-func ColumnAlreadyExistErr(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// Error ends up looking like something like this: Column already exists: _string at [1:39]
-	return strings.Contains(err.Error(), "Column already exists")
-}
-
 func TableUpdateQuotaErr(err error) bool {
 	return strings.Contains(err.Error(), "Exceeded rate limits: too many table update operations for this table")
 }

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -242,7 +242,11 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("config is invalid, flush size pool has to be a positive number, current value: %v", c.FlushSizeKb)
 	}
 
-	if !numbers.BetweenEq(flushIntervalSecondsStart, flushIntervalSecondsEnd, c.FlushIntervalSeconds) {
+	if !numbers.BetweenEq(numbers.BetweenEqArgs{
+		Start:  flushIntervalSecondsStart,
+		End:    flushIntervalSecondsEnd,
+		Number: c.FlushIntervalSeconds,
+	}) {
 		return fmt.Errorf("config is invalid, flush interval is outside of our range, seconds: %v, expected start: %v, end: %v",
 			c.FlushIntervalSeconds, flushIntervalSecondsStart, flushIntervalSecondsEnd)
 	}

--- a/lib/numbers/numbers.go
+++ b/lib/numbers/numbers.go
@@ -4,3 +4,11 @@ package numbers
 func BetweenEq(start, end, number int) bool {
 	return number >= start && number <= end
 }
+
+func MaxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
+}

--- a/lib/numbers/numbers.go
+++ b/lib/numbers/numbers.go
@@ -1,8 +1,14 @@
 package numbers
 
+type BetweenEqArgs struct {
+	Start  int
+	End    int
+	Number int
+}
+
 // BetweenEq - Looks something like this. start <= number <= end
-func BetweenEq(start, end, number int) bool {
-	return number >= start && number <= end
+func BetweenEq(args BetweenEqArgs) bool {
+	return args.Number >= args.Start && args.Number <= args.End
 }
 
 func MaxInt(a, b int) int {

--- a/lib/numbers/numbers_test.go
+++ b/lib/numbers/numbers_test.go
@@ -1,8 +1,9 @@
 package numbers
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBetweenEq(t *testing.T) {
@@ -22,6 +23,10 @@ func TestBetweenEq(t *testing.T) {
 	}
 
 	for _, _case := range cases {
-		assert.Equal(t, _case.result, BetweenEq(_case.start, _case.end, _case.number), _case)
+		assert.Equal(t, _case.result, BetweenEq(BetweenEqArgs{
+			Start:  _case.start,
+			End:    _case.end,
+			Number: _case.number,
+		}), _case)
 	}
 }

--- a/lib/numbers/numbers_test.go
+++ b/lib/numbers/numbers_test.go
@@ -6,6 +6,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMaxInt(t *testing.T) {
+	type testCase struct {
+		a        int
+		b        int
+		expected int
+	}
+
+	tcs := []testCase{
+		{
+			a:        1,
+			b:        2,
+			expected: 2,
+		},
+		{
+			a:        9,
+			b:        1,
+			expected: 9,
+		},
+	}
+
+	for _, tc := range tcs {
+		assert.Equal(t, tc.expected, MaxInt(tc.a, tc.b))
+	}
+}
+
 func TestBetweenEq(t *testing.T) {
 	type testCase struct {
 		result bool

--- a/lib/typing/bigquery.go
+++ b/lib/typing/bigquery.go
@@ -33,14 +33,20 @@ func BigQueryTypeToKind(rawBqType string) KindDetails {
 	// Geography, geometry date, time, varbinary, binary are currently not supported.
 	switch strings.TrimSpace(strings.ToLower(bqType[:idxStop])) {
 	case "numeric":
-		if rawBqType == "numeric" {
+		if rawBqType == "numeric" || rawBqType == "bignumeric" {
 			// This is a specific thing to BigQuery
 			// A `NUMERIC` type without precision or scale specified is NUMERIC(38, 9)
 			return EDecimal
 		}
 
 		return ParseNumeric(defaultPrefix, rawBqType)
-	case "decimal", "float", "float64", "bignumeric", "bigdecimal":
+	case "bignumeric":
+		if rawBqType == "bignumeric" {
+			return EDecimal
+		}
+
+		return ParseNumeric("bignumeric", rawBqType)
+	case "decimal", "float", "float64", "bigdecimal":
 		return Float
 	case "int", "integer", "int64":
 		return Integer

--- a/lib/typing/bigquery_test.go
+++ b/lib/typing/bigquery_test.go
@@ -12,11 +12,12 @@ import (
 func TestBigQueryTypeToKind(t *testing.T) {
 	bqColToExpectedKind := map[string]KindDetails{
 		//// Number
-		"numeric":       EDecimal,
-		"numeric(5)":    Integer,
-		"numeric(5, 0)": Integer,
-		"numeric(5, 2)": EDecimal,
-		"numeric(8, 6)": EDecimal,
+		"numeric":           EDecimal,
+		"numeric(5)":        Integer,
+		"numeric(5, 0)":     Integer,
+		"numeric(5, 2)":     EDecimal,
+		"numeric(8, 6)":     EDecimal,
+		"bignumeric(38, 2)": EDecimal,
 
 		// Integer
 		"int":     Integer,

--- a/lib/typing/decimal/decimal.go
+++ b/lib/typing/decimal/decimal.go
@@ -114,7 +114,7 @@ func (d *Decimal) Numeric() bool {
 		return false
 	}
 
-	// 0 <= s <= 38
+	// 0 <= s <= 9
 	if !numbers.BetweenEq(numbers.BetweenEqArgs{Start: 0, End: 9, Number: d.scale}) {
 		return false
 	}

--- a/lib/typing/decimal/decimal.go
+++ b/lib/typing/decimal/decimal.go
@@ -24,11 +24,6 @@ const (
 // MaxPrecisionBeforeString - if the precision is greater than 38, we'll cast it as a string.
 // This is because Snowflake and BigQuery both do not have NUMERIC data types that go beyond 38.
 const MaxPrecisionBeforeString = 38
-const MaxPrecisionBeforeStringBigQuery = 31
-
-// MaxScaleBeforeStringBigQuery - when scale exceeds 9, we'll set this to a STRING.
-// Anything above 9 will exceed the NUMERIC data type in BigQuery, ref: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
-const MaxScaleBeforeStringBigQuery = 9
 
 func NewDecimal(scale int, precision *int, value *big.Float) *Decimal {
 	if precision != nil {
@@ -102,6 +97,10 @@ func (d *Decimal) RedshiftKind() string {
 
 	return fmt.Sprintf("NUMERIC(%v, %v)", precision, d.scale)
 }
+
+// MaxScaleBeforeStringBigQuery - when scale exceeds 9, we'll set this to a STRING.
+// Anything above 9 will exceed the NUMERIC data type in BigQuery, ref: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
+const MaxScaleBeforeStringBigQuery = 9
 
 func (d *Decimal) BigQueryKind() string {
 	if d.precision == nil || *d.precision == -1 {

--- a/lib/typing/decimal/decimal_test.go
+++ b/lib/typing/decimal/decimal_test.go
@@ -28,12 +28,20 @@ func TestDecimalKind(t *testing.T) {
 			ExpectedBigQueryKind:  "STRING",
 		},
 		{
+			Name:                  "numeric(39, 0)",
+			Precision:             39,
+			Scale:                 0,
+			ExpectedSnowflakeKind: "STRING",
+			ExpectedRedshiftKind:  "TEXT",
+			ExpectedBigQueryKind:  "STRING",
+		},
+		{
 			Name:                  "numeric(39, 5)",
 			Precision:             39,
 			Scale:                 5,
 			ExpectedSnowflakeKind: "STRING",
 			ExpectedRedshiftKind:  "TEXT",
-			ExpectedBigQueryKind:  "STRING",
+			ExpectedBigQueryKind:  "BIGNUMERIC(39, 5)",
 		},
 		{
 			Name:                  "numeric(38, 2)",
@@ -41,7 +49,7 @@ func TestDecimalKind(t *testing.T) {
 			Scale:                 2,
 			ExpectedSnowflakeKind: "NUMERIC(38, 2)",
 			ExpectedRedshiftKind:  "NUMERIC(38, 2)",
-			ExpectedBigQueryKind:  "STRING",
+			ExpectedBigQueryKind:  "BIGNUMERIC(38, 2)",
 		},
 		{
 			Name:                  "numeric(31, 2)",
@@ -50,6 +58,14 @@ func TestDecimalKind(t *testing.T) {
 			ExpectedSnowflakeKind: "NUMERIC(31, 2)",
 			ExpectedRedshiftKind:  "NUMERIC(31, 2)",
 			ExpectedBigQueryKind:  "NUMERIC(31, 2)",
+		},
+		{
+			Name:                  "bignumeric(76, 38)",
+			Precision:             76,
+			Scale:                 38,
+			ExpectedSnowflakeKind: "STRING",
+			ExpectedRedshiftKind:  "TEXT",
+			ExpectedBigQueryKind:  "BIGNUMERIC(76, 38)",
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/artie-labs/transfer/issues/170

## Changes

1. Adding `BetweenEqArgs` to be more explicit about setting `start`, `end` and ` number`
2. Adding support for BIGNUMERIC in BigQuery
3. Adding the proper support for NUMERIC in BigQuery by following the equation from the issue
