### PR TITLE
Fix JSON Default Values

### DIFF
--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -16,7 +16,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func CastColVal(ctx context.Context, colVal interface{}, colKind columns.Column) (interface{}, error) {
+func castColVal(ctx context.Context, colVal interface{}, colKind columns.Column) (interface{}, error) {
 	if colVal != nil {
 		switch colKind.KindDetails.Kind {
 		case typing.EDecimal.Kind:

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -127,7 +127,7 @@ func (b *BigQueryTestSuite) TestCastColVal() {
 	}
 
 	for _, testCase := range testCases {
-		actualString, actualErr := CastColVal(b.ctx, testCase.colVal, testCase.colKind)
+		actualString, actualErr := castColVal(b.ctx, testCase.colVal, testCase.colKind)
 		assert.Equal(b.T(), testCase.expectedErr, actualErr, testCase.name)
 		assert.Equal(b.T(), testCase.expectedValue, actualString, testCase.name)
 	}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -43,7 +43,7 @@ func merge(ctx context.Context, tableData *optimization.TableData) ([]*Row, erro
 		data := make(map[string]bigquery.Value)
 		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(ctx, nil) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
-			colVal, err := CastColVal(ctx, value[col], colKind)
+			colVal, err := castColVal(ctx, value[col], colKind)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast col: %v, err: %v", col, err)
 			}

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -120,7 +120,7 @@ const (
 	S3              DestinationKind = "s3"
 )
 
-var validDestinations = []DestinationKind{
+var ValidDestinations = []DestinationKind{
 	BigQuery,
 	Snowflake,
 	SnowflakeStages,
@@ -130,7 +130,7 @@ var validDestinations = []DestinationKind{
 }
 
 func IsValidDestination(destination DestinationKind) bool {
-	for _, validDest := range validDestinations {
+	for _, validDest := range ValidDestinations {
 		if destination == validDest {
 			return true
 		}

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -2,9 +2,10 @@ package size
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVariableToBytes(t *testing.T) {
@@ -12,13 +13,13 @@ func TestVariableToBytes(t *testing.T) {
 	assert.NoError(t, os.RemoveAll(filePath))
 
 	rowsData := make(map[string]map[string]interface{}) // pk -> { col -> val }
-	for i := 0; i < 500; i ++ {
+	for i := 0; i < 500; i++ {
 		rowsData[fmt.Sprintf("key-%v", i)] = map[string]interface{}{
-			"id": fmt.Sprintf("key-%v", i),
-			"artie": "transfer",
-			"dusty": "the mini aussie",
+			"id":         fmt.Sprintf("key-%v", i),
+			"artie":      "transfer",
+			"dusty":      "the mini aussie",
 			"next_puppy": true,
-			"team": []string{"charlie", "robin", "jacqueline"},
+			"team":       []string{"charlie", "robin", "jacqueline"},
 		}
 	}
 
@@ -29,6 +30,5 @@ func TestVariableToBytes(t *testing.T) {
 	assert.NoError(t, err)
 
 	size := GetApproxSize(rowsData)
-	assert.NoError(t, err)
 	assert.Equal(t, int(stat.Size()), size)
 }

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -33,7 +33,9 @@ func (c *Column) DefaultValue(ctx context.Context, args *DefaultValueArgs) (inte
 		switch args.DestKind {
 		case constants.BigQuery:
 			return "JSON" + stringutil.Wrap(c.defaultValue, false), nil
-		case constants.Redshift, constants.Snowflake:
+		case constants.Redshift:
+			return fmt.Sprintf("JSON_PARSE(%s)", stringutil.Wrap(c.defaultValue, false)), nil
+		case constants.Snowflake:
 			return stringutil.Wrap(c.defaultValue, false), nil
 		}
 	case typing.ETime.Kind:

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -33,7 +33,7 @@ func (c *Column) DefaultValue(ctx context.Context, args *DefaultValueArgs) (inte
 		switch args.DestKind {
 		case constants.BigQuery:
 			return "JSON" + stringutil.Wrap(c.defaultValue, false), nil
-		case constants.Redshift:
+		case constants.Redshift, constants.Snowflake:
 			return stringutil.Wrap(c.defaultValue, false), nil
 		}
 	case typing.ETime.Kind:

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -1,11 +1,12 @@
 package columns
 
 import (
+	"fmt"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/typing/ext"
-
 	"github.com/artie-labs/transfer/lib/config/constants"
+
+	"github.com/artie-labs/transfer/lib/typing/ext"
 
 	"github.com/artie-labs/transfer/lib/typing"
 
@@ -14,11 +15,12 @@ import (
 
 func (c *ColumnsTestSuite) TestColumn_DefaultValue() {
 	type _testCase struct {
-		name          string
-		col           *Column
-		args          *DefaultValueArgs
-		expectedValue interface{}
-		expectedEr    bool
+		name                       string
+		col                        *Column
+		args                       *DefaultValueArgs
+		expectedValue              interface{}
+		destKindToExpectedValueMap map[constants.DestinationKind]interface{}
+		expectedEr                 bool
 	}
 
 	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
@@ -73,31 +75,11 @@ func (c *ColumnsTestSuite) TestColumn_DefaultValue() {
 			args: &DefaultValueArgs{
 				Escape: true,
 			},
-			expectedValue: "{}",
-		},
-		{
-			name: "json (bigquery)",
-			col: &Column{
-				KindDetails:  typing.Struct,
-				defaultValue: "{}",
+			expectedValue: `{}`,
+			destKindToExpectedValueMap: map[constants.DestinationKind]interface{}{
+				constants.BigQuery: "JSON'{}'",
+				constants.Redshift: `'{}'`,
 			},
-			args: &DefaultValueArgs{
-				Escape:   true,
-				DestKind: constants.BigQuery,
-			},
-			expectedValue: "JSON'{}'",
-		},
-		{
-			name: "json (redshift)",
-			col: &Column{
-				KindDetails:  typing.Struct,
-				defaultValue: "{}",
-			},
-			args: &DefaultValueArgs{
-				Escape:   true,
-				DestKind: constants.Redshift,
-			},
-			expectedValue: "'{}'",
 		},
 		{
 			name: "date",
@@ -135,13 +117,25 @@ func (c *ColumnsTestSuite) TestColumn_DefaultValue() {
 	}
 
 	for _, testCase := range testCases {
-		actualValue, actualErr := testCase.col.DefaultValue(c.ctx, testCase.args)
-		if testCase.expectedEr {
-			assert.Error(c.T(), actualErr, testCase.name)
-		} else {
-			assert.NoError(c.T(), actualErr, testCase.name)
-		}
+		for _, validDest := range constants.ValidDestinations {
+			if testCase.args != nil {
+				testCase.args.DestKind = validDest
+			}
 
-		assert.Equal(c.T(), testCase.expectedValue, actualValue, testCase.name)
+			actualValue, actualErr := testCase.col.DefaultValue(c.ctx, testCase.args)
+			if testCase.expectedEr {
+				assert.Error(c.T(), actualErr, fmt.Sprintf("%s %s", testCase.name, validDest))
+			} else {
+				assert.NoError(c.T(), actualErr, fmt.Sprintf("%s %s", testCase.name, validDest))
+			}
+
+			expectedValue := testCase.expectedValue
+			if potentialValue, isOk := testCase.destKindToExpectedValueMap[validDest]; isOk {
+				// Not everything requires a destination specific value, so only use this if necessary.
+				expectedValue = potentialValue
+			}
+
+			assert.Equal(c.T(), expectedValue, actualValue, fmt.Sprintf("%s %s", testCase.name, validDest))
+		}
 	}
 }

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -77,8 +77,9 @@ func (c *ColumnsTestSuite) TestColumn_DefaultValue() {
 			},
 			expectedValue: `{}`,
 			destKindToExpectedValueMap: map[constants.DestinationKind]interface{}{
-				constants.BigQuery: "JSON'{}'",
-				constants.Redshift: `'{}'`,
+				constants.BigQuery:  "JSON'{}'",
+				constants.Redshift:  `'{}'`,
+				constants.Snowflake: `'{}'`,
 			},
 		},
 		{

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -78,8 +78,24 @@ func (c *ColumnsTestSuite) TestColumn_DefaultValue() {
 			expectedValue: `{}`,
 			destKindToExpectedValueMap: map[constants.DestinationKind]interface{}{
 				constants.BigQuery:  "JSON'{}'",
-				constants.Redshift:  `'{}'`,
+				constants.Redshift:  `JSON_PARSE('{}')`,
 				constants.Snowflake: `'{}'`,
+			},
+		},
+		{
+			name: "json w/ some values",
+			col: &Column{
+				KindDetails:  typing.Struct,
+				defaultValue: "{\"age\": 0, \"membership_level\": \"standard\"}",
+			},
+			args: &DefaultValueArgs{
+				Escape: true,
+			},
+			expectedValue: "{\"age\": 0, \"membership_level\": \"standard\"}",
+			destKindToExpectedValueMap: map[constants.DestinationKind]interface{}{
+				constants.BigQuery:  "JSON'{\"age\": 0, \"membership_level\": \"standard\"}'",
+				constants.Redshift:  "JSON_PARSE('{\"age\": 0, \"membership_level\": \"standard\"}')",
+				constants.Snowflake: "'{\"age\": 0, \"membership_level\": \"standard\"}'",
 			},
 		},
 		{


### PR DESCRIPTION
## Motivation

We were not correctly backfilling the default values for JSON columns for Snowflake and Redshift. 

## Changes

1. Changed `castColVal` for BigQuery to be private (was not used elsewhere)
2. Fixed default value parsing for Snowflake and Redshift (the default values for JSON arrives in a STRING format).