### PR TITLE
Refactoring TableData ToFqName

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -37,7 +37,7 @@ type Store struct {
 func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.TableData) (*types.DwhTableConfig, error) {
 	return utils.GetTableConfig(ctx, utils.GetTableCfgArgs{
 		Dwh:       s,
-		FqName:    tableData.ToFqName(ctx, s.Label(), true, ""),
+		FqName:    tableData.ToFqName(ctx, s.Label(), true, s.projectID),
 		ConfigMap: s.configMap,
 		Query: fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';",
 			tableData.TopicConfig.Database, tableData.Name(ctx, nil)),

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -29,13 +29,15 @@ const (
 type Store struct {
 	configMap *types.DwhToTablesConfigMap
 	batchSize int
+	projectID string
+
 	db.Store
 }
 
 func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.TableData) (*types.DwhTableConfig, error) {
 	return utils.GetTableConfig(ctx, utils.GetTableCfgArgs{
 		Dwh:       s,
-		FqName:    tableData.ToFqName(ctx, s.Label(), true),
+		FqName:    tableData.ToFqName(ctx, s.Label(), true, ""),
 		ConfigMap: s.configMap,
 		Query: fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';",
 			tableData.TopicConfig.Database, tableData.Name(ctx, nil)),
@@ -89,6 +91,7 @@ func LoadBigQuery(ctx context.Context, _store *db.Store) *Store {
 		// Used for tests.
 		return &Store{
 			Store:     *_store,
+			projectID: "",
 			configMap: &types.DwhToTablesConfigMap{},
 		}
 	}
@@ -108,5 +111,6 @@ func LoadBigQuery(ctx context.Context, _store *db.Store) *Store {
 		Store:     db.Open(ctx, "bigquery", settings.Config.BigQuery.DSN()),
 		configMap: &types.DwhToTablesConfigMap{},
 		batchSize: settings.Config.BigQuery.BatchSize,
+		projectID: settings.Config.BigQuery.ProjectID,
 	}
 }

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -87,17 +87,17 @@ func (s *Store) PutTable(ctx context.Context, dataset, tableName string, rows []
 }
 
 func LoadBigQuery(ctx context.Context, _store *db.Store) *Store {
+	settings := config.FromContext(ctx)
+	settings.Config.BigQuery.LoadDefaultValues()
 	if _store != nil {
 		// Used for tests.
 		return &Store{
 			Store:     *_store,
-			projectID: "",
+			projectID: settings.Config.BigQuery.ProjectID,
 			configMap: &types.DwhToTablesConfigMap{},
 		}
 	}
 
-	settings := config.FromContext(ctx)
-	settings.Config.BigQuery.LoadDefaultValues()
 	if credPath := settings.Config.BigQuery.PathToCredentials; credPath != "" {
 		// If the credPath is set, let's set it into the env var.
 		logger.FromContext(ctx).Debug("writing the path to BQ credentials to env var for google auth")

--- a/clients/bigquery/bigquery_suite_test.go
+++ b/clients/bigquery/bigquery_suite_test.go
@@ -21,6 +21,11 @@ type BigQueryTestSuite struct {
 func (b *BigQueryTestSuite) SetupTest() {
 	b.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
 		VerboseLogging: false,
+		Config: &config.Config{
+			BigQuery: &config.BigQuery{
+				ProjectID: "artie",
+			},
+		},
 	})
 
 	b.fakeStore = &mocks.FakeStore{}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -115,10 +115,12 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	// Check if all the columns exist in BigQuery
 	srcKeysMissing, targetKeysMissing := columns.Diff(ctx, tableData.ReadOnlyInMemoryCols(),
 		tableConfig.Columns(), tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt)
+
+	tableName := tableData.ToFqName(ctx, s.Label(), true, s.projectID)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,
 		Tc:          tableConfig,
-		FqTableName: tableData.ToFqName(ctx, s.Label(), true),
+		FqTableName: tableName,
 		CreateTable: tableConfig.CreateTable(),
 		ColumnOp:    constants.Add,
 		CdcTime:     tableData.LatestCDCTs,
@@ -137,7 +139,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	deleteAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:                    s,
 		Tc:                     tableConfig,
-		FqTableName:            tableData.ToFqName(ctx, s.Label(), true),
+		FqTableName:            tableName,
 		CreateTable:            false,
 		ColumnOp:               constants.Delete,
 		ContainOtherOperations: tableData.ContainOtherOperations(),
@@ -159,7 +161,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	tempAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:            s,
 		Tc:             tableConfig,
-		FqTableName:    fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false), tableData.TempTableSuffix()),
+		FqTableName:    fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false, s.projectID), tableData.TempTableSuffix()),
 		CreateTable:    true,
 		TemporaryTable: true,
 		ColumnOp:       constants.Add,
@@ -178,7 +180,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 		var attempts int
 		for {
-			err = s.backfillColumn(ctx, col, tableData.ToFqName(ctx, s.Label(), true))
+			err = s.backfillColumn(ctx, col, tableName)
 			if err == nil {
 				tableConfig.Columns().UpsertColumn(col.Name(ctx, nil), columns.UpsertColumnArg{
 					Backfilled: ptr.ToBool(true),
@@ -206,10 +208,10 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		return err
 	}
 
-	tableName := fmt.Sprintf("%s_%s", tableData.Name(ctx, nil), tableData.TempTableSuffix())
-	err = s.PutTable(ctx, tableData.TopicConfig.Database, tableName, rows)
+	tempTableName := fmt.Sprintf("%s_%s", tableData.Name(ctx, nil), tableData.TempTableSuffix())
+	err = s.PutTable(ctx, tableData.TopicConfig.Database, tempTableName, rows)
 	if err != nil {
-		return fmt.Errorf("failed to insert into temp table: %s, error: %v", tableName, err)
+		return fmt.Errorf("failed to insert into temp table: %s, error: %v", tempTableName, err)
 	}
 
 	var additionalEqualityStrings []string
@@ -229,7 +231,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	mergeQuery, err := dml.MergeStatement(ctx, &dml.MergeArgument{
-		FqTableName:               tableData.ToFqName(ctx, constants.BigQuery, true),
+		FqTableName:               tableName,
 		AdditionalEqualityStrings: additionalEqualityStrings,
 		SubQuery:                  tempAlterTableArgs.FqTableName,
 		IdempotentKey:             tableData.TopicConfig.IdempotentKey,

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -82,7 +82,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 			continue
 		}
 
-		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true, ""))
+		err = utils.BackfillColumn(ctx, s, col, fqName)
 		if err != nil {
 			return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v", col.RawName(), col.RawDefaultValue(), err)
 		}

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -28,7 +28,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	log := logger.FromContext(ctx)
-	fqName := tableData.ToFqName(ctx, s.Label(), true)
+	fqName := tableData.ToFqName(ctx, s.Label(), true, "")
 	// Check if all the columns exist in Redshift
 	srcKeysMissing, targetKeysMissing := columns.Diff(ctx, tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
 		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt)
@@ -71,7 +71,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	tableData.MergeColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
 
 	// Temporary tables cannot specify schemas, so we just prefix it instead.
-	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false), tableData.TempTableSuffix())
+	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false, ""), tableData.TempTableSuffix())
 	if err = s.prepareTempTable(ctx, tableData, tableConfig, temporaryTableName); err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 			continue
 		}
 
