### PR TITLE
Emitting Kafka row lag

### DIFF
--- a/lib/artie/message.go
+++ b/lib/artie/message.go
@@ -56,6 +56,20 @@ func (m *Message) Kind() Kind {
 	return Invalid
 }
 
+// EmitRowLag will diff against the partition's high watermark and the message's offset
+func (m *Message) EmitRowLag(ctx context.Context, groupID, table string) {
+	if m.KafkaMsg == nil {
+		return
+	}
+
+	metrics.FromContext(ctx).Gauge("row.lag", float64(m.KafkaMsg.HighWaterMark-m.KafkaMsg.Offset), map[string]string{
+		"groupID":   groupID,
+		"topic":     m.Topic(),
+		"table":     table,
+		"partition": m.Partition(),
+	})
+}
+
 func (m *Message) EmitIngestionLag(ctx context.Context, groupID, table string) {
 	metrics.FromContext(ctx).Timing("ingestion.lag", time.Since(m.PublishTime()), map[string]string{
 		"groupID":   groupID,

--- a/lib/artie/message.go
+++ b/lib/artie/message.go
@@ -62,12 +62,12 @@ func (m *Message) EmitRowLag(ctx context.Context, groupID, table string) {
 		return
 	}
 
-	metrics.FromContext(ctx).Gauge("row.lag", float64(m.KafkaMsg.HighWaterMark-m.KafkaMsg.Offset), map[string]string{
+	metrics.FromContext(ctx).GaugeWithSample("row.lag", float64(m.KafkaMsg.HighWaterMark-m.KafkaMsg.Offset), map[string]string{
 		"groupID":   groupID,
 		"topic":     m.Topic(),
 		"table":     table,
 		"partition": m.Partition(),
-	})
+	}, 0.5)
 }
 
 func (m *Message) EmitIngestionLag(ctx context.Context, groupID, table string) {

--- a/lib/artie/message.go
+++ b/lib/artie/message.go
@@ -57,6 +57,7 @@ func (m *Message) Kind() Kind {
 }
 
 // EmitRowLag will diff against the partition's high watermark and the message's offset
+// This function is only available for Kafka since Kafka has the concept of offsets and watermarks.
 func (m *Message) EmitRowLag(ctx context.Context, groupID, table string) {
 	if m.KafkaMsg == nil {
 		return

--- a/lib/telemetry/metrics/base/provider.go
+++ b/lib/telemetry/metrics/base/provider.go
@@ -7,4 +7,5 @@ type Client interface {
 	Incr(name string, tags map[string]string)
 	Count(name string, value int64, tags map[string]string)
 	Gauge(name string, value float64, tags map[string]string)
+	GaugeWithSample(name string, value float64, tags map[string]string, sample float64)
 }

--- a/lib/telemetry/metrics/datadog/datadog.go
+++ b/lib/telemetry/metrics/datadog/datadog.go
@@ -89,3 +89,7 @@ func (s *statsClient) Count(name string, value int64, tags map[string]string) {
 func (s *statsClient) Gauge(name string, value float64, tags map[string]string) {
 	_ = s.client.Gauge(name, value, toDatadogTags(tags), s.rate)
 }
+
+func (s *statsClient) GaugeWithSample(name string, value float64, tags map[string]string, sample float64) {
+	_ = s.client.Gauge(name, value, toDatadogTags(tags), sample)
+}

--- a/lib/telemetry/metrics/null_provider.go
+++ b/lib/telemetry/metrics/null_provider.go
@@ -8,6 +8,10 @@ func (n NullMetricsProvider) Gauge(name string, value float64, tags map[string]s
 	return
 }
 
+func (n NullMetricsProvider) GaugeWithSample(name string, value float64, tags map[string]string, sample float64) {
+	return
+}
+
 func (n NullMetricsProvider) Count(name string, value int64, tags map[string]string) {
 	return
 }

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -136,6 +136,7 @@ func StartConsumer(ctx context.Context) {
 				})
 
 				msg.EmitIngestionLag(ctx, kafkaConsumer.Config().GroupID, tableName)
+				msg.EmitRowLag(ctx, kafkaConsumer.Config().GroupID, tableName)
 				if processErr != nil {
 					log.WithError(processErr).WithFields(logFields).Warn("skipping message...")
 				}


### PR DESCRIPTION
## Motivation

Today, we are emitting ingestion lag by diffing the timestamp within the Kafka or Pub/Sub message against the current timestamp. 

However, that is the ingestion age, not how long it will take to get to queue 0, where the time to `queue 0` is an output from:

1. Rate of change of the row lag: 
   * How many rows are we processing
   * How many rows are we adding
2. How large is the backlog (row lag)

Visually, it'll look something like this:
![image](https://github.com/artie-labs/transfer/assets/4412200/ef81b4c2-8556-4cea-86c8-242e27a7a1ab)


Today, the ingestion age will just tell you how old is the message you are processing. With this PR, we will soon have the ability to **display time to queue 0** within our Analytics Portal.

## Changes

1. We are calculating high watermark by diffing the current message offset along with the Kafka partition's high watermark
2. We are sending 50% of this data to Datadog such that it will only add minimal latency to data processing time