### PR TITLE
[Redshift] Ability to infer VARCHAR length

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -168,7 +168,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	// Infer the right data types from BigQuery before temp table creation.
-	tableData.UpdateInMemoryColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
+	tableData.MergeColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
 
 	// Start temporary table creation
 	tempAlterTableArgs := ddl.AlterTableArgs{

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -84,7 +84,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		}
 	}
 
-	tableData.UpdateInMemoryColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
+	tableData.MergeColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
 
 	// Temporary tables cannot specify schemas, so we just prefix it instead.
 	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false), tableData.TempTableSuffix())

--- a/clients/redshift/queries.go
+++ b/clients/redshift/queries.go
@@ -25,9 +25,9 @@ SELECT
         WHEN c.data_type = 'numeric' THEN 
             'numeric(' || COALESCE(CAST(c.numeric_precision AS VARCHAR), '') || ',' || COALESCE(CAST(c.numeric_scale AS VARCHAR), '') || ')'
         ELSE 
-            c.data_type,
-	c.%s,
+            c.data_type
     END AS data_type,
+    c.%s,
     d.description
 FROM 
     information_schema.columns c 

--- a/clients/redshift/queries.go
+++ b/clients/redshift/queries.go
@@ -3,6 +3,8 @@ package redshift
 import (
 	"fmt"
 	"strings"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
 )
 
 type describeArgs struct {
@@ -23,7 +25,8 @@ SELECT
         WHEN c.data_type = 'numeric' THEN 
             'numeric(' || COALESCE(CAST(c.numeric_precision AS VARCHAR), '') || ',' || COALESCE(CAST(c.numeric_scale AS VARCHAR), '') || ')'
         ELSE 
-            c.data_type 
+            c.data_type,
+	c.%s,
     END AS data_type,
     d.description
 FROM 
@@ -36,5 +39,5 @@ LEFT JOIN
     pg_catalog.pg_description d ON d.objsubid=c.ordinal_position AND d.objoid=c1.oid 
 WHERE 
     LOWER(c.table_name) = LOWER('%s') AND LOWER(c.table_schema) = LOWER('%s');
-`, args.RawTableName, args.Schema), nil
+`, constants.StrPrecisionCol, args.RawTableName, args.Schema), nil
 }

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -59,21 +59,20 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	err := s.mergeWithStages(ctx, tableData)
 	if AuthenticationExpirationErr(err) {
 		logger.FromContext(ctx).WithError(err).Warn("authentication has expired, will reload the Snowflake store and retry merging")
-		s.ReestablishConnection(ctx)
+		s.reestablishConnection(ctx)
 		return s.Merge(ctx, tableData)
 	}
 
 	return err
 }
 
-func (s *Store) ReestablishConnection(ctx context.Context) {
+func (s *Store) reestablishConnection(ctx context.Context) {
 	if s.testDB {
 		// Don't actually re-establish for tests.
 		return
 	}
 
 	settings := config.FromContext(ctx)
-
 	cfg := &gosnowflake.Config{
 		Account:   settings.Config.Snowflake.AccountID,
 		User:      settings.Config.Snowflake.Username,
@@ -110,6 +109,6 @@ func LoadSnowflake(ctx context.Context, _store *db.Store) *Store {
 		configMap: &types.DwhToTablesConfigMap{},
 	}
 
-	s.ReestablishConnection(ctx)
+	s.reestablishConnection(ctx)
 	return s
 }

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -177,7 +177,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		}
 	}
 
-	tableData.UpdateInMemoryColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
+	tableData.MergeColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
 	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false), tableData.TempTableSuffix())
 	if err = s.prepareTempTable(ctx, tableData, tableConfig, temporaryTableName); err != nil {
 		return err

--- a/clients/utils/table_config.go
+++ b/clients/utils/table_config.go
@@ -111,7 +111,7 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 		case constants.BigQuery:
 			kd = typing.BigQueryTypeToKind(row[args.ColumnTypeLabel])
 		case constants.Redshift:
-			kd = typing.RedshiftTypeToKind(row[args.ColumnTypeLabel])
+			kd = typing.RedshiftTypeToKind(row[args.ColumnTypeLabel], constants.StrPrecisionCol)
 		default:
 			return nil, fmt.Errorf("unexpected dwh kind, label: %v", args.Dwh.Label())
 		}