-		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true))
+		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true, ""))
 		if err != nil {
 			defaultVal, _ := col.DefaultValue(ctx, nil)
 			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v",

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -57,7 +57,7 @@ func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.Tabl
 
 	return utils.GetTableConfig(ctx, utils.GetTableCfgArgs{
 		Dwh:                s,
-		FqName:             tableData.ToFqName(ctx, s.Label(), true),
+		FqName:             tableData.ToFqName(ctx, s.Label(), true, ""),
 		ConfigMap:          s.configMap,
 		Query:              describeQuery,
 		ColumnNameLabel:    describeNameCol,

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -51,7 +51,7 @@ func (s *Store) Label() constants.DestinationKind {
 // It will look like something like this:
 // > optionalPrefix/fullyQualifiedTableName/YYYY-MM-DD
 func (s *Store) ObjectPrefix(ctx context.Context, tableData *optimization.TableData) string {
-	fqTableName := tableData.ToFqName(ctx, s.Label(), false)
+	fqTableName := tableData.ToFqName(ctx, s.Label(), false, "")
 	yyyyMMDDFormat := tableData.LatestCDCTs.Format(ext.PostgresDateFormat)
 
 	if len(s.Settings.OptionalPrefix) > 0 {

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -64,7 +64,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		anotherCols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true),
+	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, ""),
 		types.NewDwhTableConfig(&anotherCols, nil, false, true))
 
 	err := s.stageStore.Merge(s.ctx, tableData)
@@ -110,7 +110,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		tableData.InsertRow(pk, row, false)
 	}
 
-	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true),
+	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, ""),
 		types.NewDwhTableConfig(&cols, nil, false, true))
 
 	s.fakeStageStore.ExecReturnsOnCall(0, nil, fmt.Errorf("390114: Authentication token has expired. The user must authenticate again."))
