### PR TITLE
[Redshift] Describe tables that require escaping bug

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -35,7 +35,7 @@ type Store struct {
 func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.TableData) (*types.DwhTableConfig, error) {
 	return utils.GetTableConfig(ctx, utils.GetTableCfgArgs{
 		Dwh:       s,
-		FqName:    tableData.ToFqName(ctx, constants.BigQuery, true),
+		FqName:    tableData.ToFqName(ctx, s.Label(), true),
 		ConfigMap: s.configMap,
 		Query: fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';",
 			tableData.TopicConfig.Database, tableData.Name(ctx, nil)),

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -23,9 +23,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	tableConfig, err := s.getTableConfig(ctx, getTableConfigArgs{
-		TableData:          tableData,
-		Schema:             tableData.TopicConfig.Schema,
-		DropDeletedColumns: tableData.TopicConfig.DropDeletedColumns,
+		TableData: tableData,
 	})
 	if err != nil {
 		return err

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -22,9 +22,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		return nil
 	}
 
-	tableConfig, err := s.getTableConfig(ctx, getTableConfigArgs{
-		TableData: tableData,
-	})
+	tableConfig, err := s.getTableConfig(ctx, tableData)
 	if err != nil {
 		return err
 	}

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -23,10 +23,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	tableConfig, err := s.getTableConfig(ctx, getTableConfigArgs{
-		Table: tableData.Name(ctx, &sql.NameArgs{
-			Escape:   true,
-			DestKind: s.Label(),
-		}),
+		TableData:          tableData,
 		Schema:             tableData.TopicConfig.Schema,
 		DropDeletedColumns: tableData.TopicConfig.DropDeletedColumns,
 	})

--- a/clients/redshift/queries.go
+++ b/clients/redshift/queries.go
@@ -1,13 +1,20 @@
 package redshift
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type describeArgs struct {
 	RawTableName string
 	Schema       string
 }
 
-func describeTableQuery(args describeArgs) string {
+func describeTableQuery(args describeArgs) (string, error) {
+	if strings.Contains(args.RawTableName, `"`) {
+		return "", fmt.Errorf("table name cannot contain double quotes")
+	}
+
 	// This query is a modified fork from: https://gist.github.com/alexanderlz/7302623
 	return fmt.Sprintf(`
 SELECT 
@@ -29,5 +36,5 @@ LEFT JOIN
     pg_catalog.pg_description d ON d.objsubid=c.ordinal_position AND d.objoid=c1.oid 
 WHERE 
     LOWER(c.table_name) = LOWER('%s') AND LOWER(c.table_schema) = LOWER('%s');
-`, args.RawTableName, args.Schema)
+`, args.RawTableName, args.Schema), nil
 }

--- a/clients/redshift/queries.go
+++ b/clients/redshift/queries.go
@@ -1,0 +1,33 @@
+package redshift
+
+import "fmt"
+
+type describeArgs struct {
+	RawTableName string
+	Schema       string
+}
+
+func describeTableQuery(args describeArgs) string {
+	// This query is a modified fork from: https://gist.github.com/alexanderlz/7302623
+	return fmt.Sprintf(`
+SELECT 
+    c.column_name,
+    CASE 
+        WHEN c.data_type = 'numeric' THEN 
+            'numeric(' || COALESCE(CAST(c.numeric_precision AS VARCHAR), '') || ',' || COALESCE(CAST(c.numeric_scale AS VARCHAR), '') || ')'
+        ELSE 
+            c.data_type 
+    END AS data_type,
+    d.description
+FROM 
+    information_schema.columns c 
+LEFT JOIN 
+    pg_class c1 ON c.table_name=c1.relname 
+LEFT JOIN 
+    pg_catalog.pg_namespace n ON c.table_schema=n.nspname AND c1.relnamespace=n.oid 
+LEFT JOIN 
+    pg_catalog.pg_description d ON d.objsubid=c.ordinal_position AND d.objoid=c1.oid 
+WHERE 
+    LOWER(c.table_name) = LOWER('%s') AND LOWER(c.table_schema) = LOWER('%s');
+`, args.RawTableName, args.Schema)
+}

--- a/clients/redshift/queries_test.go
+++ b/clients/redshift/queries_test.go
@@ -1,0 +1,36 @@
+package redshift
+
+import "github.com/stretchr/testify/assert"
+
+func (r *RedshiftTestSuite) Test_DescribeTableQuery() {
+	type _tc struct {
+		tableName string
+		expectErr bool
+	}
+
+	tcs := []_tc{
+		{
+			tableName: "delta",
+		},
+		{
+			tableName: "delta123",
+		},
+		{
+			tableName: `"delta"`,
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		_, err := describeTableQuery(describeArgs{
+			RawTableName: tc.tableName,
+			Schema:       "foo",
+		})
+
+		if tc.expectErr {
+			assert.Error(r.T(), err, tc.tableName)
+		} else {
+			assert.NoError(r.T(), err, tc.tableName)
+		}
+	}
+}

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -46,14 +46,20 @@ const (
 )
 
 func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.TableData) (*types.DwhTableConfig, error) {
+	describeQuery, err := describeTableQuery(describeArgs{
+		RawTableName: tableData.Name(ctx, nil),
+		Schema:       tableData.TopicConfig.Schema,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
 	return utils.GetTableConfig(ctx, utils.GetTableCfgArgs{
-		Dwh:       s,
-		FqName:    tableData.ToFqName(ctx, s.Label(), true),
-		ConfigMap: s.configMap,
-		Query: describeTableQuery(describeArgs{
-			RawTableName: tableData.Name(ctx, nil),
-			Schema:       tableData.TopicConfig.Schema,
-		}),
+		Dwh:                s,
+		FqName:             tableData.ToFqName(ctx, s.Label(), true),
+		ConfigMap:          s.configMap,
+		Query:              describeQuery,
 		ColumnNameLabel:    describeNameCol,
 		ColumnTypeLabel:    describeTypeCol,
 		ColumnDescLabel:    describeDescriptionCol,

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -42,9 +42,7 @@ func (s *Store) Label() constants.DestinationKind {
 }
 
 type getTableConfigArgs struct {
-	TableData          *optimization.TableData
-	Schema             string
-	DropDeletedColumns bool
+	TableData *optimization.TableData
 }
 
 const (
@@ -66,35 +64,18 @@ func (s *Store) getTableConfig(ctx context.Context, args getTableConfigArgs) (*t
 
 	return utils.GetTableConfig(ctx, utils.GetTableCfgArgs{
 		Dwh:       s,
-		FqName:    fmt.Sprintf("%s.%s", args.Schema, escapedTableName),
+		FqName:    fmt.Sprintf("%s.%s", args.TableData.TopicConfig.Schema, escapedTableName),
 		ConfigMap: s.configMap,
-		// This query is a modified fork from: https://gist.github.com/alexanderlz/7302623
-		Query: fmt.Sprintf(`
-SELECT 
-    c.column_name,
-    CASE 
-        WHEN c.data_type = 'numeric' THEN 
-            'numeric(' || COALESCE(CAST(c.numeric_precision AS VARCHAR), '') || ',' || COALESCE(CAST(c.numeric_scale AS VARCHAR), '') || ')'
-        ELSE 
-            c.data_type 
-    END AS data_type,
-    d.description
-FROM 
-    information_schema.columns c 
-LEFT JOIN 
-    pg_class c1 ON c.table_name=c1.relname 
-LEFT JOIN 
-    pg_catalog.pg_namespace n ON c.table_schema=n.nspname AND c1.relnamespace=n.oid 
-LEFT JOIN 
-    pg_catalog.pg_description d ON d.objsubid=c.ordinal_position AND d.objoid=c1.oid 
-WHERE 
-    LOWER(c.table_name) = LOWER('%s') AND LOWER(c.table_schema) = LOWER('%s');
-`, rawTableName, args.Schema),
+
+		Query: describeTableQuery(describeArgs{
+			RawTableName: rawTableName,
+			Schema:       args.TableData.TopicConfig.Schema,
+		}),
 		ColumnNameLabel:    describeNameCol,
 		ColumnTypeLabel:    describeTypeCol,
 		ColumnDescLabel:    describeDescriptionCol,
 		EmptyCommentValue:  ptr.ToString("<nil>"),
-		DropDeletedColumns: args.DropDeletedColumns,
+		DropDeletedColumns: args.TableData.TopicConfig.DropDeletedColumns,
 	})
 }
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -39,30 +39,26 @@ func (s *Store) Label() constants.DestinationKind {
 	return constants.Redshift
 }
 
-type getTableConfigArgs struct {
-	TableData *optimization.TableData
-}
-
 const (
 	describeNameCol        = "column_name"
 	describeTypeCol        = "data_type"
 	describeDescriptionCol = "description"
 )
 
-func (s *Store) getTableConfig(ctx context.Context, args getTableConfigArgs) (*types.DwhTableConfig, error) {
+func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.TableData) (*types.DwhTableConfig, error) {
 	return utils.GetTableConfig(ctx, utils.GetTableCfgArgs{
 		Dwh:       s,
-		FqName:    args.TableData.ToFqName(ctx, s.Label(), true),
+		FqName:    tableData.ToFqName(ctx, s.Label(), true),
 		ConfigMap: s.configMap,
 		Query: describeTableQuery(describeArgs{
-			RawTableName: args.TableData.Name(ctx, nil),
-			Schema:       args.TableData.TopicConfig.Schema,
+			RawTableName: tableData.Name(ctx, nil),
+			Schema:       tableData.TopicConfig.Schema,
 		}),
 		ColumnNameLabel:    describeNameCol,
 		ColumnTypeLabel:    describeTypeCol,
 		ColumnDescLabel:    describeDescriptionCol,
 		EmptyCommentValue:  ptr.ToString("<nil>"),
-		DropDeletedColumns: args.TableData.TopicConfig.DropDeletedColumns,
+		DropDeletedColumns: tableData.TopicConfig.DropDeletedColumns,
 	})
 }
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/artie-labs/transfer/lib/sql"
-
 	"github.com/artie-labs/transfer/lib/optimization"
 
 	"github.com/artie-labs/transfer/clients/utils"
@@ -52,23 +50,12 @@ const (
 )
 
 func (s *Store) getTableConfig(ctx context.Context, args getTableConfigArgs) (*types.DwhTableConfig, error) {
-	escapedTableName := args.TableData.Name(ctx, &sql.NameArgs{
-		Escape:   true,
-		DestKind: s.Label(),
-	})
-
-	rawTableName := args.TableData.Name(ctx, &sql.NameArgs{
-		Escape:   false,
-		DestKind: s.Label(),
-	})
-
 	return utils.GetTableConfig(ctx, utils.GetTableCfgArgs{
 		Dwh:       s,
-		FqName:    fmt.Sprintf("%s.%s", args.TableData.TopicConfig.Schema, escapedTableName),
+		FqName:    args.TableData.ToFqName(ctx, s.Label(), true),
 		ConfigMap: s.configMap,
-
 		Query: describeTableQuery(describeArgs{
-			RawTableName: rawTableName,
+			RawTableName: args.TableData.Name(ctx, nil),
 			Schema:       args.TableData.TopicConfig.Schema,
 		}),
 		ColumnNameLabel:    describeNameCol,


### PR DESCRIPTION
## Problem

Artie is not running describe table correctly for Redshift tables that require escaping. We are querying `information_schema.columns` which does not require escaping table names.