### PR TITLE
[Refactor] Adding RawValue functions

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -38,7 +38,7 @@ func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.Tabl
 		FqName:    tableData.ToFqName(ctx, s.Label(), true),
 		ConfigMap: s.configMap,
 		Query: fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';",
-			tableData.TopicConfig.Database, tableData.Name(ctx, nil)),
+			tableData.TopicConfig.Database, tableData.RawName()),
 		ColumnNameLabel:    describeNameCol,
 		ColumnTypeLabel:    describeTypeCol,
 		ColumnDescLabel:    describeCommentCol,

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -113,7 +113,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in BigQuery
-	srcKeysMissing, targetKeysMissing := columns.Diff(ctx, tableData.ReadOnlyInMemoryCols(),
+	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(),
 		tableConfig.Columns(), tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -191,8 +191,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 				attempts += 1
 				time.Sleep(time.Duration(jitter.JitterMs(1500, attempts)) * time.Millisecond)
 			} else {
-				return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v",
-					col.RawName(), col.RawDefaultValue(), err)
+				return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v", col.RawName(), col.RawDefaultValue(), err)
 			}
 		}
 

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -150,7 +150,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		return err
 	}
 
-	tableConfig.AuditColumnsToDelete(ctx, srcKeysMissing)
+	tableConfig.AuditColumnsToDelete(srcKeysMissing)
 
 	// Infer the right data types from BigQuery before temp table creation.
 	tableData.MergeColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
@@ -191,9 +191,8 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 				attempts += 1
 				time.Sleep(time.Duration(jitter.JitterMs(1500, attempts)) * time.Millisecond)
 			} else {
-				defaultVal, _ := col.DefaultValue(ctx, nil)
 				return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v",
-					col.Name(ctx, nil), defaultVal, err)
+					col.Name(ctx, nil), col.RawDefaultValue(), err)
 			}
 		}
 

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -153,7 +153,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	tableConfig.AuditColumnsToDelete(srcKeysMissing)
 
 	// Infer the right data types from BigQuery before temp table creation.
-	tableData.MergeColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
+	tableData.MergeColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 
 	// Start temporary table creation
 	tempAlterTableArgs := ddl.AlterTableArgs{

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -82,7 +82,7 @@ func (s *Store) backfillColumn(ctx context.Context, column columns.Column, fqTab
 		fqTableName, escapedCol, defaultVal, escapedCol)
 
 	logger.FromContext(ctx).WithFields(map[string]interface{}{
-		"colName": column.Name(ctx, nil),
+		"colName": column.RawName(),
 		"query":   query,
 		"table":   fqTableName,
 	}).Info("backfilling column")
@@ -180,7 +180,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		for {
 			err = s.backfillColumn(ctx, col, tableData.ToFqName(ctx, s.Label(), true))
 			if err == nil {
-				tableConfig.Columns().UpsertColumn(col.Name(ctx, nil), columns.UpsertColumnArg{
+				tableConfig.Columns().UpsertColumn(col.RawName(), columns.UpsertColumnArg{
 					Backfilled: ptr.ToBool(true),
 				})
 				break
@@ -192,7 +192,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 				time.Sleep(time.Duration(jitter.JitterMs(1500, attempts)) * time.Millisecond)
 			} else {
 				return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v",
-					col.Name(ctx, nil), col.RawDefaultValue(), err)
+					col.RawName(), col.RawDefaultValue(), err)
 			}
 		}
 
@@ -205,7 +205,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		return err
 	}
 
-	tableName := fmt.Sprintf("%s_%s", tableData.Name(ctx, nil), tableData.TempTableSuffix())
+	tableName := fmt.Sprintf("%s_%s", tableData.RawName(), tableData.TempTableSuffix())
 	err = s.PutTable(ctx, tableData.TopicConfig.Database, tableName, rows)
 	if err != nil {
 		return fmt.Errorf("failed to insert into temp table: %s, error: %v", tableName, err)

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -84,7 +84,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true))
 		if err != nil {
-			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v", col.RawName(), col.RawDefaultValue(), err)
+			return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v", col.RawName(), col.RawDefaultValue(), err)
 		}
 
 		tableConfig.Columns().UpsertColumn(col.RawName(), columns.UpsertColumnArg{

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -68,7 +68,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	tableConfig.AuditColumnsToDelete(srcKeysMissing)
-	tableData.MergeColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
+	tableData.MergeColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 
 	// Temporary tables cannot specify schemas, so we just prefix it instead.
 	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false), tableData.TempTableSuffix())

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -87,7 +87,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v", col.RawName(), col.RawDefaultValue(), err)
 		}
 