@@ -160,7 +160,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 
 	var idx int
 	for _, destKind := range []constants.DestinationKind{constants.Snowflake, constants.SnowflakeStages} {
-		fqName := tableData.ToFqName(s.ctx, destKind, true)
+		fqName := tableData.ToFqName(s.ctx, destKind, true, "")
 		s.stageStore.configMap.AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, true))
 		err := s.stageStore.Merge(s.ctx, tableData)
 		assert.Nil(s.T(), err)
@@ -244,7 +244,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 	sflkCols.AddColumn(columns.NewColumn("new", typing.String))
 	config := types.NewDwhTableConfig(&sflkCols, nil, false, true)
-	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true), config)
+	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, ""), config)
 
 	err := s.stageStore.Merge(s.ctx, tableData)
 	assert.Nil(s.T(), err)
@@ -252,10 +252,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	assert.Equal(s.T(), s.fakeStageStore.ExecCallCount(), 5, "called merge")
 
 	// Check the temp deletion table now.
-	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true)).ReadOnlyColumnsToDelete()), 1,
-		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true)).ReadOnlyColumnsToDelete())
+	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, "")).ReadOnlyColumnsToDelete()), 1,
+		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, "")).ReadOnlyColumnsToDelete())
 
-	_, isOk := s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true)).ReadOnlyColumnsToDelete()["new"]
+	_, isOk := s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, "")).ReadOnlyColumnsToDelete()["new"]
 	assert.True(s.T(), isOk)
 
 	// Now try to execute merge where 1 of the rows have the column now
@@ -276,8 +276,8 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	assert.Equal(s.T(), s.fakeStageStore.ExecCallCount(), 10, "called merge again")
 
 	// Caught up now, so columns should be 0.
-	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true)).ReadOnlyColumnsToDelete()), 0,
-		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true)).ReadOnlyColumnsToDelete())
+	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, "")).ReadOnlyColumnsToDelete()), 0,
+		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, "")).ReadOnlyColumnsToDelete())
 }
 
 func (s *SnowflakeTestSuite) TestExecuteMergeExitEarly() {

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -115,7 +115,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		return nil
 	}
 
-	fqName := tableData.ToFqName(ctx, constants.Snowflake, true, "")
+	fqName := tableData.ToFqName(ctx, s.Label(), true, "")
 	tableConfig, err := s.getTableConfig(ctx, fqName, tableData.TopicConfig.DropDeletedColumns)
 	if err != nil {
 		return err
@@ -173,7 +173,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 			continue
 		}
 
-		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true, ""))
+		err = utils.BackfillColumn(ctx, s, col, fqName)
 		if err != nil {
 			defaultVal, _ := col.DefaultValue(ctx, nil)
 			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v",

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -77,6 +77,8 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 		return err
 	}
 
+	// TODO: Early exit if cols is empty.
+
 	var mutateCol []columns.Column
 	// It's okay to combine since args.ColumnOp only takes one of: `Delete` or `Add`
 	var colSQLParts []string

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -77,7 +77,9 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 		return err
 	}
 
-	// TODO: Early exit if cols is empty.
+	if len(cols) == 0 {
+		return nil
+	}
 
 	var mutateCol []columns.Column
 	// It's okay to combine since args.ColumnOp only takes one of: `Delete` or `Add`

