### PR TITLE
[Redshift] Edge case with schema inference

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -23,7 +23,7 @@ const (
 
 // replaceExceededValues - takes `colVal` interface{} and `colKind` columns.Column and replaces the value with an empty string if it exceeds the max length.
 // This currently only works for STRING and SUPER data types.
-func replaceExceededValues(colVal string, colKind columns.Column) interface{} {
+func replaceExceededValues(colVal string, colKind columns.Column) string {
 	numOfChars := len(colVal)
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind: // Assuming this corresponds to SUPER type in Redshift
@@ -124,7 +124,7 @@ func (s *Store) CastColValStaging(ctx context.Context, colVal interface{}, colKi
 
 	// Checks for DDL overflow needs to be done at the end in case there are any conversions that need to be done.
 	if s.skipLgCols {
-		colValString = fmt.Sprint(replaceExceededValues(colValString, colKind))
+		colValString = replaceExceededValues(colValString, colKind)
 	}
 
 	return colValString, nil

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -23,8 +23,8 @@ const (
 
 // replaceExceededValues - takes `colVal` interface{} and `colKind` columns.Column and replaces the value with an empty string if it exceeds the max length.
 // This currently only works for STRING and SUPER data types.
-func replaceExceededValues(colVal interface{}, colKind columns.Column) interface{} {
-	numOfChars := len(fmt.Sprint(colVal))
+func replaceExceededValues(colVal string, colKind columns.Column) interface{} {
+	numOfChars := len(colVal)
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind: // Assuming this corresponds to SUPER type in Redshift
 		if numOfChars > maxRedshiftSuperLen {
@@ -124,7 +124,7 @@ func (s *Store) CastColValStaging(ctx context.Context, colVal interface{}, colKi
 
 	// Checks for DDL overflow needs to be done at the end in case there are any conversions that need to be done.
 	if s.skipLgCols {
-		colValString = fmt.Sprint(replaceExceededValues(colVal, colKind))
+		colValString = fmt.Sprint(replaceExceededValues(colValString, colKind))
 	}
 
 	return colValString, nil

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -73,9 +73,21 @@ func (s *Store) CastColValStaging(ctx context.Context, colVal interface{}, colKi
 		}
 
 	case typing.String.Kind:
+		// Check for arrays
 		list, err := array.InterfaceToArrayString(colVal, false)
 		if err == nil {
 			colValString = "[" + strings.Join(list, ",") + "]"
+		}
+
+		// This should also check if the colValString contains Go's internal string representation of a map[string]interface{}
+		_, isOk := colVal.(map[string]interface{})
+		if isOk {
+			colValBytes, err := json.Marshal(colVal)
+			if err != nil {
+				return "", err
+			}
+
+			colValString = string(colValBytes)
 		}
 	case typing.Struct.Kind:
 		if colKind.KindDetails == typing.Struct {

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -246,6 +246,14 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Array() {
 			},
 			expectedString: `{"foo":"bar"}`,
 		},
+		{
+			name:   "string",
+			colVal: "hello world",
+			colKind: columns.Column{
+				KindDetails: typing.String,
+			},
+			expectedString: "hello world",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -236,6 +236,16 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Array() {
 			},
 			expectedString: `[true,true,false,false,true]`,
 		},
+		{
+			name: "json object, but this is inferred as a string",
+			colVal: map[string]interface{}{
+				"foo": "bar",
+			},
+			colKind: columns.Column{
+				KindDetails: typing.String,
+			},
+			expectedString: `{"foo":"bar"}`,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -30,7 +30,7 @@ import (
 func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 	type _tc struct {
 		name           string
-		colVal         interface{}
+		colVal         string
 		colKind        columns.Column
 		expectedResult interface{}
 	}
@@ -245,6 +245,21 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Array() {
 				KindDetails: typing.String,
 			},
 			expectedString: `{"foo":"bar"}`,
+		},
+		{
+			name: "list of json object, but this is inferred as a string",
+			colVal: []map[string]interface{}{
+				{
+					"foo": "bar",
+				},
+				{
+					"hello": "world",
+				},
+			},
+			colKind: columns.Column{
+				KindDetails: typing.String,
+			},
+			expectedString: `[{"foo":"bar"},{"hello":"world"}]`,
 		},
 		{
 			name:   "string",

--- a/clients/redshift/redshift_suite_test.go
+++ b/clients/redshift/redshift_suite_test.go
@@ -28,6 +28,7 @@ func (r *RedshiftTestSuite) SetupTest() {
 	r.fakeStore = &mocks.FakeStore{}
 	store := db.Store(r.fakeStore)
 	r.store = LoadRedshift(r.ctx, &store)
+	r.store.skipLgCols = true
 }
 
 func TestRedshiftTestSuite(t *testing.T) {


### PR DESCRIPTION
## Problem

Say we are syncing from MongoDB and the column can be both JSON and STRING.

In Redshift, we are casting this column as `VARCHAR(MAX)` since `SUPER` doesn't like certain non-ASCII characters. 
Transfer's inference library will use Redshift as the source of truth and cast all these values down into STRING.

However the JSON object that is being casted as a string looks like `map[foo] = bar` as opposed to `{"foo": "bar"}`