-		tableConfig.Columns().UpsertColumn(col.Name(ctx, nil), columns.UpsertColumnArg{
+		tableConfig.Columns().UpsertColumn(col.RawName(), columns.UpsertColumnArg{
 			Backfilled: ptr.ToBool(true),
 		})
 	}

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -30,7 +30,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	log := logger.FromContext(ctx)
 	fqName := tableData.ToFqName(ctx, s.Label(), true)
 	// Check if all the columns exist in Redshift
-	srcKeysMissing, targetKeysMissing := columns.Diff(ctx, tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
+	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
 		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -67,7 +67,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		return err
 	}
 
-	tableConfig.AuditColumnsToDelete(ctx, srcKeysMissing)
+	tableConfig.AuditColumnsToDelete(srcKeysMissing)
 	tableData.MergeColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
 
 	// Temporary tables cannot specify schemas, so we just prefix it instead.
@@ -84,9 +84,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true))
 		if err != nil {
-			defaultVal, _ := col.DefaultValue(ctx, nil)
-			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v",
-				col.Name(ctx, nil), defaultVal, err)
+			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v", col.RawName(), col.RawDefaultValue(), err)
 		}
 
 		tableConfig.Columns().UpsertColumn(col.Name(ctx, nil), columns.UpsertColumnArg{

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -47,7 +47,7 @@ const (
 
 func (s *Store) getTableConfig(ctx context.Context, tableData *optimization.TableData) (*types.DwhTableConfig, error) {
 	describeQuery, err := describeTableQuery(describeArgs{
-		RawTableName: tableData.Name(ctx, nil),
+		RawTableName: tableData.RawName(),
 		Schema:       tableData.TopicConfig.Schema,
 	})
 

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -41,7 +41,7 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(fqName).ReadOnlyColumnsToDelete()), 1)
 
 	// Now let's try to add this column back, it should delete it from the cache.
-	tc.MutateInMemoryColumns(s.ctx, false, constants.Add, nameCol)
+	tc.MutateInMemoryColumns(false, constants.Add, nameCol)
 	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(fqName).ReadOnlyColumnsToDelete()), 0)
 }
 

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -36,7 +36,7 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 	nameCol := columns.NewColumn("name", typing.String)
 	tc := s.stageStore.configMap.TableConfig(fqName)
 
-	val := tc.ShouldDeleteColumn(s.ctx, nameCol.Name(s.ctx, nil), time.Now().Add(-1*6*time.Hour), true)
+	val := tc.ShouldDeleteColumn(s.ctx, nameCol.RawName(), time.Now().Add(-1*6*time.Hour), true)
 	assert.False(s.T(), val, "should not try to delete this column")
 	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(fqName).ReadOnlyColumnsToDelete()), 1)
 
@@ -63,23 +63,23 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 
 	nameCol := columns.NewColumn("name", typing.String)
 	// Let's try to delete name.
-	allowed := s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(s.ctx, nil),
+	allowed := s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.RawName(),
 		time.Now().Add(-1*(6*time.Hour)), true)
 
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete")
 
 	// Process tried to delete, but it's lagged.
-	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(s.ctx, nil),
+	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.RawName(),
 		time.Now().Add(-1*(6*time.Hour)), true)
 
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete")
 
 	// Process now caught up, and is asking if we can delete, should still be no.
-	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(s.ctx, nil), time.Now(), true)
+	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.RawName(), time.Now(), true)
 	assert.Equal(s.T(), allowed, false, "should not be allowed to delete still")
 
 	// Process is finally ahead, has permission to delete now.
-	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.Name(s.ctx, nil),
+	allowed = s.stageStore.configMap.TableConfig(fqName).ShouldDeleteColumn(s.ctx, nameCol.RawName(),
 		time.Now().Add(2*constants.DeletionConfidencePadding), true)
 
 	assert.Equal(s.T(), allowed, true, "should now be allowed to delete")

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -47,7 +47,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	}
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
-	assert.Equal(s.T(), topicConfig.TableName, tableData.Name(s.ctx, nil), "override is working")
+	assert.Equal(s.T(), topicConfig.TableName, tableData.RawName(), "override is working")
 
 	for pk, row := range rowsData {
 		tableData.InsertRow(pk, row, false)

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -160,7 +160,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		return err
 	}
 
-	tableConfig.AuditColumnsToDelete(ctx, srcKeysMissing)
+	tableConfig.AuditColumnsToDelete(srcKeysMissing)
 	tableData.MergeColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
 	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false), tableData.TempTableSuffix())
 	if err = s.prepareTempTable(ctx, tableData, tableConfig, temporaryTableName); err != nil {
@@ -175,12 +175,10 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 
 		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true))
 		if err != nil {
-			defaultVal, _ := col.DefaultValue(ctx, nil)
-			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v",
-				col.Name(ctx, nil), defaultVal, err)
+			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v", col.RawName(), col.RawDefaultValue(), err)
 		}
 