--- a/lib/destination/ddl/ddl_alter_delete_test.go
+++ b/lib/destination/ddl/ddl_alter_delete_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/config"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
 	"github.com/artie-labs/transfer/lib/destination/types"
@@ -29,9 +31,9 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	}, "tableName")
 
 	originalColumnLength := len(cols.GetColumns())
-	bqName := td.ToFqName(d.bqCtx, constants.BigQuery, true)
-	redshiftName := td.ToFqName(d.ctx, constants.Redshift, true)
-	snowflakeName := td.ToFqName(d.ctx, constants.Snowflake, true)
+	bqName := td.ToFqName(d.bqCtx, constants.BigQuery, true, config.FromContext(d.bqCtx).Config.BigQuery.ProjectID)
+	redshiftName := td.ToFqName(d.ctx, constants.Redshift, true, "")
+	snowflakeName := td.ToFqName(d.ctx, constants.Snowflake, true, "")
 
 	// Testing 3 scenarios here
 	// 1. DropDeletedColumns = false, ContainOtherOperations = true, don't delete ever.

--- a/lib/destination/ddl/ddl_bq_test.go
+++ b/lib/destination/ddl/ddl_bq_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/config"
+
 	artieSQL "github.com/artie-labs/transfer/lib/sql"
 
 	"github.com/artie-labs/transfer/lib/typing/columns"
@@ -42,7 +44,8 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	fqName := td.ToFqName(d.bqCtx, constants.BigQuery, true)
+	bqProjectID := config.FromContext(d.bqCtx).Config.BigQuery.ProjectID
+	fqName := td.ToFqName(d.bqCtx, constants.BigQuery, true, bqProjectID)
 	originalColumnLength := len(cols.GetColumns())
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, true))
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)
@@ -241,7 +244,8 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	fqName := td.ToFqName(d.bqCtx, constants.BigQuery, true)
+	bqProjectID := config.FromContext(d.bqCtx).Config.BigQuery.ProjectID
+	fqName := td.ToFqName(d.bqCtx, constants.BigQuery, true, bqProjectID)
 	originalColumnLength := len(columnNameToKindDetailsMap)
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, false))
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)

