### PR TITLE
[BigQuery bug] Fix dropping temporary tables

### DIFF
--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -22,7 +22,7 @@ import (
 // Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(10)
 func DropTemporaryTable(ctx context.Context, dwh destination.DataWarehouse, fqTableName string, shouldReturnError bool) error {
 	if dwh.Label() != constants.BigQuery {
-		// BigQuery does not require lower-casing the table name, but Redshift and Snowflake does.
+		// BigQuery is case-sensitive, so lets no lower.
 		fqTableName = strings.ToLower(fqTableName)
 	}
 

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -21,8 +21,11 @@ import (
 // It has a safety check to make sure the tableName contains the `constants.ArtiePrefix` key.
 // Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(10)
 func DropTemporaryTable(ctx context.Context, dwh destination.DataWarehouse, fqTableName string, shouldReturnError bool) error {
-	// Need to lower it because Snowflake upper-cases.
-	fqTableName = strings.ToLower(fqTableName)
+	if dwh.Label() != constants.BigQuery {
+		// BigQuery does not require lower-casing the table name, but Redshift and Snowflake does.
+		fqTableName = strings.ToLower(fqTableName)
+	}
+
 	if strings.Contains(fqTableName, constants.ArtiePrefix) {
 		// https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_table_statement
 		// https://docs.snowflake.com/en/sql-reference/sql/drop-table


### PR DESCRIPTION
## Problem

Addresses https://github.com/artie-labs/transfer/issues/227

The problem here is that `stringutil.Random(...)` could return capital letters, but our DROP TABLE statement is lowercasing it for Snowflake and Redshift.

This leads to temporary tables not being deleted in BigQuery, also BigQuery does not require us to escape table names, below SQL statement works.

```sql
DROP TABLE foo.bar_artie_AAA;
```

