### PR TITLE
Adding types for size.go

### DIFF
--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -5,13 +5,13 @@ import (
 )
 
 func GetApproxSize(value interface{}) int {
+	// We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal.
+	// We also chose not to use gob.NewEncoder because it does not work for all data types and had a huge computational overhead.
+	// Another plus here is that this will not error out.
 	if value == nil {
 		return 0
 	}
 
-	// We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal.
-	// We also chose not to use gob.NewEncoder because it does not work for all data types and had a huge computational overhead.
-	// Another plus here is that this will not error out.
 	switch v := value.(type) {
 	case string:
 		return len(v)
@@ -29,7 +29,7 @@ func GetApproxSize(value interface{}) int {
 		// int, uint are platform dependent - but to be safe, let's over approximate and assume 64-bit system
 		return 8
 	case complex128:
-		return 16 // Approximation for complex types
+		return 16
 	case map[string]interface{}:
 		var size int
 		for _, val := range v {

--- a/lib/size/size.go
+++ b/lib/size/size.go
@@ -5,6 +5,10 @@ import (
 )
 
 func GetApproxSize(value interface{}) int {
+	if value == nil {
+		return 0
+	}
+
 	// We chose not to use unsafe.SizeOf or reflect.Type.Size (both are akin) because they do not do recursive traversal.
 	// We also chose not to use gob.NewEncoder because it does not work for all data types and had a huge computational overhead.
 	// Another plus here is that this will not error out.
@@ -39,6 +43,12 @@ func GetApproxSize(value interface{}) int {
 		}
 		return size
 	case []string:
+		var size int
+		for _, val := range v {
+			size += GetApproxSize(val)
+		}
+		return size
+	case []interface{}:
 		var size int
 		for _, val := range v {
 			size += GetApproxSize(val)

--- a/lib/size/size_test.go
+++ b/lib/size/size_test.go
@@ -15,6 +15,7 @@ func TestGetApproxSize(t *testing.T) {
 			"artie":      "transfer",
 			"dusty":      "the mini aussie",
 			"next_puppy": true,
+			"foo":        []interface{}{"bar", "baz", "qux"},
 			"team":       []string{"charlie", "robin", "jacqueline"},
 			"arrays":     []string{"foo", "bar", "baz"},
 			"nested": map[string]interface{}{


### PR DESCRIPTION
Follow up to PR #238, adding 2 more types; `nil` and `[]interface{}`