### PR TITLE
Fixing a potential panic in our Typing library

### DIFF
--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -73,11 +73,13 @@ func NewKindDetailsFromTemplate(details KindDetails, extendedType ext.ExtendedTi
 // Once there, we will then check if it's a JSON string or not.
 // This is an optimization since JSON string checking is expensive.
 func IsJSON(str string) bool {
+	str = strings.TrimSpace(str)
+
 	if len(str) < 2 {
 		return false
 	}
 
-	valStringChars := []rune(strings.TrimSpace(str))
+	valStringChars := []rune(str)
 	firstChar := string(valStringChars[0])
 	lastChar := string(valStringChars[len(valStringChars)-1])
 

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -74,7 +74,6 @@ func NewKindDetailsFromTemplate(details KindDetails, extendedType ext.ExtendedTi
 // This is an optimization since JSON string checking is expensive.
 func IsJSON(str string) bool {
 	str = strings.TrimSpace(str)
-
 	if len(str) < 2 {
 		return false
 	}

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -63,6 +63,13 @@ func (t *TypingTestSuite) TestJSONString() {
 		{
 			input: `[1, 2, 3, 4`,
 		},
+		{
+			input: ``,
+		},
+		{
+			input:    `   `,
+			expected: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -67,8 +67,7 @@ func (t *TypingTestSuite) TestJSONString() {
 			input: ``,
 		},
 		{
-			input:    `   `,
-			expected: true,
+			input: `   `,
 		},
 	}
 


### PR DESCRIPTION
## Problem

In our Typing library's `IsJSON(...)` function, we are trimming whitespace after the length check. This means that we can run into a potential panic situation where the value is empty and then we try to fetch the first and last character of an empty string.

## Solution

We should be trimming space before the length check and fail early