### PR TITLE
[Refactor] Part 3 - Removing `context` from `lib/typing`

### DIFF
--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -1,7 +1,6 @@
 package bigquery
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -16,7 +15,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func castColVal(ctx context.Context, colVal interface{}, colKind columns.Column) (interface{}, error) {
+func castColVal(colVal interface{}, colKind columns.Column, additionalDateFmts []string) (interface{}, error) {
 	if colVal != nil {
 		switch colKind.KindDetails.Kind {
 		case typing.EDecimal.Kind:
@@ -27,7 +26,7 @@ func castColVal(ctx context.Context, colVal interface{}, colKind columns.Column)
 
 			return val.Value(), nil
 		case typing.ETime.Kind:
-			extTime, err := ext.ParseFromInterface(ctx, colVal)
+			extTime, err := ext.ParseFromInterface(additionalDateFmts, colVal)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 			}

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -26,7 +26,7 @@ func castColVal(colVal interface{}, colKind columns.Column, additionalDateFmts [
 
 			return val.Value(), nil
 		case typing.ETime.Kind:
-			extTime, err := ext.ParseFromInterface(additionalDateFmts, colVal)
+			extTime, err := ext.ParseFromInterface(colVal, additionalDateFmts)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 			}

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -127,7 +127,7 @@ func (b *BigQueryTestSuite) TestCastColVal() {
 	}
 
 	for _, testCase := range testCases {
-		actualString, actualErr := castColVal(b.ctx, testCase.colVal, testCase.colKind)
+		actualString, actualErr := castColVal(testCase.colVal, testCase.colKind, nil)
 		assert.Equal(b.T(), testCase.expectedErr, actualErr, testCase.name)
 		assert.Equal(b.T(), testCase.expectedValue, actualString, testCase.name)
 	}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -5,24 +5,18 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/config"
-
-	"github.com/artie-labs/transfer/lib/sql"
-
-	"github.com/artie-labs/transfer/lib/ptr"
-
-	"github.com/artie-labs/transfer/lib/jitter"
-
-	"github.com/artie-labs/transfer/lib/typing/columns"
-
 	"cloud.google.com/go/bigquery"
 
-	"github.com/artie-labs/transfer/lib/destination/dml"
-
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
+	"github.com/artie-labs/transfer/lib/destination/dml"
+	"github.com/artie-labs/transfer/lib/jitter"
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/optimization"
+	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/artie-labs/transfer/lib/sql"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
 type Row struct {

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -211,7 +211,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	var additionalEqualityStrings []string
 	if tableData.TopicConfig.BigQueryPartitionSettings != nil {
 		additionalDateFmts := config.FromContext(ctx).Config.SharedTransferConfig.AdditionalDateFormats
-		distinctDates, err := tableData.DistinctDates(additionalDateFmts, tableData.TopicConfig.BigQueryPartitionSettings.PartitionField)
+		distinctDates, err := tableData.DistinctDates(tableData.TopicConfig.BigQueryPartitionSettings.PartitionField, additionalDateFmts)
 		if err != nil {
 			return fmt.Errorf("failed to generate distinct dates, err: %v", err)
 		}

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -55,7 +55,7 @@ func (s *Store) CastColValStaging(colVal interface{}, colKind columns.Column, ad
 	switch colKind.KindDetails.Kind {
 	// All the other types do not need string wrapping.
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(additionalDateFmts, colVal)
+		extTime, err := ext.ParseFromInterface(colVal, additionalDateFmts)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 		}

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -1,7 +1,6 @@
 package redshift
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -41,7 +40,7 @@ func replaceExceededValues(colVal string, colKind columns.Column) string {
 
 // CastColValStaging - takes `colVal` interface{} and `colKind` typing.Column and converts the value into a string value
 // This is necessary because CSV writers require values to in `string`.
-func (s *Store) CastColValStaging(ctx context.Context, colVal interface{}, colKind columns.Column) (string, error) {
+func (s *Store) CastColValStaging(colVal interface{}, colKind columns.Column, additionalDateFmts []string) (string, error) {
 	if colVal == nil {
 		if colKind.KindDetails == typing.Struct {
 			// Returning empty here because if it's a struct, it will go through JSON PARSE and JSON_PARSE("") = null
@@ -56,7 +55,7 @@ func (s *Store) CastColValStaging(ctx context.Context, colVal interface{}, colKi
 	switch colKind.KindDetails.Kind {
 	// All the other types do not need string wrapping.
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(ctx, colVal)
+		extTime, err := ext.ParseFromInterface(additionalDateFmts, colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 		}

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -84,8 +84,8 @@ type _testCase struct {
 	expectErr      bool
 }
 
-func evaluateTestCase(t *testing.T, ctx context.Context, store *Store, testCase _testCase) {
-	actualString, actualErr := store.CastColValStaging(ctx, testCase.colVal, testCase.colKind)
+func evaluateTestCase(t *testing.T, store *Store, testCase _testCase) {
+	actualString, actualErr := store.CastColValStaging(testCase.colVal, testCase.colKind, nil)
 	if testCase.expectErr {
 		assert.Error(t, actualErr, testCase.name)
 	} else {
@@ -190,7 +190,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Basic() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.ctx, r.store, testCase)
+		evaluateTestCase(r.T(), r.store, testCase)
 	}
 }
 
@@ -272,7 +272,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Array() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.ctx, r.store, testCase)
+		evaluateTestCase(r.T(), r.store, testCase)
 	}
 }
 
@@ -334,7 +334,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Time() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.ctx, r.store, testCase)
+		evaluateTestCase(r.T(), r.store, testCase)
 	}
 }
 
@@ -353,7 +353,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_TOAST() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.ctx, r.store, testCase)
+		evaluateTestCase(r.T(), r.store, testCase)
 	}
 }
 
@@ -406,7 +406,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_ExceededValues() {
 	skipLargeRowsStore := LoadRedshift(ctx, &store)
 
 	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.ctx, skipLargeRowsStore, testCase)
+		evaluateTestCase(r.T(), skipLargeRowsStore, testCase)
 	}
 
 }

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/config"
+
 	"github.com/artie-labs/transfer/lib/typing"
 
 	"github.com/artie-labs/transfer/lib/s3lib"
@@ -83,11 +85,13 @@ func (s *Store) loadTemporaryTable(ctx context.Context, tableData *optimization.
 
 	writer := csv.NewWriter(gzipWriter) // Create a CSV writer on top of the gzip writer
 	writer.Comma = '\t'
+
+	additionalDateFmts := config.FromContext(ctx).Config.SharedTransferConfig.AdditionalDateFormats
 	for _, value := range tableData.RowsData() {
 		var row []string
 		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(ctx, nil) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
-			castedValue, castErr := s.CastColValStaging(ctx, value[col], colKind)
+			castedValue, castErr := s.CastColValStaging(value[col], colKind, additionalDateFmts)
 			if castErr != nil {
 				return "", castErr
 			}

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -97,6 +97,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		return fmt.Errorf("failed to instantiate parquet writer, err: %v", err)
 	}
 
+	additionalDateFmts := config.FromContext(ctx).Config.SharedTransferConfig.AdditionalDateFormats
 	pw.CompressionType = parquet.CompressionCodec_GZIP
 	for _, val := range tableData.RowsData() {
 		row := make(map[string]interface{})
@@ -106,7 +107,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 				return fmt.Errorf("expected column: %v to exist in readOnlyInMemoryCols(...) but it does not", col)
 			}
 
-			value, err := parquetutil.ParseValue(ctx, val[col], colKind)
+			value, err := parquetutil.ParseValue(val[col], colKind, additionalDateFmts)
 			if err != nil {
 				return fmt.Errorf("failed to parse value, err: %v, value: %v, column: %v", err, val[col], col)
 			}

--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -1,7 +1,6 @@
 package snowflake
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -17,7 +16,7 @@ import (
 
 // castColValStaging - takes `colVal` interface{} and `colKind` typing.Column and converts the value into a string value
 // This is necessary because CSV writers require values to in `string`.
-func castColValStaging(ctx context.Context, colVal interface{}, colKind columns.Column) (string, error) {
+func castColValStaging(colVal interface{}, colKind columns.Column, additionalDateFmts []string) (string, error) {
 	if colVal == nil {
 		// \\N needs to match NULL_IF(...) from ddl.go
 		return `\\N`, nil
@@ -26,7 +25,7 @@ func castColValStaging(ctx context.Context, colVal interface{}, colKind columns.
 	colValString := fmt.Sprint(colVal)
 	switch colKind.KindDetails.Kind {
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(ctx, colVal)
+		extTime, err := ext.ParseFromInterface(additionalDateFmts, colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 		}

--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -25,7 +25,7 @@ func castColValStaging(colVal interface{}, colKind columns.Column, additionalDat
 	colValString := fmt.Sprint(colVal)
 	switch colKind.KindDetails.Kind {
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(additionalDateFmts, colVal)
+		extTime, err := ext.ParseFromInterface(colVal, additionalDateFmts)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 		}

--- a/clients/snowflake/cast_test.go
+++ b/clients/snowflake/cast_test.go
@@ -1,7 +1,6 @@
 package snowflake
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"testing"
@@ -30,8 +29,8 @@ type _testCase struct {
 	expectErr      bool
 }
 
-func evaluateTestCase(t *testing.T, ctx context.Context, testCase _testCase) {
-	actualString, actualErr := castColValStaging(ctx, testCase.colVal, testCase.colKind)
+func evaluateTestCase(t *testing.T, testCase _testCase) {
+	actualString, actualErr := castColValStaging(testCase.colVal, testCase.colKind, nil)
 	if testCase.expectErr {
 		assert.Error(t, actualErr, testCase.name)
 	} else {
@@ -138,7 +137,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(s.T(), s.ctx, testCase)
+		evaluateTestCase(s.T(), testCase)
 	}
 }
 
@@ -187,7 +186,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Array() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(s.T(), s.ctx, testCase)
+		evaluateTestCase(s.T(), testCase)
 	}
 }
 
@@ -249,7 +248,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Time() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(s.T(), s.ctx, testCase)
+		evaluateTestCase(s.T(), testCase)
 	}
 }
 
@@ -268,6 +267,6 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_TOAST() {
 	}
 
 	for _, testCase := range testCases {
-		evaluateTestCase(s.T(), s.ctx, testCase)
+		evaluateTestCase(s.T(), testCase)
 	}
 }

--- a/clients/snowflake/snowflake_suite_test.go
+++ b/clients/snowflake/snowflake_suite_test.go
@@ -22,6 +22,7 @@ type SnowflakeTestSuite struct {
 func (s *SnowflakeTestSuite) SetupTest() {
 	s.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
 		VerboseLogging: false,
+		Config:         &config.Config{},
 	})
 
 	s.ResetStore()

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -7,22 +7,17 @@ import (
 	"os"
 	"strings"
 
-	"github.com/artie-labs/transfer/lib/config"
-
-	"github.com/artie-labs/transfer/lib/sql"
-
 	"github.com/artie-labs/transfer/clients/utils"
-
-	"github.com/artie-labs/transfer/lib/ptr"
-
-	"github.com/artie-labs/transfer/lib/typing/columns"
-
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
 	"github.com/artie-labs/transfer/lib/destination/dml"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/optimization"
+	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/artie-labs/transfer/lib/sql"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
 // prepareTempTable does the following:

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/config"
+
 	"github.com/artie-labs/transfer/lib/sql"
 
 	"github.com/artie-labs/transfer/clients/utils"
@@ -85,13 +87,15 @@ func (s *Store) loadTemporaryTable(ctx context.Context, tableData *optimization.
 	defer file.Close()
 	writer := csv.NewWriter(file)
 	writer.Comma = '\t'
+
+	additionalDateFmts := config.FromContext(ctx).Config.SharedTransferConfig.AdditionalDateFormats
 	for _, value := range tableData.RowsData() {
 		var row []string
 		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(ctx, nil) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			colVal := value[col]
 			// Check
-			castedValue, castErr := castColValStaging(ctx, colVal, colKind)
+			castedValue, castErr := castColValStaging(colVal, colKind, additionalDateFmts)
 			if castErr != nil {
 				return "", castErr
 			}

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -59,7 +59,7 @@ func (s *SnowflakeTestSuite) TestBackfillColumn() {
 		{
 			name:        "default col that has default value that needs to be backfilled",
 			col:         needsBackfillColDefault,
-			backfillSQL: `UPDATE db.public.tableName SET default = true WHERE "default" IS NULL;`,
+			backfillSQL: `UPDATE db.public.tableName SET default = true WHERE "DEFAULT" IS NULL;`,
 			commentSQL:  `COMMENT ON COLUMN db.public.tableName.default IS '{"backfilled": true}';`,
 		},
 	}

--- a/clients/utils/utils.go
+++ b/clients/utils/utils.go
@@ -38,7 +38,7 @@ func BackfillColumn(ctx context.Context, dwh destination.DataWarehouse, column c
 	additionalEscapedCol := escapedCol
 	if additionalEscapedCol == "default" && dwh.Label() == constants.Snowflake {
 		// It should be uppercase because Snowflake's default column is uppercase and since it's not a reserved column name, it uses the default setting.
-		additionalEscapedCol = "DEFAULT"
+		additionalEscapedCol = `"DEFAULT"`
 	}
 
 	query := fmt.Sprintf(`UPDATE %s SET %s = %v WHERE %s IS NULL;`,

--- a/clients/utils/utils.go
+++ b/clients/utils/utils.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/artie-labs/transfer/lib/config"
+
 	"github.com/artie-labs/transfer/lib/sql"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -23,10 +25,8 @@ func BackfillColumn(ctx context.Context, dwh destination.DataWarehouse, column c
 		return nil
 	}
 
-	defaultVal, err := column.DefaultValue(ctx, &columns.DefaultValueArgs{
-		Escape:   true,
-		DestKind: dwh.Label(),
-	})
+	additionalDateFmts := config.FromContext(ctx).Config.SharedTransferConfig.AdditionalDateFormats
+	defaultVal, err := column.DefaultValue(&columns.DefaultValueArgs{Escape: true, DestKind: dwh.Label()}, additionalDateFmts)
 	if err != nil {
 		return fmt.Errorf("failed to escape default value, err: %v", err)
 	}

--- a/clients/utils/utils.go
+++ b/clients/utils/utils.go
@@ -37,7 +37,8 @@ func BackfillColumn(ctx context.Context, dwh destination.DataWarehouse, column c
 	// Once we escape everything by default, we can remove this patch of code.
 	additionalEscapedCol := escapedCol
 	if additionalEscapedCol == "default" && dwh.Label() == constants.Snowflake {
-		additionalEscapedCol = fmt.Sprintf(`"%s"`, additionalEscapedCol)
+		// It should be uppercase because Snowflake's default column is uppercase and since it's not a reserved column name, it uses the default setting.
+		additionalEscapedCol = "DEFAULT"
 	}
 
 	query := fmt.Sprintf(`UPDATE %s SET %s = %v WHERE %s IS NULL;`,

--- a/lib/cdc/mongo/mongo_suite_test.go
+++ b/lib/cdc/mongo/mongo_suite_test.go
@@ -23,6 +23,7 @@ func (p *MongoTestSuite) SetupTest() {
 
 	p.ctx = config.InjectSettingsIntoContext(context.Background(), &config.Settings{
 		VerboseLogging: true,
+		Config:         &config.Config{},
 	})
 	p.ctx = logger.InjectLoggerIntoCtx(p.ctx)
 }

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -6,14 +6,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/artie-labs/transfer/lib/stringutil"
-
-	"github.com/artie-labs/transfer/lib/numbers"
 	"gopkg.in/yaml.v3"
 
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/numbers"
+	"github.com/artie-labs/transfer/lib/stringutil"
 )
 
 const (

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -178,7 +178,7 @@ func (t *TableData) Rows() uint {
 	return uint(len(t.rowsData))
 }
 
-func (t *TableData) DistinctDates(additionalDateFmts []string, colName string) ([]string, error) {
+func (t *TableData) DistinctDates(colName string, additionalDateFmts []string) ([]string, error) {
 	retMap := make(map[string]bool)
 	for _, row := range t.rowsData {
 		val, isOk := row[colName]

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -186,7 +186,7 @@ func (t *TableData) DistinctDates(additionalDateFmts []string, colName string) (
 			return nil, fmt.Errorf("col: %v does not exist on row: %v", colName, row)
 		}
 
-		extTime, err := ext.ParseFromInterface(additionalDateFmts, val)
+		extTime, err := ext.ParseFromInterface(val, additionalDateFmts)
 		if err != nil {
 			return nil, fmt.Errorf("col: %v is not a time column, value: %v, err: %v", colName, val, err)
 		}

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -181,7 +181,7 @@ func (t *TableData) Rows() uint {
 	return uint(len(t.rowsData))
 }
 
-func (t *TableData) DistinctDates(ctx context.Context, colName string) ([]string, error) {
+func (t *TableData) DistinctDates(additionalDateFmts []string, colName string) ([]string, error) {
 	retMap := make(map[string]bool)
 	for _, row := range t.rowsData {
 		val, isOk := row[colName]
@@ -189,7 +189,7 @@ func (t *TableData) DistinctDates(ctx context.Context, colName string) ([]string
 			return nil, fmt.Errorf("col: %v does not exist on row: %v", colName, row)
 		}
 
-		extTime, err := ext.ParseFromInterface(ctx, val)
+		extTime, err := ext.ParseFromInterface(additionalDateFmts, val)
 		if err != nil {
 			return nil, fmt.Errorf("col: %v is not a time column, value: %v, err: %v", colName, val, err)
 		}

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -6,18 +6,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/sql"
-
-	"github.com/artie-labs/transfer/lib/typing/columns"
-
-	"github.com/artie-labs/transfer/lib/stringutil"
-
 	"github.com/artie-labs/transfer/lib/artie"
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/size"
+	"github.com/artie-labs/transfer/lib/sql"
+	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -85,7 +85,7 @@ func (o *OptimizationTestSuite) TestDistinctDates() {
 			rowsData: testCase.rowData,
 		}
 
-		actualValues, actualErr := t.DistinctDates(o.ctx, "ts")
+		actualValues, actualErr := t.DistinctDates(nil, "ts")
 		if testCase.expectErr {
 			assert.Error(o.T(), actualErr, testCase.name)
 		} else {

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -85,7 +85,7 @@ func (o *OptimizationTestSuite) TestDistinctDates() {
 			rowsData: testCase.rowData,
 		}
 
-		actualValues, actualErr := t.DistinctDates(nil, "ts")
+		actualValues, actualErr := t.DistinctDates("ts", nil)
 		if testCase.expectErr {
 			assert.Error(o.T(), actualErr, testCase.name)
 		} else {

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -21,7 +21,7 @@ func ParseValue(colVal interface{}, colKind columns.Column, additionalDateFmts [
 
 	switch colKind.KindDetails.Kind {
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(additionalDateFmts, colVal)
+		extTime, err := ext.ParseFromInterface(colVal, additionalDateFmts)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 		}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -1,7 +1,6 @@
 package parquetutil
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -15,14 +14,14 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
-func ParseValue(ctx context.Context, colVal interface{}, colKind columns.Column) (interface{}, error) {
+func ParseValue(colVal interface{}, colKind columns.Column, additionalDateFmts []string) (interface{}, error) {
 	if colVal == nil {
 		return nil, nil
 	}
 
 	switch colKind.KindDetails.Kind {
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(ctx, colVal)
+		extTime, err := ext.ParseFromInterface(additionalDateFmts, colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", colVal, err)
 		}

--- a/lib/parquetutil/parse_values_test.go
+++ b/lib/parquetutil/parse_values_test.go
@@ -93,7 +93,7 @@ func (p *ParquetUtilTestSuite) TestParseValue() {
 	}
 
 	for _, tc := range testCases {
-		actualValue, actualErr := ParseValue(p.ctx, tc.colVal, tc.colKind)
+		actualValue, actualErr := ParseValue(tc.colVal, tc.colKind, nil)
 		if tc.expectErr {
 			assert.Error(p.T(), actualErr, tc.name)
 		} else {

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -1,7 +1,6 @@
 package columns
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -22,7 +21,7 @@ func (c *Column) RawDefaultValue() interface{} {
 	return c.defaultValue
 }
 
-func (c *Column) DefaultValue(ctx context.Context, args *DefaultValueArgs) (interface{}, error) {
+func (c *Column) DefaultValue(args *DefaultValueArgs, additionalDateFmts []string) (interface{}, error) {
 	if args == nil || !args.Escape || c.defaultValue == nil {
 		return c.defaultValue, nil
 	}
@@ -42,7 +41,7 @@ func (c *Column) DefaultValue(ctx context.Context, args *DefaultValueArgs) (inte
 			return nil, fmt.Errorf("column kind details for extended time is nil")
 		}
 
-		extTime, err := ext.ParseFromInterface(ctx, c.defaultValue)
+		extTime, err := ext.ParseFromInterface(additionalDateFmts, c.defaultValue)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", c.defaultValue, err)
 		}

--- a/lib/typing/columns/default.go
+++ b/lib/typing/columns/default.go
@@ -41,7 +41,7 @@ func (c *Column) DefaultValue(args *DefaultValueArgs, additionalDateFmts []strin
 			return nil, fmt.Errorf("column kind details for extended time is nil")
 		}
 
-		extTime, err := ext.ParseFromInterface(additionalDateFmts, c.defaultValue)
+		extTime, err := ext.ParseFromInterface(c.defaultValue, additionalDateFmts)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", c.defaultValue, err)
 		}

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -150,7 +150,7 @@ func (c *ColumnsTestSuite) TestColumn_DefaultValue() {
 				testCase.args.DestKind = validDest
 			}
 
-			actualValue, actualErr := testCase.col.DefaultValue(c.ctx, testCase.args)
+			actualValue, actualErr := testCase.col.DefaultValue(testCase.args, nil)
 			if testCase.expectedEr {
 				assert.Error(c.T(), actualErr, fmt.Sprintf("%s %s", testCase.name, validDest))
 			} else {

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -24,7 +24,7 @@ func (c *ColumnsTestSuite) TestColumn_DefaultValue() {
 	}
 
 	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
-	birthdayExtDateTime, err := ext.ParseExtendedDateTime(c.ctx, birthday.Format(ext.ISO8601))
+	birthdayExtDateTime, err := ext.ParseExtendedDateTime(nil, birthday.Format(ext.ISO8601))
 	assert.NoError(c.T(), err)
 
 	// date

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -24,7 +24,7 @@ func (c *ColumnsTestSuite) TestColumn_DefaultValue() {
 	}
 
 	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
-	birthdayExtDateTime, err := ext.ParseExtendedDateTime(nil, birthday.Format(ext.ISO8601))
+	birthdayExtDateTime, err := ext.ParseExtendedDateTime(birthday.Format(ext.ISO8601), nil)
 	assert.NoError(c.T(), err)
 
 	// date

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -1,14 +1,11 @@
 package ext
 
 import (
-	"context"
 	"fmt"
 	"time"
-
-	"github.com/artie-labs/transfer/lib/config"
 )
 
-func ParseFromInterface(ctx context.Context, val interface{}) (*ExtendedTime, error) {
+func ParseFromInterface(additionalDateFormats []string, val interface{}) (*ExtendedTime, error) {
 	if val == nil {
 		return nil, fmt.Errorf("val is nil")
 	}
@@ -19,7 +16,7 @@ func ParseFromInterface(ctx context.Context, val interface{}) (*ExtendedTime, er
 	}
 
 	var err error
-	extendedTime, err = ParseExtendedDateTime(ctx, fmt.Sprint(val))
+	extendedTime, err = ParseExtendedDateTime(additionalDateFormats, fmt.Sprint(val))
 	if err != nil {
 		return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", val, err)
 	}
@@ -49,7 +46,7 @@ func ParseTimeExactMatch(layout, potentialDateTimeString string) (time.Time, boo
 // 1) Precision loss in translation
 // 2) Original format preservation (with tz locale).
 // If it cannot find it, then it will give you the next best thing.
-func ParseExtendedDateTime(ctx context.Context, dtString string) (*ExtendedTime, error) {
+func ParseExtendedDateTime(additionalDateFormats []string, dtString string) (*ExtendedTime, error) {
 	// Check all the timestamp formats
 	var potentialFormat string
 	var potentialTime time.Time
@@ -65,8 +62,8 @@ func ParseExtendedDateTime(ctx context.Context, dtString string) (*ExtendedTime,
 	}
 
 	allSupportedDateFormats := supportedDateFormats
-	if len(config.FromContext(ctx).Config.SharedTransferConfig.AdditionalDateFormats) > 0 {
-		allSupportedDateFormats = append(allSupportedDateFormats, config.FromContext(ctx).Config.SharedTransferConfig.AdditionalDateFormats...)
+	if len(additionalDateFormats) > 0 {
+		allSupportedDateFormats = append(allSupportedDateFormats, additionalDateFormats...)
 	}
 
 	// Now check DATE formats

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func ParseFromInterface(additionalDateFormats []string, val interface{}) (*ExtendedTime, error) {
+func ParseFromInterface(val interface{}, additionalDateFormats []string) (*ExtendedTime, error) {
 	if val == nil {
 		return nil, fmt.Errorf("val is nil")
 	}
@@ -16,7 +16,7 @@ func ParseFromInterface(additionalDateFormats []string, val interface{}) (*Exten
 	}
 
 	var err error
-	extendedTime, err = ParseExtendedDateTime(additionalDateFormats, fmt.Sprint(val))
+	extendedTime, err = ParseExtendedDateTime(fmt.Sprint(val), additionalDateFormats)
 	if err != nil {
 		return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %v", val, err)
 	}
@@ -46,7 +46,7 @@ func ParseTimeExactMatch(layout, potentialDateTimeString string) (time.Time, boo
 // 1) Precision loss in translation
 // 2) Original format preservation (with tz locale).
 // If it cannot find it, then it will give you the next best thing.
-func ParseExtendedDateTime(additionalDateFormats []string, dtString string) (*ExtendedTime, error) {
+func ParseExtendedDateTime(dtString string, additionalDateFormats []string) (*ExtendedTime, error) {
 	// Check all the timestamp formats
 	var potentialFormat string
 	var potentialTime time.Time
@@ -61,10 +61,8 @@ func ParseExtendedDateTime(additionalDateFormats []string, dtString string) (*Ex
 		}
 	}
 
-	// We can append nil arrays
-	allSupportedDateFormats := append(supportedDateFormats, additionalDateFormats...)
-	// Now check DATE formats
-	for _, supportedDateFormat := range allSupportedDateFormats {
+	// Now check DATE formats, btw you can append nil arrays
+	for _, supportedDateFormat := range append(supportedDateFormats, additionalDateFormats...) {
 		ts, exactMatch, err := ParseTimeExactMatch(supportedDateFormat, dtString)
 		if err == nil && exactMatch {
 			return NewExtendedTime(ts, DateKindType, supportedDateFormat)

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -61,11 +61,8 @@ func ParseExtendedDateTime(additionalDateFormats []string, dtString string) (*Ex
 		}
 	}
 
-	allSupportedDateFormats := supportedDateFormats
-	if len(additionalDateFormats) > 0 {
-		allSupportedDateFormats = append(allSupportedDateFormats, additionalDateFormats...)
-	}
-
+	// We can append nil arrays
+	allSupportedDateFormats := append(supportedDateFormats, additionalDateFormats...)
 	// Now check DATE formats
 	for _, supportedDateFormat := range allSupportedDateFormats {
 		ts, exactMatch, err := ParseTimeExactMatch(supportedDateFormat, dtString)

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -29,7 +29,7 @@ func (e *ExtTestSuite) TestParseFromInterface() {
 	})
 
 	for _, val := range vals {
-		extTime, err := ParseFromInterface(e.ctx, val)
+		extTime, err := ParseFromInterface(nil, val)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), val, extTime)
 	}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -3,8 +3,6 @@ package ext
 import (
 	"time"
 
-	"github.com/artie-labs/transfer/lib/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +40,7 @@ func (e *ExtTestSuite) TestParseFromInterface() {
 		false,
 	}
 	for _, invalidVal := range invalidVals {
-		_, err := ParseFromInterface(e.ctx, invalidVal)
+		_, err := ParseFromInterface(nil, invalidVal)
 		assert.Error(e.T(), err)
 	}
 }
@@ -50,7 +48,7 @@ func (e *ExtTestSuite) TestParseFromInterface() {
 func (e *ExtTestSuite) TestParseFromInterfaceDateTime() {
 	now := time.Now().In(time.UTC)
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		et, err := ParseFromInterface(e.ctx, now.Format(supportedDateTimeLayout))
+		et, err := ParseFromInterface(nil, now.Format(supportedDateTimeLayout))
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), et.NestedKind.Type, DateTimeKindType)
 		assert.Equal(e.T(), et.String(""), now.Format(supportedDateTimeLayout))
@@ -60,7 +58,7 @@ func (e *ExtTestSuite) TestParseFromInterfaceDateTime() {
 func (e *ExtTestSuite) TestParseFromInterfaceTime() {
 	now := time.Now()
 	for _, supportedTimeFormat := range supportedTimeFormats {
-		et, err := ParseFromInterface(e.ctx, now.Format(supportedTimeFormat))
+		et, err := ParseFromInterface(nil, now.Format(supportedTimeFormat))
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), et.NestedKind.Type, TimeKindType)
 		// Without passing an override format, this should return the same preserved dt format.
@@ -71,7 +69,7 @@ func (e *ExtTestSuite) TestParseFromInterfaceTime() {
 func (e *ExtTestSuite) TestParseFromInterfaceDate() {
 	now := time.Now()
 	for _, supportedDateFormat := range supportedDateFormats {
-		et, err := ParseFromInterface(e.ctx, now.Format(supportedDateFormat))
+		et, err := ParseFromInterface(nil, now.Format(supportedDateFormat))
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), et.NestedKind.Type, DateKindType)
 
@@ -82,23 +80,14 @@ func (e *ExtTestSuite) TestParseFromInterfaceDate() {
 
 func (e *ExtTestSuite) TestParseExtendedDateTime_Timestamp() {
 	tsString := "2023-04-24T17:29:05.69944Z"
-	extTime, err := ParseExtendedDateTime(e.ctx, tsString)
+	extTime, err := ParseExtendedDateTime(nil, tsString)
 	assert.NoError(e.T(), err)
 	assert.Equal(e.T(), "2023-04-24T17:29:05.69944Z", extTime.String(""))
 }
 
 func (e *ExtTestSuite) TestParseExtendedDateTime() {
-	ctx := config.InjectSettingsIntoContext(e.ctx, &config.Settings{
-		Config: &config.Config{
-			SharedTransferConfig: config.SharedTransferConfig{
-				// DD-MM-YY
-				AdditionalDateFormats: []string{"02/01/06"},
-			},
-		},
-	})
-
 	dateString := "27/12/82"
-	extTime, err := ParseExtendedDateTime(ctx, dateString)
+	extTime, err := ParseExtendedDateTime([]string{"02/01/06"}, dateString)
 	assert.NoError(e.T(), err)
 	assert.Equal(e.T(), "27/12/82", extTime.String(""))
 }
@@ -108,7 +97,7 @@ func (e *ExtTestSuite) TestTimeLayout() {
 
 	for _, supportedFormat := range supportedTimeFormats {
 		parsedTsString := ts.Format(supportedFormat)
-		extTime, err := ParseExtendedDateTime(e.ctx, parsedTsString)
+		extTime, err := ParseExtendedDateTime(nil, parsedTsString)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), parsedTsString, extTime.String(""))
 	}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -29,7 +29,7 @@ func (e *ExtTestSuite) TestParseFromInterface() {
 	})
 
 	for _, val := range vals {
-		extTime, err := ParseFromInterface(nil, val)
+		extTime, err := ParseFromInterface(val, nil)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), val, extTime)
 	}
@@ -40,7 +40,7 @@ func (e *ExtTestSuite) TestParseFromInterface() {
 		false,
 	}
 	for _, invalidVal := range invalidVals {
-		_, err := ParseFromInterface(nil, invalidVal)
+		_, err := ParseFromInterface(invalidVal, nil)
 		assert.Error(e.T(), err)
 	}
 }
@@ -48,7 +48,7 @@ func (e *ExtTestSuite) TestParseFromInterface() {
 func (e *ExtTestSuite) TestParseFromInterfaceDateTime() {
 	now := time.Now().In(time.UTC)
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		et, err := ParseFromInterface(nil, now.Format(supportedDateTimeLayout))
+		et, err := ParseFromInterface(now.Format(supportedDateTimeLayout), nil)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), et.NestedKind.Type, DateTimeKindType)
 		assert.Equal(e.T(), et.String(""), now.Format(supportedDateTimeLayout))
@@ -58,7 +58,7 @@ func (e *ExtTestSuite) TestParseFromInterfaceDateTime() {
 func (e *ExtTestSuite) TestParseFromInterfaceTime() {
 	now := time.Now()
 	for _, supportedTimeFormat := range supportedTimeFormats {
-		et, err := ParseFromInterface(nil, now.Format(supportedTimeFormat))
+		et, err := ParseFromInterface(now.Format(supportedTimeFormat), nil)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), et.NestedKind.Type, TimeKindType)
 		// Without passing an override format, this should return the same preserved dt format.
@@ -69,7 +69,7 @@ func (e *ExtTestSuite) TestParseFromInterfaceTime() {
 func (e *ExtTestSuite) TestParseFromInterfaceDate() {
 	now := time.Now()
 	for _, supportedDateFormat := range supportedDateFormats {
-		et, err := ParseFromInterface(nil, now.Format(supportedDateFormat))
+		et, err := ParseFromInterface(now.Format(supportedDateFormat), nil)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), et.NestedKind.Type, DateKindType)
 
@@ -80,14 +80,14 @@ func (e *ExtTestSuite) TestParseFromInterfaceDate() {
 
 func (e *ExtTestSuite) TestParseExtendedDateTime_Timestamp() {
 	tsString := "2023-04-24T17:29:05.69944Z"
-	extTime, err := ParseExtendedDateTime(nil, tsString)
+	extTime, err := ParseExtendedDateTime(tsString, nil)
 	assert.NoError(e.T(), err)
 	assert.Equal(e.T(), "2023-04-24T17:29:05.69944Z", extTime.String(""))
 }
 
 func (e *ExtTestSuite) TestParseExtendedDateTime() {
 	dateString := "27/12/82"
-	extTime, err := ParseExtendedDateTime([]string{"02/01/06"}, dateString)
+	extTime, err := ParseExtendedDateTime(dateString, []string{"02/01/06"})
 	assert.NoError(e.T(), err)
 	assert.Equal(e.T(), "27/12/82", extTime.String(""))
 }
@@ -97,7 +97,7 @@ func (e *ExtTestSuite) TestTimeLayout() {
 
 	for _, supportedFormat := range supportedTimeFormats {
 		parsedTsString := ts.Format(supportedFormat)
-		extTime, err := ParseExtendedDateTime(nil, parsedTsString)
+		extTime, err := ParseExtendedDateTime(parsedTsString, nil)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), parsedTsString, extTime.String(""))
 	}

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -133,7 +133,7 @@ func ParseValue(ctx context.Context, key string, optionalSchema map[string]KindD
 		// This way, we don't penalize every string into going through this loop
 		// In the future, we can have specific layout RFCs run depending on the char
 		if strings.Contains(convertedVal, ":") || strings.Contains(convertedVal, "-") {
-			extendedKind, err := ext.ParseExtendedDateTime(cfg.SharedTransferConfig.AdditionalDateFormats, convertedVal)
+			extendedKind, err := ext.ParseExtendedDateTime(convertedVal, cfg.SharedTransferConfig.AdditionalDateFormats)
 			if err == nil {
 				return KindDetails{
 					Kind:                ETime.Kind,

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -133,7 +133,7 @@ func ParseValue(ctx context.Context, key string, optionalSchema map[string]KindD
 		// This way, we don't penalize every string into going through this loop
 		// In the future, we can have specific layout RFCs run depending on the char
 		if strings.Contains(convertedVal, ":") || strings.Contains(convertedVal, "-") {
-			extendedKind, err := ext.ParseExtendedDateTime(ctx, convertedVal)
+			extendedKind, err := ext.ParseExtendedDateTime(cfg.SharedTransferConfig.AdditionalDateFormats, convertedVal)
 			if err == nil {
 				return KindDetails{
 					Kind:                ETime.Kind,

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -152,19 +152,19 @@ func (t *TypingTestSuite) TestDateTime() {
 		assert.Equal(t.T(), ParseValue(t.ctx, "", nil, possibleDate).ExtendedTimeDetails.Type, ext.DateTime.Type, fmt.Sprintf("Failed format, value is: %v", possibleDate))
 
 		// Test the parseDT function as well.
-		ts, err := ext.ParseExtendedDateTime(t.ctx, fmt.Sprint(possibleDate))
+		ts, err := ext.ParseExtendedDateTime([]string{}, fmt.Sprint(possibleDate))
 		assert.NoError(t.T(), err, err)
 		assert.False(t.T(), ts.IsZero(), ts)
 	}
 
-	ts, err := ext.ParseExtendedDateTime(t.ctx, "random")
+	ts, err := ext.ParseExtendedDateTime([]string{}, "random")
 	assert.Error(t.T(), err, err)
 	assert.Nil(t.T(), ts)
 }
 
 func (t *TypingTestSuite) TestDateTime_Fallback() {
 	dtString := "Mon Jan 02 15:04:05.69944 -0700 2006"
-	ts, err := ext.ParseExtendedDateTime(t.ctx, dtString)
+	ts, err := ext.ParseExtendedDateTime(nil, dtString)
 	assert.NoError(t.T(), err)
 	assert.NotEqual(t.T(), ts.String(""), dtString)
 }

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -152,19 +152,19 @@ func (t *TypingTestSuite) TestDateTime() {
 		assert.Equal(t.T(), ParseValue(t.ctx, "", nil, possibleDate).ExtendedTimeDetails.Type, ext.DateTime.Type, fmt.Sprintf("Failed format, value is: %v", possibleDate))
 
 		// Test the parseDT function as well.
-		ts, err := ext.ParseExtendedDateTime([]string{}, fmt.Sprint(possibleDate))
+		ts, err := ext.ParseExtendedDateTime(fmt.Sprint(possibleDate), []string{})
 		assert.NoError(t.T(), err, err)
 		assert.False(t.T(), ts.IsZero(), ts)
 	}
 
-	ts, err := ext.ParseExtendedDateTime([]string{}, "random")
+	ts, err := ext.ParseExtendedDateTime("random", []string{})
 	assert.Error(t.T(), err, err)
 	assert.Nil(t.T(), ts)
 }
 
 func (t *TypingTestSuite) TestDateTime_Fallback() {
 	dtString := "Mon Jan 02 15:04:05.69944 -0700 2006"
-	ts, err := ext.ParseExtendedDateTime(nil, dtString)
+	ts, err := ext.ParseExtendedDateTime(dtString, nil)
 	assert.NoError(t.T(), err)
 	assert.NotEqual(t.T(), ts.String(""), dtString)
 }


### PR DESCRIPTION
## Changes

This is the 3rd PR (should be one more after this) to remove `context` from Artie Transfer's typing library.

This time, we're changing the function signatures of:
* ParseFromInterface
* ParseExtendedDateTime

...to not have `ctx` and take in an array of strings for the `additionalDateFormats`