-		tableConfig.Columns().UpsertColumn(col.Name(ctx, nil), columns.UpsertColumnArg{
+		tableConfig.Columns().UpsertColumn(col.RawName(), columns.UpsertColumnArg{
 			Backfilled: ptr.ToBool(true),
 		})
 	}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -175,7 +175,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 
 		err = utils.BackfillColumn(ctx, s, col, tableData.ToFqName(ctx, s.Label(), true))
 		if err != nil {
-			return fmt.Errorf("failed to backfill col: %v, default value: %v, error: %v", col.RawName(), col.RawDefaultValue(), err)
+			return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v", col.RawName(), col.RawDefaultValue(), err)
 		}
 
 		tableConfig.Columns().UpsertColumn(col.RawName(), columns.UpsertColumnArg{

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -123,7 +123,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 
 	log := logger.FromContext(ctx)
 	// Check if all the columns exist in Snowflake
-	srcKeysMissing, targetKeysMissing := columns.Diff(ctx, tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
+	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
 		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:         s,

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -161,7 +161,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 	}
 
 	tableConfig.AuditColumnsToDelete(srcKeysMissing)
-	tableData.MergeColumnsFromDestination(ctx, tableConfig.Columns().GetColumns()...)
+	tableData.MergeColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false), tableData.TempTableSuffix())
 	if err = s.prepareTempTable(ctx, tableData, tableConfig, temporaryTableName); err != nil {
 		return err

--- a/clients/utils/utils.go
+++ b/clients/utils/utils.go
@@ -37,7 +37,7 @@ func BackfillColumn(ctx context.Context, dwh destination.DataWarehouse, column c
 		fqTableName, escapedCol, defaultVal, escapedCol,
 	)
 	logger.FromContext(ctx).WithFields(map[string]interface{}{
-		"colName": column.Name(ctx, nil),
+		"colName": column.RawName(),
 		"query":   query,
 		"table":   fqTableName,
 	}).Info("backfilling column")

--- a/lib/cdc/mysql/debezium_test.go
+++ b/lib/cdc/mysql/debezium_test.go
@@ -320,14 +320,14 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 
 	col, isOk := cols.GetColumn("abcdef")
 	assert.True(m.T(), isOk)
-	assert.Equal(m.T(), "abcdef", col.Name(m.ctx, nil))
+	assert.Equal(m.T(), "abcdef", col.RawName())
 	for key := range evtData {
 		if strings.Contains(key, constants.ArtiePrefix) {
 			continue
 		}
 
-		col, isOk := cols.GetColumn(strings.ToLower(key))
+		col, isOk = cols.GetColumn(strings.ToLower(key))
 		assert.Equal(m.T(), true, isOk, key)
-		assert.Equal(m.T(), typing.Invalid, col.KindDetails, fmt.Sprintf("colName: %v, evtData key: %v", col.Name(m.ctx, nil), key))
+		assert.Equal(m.T(), typing.Invalid, col.KindDetails, fmt.Sprintf("colName: %v, evtData key: %v", col.RawName(), key))
 	}
 }

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -67,17 +67,12 @@ func (u *UtilTestSuite) TestSource_GetOptionalSchema() {
 
 	col, isOk := cols.GetColumn("boolean_column")
 	assert.True(u.T(), isOk)
-
-	defaultVal, err := col.DefaultValue(u.ctx, nil)
-	assert.NoError(u.T(), err)
-	assert.Equal(u.T(), false, defaultVal)
+	assert.Equal(u.T(), false, col.RawDefaultValue())
 
 	for _, _col := range cols.GetColumns() {
 		// All the other columns do not have a default value.
-		if _col.Name(u.ctx, nil) != "boolean_column" {
-			defaultVal, err = _col.DefaultValue(u.ctx, nil)
-			assert.NoError(u.T(), err)
-			assert.Nil(u.T(), defaultVal, _col.Name(u.ctx, nil))
+		if _col.RawName() != "boolean_column" {
+			assert.Nil(u.T(), _col.RawDefaultValue(), _col.RawName())
 		}
 	}
 }

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -157,7 +157,7 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 
 	if err == nil {
 		// createTable = false since it all successfully updated.
-		args.Tc.MutateInMemoryColumns(ctx, false, args.ColumnOp, mutateCol...)
+		args.Tc.MutateInMemoryColumns(false, args.ColumnOp, mutateCol...)
 	}
 
 	return nil

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -87,7 +87,7 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 		}
 
 		if args.ColumnOp == constants.Delete {
-			if !args.Tc.ShouldDeleteColumn(ctx, col.Name(ctx, nil), args.CdcTime, args.ContainOtherOperations) {
+			if !args.Tc.ShouldDeleteColumn(ctx, col.RawName(), args.CdcTime, args.ContainOtherOperations) {
 				continue
 			}
 		}

--- a/lib/destination/ddl/ddl_bq_test.go
+++ b/lib/destination/ddl/ddl_bq_test.go
@@ -157,10 +157,10 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 	assert.Equal(d.T(), newColsLen+existingColsLen, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns())
 	// Check by iterating over the columns
 	for _, column := range d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns() {
-		existingCol, isOk := existingCols.GetColumn(column.Name(d.ctx, nil))
+		existingCol, isOk := existingCols.GetColumn(column.RawName())
 		if !isOk {
 			// Check new cols?
-			existingCol.KindDetails, isOk = newCols[column.Name(d.ctx, nil)]
+			existingCol.KindDetails, isOk = newCols[column.RawName()]
 		}
 
 		assert.True(d.T(), isOk)
@@ -216,7 +216,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 	assert.Equal(d.T(), existingColsLen, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns())
 	// Check by iterating over the columns
 	for _, column := range d.bigQueryStore.GetConfigMap().TableConfig(fqName).Columns().GetColumns() {
-		existingCol, isOk := existingCols.GetColumn(column.Name(d.ctx, nil))
+		existingCol, isOk := existingCols.GetColumn(column.RawName())
 		assert.True(d.T(), isOk)
 		assert.Equal(d.T(), column.KindDetails, existingCol.KindDetails)
 	}

--- a/lib/destination/ddl/ddl_sflk_test.go
+++ b/lib/destination/ddl/ddl_sflk_test.go
@@ -112,15 +112,15 @@ func (d *DDLTestSuite) TestAlterTableAdd() {
 	for _, column := range tableConfig.Columns().GetColumns() {
 		var found bool
 		for _, expCol := range cols {
-			if found = column.Name(d.ctx, nil) == expCol.Name(d.ctx, nil); found {
-				assert.Equal(d.T(), column.KindDetails, expCol.KindDetails, fmt.Sprintf("wrong col kind, col: %s", column.Name(d.ctx, nil)))
+			if found = column.RawName() == expCol.RawName(); found {
+				assert.Equal(d.T(), column.KindDetails, expCol.KindDetails, fmt.Sprintf("wrong col kind, col: %s", column.RawName()))
 				break
 			}
 		}
 
 		assert.True(d.T(), found,
 			fmt.Sprintf("Col not found: %s, actual list: %v, expected list: %v",
-				column.Name(d.ctx, nil), tableConfig.Columns(), cols))
+				column.RawName(), tableConfig.Columns(), cols))
 	}
 }
 
@@ -153,7 +153,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	for col := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, expCol := range cols {
-			if found = col == expCol.Name(d.ctx, nil); found {
+			if found = col == expCol.RawName(); found {
 				break
 			}
 		}
@@ -164,7 +164,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	}
 
 	for i := 0; i < len(cols); i++ {
-		colToActuallyDelete := cols[i].Name(d.ctx, nil)
+		colToActuallyDelete := cols[i].RawName()
 		// Now let's check the timestamp
 		assert.True(d.T(), tableConfig.ReadOnlyColumnsToDelete()[colToActuallyDelete].After(time.Now()))
 		// Now let's actually try to dial the time back, and it should actually try to delete.
@@ -220,7 +220,7 @@ func (d *DDLTestSuite) TestAlterTableDelete() {
 	for col := range tableConfig.ReadOnlyColumnsToDelete() {
 		var found bool
 		for _, expCol := range cols {
-			if found = col == expCol.Name(d.ctx, nil); found {
+			if found = col == expCol.RawName(); found {
 				break
 			}
 		}

--- a/lib/destination/types/table_config.go
+++ b/lib/destination/types/table_config.go
@@ -56,7 +56,7 @@ func (d *DwhTableConfig) Columns() *columns.Columns {
 	return d.columns
 }
 
-func (d *DwhTableConfig) MutateInMemoryColumns(ctx context.Context, createTable bool, columnOp constants.ColumnOperation, cols ...columns.Column) {
+func (d *DwhTableConfig) MutateInMemoryColumns(createTable bool, columnOp constants.ColumnOperation, cols ...columns.Column) {
 	d.Lock()
 	defer d.Unlock()
 	switch columnOp {
@@ -64,22 +64,22 @@ func (d *DwhTableConfig) MutateInMemoryColumns(ctx context.Context, createTable 
 		for _, col := range cols {
 			d.columns.AddColumn(col)
 			// Delete from the permissions table, if exists.
-			delete(d.columnsToDelete, col.Name(ctx, nil))
+			delete(d.columnsToDelete, col.RawName())
 		}
 
 		d.createTable = createTable
 	case constants.Delete:
 		for _, col := range cols {
 			// Delete from the permissions and in-memory table
-			d.columns.DeleteColumn(col.Name(ctx, nil))
-			delete(d.columnsToDelete, col.Name(ctx, nil))
+			d.columns.DeleteColumn(col.RawName())
+			delete(d.columnsToDelete, col.RawName())
 		}
 	}
 }
 
 // AuditColumnsToDelete - will check its (*DwhTableConfig) columnsToDelete against `colsToDelete` and remove any columns that are not in `colsToDelete`.
 // `colsToDelete` is derived from diffing the destination and source (if destination has extra columns)
-func (d *DwhTableConfig) AuditColumnsToDelete(ctx context.Context, colsToDelete []columns.Column) {
+func (d *DwhTableConfig) AuditColumnsToDelete(colsToDelete []columns.Column) {
 	if !d.dropDeletedColumns {
 		// If `dropDeletedColumns` is false, then let's skip this.
 		return
@@ -91,7 +91,7 @@ func (d *DwhTableConfig) AuditColumnsToDelete(ctx context.Context, colsToDelete 
 	for colName := range d.columnsToDelete {
 		var found bool
 		for _, col := range colsToDelete {
-			if found = col.Name(ctx, nil) == colName; found {
+			if found = col.RawName() == colName; found {
 				break
 			}
 		}

--- a/lib/destination/types/table_config_test.go
+++ b/lib/destination/types/table_config_test.go
@@ -86,7 +86,7 @@ func TestDwhTableConfig_ColumnsConcurrency(t *testing.T) {
 func (t *TypesTestSuite) TestDwhTableConfig_MutateInMemoryColumns() {
 	tc := NewDwhTableConfig(&columns.Columns{}, nil, false, false)
 	for _, col := range []string{"a", "b", "c", "d", "e"} {
-		tc.MutateInMemoryColumns(t.ctx, false, constants.Add, columns.NewColumn(col, typing.String))
+		tc.MutateInMemoryColumns(false, constants.Add, columns.NewColumn(col, typing.String))
 	}
 
 	assert.Equal(t.T(), 5, len(tc.columns.GetColumns()))
@@ -95,7 +95,7 @@ func (t *TypesTestSuite) TestDwhTableConfig_MutateInMemoryColumns() {
 		wg.Add(1)
 		go func(colName string) {
 			defer wg.Done()
-			tc.MutateInMemoryColumns(t.ctx, false, constants.Add, columns.NewColumn(colName, typing.String))
+			tc.MutateInMemoryColumns(false, constants.Add, columns.NewColumn(colName, typing.String))
 		}(addCol)
 	}
 
@@ -103,7 +103,7 @@ func (t *TypesTestSuite) TestDwhTableConfig_MutateInMemoryColumns() {
 		wg.Add(1)
 		go func(colName string) {
 			defer wg.Done()
-			tc.MutateInMemoryColumns(t.ctx, false, constants.Delete, columns.NewColumn(colName, typing.Invalid))
+			tc.MutateInMemoryColumns(false, constants.Delete, columns.NewColumn(colName, typing.Invalid))
 		}(removeCol)
 	}
 
@@ -169,7 +169,7 @@ func (t *TypesTestSuite) TestAuditColumnsToDelete() {
 			cols = append(cols, columns.NewColumn(colToDelete, typing.String))
 		}
 
-		dwhTc.AuditColumnsToDelete(t.ctx, cols)
+		dwhTc.AuditColumnsToDelete(cols)
 		var actualCols []string
 		for col := range dwhTc.ReadOnlyColumnsToDelete() {
 			actualCols = append(actualCols, col)

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -235,7 +235,8 @@ func (t *TableData) ShouldFlush(ctx context.Context) (bool, string) {
 // Prior to merging, we will need to treat `tableConfig` as the source-of-truth and whenever there's discrepancies
 // We will prioritize using the values coming from (2) TableConfig. We also cannot simply do a replacement, as we have in-memory columns
 // That carry metadata for Artie Transfer. They are prefixed with __artie.
-func (t *TableData) MergeColumnsFromDestination(ctx context.Context, destCols ...columns.Column) {
+func (t *TableData) MergeColumnsFromDestination(destCols ...columns.Column) {
+	// TODO: Should add an early exit for when `destCols` is empty
 	if t == nil {
 		return
 	}
@@ -244,7 +245,7 @@ func (t *TableData) MergeColumnsFromDestination(ctx context.Context, destCols ..
 		var foundColumn columns.Column
 		var found bool
 		for _, destCol := range destCols {
-			if destCol.Name(ctx, nil) == strings.ToLower(inMemoryCol.Name(ctx, nil)) {
+			if destCol.RawName() == strings.ToLower(inMemoryCol.RawName()) {
 				foundColumn = destCol
 				found = true
 				break

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -60,6 +60,10 @@ func (t *TableData) PrimaryKeys(ctx context.Context, args *sql.NameArgs) []colum
 	return primaryKeysEscaped
 }
 
+func (t *TableData) RawName() string {
+	return t.name
+}
+
 func (t *TableData) Name(ctx context.Context, args *sql.NameArgs) string {
 	return sql.EscapeName(ctx, t.name, args)
 }

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -171,7 +171,7 @@ func (o *OptimizationTestSuite) TestNewTableData_TableName() {
 			TableName: testCase.overrideName,
 			Schema:    testCase.schema,
 		}, testCase.tableName)
-		assert.Equal(o.T(), testCase.expectedName, td.Name(o.ctx, nil), testCase.name)
+		assert.Equal(o.T(), testCase.expectedName, td.RawName(), testCase.name)
 		assert.Equal(o.T(), testCase.expectedName, td.name, testCase.name)
 		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.SnowflakeStages, true), testCase.name)
 		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.Snowflake, true), testCase.name)
@@ -220,7 +220,7 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumns() {
 	assert.True(o.T(), isOk)
 
 	extCol.KindDetails.ExtendedTimeDetails.Format = time.RFC3339Nano
-	tableData.inMemoryColumns.UpdateColumn(columns.NewColumn(extCol.Name(o.ctx, nil), extCol.KindDetails))
+	tableData.inMemoryColumns.UpdateColumn(columns.NewColumn(extCol.RawName(), extCol.KindDetails))
 
 	for name, colKindDetails := range map[string]typing.KindDetails{
 		"foo":                  typing.String,

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -228,7 +228,7 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumns() {
 		"bar":                  typing.Boolean,
 		"do_not_change_format": typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
 	} {
-		tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn(name, colKindDetails))
+		tableData.MergeColumnsFromDestination(columns.NewColumn(name, colKindDetails))
 	}
 
 	// It's saved back in the original format.

--- a/lib/optimization/event_update_test.go
+++ b/lib/optimization/event_update_test.go
@@ -41,36 +41,36 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 	}
 
 	// Testing to make sure we don't copy over non-existent columns
-	tableData.MergeColumnsFromDestination(o.ctx, nonExistentCols...)
+	tableData.MergeColumnsFromDestination(nonExistentCols...)
 	for _, nonExistentTableCol := range nonExistentTableCols {
 		_, isOk := tableData.inMemoryColumns.GetColumn(nonExistentTableCol)
 		assert.False(o.T(), isOk, nonExistentTableCol)
 	}
 
 	// Making sure it's still numeric
-	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("numeric_test", typing.Integer))
+	tableData.MergeColumnsFromDestination(columns.NewColumn("numeric_test", typing.Integer))
 	numericCol, isOk := tableData.inMemoryColumns.GetColumn("numeric_test")
 	assert.True(o.T(), isOk)
 	assert.Equal(o.T(), typing.EDecimal.Kind, numericCol.KindDetails.Kind, "numeric_test")
 
 	// Testing to make sure we're copying the kindDetails over.
-	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("prev_invalid", typing.String))
+	tableData.MergeColumnsFromDestination(columns.NewColumn("prev_invalid", typing.String))
 	prevInvalidCol, isOk := tableData.inMemoryColumns.GetColumn("prev_invalid")
 	assert.True(o.T(), isOk)
 	assert.Equal(o.T(), typing.String, prevInvalidCol.KindDetails)
 
 	// Testing backfill
 	for _, inMemoryCol := range tableData.inMemoryColumns.GetColumns() {
-		assert.False(o.T(), inMemoryCol.Backfilled(), inMemoryCol.Name(o.ctx, nil))
+		assert.False(o.T(), inMemoryCol.Backfilled(), inMemoryCol.RawName())
 	}
 	backfilledCol := columns.NewColumn("bool_backfill", typing.Boolean)
 	backfilledCol.SetBackfilled(true)
-	tableData.MergeColumnsFromDestination(o.ctx, backfilledCol)
+	tableData.MergeColumnsFromDestination(backfilledCol)
 	for _, inMemoryCol := range tableData.inMemoryColumns.GetColumns() {
-		if inMemoryCol.Name(o.ctx, nil) == backfilledCol.Name(o.ctx, nil) {
-			assert.True(o.T(), inMemoryCol.Backfilled(), inMemoryCol.Name(o.ctx, nil))
+		if inMemoryCol.RawName() == backfilledCol.RawName() {
+			assert.True(o.T(), inMemoryCol.Backfilled(), inMemoryCol.RawName())
 		} else {
-			assert.False(o.T(), inMemoryCol.Backfilled(), inMemoryCol.Name(o.ctx, nil))
+			assert.False(o.T(), inMemoryCol.Backfilled(), inMemoryCol.RawName())
 		}
 	}
 
@@ -82,9 +82,9 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 		assert.Nil(o.T(), col.KindDetails.ExtendedTimeDetails, extTimeDetailsCol)
 	}
 
-	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("ext_time", typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType)))
-	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("ext_date", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType)))
-	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("ext_datetime", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)))
+	tableData.MergeColumnsFromDestination(columns.NewColumn("ext_time", typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType)))
+	tableData.MergeColumnsFromDestination(columns.NewColumn("ext_date", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType)))
+	tableData.MergeColumnsFromDestination(columns.NewColumn("ext_datetime", typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)))
 
 	dateCol, isOk := tableData.inMemoryColumns.GetColumn("ext_date")
 	assert.True(o.T(), isOk)
@@ -109,7 +109,7 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 
 	extDecimal := typing.EDecimal
 	extDecimal.ExtendedDecimalDetails = decimal.NewDecimal(2, ptr.ToInt(30), nil)
-	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("ext_dec", extDecimal))
+	tableData.MergeColumnsFromDestination(columns.NewColumn("ext_dec", extDecimal))
 	// Now it should be ext decimal type
 	extDecCol, isOk = tableData.inMemoryColumns.GetColumn("ext_dec")
 	assert.True(o.T(), isOk)
@@ -126,7 +126,7 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 	assert.Equal(o.T(), 22, *extDecColFilled.KindDetails.ExtendedDecimalDetails.Precision())
 	assert.Equal(o.T(), 2, extDecColFilled.KindDetails.ExtendedDecimalDetails.Scale())
 
-	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn("ext_dec_filled", extDecimal))
+	tableData.MergeColumnsFromDestination(columns.NewColumn("ext_dec_filled", extDecimal))
 	extDecColFilled, isOk = tableData.inMemoryColumns.GetColumn("ext_dec_filled")
 	assert.True(o.T(), isOk)
 	assert.Equal(o.T(), typing.EDecimal.Kind, extDecColFilled.KindDetails.Kind)
@@ -139,7 +139,7 @@ func (o *OptimizationTestSuite) TestTableData_UpdateInMemoryColumnsFromDestinati
 		Kind:                         typing.String.Kind,
 		OptionalRedshiftStrPrecision: ptr.ToInt(123),
 	}
-	tableData.MergeColumnsFromDestination(o.ctx, columns.NewColumn(strCol, stringKindWithPrecision))
+	tableData.MergeColumnsFromDestination(columns.NewColumn(strCol, stringKindWithPrecision))
 	foundStrCol, isOk := tableData.inMemoryColumns.GetColumn(strCol)
 	assert.True(o.T(), isOk)
 	assert.Equal(o.T(), typing.String.Kind, foundStrCol.KindDetails.Kind)

--- a/lib/parquetutil/generate_schema.go
+++ b/lib/parquetutil/generate_schema.go
@@ -13,7 +13,7 @@ func GenerateJSONSchema(ctx context.Context, columns []columns.Column) (string, 
 	var fields []typing.Field
 	for _, column := range columns {
 		// We don't need to escape the column name here.
-		field, err := column.KindDetails.ParquetAnnotation(column.Name(ctx, nil))
+		field, err := column.KindDetails.ParquetAnnotation(column.RawName())
 		if err != nil {
 			return "", err
 		}

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -38,15 +38,6 @@ func (c *Column) ShouldSkip() bool {
 	return false
 }
 
-func UnescapeColumnName(escapedName string, destKind constants.DestinationKind) string {
-	if destKind == constants.BigQuery {
-		return strings.ReplaceAll(escapedName, "`", "")
-	} else {
-		// Snowflake does not return escaping.
-		return escapedName
-	}
-}
-
 func NewColumn(name string, kd typing.KindDetails) Column {
 	return Column{
 		name:        name,

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -85,6 +85,10 @@ func (c *Column) ShouldBackfill() bool {
 	return c.defaultValue != nil && !c.backfilled
 }
 
+func (c *Column) RawName() string {
+	return c.name
+}
+
 // Name will give you c.name
 // However, if you pass in escape, we will escape if the column name is part of the reserved words from destinations.
 // If so, it'll change from `start` => `"start"` as suggested by Snowflake.

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -132,38 +132,6 @@ func (c *ColumnsTestSuite) TestColumn_ShouldBackfill() {
 	}
 }
 
-func (c *ColumnsTestSuite) TestUnescapeColumnName() {
-	type _testCase struct {
-		escapedName           string
-		expectedBigQueryName  string
-		expectedSnowflakeName string
-		expectedOtherName     string
-	}
-
-	testCases := []_testCase{
-		{
-			escapedName:           "foo",
-			expectedBigQueryName:  "foo",
-			expectedSnowflakeName: "foo",
-			expectedOtherName:     "foo",
-		},
-		{
-			escapedName: "`start`",
-			// Should only escape BigQuery
-			expectedBigQueryName:  "start",
-			expectedSnowflakeName: "`start`",
-			expectedOtherName:     "`start`",
-		},
-	}
-
-	for _, testCase := range testCases {
-		assert.Equal(c.T(), testCase.expectedBigQueryName, UnescapeColumnName(testCase.escapedName, constants.BigQuery))
-		assert.Equal(c.T(), testCase.expectedSnowflakeName, UnescapeColumnName(testCase.escapedName, constants.Snowflake))
-		assert.Equal(c.T(), testCase.expectedSnowflakeName, UnescapeColumnName(testCase.escapedName, constants.SnowflakeStages))
-		assert.Equal(c.T(), testCase.expectedOtherName, UnescapeColumnName(testCase.escapedName, ""))
-	}
-}
-
 func (c *ColumnsTestSuite) TestColumn_Name() {
 	type _testCase struct {
 		colName      string

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -200,7 +200,7 @@ func (c *ColumnsTestSuite) TestColumn_Name() {
 			name: testCase.colName,
 		}
 
-		assert.Equal(c.T(), testCase.expectedName, col.Name(c.ctx, nil), testCase.colName)
+		assert.Equal(c.T(), testCase.expectedName, col.RawName(), testCase.colName)
 		assert.Equal(c.T(), testCase.expectedName, col.Name(c.ctx, &sql.NameArgs{
 			Escape: false,
 		}), testCase.colName)

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -18,6 +18,10 @@ type DefaultValueArgs struct {
 	DestKind constants.DestinationKind
 }
 
+func (c *Column) RawDefaultValue() interface{} {
+	return c.defaultValue
+}
+
 func (c *Column) DefaultValue(ctx context.Context, args *DefaultValueArgs) (interface{}, error) {
 	if args == nil || !args.Escape || c.defaultValue == nil {
 		return c.defaultValue, nil

--- a/lib/typing/columns/diff.go
+++ b/lib/typing/columns/diff.go
@@ -1,7 +1,6 @@
 package columns
 
 import (
-	"context"
 	"strings"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -28,12 +27,12 @@ func shouldSkipColumn(colName string, softDelete bool, includeArtieUpdatedAt boo
 
 // Diff - when given 2 maps, a source and target
 // It will provide a diff in the form of 2 variables
-func Diff(ctx context.Context, columnsInSource *Columns, columnsInDestination *Columns, softDelete bool, includeArtieUpdatedAt bool) ([]Column, []Column) {
+func Diff(columnsInSource *Columns, columnsInDestination *Columns, softDelete bool, includeArtieUpdatedAt bool) ([]Column, []Column) {
 	src := CloneColumns(columnsInSource)
 	targ := CloneColumns(columnsInDestination)
 	var colsToDelete []Column
 	for _, col := range src.GetColumns() {
-		_, isOk := targ.GetColumn(col.Name(ctx, nil))
+		_, isOk := targ.GetColumn(col.RawName())
 		if isOk {
 			colsToDelete = append(colsToDelete, col)
 
@@ -42,13 +41,13 @@ func Diff(ctx context.Context, columnsInSource *Columns, columnsInDestination *C
 
 	// We cannot delete inside a for-loop that is iterating over src.GetColumns() because we are messing up the array order.
 	for _, colToDelete := range colsToDelete {
-		src.DeleteColumn(colToDelete.Name(ctx, nil))
-		targ.DeleteColumn(colToDelete.Name(ctx, nil))
+		src.DeleteColumn(colToDelete.RawName())
+		targ.DeleteColumn(colToDelete.RawName())
 	}
 
 	var targetColumnsMissing Columns
 	for _, col := range src.GetColumns() {
-		if shouldSkipColumn(col.Name(ctx, nil), softDelete, includeArtieUpdatedAt) {
+		if shouldSkipColumn(col.RawName(), softDelete, includeArtieUpdatedAt) {
 			continue
 		}
 
@@ -57,7 +56,7 @@ func Diff(ctx context.Context, columnsInSource *Columns, columnsInDestination *C
 
 	var sourceColumnsMissing Columns
 	for _, col := range targ.GetColumns() {
-		if shouldSkipColumn(col.Name(ctx, nil), softDelete, includeArtieUpdatedAt) {
+		if shouldSkipColumn(col.RawName(), softDelete, includeArtieUpdatedAt) {
 			continue
 		}
 

--- a/lib/typing/columns/diff_test.go
+++ b/lib/typing/columns/diff_test.go
@@ -109,7 +109,7 @@ func (c *ColumnsTestSuite) TestDiff_VariousNils() {
 	}
 
 	for _, testCase := range testCases {
-		actualSrcKeysMissing, actualTargKeysMissing := Diff(c.ctx, testCase.sourceCols, testCase.targCols, false, false)
+		actualSrcKeysMissing, actualTargKeysMissing := Diff(testCase.sourceCols, testCase.targCols, false, false)
 		assert.Equal(c.T(), testCase.expectedSrcKeyLength, len(actualSrcKeysMissing), testCase.name)
 		assert.Equal(c.T(), testCase.expectedTargKeyLength, len(actualTargKeysMissing), testCase.name)
 	}
@@ -119,7 +119,7 @@ func (c *ColumnsTestSuite) TestDiffBasic() {
 	var source Columns
 	source.AddColumn(NewColumn("a", typing.Integer))
 
-	srcKeyMissing, targKeyMissing := Diff(c.ctx, &source, &source, false, false)
+	srcKeyMissing, targKeyMissing := Diff(&source, &source, false, false)
 	assert.Equal(c.T(), len(srcKeyMissing), 0)
 	assert.Equal(c.T(), len(targKeyMissing), 0)
 }
@@ -143,7 +143,7 @@ func (c *ColumnsTestSuite) TestDiffDelta1() {
 		targCols.AddColumn(NewColumn(colName, kindDetails))
 	}
 
-	srcKeyMissing, targKeyMissing := Diff(c.ctx, &sourceCols, &targCols, false, false)
+	srcKeyMissing, targKeyMissing := Diff(&sourceCols, &targCols, false, false)
 	assert.Equal(c.T(), len(srcKeyMissing), 2, srcKeyMissing)   // Missing aa, cc
 	assert.Equal(c.T(), len(targKeyMissing), 2, targKeyMissing) // Missing aa, cc
 }
@@ -175,7 +175,7 @@ func (c *ColumnsTestSuite) TestDiffDelta2() {
 		targetCols.AddColumn(NewColumn(colName, kindDetails))
 	}
 
-	srcKeyMissing, targKeyMissing := Diff(c.ctx, &sourceCols, &targetCols, false, false)
+	srcKeyMissing, targKeyMissing := Diff(&sourceCols, &targetCols, false, false)
 	assert.Equal(c.T(), len(srcKeyMissing), 1, srcKeyMissing)   // Missing dd
 	assert.Equal(c.T(), len(targKeyMissing), 3, targKeyMissing) // Missing a, c, d
 }
@@ -190,7 +190,7 @@ func (c *ColumnsTestSuite) TestDiffDeterministic() {
 	sourceCols.AddColumn(NewColumn("name", typing.String))
 
 	for i := 0; i < 500; i++ {
-		keysMissing, targetKeysMissing := Diff(c.ctx, &sourceCols, &targCols, false, false)
+		keysMissing, targetKeysMissing := Diff(&sourceCols, &targCols, false, false)
 		assert.Equal(c.T(), 0, len(keysMissing), keysMissing)
 
 		var key string

--- a/lib/typing/columns/diff_test.go
+++ b/lib/typing/columns/diff_test.go
@@ -195,7 +195,7 @@ func (c *ColumnsTestSuite) TestDiffDeterministic() {
 
 		var key string
 		for _, targetKeyMissing := range targetKeysMissing {
-			key += targetKeyMissing.Name(c.ctx, nil)
+			key += targetKeyMissing.RawName()
 		}
 
 		retMap[key] = false

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -49,7 +49,7 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	// Check the in-memory DB columns.
 	var found int
 	for _, col := range optimization.ReadOnlyInMemoryCols().GetColumns() {
-		if col.Name(e.ctx, nil) == expectedLowerCol || col.Name(e.ctx, nil) == anotherLowerCol {
+		if col.RawName() == expectedLowerCol || col.RawName() == anotherLowerCol {
 			found += 1
 		}
 
@@ -178,16 +178,16 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	td := models.GetMemoryDB(e.ctx).GetOrCreateTableData("non_existent")
 	var prevKey string
 	for _, col := range td.ReadOnlyInMemoryCols().GetColumns() {
-		if col.Name(e.ctx, nil) == constants.DeleteColumnMarker {
+		if col.RawName() == constants.DeleteColumnMarker {
 			continue
 		}
 
 		if prevKey == "" {
-			prevKey = col.Name(e.ctx, nil)
+			prevKey = col.RawName()
 			continue
 		}
 
-		currentKeyParsed, err := strconv.Atoi(col.Name(e.ctx, nil))
+		currentKeyParsed, err := strconv.Atoi(col.RawName())
 		assert.NoError(e.T(), err)
 
 		prevKeyParsed, err := strconv.Atoi(prevKey)
@@ -201,7 +201,7 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	evt.Columns.AddColumn(columns.NewColumn("foo", typing.Invalid))
 	var index int
 	for idx, col := range evt.Columns.GetColumns() {
-		if col.Name(e.ctx, nil) == "foo" {
+		if col.RawName() == "foo" {
 			index = idx
 		}
 	}


### PR DESCRIPTION
## Changes

* Adding `col.RawDefaultValue()` which will just return the variable without any manipulation (used for logging)
* Adding `col.RawName()` which will also just return the name without any manipulation
* Adding `tableData.RawName()`

By doing so, we are able to remove `context` from intermediary functions and simplify the codepaths. This PR will tee us up to remove `context.Context` from our Typing library.