### PR TITLE
Adding `default` to the list of reserved keywords

### DIFF
--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -42,6 +42,7 @@ var ReservedKeywords = []string{
 	"connect",
 	"create",
 	"current",
+	"default", // default isn't in this list, but it should be.
 	"delete",
 	"distinct",
 	"drop",


### PR DESCRIPTION
As per title, adding `default`