### PR TITLE
[Redshift] Correctly parse character varying

### DIFF
--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -49,12 +49,10 @@ type TopicConfig struct {
 
 const (
 	defaultKeyFormat = "org.apache.kafka.connect.storage.StringConverter"
+	jsonFormat       = "org.apache.kafka.connect.json.JsonConverter"
 )
 
-var (
-	validKeyFormats = []string{"org.apache.kafka.connect.json.JsonConverter",
-		"org.apache.kafka.connect.storage.StringConverter"}
-)
+var validKeyFormats = []string{defaultKeyFormat, jsonFormat}
 
 func (t *TopicConfig) String() string {
 	if t == nil {

--- a/lib/typing/redshift.go
+++ b/lib/typing/redshift.go
@@ -12,13 +12,15 @@ func RedshiftTypeToKind(rawType string) KindDetails {
 		return ParseNumeric(defaultPrefix, rawType)
 	}
 
-	switch strings.ToLower(rawType) {
+	if strings.Contains(rawType, "character varying") {
+		return String
+	}
+
+	switch rawType {
 	case "super":
 		return Struct
 	case "integer", "bigint":
 		return Integer
-	case "character varying":
-		return String
 	case "double precision":
 		return Float
 	case "timestamp with time zone", "timestamp without time zone":

--- a/lib/typing/redshift_test.go
+++ b/lib/typing/redshift_test.go
@@ -25,6 +25,16 @@ func TestRedshiftTypeToKind(t *testing.T) {
 			expectedKd: String,
 		},
 		{
+			name:       "String",
+			rawTypes:   []string{"character varying"},
+			expectedKd: String,
+		},
+		{
+			name:       "String",
+			rawTypes:   []string{"character varying(65535)"},
+			expectedKd: String,
+		},
+		{
 			name:       "Double Precision",
 			rawTypes:   []string{"double precision", "DOUBLE precision"},
 			expectedKd: Float,


### PR DESCRIPTION
We were not correctly parsing the describe table contents from Redshift. This PR fixes that.