### PR TITLE
Correctly parsing negative numbers from Decimal

### DIFF
--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -149,6 +149,5 @@ func (f Field) DecodeDebeziumVariableDecimal(value interface{}) (*decimal.Decima
 		KafkaDecimalPrecisionKey: "-1",
 	}
 
-	fmt.Println("value", val)
 	return f.DecodeDecimal(fmt.Sprint(val))
 }

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -101,15 +101,18 @@ func (f Field) DecodeDecimal(encoded string) (*decimal.Decimal, error) {
 	}
 
 	bigInt := new(big.Int)
+
 	// If the data represents a negative number, the sign bit will be set.
 	if len(data) > 0 && data[0] >= 0x80 {
 		// To convert the data to a two's complement integer, we need to invert the bytes and add one.
 		for i := range data {
 			data[i] = ^data[i]
 		}
+
 		bigInt.SetBytes(data)
+		// We are adding this because Debezium (Java) encoded this value and uses two's complement binary representation for negative numbers
 		bigInt.Add(bigInt, big.NewInt(1))
-		bigInt.Neg(bigInt) // Negate the integer to get the correct negative value.
+		bigInt.Neg(bigInt)
 	} else {
 		bigInt.SetBytes(data)
 	}

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -266,6 +266,15 @@ func TestDecodeDebeziumVariableDecimal(t *testing.T) {
 			expectValue: "123.45",
 			expectScale: 2,
 		},
+		{
+			name: "negative numbers (scale 7)",
+			value: map[string]interface{}{
+				"scale": 7,
+				"value": "wT9Wmw==",
+			},
+			expectValue: "-105.2813669",
+			expectScale: 7,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
## Problem

We were previously not parsing negative numbers correctly from Debezium's DECIMAL type as we were ignoring the sign.

This PR adds the ability for us to parse negative numbers correctly.