--- a/clients/utils/table_config.go
+++ b/clients/utils/table_config.go
@@ -111,7 +111,7 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 		case constants.BigQuery:
 			kd = typing.BigQueryTypeToKind(row[args.ColumnTypeLabel])
 		case constants.Redshift:
-			kd = typing.RedshiftTypeToKind(row[args.ColumnTypeLabel], constants.StrPrecisionCol)
+			kd = typing.RedshiftTypeToKind(row[args.ColumnTypeLabel], row[constants.StrPrecisionCol])
 		default:
 			return nil, fmt.Errorf("unexpected dwh kind, label: %v", args.Dwh.Label())
 		}

--- a/lib/config/constants/redshift.go
+++ b/lib/config/constants/redshift.go
@@ -162,3 +162,5 @@ var RedshiftReservedKeywords = []string{
 	"with",
 	"without",
 }
+
+const StrPrecisionCol = "character_maximum_length"

--- a/lib/destination/ddl/ddl_bq_test.go
+++ b/lib/destination/ddl/ddl_bq_test.go
@@ -208,8 +208,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(d.ctx, &artieSQL.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
-		}),
-			typing.KindToDWHType(column.KindDetails, d.bigQueryStore.Label())), query)
+		}), typing.KindToDWHType(column.KindDetails, d.bigQueryStore.Label())), query)
 		callIdx += 1
 	}
 

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -228,7 +228,7 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumns() {
 		"bar":                  typing.Boolean,
 		"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn(name, colKindDetails))
+		tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn(name, colKindDetails))
 	}
 
 	// It's saved back in the original format.

--- a/lib/optimization/event_update_test.go
+++ b/lib/optimization/event_update_test.go
@@ -37,20 +37,20 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 	}
 
 	// Testing to make sure we don't copy over non-existent columns
-	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, nonExistentCols...)
+	tableData.MergeColumnsFromDestination(o.ctx, nonExistentCols...)
 	for _, nonExistentTableCol := range nonExistentTableCols {
 		_, isOk := tableData.inMemoryColumns.GetColumn(nonExistentTableCol)
 		assert.False(o.T(), isOk, nonExistentTableCol)
 	}
 
 	// Making sure it's still numeric
-	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("numeric_test", typing.Integer))
+	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("numeric_test", typing.Integer))
 	numericCol, isOk := tableData.inMemoryColumns.GetColumn("numeric_test")
 	assert.True(o.T(), isOk)
 	assert.Equal(o.T(), typing.EDecimal.Kind, numericCol.KindDetails.Kind, "numeric_test")
 
 	// Testing to make sure we're copying the kindDetails over.
-	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("prev_invalid", typing.String))
+	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("prev_invalid", typing.String))
 	prevInvalidCol, isOk := tableData.inMemoryColumns.GetColumn("prev_invalid")
 	assert.True(o.T(), isOk)
 	assert.Equal(o.T(), typing.String, prevInvalidCol.KindDetails)
@@ -61,7 +61,7 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 	}
 	backfilledCol := columns.NewColumn("bool_backfill", typing.Boolean)
 	backfilledCol.SetBackfilled(true)
-	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, backfilledCol)
+	tableData.MergeColumnsFromDestination(o.ctx, backfilledCol)
 	for _, inMemoryCol := range tableData.inMemoryColumns.GetColumns() {
 		if inMemoryCol.Name(o.ctx, nil) == backfilledCol.Name(o.ctx, nil) {
 			assert.True(o.T(), inMemoryCol.Backfilled(), inMemoryCol.Name(o.ctx, nil))
@@ -78,9 +78,9 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 		assert.Nil(o.T(), col.KindDetails.ExtendedTimeDetails, extTimeDetailsCol)
 	}
 
-	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("ext_time", typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType)))
-	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("ext_date", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType)))
-	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("ext_datetime", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)))
+	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("ext_time", typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType)))
+	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("ext_date", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType)))
+	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("ext_datetime", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)))
 
 	dateCol, isOk := tableData.inMemoryColumns.GetColumn("ext_date")
 	assert.True(o.T(), isOk)
