### PR TITLE
Additional scenarios to escape column

### DIFF
--- a/lib/sql/escape_test.go
+++ b/lib/sql/escape_test.go
@@ -100,7 +100,7 @@ func (s *SqlTestSuite) TestEscapeName() {
 			expectedNameWhenUpperCfg: `"DELTA"`,
 		},
 		{
-			name: "escape = true, redshift, #1 (delta)",
+			name: "escape = true, snowflake, #1 (delta)",
 			args: &NameArgs{
 				Escape:   true,
 				DestKind: constants.Snowflake,
@@ -108,6 +108,26 @@ func (s *SqlTestSuite) TestEscapeName() {
 			nameToEscape:             "delta",
 			expectedName:             `delta`,
 			expectedNameWhenUpperCfg: `delta`,
+		},
+		{
+			name: "escape = true, redshift, symbols",
+			args: &NameArgs{
+				Escape:   true,
+				DestKind: constants.Redshift,
+			},
+			nameToEscape:             "receivedat:__",
+			expectedName:             `"receivedat:__"`,
+			expectedNameWhenUpperCfg: `"RECEIVEDAT:__"`,
+		},
+		{
+			name: "escape = true, redshift, numbers",
+			args: &NameArgs{
+				Escape:   true,
+				DestKind: constants.Redshift,
+			},
+			nameToEscape:             "0",
+			expectedName:             `"0"`,
+			expectedNameWhenUpperCfg: `"0"`,
 		},
 	}
 


### PR DESCRIPTION
## Changes

We were previously not escaping columns that either contained symbols or were numbers. This PR will now escape both of these scenarios.

## Outcome

| Column Name | Before | After |
| -------------- | ------- | ---- |
| receivedAt:__ | Not escaped | Escaped |
| 1234 | Not escaped | Escaped |