### PR TITLE
Optimizing the way we calculate our in-memory pool size

### DIFF
--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -287,7 +287,7 @@ func TestTableData_ShouldFlushRowSize(t *testing.T) {
 
 	// Insert 3 rows and confirm that we need to flush.
 	td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
-	for i := 0; i < 85; i++ {
+	for i := 0; i < 100; i++ {
 		shouldFlush, flushReason := td.ShouldFlush(ctx)
 		assert.False(t, shouldFlush)
 		assert.Empty(t, flushReason)
@@ -313,6 +313,8 @@ func TestTableData_ShouldFlushRowSize(t *testing.T) {
 			"123": "9222213213j1i31j3k21j321k3j1k31jk31213123213213121322j31k2",
 		},
 	}, false)
+
+	fmt.Println("####", td.approxSize)
 
 	shouldFlush, flushReason := td.ShouldFlush(ctx)
 	assert.True(t, shouldFlush)

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -287,7 +287,7 @@ func TestTableData_ShouldFlushRowSize(t *testing.T) {
 
 	// Insert 3 rows and confirm that we need to flush.
 	td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
-	for i := 0; i < 45; i++ {
+	for i := 0; i < 85; i++ {
 		shouldFlush, flushReason := td.ShouldFlush(ctx)
 		assert.False(t, shouldFlush)
 		assert.Empty(t, flushReason)
@@ -309,6 +309,8 @@ func TestTableData_ShouldFlushRowSize(t *testing.T) {
 		"false": false,
 		"nested": map[string]interface{}{
 			"foo": "bar",
+			"bar": "xyz",
+			"123": "9222213213j1i31j3k21j321k3j1k31jk31213123213213121322j31k2",
 		},
 	}, false)
 

--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -1,19 +1,13 @@
 package size
 
-import "fmt"
+import (
+	"fmt"
+)
 
-func GetApproxSize(v map[string]interface{}) int {
+func GetApproxSize(value interface{}) int {
 	// We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal.
 	// We also chose not to use gob.NewEncoder because it does not work for all data types and had a huge computational overhead.
 	// Another plus here is that this will not error out.
-	var size int
-	for _, value := range v {
-		size += approximateSizeOfValue(value)
-	}
-	return size
-}
-
-func approximateSizeOfValue(value interface{}) int {
 	switch v := value.(type) {
 	case string:
 		return len(v)
@@ -33,7 +27,29 @@ func approximateSizeOfValue(value interface{}) int {
 	case complex128:
 		return 16 // Approximation for complex types
 	case map[string]interface{}:
-		return GetApproxSize(v) // Recursive call for nested maps
+		var size int
+		for _, val := range v {
+			size += GetApproxSize(val)
+		}
+		return size
+	case []map[string]interface{}:
+		var size int
+		for _, val := range v {
+			size += GetApproxSize(val)
+		}
+		return size
+	case []string:
+		var size int
+		for _, val := range v {
+			size += GetApproxSize(val)
+		}
+		return size
+	case [][]byte:
+		var size int
+		for _, val := range v {
+			size += GetApproxSize(val)
+		}
+		return size
 	}
 
 	return len([]byte(fmt.Sprint(value)))

--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -1,14 +1,36 @@
 package size
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // GetApproxSize will encode the actual variable into bytes and then check the length (approx) by using string encoding.
 // We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal.
 // We also chose not to use gob.NewEncoder because it does not work for all data types and had a huge computational overhead.
 // Another bonus is that there is no possible way for this to error out.
-func GetApproxSize(v interface{}) int {
-	valString := fmt.Sprint(v)
-	return len([]byte(valString))
+func GetApproxSize(v map[string]interface{}) int {
+	var size int
+	for key, value := range v {
+		size += len(key)                      // Size of the key
+		size += approximateSizeOfValue(value) // Size of the value
+	}
+	return size
+}
+
+func approximateSizeOfValue(value interface{}) int {
+	switch v := value.(type) {
+	case string:
+		return len(v)
+	case bool:
+		return 1 // Size of a boolean
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64, uintptr, float32, float64:
+		return 8 // Approximation for floating-point types
+	case complex64, complex128:
+		return 16 // Approximation for complex types
+	case map[string]interface{}:
+		return GetApproxSize(v) // Recursive call for nested maps
+	case []byte:
+		return len(v) // Size of byte slice
+	}
+
+	return len([]byte(fmt.Sprint(value)))
 }

--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -2,11 +2,10 @@ package size
 
 import "fmt"
 
-// GetApproxSize will encode the actual variable into bytes and then check the length (approx) by using string encoding.
-// We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal.
-// We also chose not to use gob.NewEncoder because it does not work for all data types and had a huge computational overhead.
-// Another bonus is that there is no possible way for this to error out.
 func GetApproxSize(v map[string]interface{}) int {
+	// We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal.
+	// We also chose not to use gob.NewEncoder because it does not work for all data types and had a huge computational overhead.
+	// Another plus here is that this will not error out.
 	var size int
 	for _, value := range v {
 		size += approximateSizeOfValue(value)

--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -8,9 +8,8 @@ import "fmt"
 // Another bonus is that there is no possible way for this to error out.
 func GetApproxSize(v map[string]interface{}) int {
 	var size int
-	for key, value := range v {
-		size += len(key)                      // Size of the key
-		size += approximateSizeOfValue(value) // Size of the value
+	for _, value := range v {
+		size += approximateSizeOfValue(value)
 	}
 	return size
 }
@@ -19,17 +18,23 @@ func approximateSizeOfValue(value interface{}) int {
 	switch v := value.(type) {
 	case string:
 		return len(v)
+	case []byte:
+		return len(v)
 	case bool:
-		return 1 // Size of a boolean
-	case int, int8, int16, int32, int64,
-		uint, uint8, uint16, uint32, uint64, uintptr, float32, float64:
-		return 8 // Approximation for floating-point types
-	case complex64, complex128:
+		return 1
+	case int8, uint8:
+		return 1
+	case int16, uint16:
+		return 2
+	case int32, uint32, float32:
+		return 4
+	case int, int64, uint, uint64, uintptr, float64, complex64:
+		// int, uint are platform dependent - but to be safe, let's over approximate and assume 64-bit system
+		return 8
+	case complex128:
 		return 16 // Approximation for complex types
 	case map[string]interface{}:
 		return GetApproxSize(v) // Recursive call for nested maps
-	case []byte:
-		return len(v) // Size of byte slice
 	}
 
 	return len([]byte(fmt.Sprint(value)))

--- a/lib/size/size_bench_test.go
+++ b/lib/size/size_bench_test.go
@@ -7,36 +7,36 @@ import (
 )
 
 func BenchmarkGetApproxSize_TallTable(b *testing.B) {
-	rowsData := make(map[string]map[string]interface{})
-	for i := 0; i < 5000; i ++ {
+	rowsData := make(map[string]interface{})
+	for i := 0; i < 5000; i++ {
 		rowsData[fmt.Sprint(i)] = map[string]interface{}{
-			"id": i,
+			"id":   i,
 			"name": "Robin",
-			"dog": "dusty the mini aussie",
+			"dog":  "dusty the mini aussie",
 		}
 	}
 
-	for n := 0; n < b.N; n ++ {
+	for n := 0; n < b.N; n++ {
 		GetApproxSize(rowsData)
 	}
 }
 
 func BenchmarkGetApproxSize_WideTable(b *testing.B) {
-	rowsData := make(map[string]map[string]interface{})
-	for i := 0; i < 5000; i ++ {
+	rowsData := make(map[string]interface{})
+	for i := 0; i < 5000; i++ {
 		rowsData[fmt.Sprint(i)] = map[string]interface{}{
-			"id": i,
-			"name": "Robin",
-			"dog": "dusty the mini aussie",
-			"favorite_fruits": []string{"strawberry", "kiwi", "oranges"},
-			"random": false,
-			"team": []string{"charlie", "jacqueline"},
-			"email": "robin@artie.so",
+			"id":                 i,
+			"name":               "Robin",
+			"dog":                "dusty the mini aussie",
+			"favorite_fruits":    []string{"strawberry", "kiwi", "oranges"},
+			"random":             false,
+			"team":               []string{"charlie", "jacqueline"},
+			"email":              "robin@artie.so",
 			"favorite_languages": []string{"go", "sql"},
 			"favorite_databases": []string{"postgres", "bigtable"},
-			"created_at": time.Now(),
-			"updated_at": time.Now(),
-			"negative_number": -500,
+			"created_at":         time.Now(),
+			"updated_at":         time.Now(),
+			"negative_number":    -500,
 			"nestedObject": map[string]interface{}{
 				"foo": "bar",
 				"abc": "def",
@@ -51,13 +51,13 @@ func BenchmarkGetApproxSize_WideTable(b *testing.B) {
 					},
 				},
 			},
-			"is_deleted": false,
-			"lorem_ipsum": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec elementum aliquet mi at efficitur. Praesent at erat ac elit faucibus convallis. Donec fermentum tellus eu nunc ornare, non convallis justo facilisis. In hac habitasse platea dictumst. Praesent eu ante vitae erat semper finibus eget ac mauris. Duis gravida cursus enim, nec sagittis arcu placerat sed. Integer semper orci justo, nec rhoncus libero convallis sed.",
+			"is_deleted":   false,
+			"lorem_ipsum":  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec elementum aliquet mi at efficitur. Praesent at erat ac elit faucibus convallis. Donec fermentum tellus eu nunc ornare, non convallis justo facilisis. In hac habitasse platea dictumst. Praesent eu ante vitae erat semper finibus eget ac mauris. Duis gravida cursus enim, nec sagittis arcu placerat sed. Integer semper orci justo, nec rhoncus libero convallis sed.",
 			"lorem_ipsum2": "Fusce vitae elementum tortor. Vestibulum consectetur ante id nibh ullamcorper, quis sodales turpis tempor. Duis pellentesque suscipit nibh porta posuere. In libero massa, efficitur at ultricies sit amet, vulputate ac ante. In euismod erat eget nulla blandit pretium. Ut tempor ante vel congue venenatis. Vestibulum at metus nec nibh iaculis consequat suscipit ac leo. Maecenas vitae rutrum nulla, quis ultrices justo. Aliquam ipsum ex, luctus ac diam eget, tempor tempor risus.",
 		}
 	}
 
-	for n := 0; n < b.N; n ++ {
+	for n := 0; n < b.N; n++ {
 		GetApproxSize(rowsData)
 	}
 }

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -12,7 +12,7 @@ func TestVariableToBytes(t *testing.T) {
 	filePath := "/tmp/size_test"
 	assert.NoError(t, os.RemoveAll(filePath))
 
-	rowsData := make(map[string]map[string]interface{}) // pk -> { col -> val }
+	rowsData := make(map[string]interface{}) // pk -> { col -> val }
 	for i := 0; i < 500; i++ {
 		rowsData[fmt.Sprintf("key-%v", i)] = map[string]interface{}{
 			"id":         fmt.Sprintf("key-%v", i),

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -16,6 +16,19 @@ func TestGetApproxSize(t *testing.T) {
 			"dusty":      "the mini aussie",
 			"next_puppy": true,
 			"team":       []string{"charlie", "robin", "jacqueline"},
+			"arrays":     []string{"foo", "bar", "baz"},
+			"nested": map[string]interface{}{
+				"foo": "bar",
+				"abc": "xyz",
+			},
+			"array_of_maps": []map[string]interface{}{
+				{
+					"foo": "bar",
+				},
+				{
+					"abc": "xyz",
+				},
+			},
 		}
 	}
 

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -2,16 +2,12 @@ package size
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVariableToBytes(t *testing.T) {
-	filePath := "/tmp/size_test"
-	assert.NoError(t, os.RemoveAll(filePath))
-
+func TestGetApproxSize(t *testing.T) {
 	rowsData := make(map[string]interface{}) // pk -> { col -> val }
 	for i := 0; i < 500; i++ {
 		rowsData[fmt.Sprintf("key-%v", i)] = map[string]interface{}{
@@ -23,12 +19,9 @@ func TestVariableToBytes(t *testing.T) {
 		}
 	}
 
-	err := os.WriteFile(filePath, []byte(fmt.Sprint(rowsData)), os.ModePerm)
-	assert.NoError(t, err)
-
-	stat, err := os.Stat(filePath)
-	assert.NoError(t, err)
-
 	size := GetApproxSize(rowsData)
-	assert.Equal(t, int(stat.Size()), size)
+
+	// Check if size is non-zero and seems plausible
+	assert.NotZero(t, size, "Size should not be zero")
+	assert.Greater(t, size, 1000, "Size should be reasonably large for the given data structure")
 }


### PR DESCRIPTION
# TL;DR
![giphy](https://github.com/artie-labs/transfer/assets/4412200/bc02bc60-b7e2-49ff-a6cf-9e7f2c889ae3)

## Problem

Previously, we were encoding the values to be string and then calculating the number of bytes to approximate how large each row is.

For super wide tables, it was pretty slow and could take up to 20ms each time it was invoked.

## Change

Now, we are iterating over the row and then calculating each row by first inspecting the primitive type and if it's indeed a string, just count the number of bytes as opposed to serializing it out again.

## Results

```
BEFORE
cpu: VirtualApple @ 2.50GHz
BenchmarkGetApproxSize_TallTable-12    	    1604	   7524981 ns/op
BenchmarkGetApproxSize_WideTable-12    	     214	  54952219 ns/op

BenchmarkTableData_ApproxSize_TallTable-12    	 7741323	      1654 ns/op
BenchmarkTableData_ApproxSize_WideTable-12    	 1000000	     11223 ns/op

-----
AFTER
BenchmarkGetApproxSize_TallTable-12    	   35970	    333518 ns/op
BenchmarkGetApproxSize_WideTable-12    	     745	  15972217 ns/op

BenchmarkTableData_ApproxSize_TallTable-12    	19568608	       743.2 ns/op
BenchmarkTableData_ApproxSize_WideTable-12    	 2203387	      6018 ns/op
```

* After is 1.8x faster for wide tables (the bottom 2 tests)
* After is 2.2x faster for tall tables