@@ -105,7 +105,7 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 
 	extDecimal := typing.EDecimal
 	extDecimal.ExtendedDecimalDetails = decimal.NewDecimal(2, ptr.ToInt(30), nil)
-	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("ext_dec", extDecimal))
+	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("ext_dec", extDecimal))
 	// Now it should be ext decimal type
 	extDecCol, isOk = tableData.inMemoryColumns.GetColumn("ext_dec")
 	assert.True(o.T(), isOk)
@@ -122,7 +122,7 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 	assert.Equal(o.T(), 22, *extDecColFilled.KindDetails.ExtendedDecimalDetails.Precision())
 	assert.Equal(o.T(), 2, extDecColFilled.KindDetails.ExtendedDecimalDetails.Scale())
 
-	tableData.UpdateInMemoryColumnsFromDestination(o.ctx, columns.NewColumn("ext_dec_filled", extDecimal))
+	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("ext_dec_filled", extDecimal))
 	extDecColFilled, isOk = tableData.inMemoryColumns.GetColumn("ext_dec_filled")
 	assert.True(o.T(), isOk)
 	assert.Equal(o.T(), typing.EDecimal.Kind, extDecColFilled.KindDetails.Kind)

--- a/lib/typing/redshift.go
+++ b/lib/typing/redshift.go
@@ -64,7 +64,7 @@ func kindToRedShift(kd KindDetails) string {
 		return "VARCHAR(MAX)"
 	case String.Kind:
 		if kd.OptionalRedshiftStrPrecision != nil {
-			return fmt.Sprintf("VARCHAR(%d)", kd.OptionalRedshiftStrPrecision)
+			return fmt.Sprintf("VARCHAR(%d)", *kd.OptionalRedshiftStrPrecision)
 		}
 
 		return "VARCHAR(MAX)"

--- a/lib/typing/redshift.go
+++ b/lib/typing/redshift.go
@@ -14,7 +14,6 @@ func RedshiftTypeToKind(rawType string, stringPrecision string) KindDetails {
 		return ParseNumeric(defaultPrefix, rawType)
 	}
 
-	// TODO: Add test
 	if strings.Contains(rawType, "character varying") {
 		var strPrecision *int
 		precision, err := strconv.Atoi(stringPrecision)

--- a/lib/typing/redshift.go
+++ b/lib/typing/redshift.go
@@ -47,7 +47,7 @@ func RedshiftTypeToKind(rawType string, stringPrecision string) KindDetails {
 	return Invalid
 }
 
-func kindToRedShift(kd KindDetails) string {
+func kindToRedshift(kd KindDetails) string {
 	switch kd.Kind {
 	case Integer.Kind:
 		// int4 is 2^31, whereas int8 is 2^63.

--- a/lib/typing/redshift_test.go
+++ b/lib/typing/redshift_test.go
@@ -3,63 +3,101 @@ package typing
 import (
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRedshiftTypeToKind(t *testing.T) {
+	type rawTypeAndPrecision struct {
+		rawType   string
+		precision string
+	}
+
 	type _testCase struct {
 		name       string
-		rawTypes   []string
+		rawTypes   []rawTypeAndPrecision
 		expectedKd KindDetails
 	}
 
 	testCases := []_testCase{
 		{
-			name:       "Integer",
-			rawTypes:   []string{"integer", "bigint", "INTEGER"},
+			name: "Integer",
+			rawTypes: []rawTypeAndPrecision{
+				{rawType: "integer"},
+				{rawType: "bigint"},
+				{rawType: "INTEGER"},
+			},
 			expectedKd: Integer,
 		},
 		{
-			name:       "String",
-			rawTypes:   []string{"character varying"},
+			name: "String w/o precision",
+			rawTypes: []rawTypeAndPrecision{
+				{rawType: "character varying"},
+				{rawType: "character varying(65535)"},
+				{
+					rawType:   "character varying",
+					precision: "not a number",
+				},
+			},
 			expectedKd: String,
 		},
 		{
-			name:       "String",
-			rawTypes:   []string{"character varying"},
-			expectedKd: String,
+			name: "String w/ precision",
+			rawTypes: []rawTypeAndPrecision{
+				{
+					rawType:   "character varying",
+					precision: "65535",
+				},
+			},
+			expectedKd: KindDetails{
+				Kind:                         String.Kind,
+				OptionalRedshiftStrPrecision: ptr.ToInt(65535),
+			},
 		},
 		{
-			name:       "String",
-			rawTypes:   []string{"character varying(65535)"},
-			expectedKd: String,
-		},
-		{
-			name:       "Double Precision",
-			rawTypes:   []string{"double precision", "DOUBLE precision"},
+			name: "Double Precision",
+			rawTypes: []rawTypeAndPrecision{
+				{rawType: "double precision"},
+				{rawType: "DOUBLE precision"},
+			},
 			expectedKd: Float,
 		},
 		{
-			name:       "Time",
-			rawTypes:   []string{"timestamp with time zone", "timestamp without time zone", "time without time zone", "date"},
+			name: "Time",
+			rawTypes: []rawTypeAndPrecision{
+				{rawType: "timestamp with time zone"},
+				{rawType: "timestamp without time zone"},
+				{rawType: "time without time zone"},
+				{rawType: "date"},
+			},
 			expectedKd: ETime,
 		},
 		{
-			name:       "Boolean",
-			rawTypes:   []string{"boolean"},
+			name: "Boolean",
+			rawTypes: []rawTypeAndPrecision{
+				{rawType: "boolean"},
+			},
 			expectedKd: Boolean,
 		},
 		{
-			name:       "numeric",
-			rawTypes:   []string{"numeric(5,2)", "numeric(5,5)"},
+			name: "numeric",
+			rawTypes: []rawTypeAndPrecision{
+				{rawType: "numeric(5,2)"},
+				{rawType: "numeric(5,5)"},
+			},
 			expectedKd: EDecimal,
 		},
 	}
 
 	for _, testCase := range testCases {
-		for _, rawType := range testCase.rawTypes {
-			kd := RedshiftTypeToKind(rawType, "")
+		for _, rawTypeAndPrec := range testCase.rawTypes {
+			kd := RedshiftTypeToKind(rawTypeAndPrec.rawType, rawTypeAndPrec.precision)
 			assert.Equal(t, testCase.expectedKd.Kind, kd.Kind, testCase.name)
+
+			if kd.OptionalRedshiftStrPrecision != nil {
+				assert.Equal(t, *testCase.expectedKd.OptionalRedshiftStrPrecision, *kd.OptionalRedshiftStrPrecision, testCase.name)
+			}
 		}
 	}
 }

--- a/lib/typing/redshift_test.go
+++ b/lib/typing/redshift_test.go
@@ -97,6 +97,8 @@ func TestRedshiftTypeToKind(t *testing.T) {
 
 			if kd.OptionalRedshiftStrPrecision != nil {
 				assert.Equal(t, *testCase.expectedKd.OptionalRedshiftStrPrecision, *kd.OptionalRedshiftStrPrecision, testCase.name)
+			} else {
+				assert.Nil(t, kd.OptionalRedshiftStrPrecision, testCase.name)
 			}
 		}
 	}

--- a/lib/typing/redshift_test.go
+++ b/lib/typing/redshift_test.go
@@ -58,7 +58,7 @@ func TestRedshiftTypeToKind(t *testing.T) {
 
 	for _, testCase := range testCases {
 		for _, rawType := range testCase.rawTypes {
-			kd := RedshiftTypeToKind(rawType)
+			kd := RedshiftTypeToKind(rawType, "")
 			assert.Equal(t, testCase.expectedKd.Kind, kd.Kind, testCase.name)
 		}
 	}

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -16,6 +16,9 @@ type KindDetails struct {
 	Kind                   string
 	ExtendedTimeDetails    *ext.NestedKind
 	ExtendedDecimalDetails *decimal.Decimal
+
+	// Optional kind details metadata
+	OptionalRedshiftStrPrecision *int
 }
 
 // Summarized this from Snowflake + Reflect.

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -177,7 +177,7 @@ func KindToDWHType(kd KindDetails, dwh constants.DestinationKind) string {
 	case constants.BigQuery:
 		return kindToBigQuery(kd)
 	case constants.Redshift:
-		return kindToRedShift(kd)
+		return kindToRedshift(kd)
 	}
 
 	return ""

--- a/lib/typing/typing_kind_test.go
+++ b/lib/typing/typing_kind_test.go
@@ -1,0 +1,25 @@
+package typing
+
+func (t *TypingTestSuite) Test_KindToDWHType() {
+	type _tc struct {
+		kd                    KindDetails
+		expectedSnowflakeType string
+		expectedBigQueryType  string
+		expectedRedshiftType  string
+	}
+
+	tcs := []_tc{
+		{
+			kd:                    String,
+			expectedSnowflakeType: "string",
+			expectedBigQueryType:  "string",
+			expectedRedshiftType:  "VARCHAR(MAX)",
+		},
+	}
+
+	for idx, tc := range tcs {
+		t.Equal(tc.expectedSnowflakeType, kindToSnowflake(tc.kd), idx)
+		t.Equal(tc.expectedBigQueryType, kindToBigQuery(tc.kd), idx)
+		t.Equal(tc.expectedRedshiftType, kindToRedShift(tc.kd), idx)
+	}
+}

--- a/lib/typing/typing_kind_test.go
+++ b/lib/typing/typing_kind_test.go
@@ -1,5 +1,10 @@
 package typing
 
+import (
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/ptr"
+)
+
 func (t *TypingTestSuite) Test_KindToDWHType() {
 	type _tc struct {
 		kd                    KindDetails
@@ -15,11 +20,20 @@ func (t *TypingTestSuite) Test_KindToDWHType() {
 			expectedBigQueryType:  "string",
 			expectedRedshiftType:  "VARCHAR(MAX)",
 		},
+		{
+			kd: KindDetails{
+				Kind:                         String.Kind,
+				OptionalRedshiftStrPrecision: ptr.ToInt(12345),
+			},
+			expectedSnowflakeType: "string",
+			expectedBigQueryType:  "string",
+			expectedRedshiftType:  "VARCHAR(12345)",
+		},
 	}
 
 	for idx, tc := range tcs {
-		t.Equal(tc.expectedSnowflakeType, kindToSnowflake(tc.kd), idx)
-		t.Equal(tc.expectedBigQueryType, kindToBigQuery(tc.kd), idx)
-		t.Equal(tc.expectedRedshiftType, kindToRedShift(tc.kd), idx)
+		t.Equal(tc.expectedSnowflakeType, KindToDWHType(tc.kd, constants.Snowflake), idx)
+		t.Equal(tc.expectedBigQueryType, KindToDWHType(tc.kd, constants.BigQuery), idx)
+		t.Equal(tc.expectedRedshiftType, KindToDWHType(tc.kd, constants.Redshift), idx)
 	}
 }


### PR DESCRIPTION
## Problem

Debezium does not expose the character precision within the actual message. For example, we don't know if the column is `VARCHAR(123) vs VARCHAR(333)`.

As such, we have been creating all string based columns as `VARCHAR(MAX)` to preserve precision. However this comes with a tradeoff of over-provisioning space. 

For Snowflake and other data warehouses, it doesn't matter - the actual space used will be the actual length of the value. However, Redshift allocates space based on the column precision.

The workaround for this has been to go into the actual table in DWH and update it yourself:

```sql
ALTER TABLE public.customers_test2 ALTER COLUMN first_name TYPE VARCHAR(123);
```

When this is done, Transfer will not try to mutate the column back to `VARCHAR(MAX)` and will just continue to reference it accordingly. However, when it is still using `VARCHAR(MAX)` to create string-based columns for delta tables.

## Change

* This PR will infer the character precision and pass that context to creation of delta tables.
* Renamed `UpdateInMemoryColumnsFromDestination` to `MergeColumnsFromDestination` to be more clear