--- a/lib/destination/ddl/ddl_suite_test.go
+++ b/lib/destination/ddl/ddl_suite_test.go
@@ -54,7 +54,7 @@ func (d *DDLTestSuite) SetupTest() {
 
 	d.fakeBigQueryStore = &mocks.FakeStore{}
 	bqStore := db.Store(d.fakeBigQueryStore)
-	d.bigQueryStore = bigquery.LoadBigQuery(ctx, &bqStore)
+	d.bigQueryStore = bigquery.LoadBigQuery(d.bqCtx, &bqStore)
 
 	d.fakeSnowflakeStagesStore = &mocks.FakeStore{}
 	snowflakeStagesStore := db.Store(d.fakeSnowflakeStagesStore)

--- a/lib/destination/types/table_config.go
+++ b/lib/destination/types/table_config.go
@@ -80,9 +80,8 @@ func (d *DwhTableConfig) MutateInMemoryColumns(ctx context.Context, createTable 
 // AuditColumnsToDelete - will check its (*DwhTableConfig) columnsToDelete against `colsToDelete` and remove any columns that are not in `colsToDelete`.
 // `colsToDelete` is derived from diffing the destination and source (if destination has extra columns)
 func (d *DwhTableConfig) AuditColumnsToDelete(ctx context.Context, colsToDelete []columns.Column) {
-	if !d.dropDeletedColumns || len(colsToDelete) == 0 {
+	if !d.dropDeletedColumns {
 		// If `dropDeletedColumns` is false, then let's skip this.
-		// Or if there are no `colsToDelete` then let's also skip this since for-loop won't run.
 		return
 	}
 

--- a/lib/destination/types/table_config.go
+++ b/lib/destination/types/table_config.go
@@ -80,7 +80,7 @@ func (d *DwhTableConfig) MutateInMemoryColumns(ctx context.Context, createTable 
 // AuditColumnsToDelete - will check its (*DwhTableConfig) columnsToDelete against `colsToDelete` and remove any columns that are not in `colsToDelete`.
 // `colsToDelete` is derived from diffing the destination and source (if destination has extra columns)
 func (d *DwhTableConfig) AuditColumnsToDelete(ctx context.Context, colsToDelete []columns.Column) {
-	if !d.dropDeletedColumns {
+	if !d.dropDeletedColumns || len(colsToDelete) == 0 {
 		// If `dropDeletedColumns` is false, then let's skip this.
 		return
 	}

--- a/lib/destination/types/table_config.go
+++ b/lib/destination/types/table_config.go
@@ -82,6 +82,7 @@ func (d *DwhTableConfig) MutateInMemoryColumns(ctx context.Context, createTable 
 func (d *DwhTableConfig) AuditColumnsToDelete(ctx context.Context, colsToDelete []columns.Column) {
 	if !d.dropDeletedColumns || len(colsToDelete) == 0 {
 		// If `dropDeletedColumns` is false, then let's skip this.
+		// Or if there are no `colsToDelete` then let's also skip this since for-loop won't run.
 		return
 	}
 

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -140,7 +140,7 @@ func (t *TableData) RowsData() map[string]map[string]interface{} {
 	return _rowsData
 }
 
-func (t *TableData) ToFqName(ctx context.Context, kind constants.DestinationKind, escape bool) string {
+func (t *TableData) ToFqName(ctx context.Context, kind constants.DestinationKind, escape bool, bigQueryProjectID string) string {
 	switch kind {
 	case constants.S3:
 		// S3 should be db.schema.tableName, but we don't need to escape, since it's not a SQL db.
@@ -157,7 +157,7 @@ func (t *TableData) ToFqName(ctx context.Context, kind constants.DestinationKind
 		}))
 	case constants.BigQuery:
 		// The fully qualified name for BigQuery is: project_id.dataset.tableName.
-		return fmt.Sprintf("%s.%s.%s", config.FromContext(ctx).Config.BigQuery.ProjectID, t.TopicConfig.Database, t.Name(ctx, &sql.NameArgs{
+		return fmt.Sprintf("%s.%s.%s", bigQueryProjectID, t.TopicConfig.Database, t.Name(ctx, &sql.NameArgs{
 			Escape:   escape,
 			DestKind: kind,
 		}))

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -157,10 +157,11 @@ func (o *OptimizationTestSuite) TestNewTableData_TableName() {
 		},
 	}
 
+	bqProjectID := "artie"
 	ctx := config.InjectSettingsIntoContext(context.Background(), &config.Settings{
 		Config: &config.Config{
 			BigQuery: &config.BigQuery{
-				ProjectID: "artie",
+				ProjectID: bqProjectID,
 			},
 		},
 	})
@@ -173,14 +174,14 @@ func (o *OptimizationTestSuite) TestNewTableData_TableName() {
 		}, testCase.tableName)
 		assert.Equal(o.T(), testCase.expectedName, td.Name(o.ctx, nil), testCase.name)
 		assert.Equal(o.T(), testCase.expectedName, td.name, testCase.name)
-		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.SnowflakeStages, true), testCase.name)
-		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.Snowflake, true), testCase.name)
-		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true), testCase.name)
-		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true), testCase.name)
+		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.SnowflakeStages, true, ""), testCase.name)
+		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.Snowflake, true, ""), testCase.name)
+		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true, bqProjectID), testCase.name)
+		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true, bqProjectID), testCase.name)
 
 		// S3 does not escape, so let's test both to make sure.
-		assert.Equal(o.T(), testCase.expectedS3FqName, td.ToFqName(ctx, constants.S3, true), testCase.name)
-		assert.Equal(o.T(), testCase.expectedS3FqName, td.ToFqName(ctx, constants.S3, false), testCase.name)
+		assert.Equal(o.T(), testCase.expectedS3FqName, td.ToFqName(ctx, constants.S3, true, ""), testCase.name)
+		assert.Equal(o.T(), testCase.expectedS3FqName, td.ToFqName(ctx, constants.S3, false, ""), testCase.name)
 	}
 }
 


### PR DESCRIPTION
## Changes

* Refactoring `tableData.ToFqName(...)` to accept another `bigQueryProjectID (if exists)`. Doing this as a pre-cursor to the larger body of work to remove `context` from the typing library.
* Change `ddl.AlterTable` to early exit if there are no columns to alter to improve readability 