### PR TITLE
[Snowflake] Deprecate `snowflake_stage` constant

### DIFF
--- a/clients/utils/table_config.go
+++ b/clients/utils/table_config.go
@@ -61,7 +61,7 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 	var tableMissing bool
 	if err != nil {
 		switch args.Dwh.Label() {
-		case constants.Snowflake, constants.SnowflakeStages:
+		case constants.Snowflake:
 			if SnowflakeTableDoesNotExistErr(err) {
 				// Swallow the error, make sure all the metadata is created
 				tableMissing = true
@@ -109,7 +109,7 @@ func GetTableConfig(ctx context.Context, args GetTableCfgArgs) (*types.DwhTableC
 
 		var kd typing.KindDetails
 		switch args.Dwh.Label() {
-		case constants.Snowflake, constants.SnowflakeStages:
+		case constants.Snowflake:
 			kd = typing.SnowflakeTypeToKind(row[args.ColumnTypeLabel])
 		case constants.BigQuery:
 			kd = typing.BigQueryTypeToKind(row[args.ColumnTypeLabel])

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -489,7 +489,7 @@ func TestConfig_Validate(t *testing.T) {
 
 	// Check Snowflake and BigQuery for large rows
 	// All should be fine.
-	for _, destKind := range []constants.DestinationKind{constants.SnowflakeStages, constants.Snowflake, constants.BigQuery} {
+	for _, destKind := range []constants.DestinationKind{constants.Snowflake, constants.BigQuery} {
 		cfg.Output = destKind
 		cfg.BufferRows = bufferPoolSizeEnd + 1
 		assert.Nil(t, cfg.Validate())

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -112,18 +112,16 @@ const (
 type DestinationKind string
 
 const (
-	SnowflakeStages DestinationKind = "snowflake_stage"
-	Snowflake       DestinationKind = "snowflake"
-	Test            DestinationKind = "test"
-	BigQuery        DestinationKind = "bigquery"
-	Redshift        DestinationKind = "redshift"
-	S3              DestinationKind = "s3"
+	Snowflake DestinationKind = "snowflake"
+	Test      DestinationKind = "test"
+	BigQuery  DestinationKind = "bigquery"
+	Redshift  DestinationKind = "redshift"
+	S3        DestinationKind = "s3"
 )
 
 var ValidDestinations = []DestinationKind{
 	BigQuery,
 	Snowflake,
-	SnowflakeStages,
 	Redshift,
 	S3,
 	Test,

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -123,7 +123,7 @@ func AlterTable(ctx context.Context, args AlterTableArgs, cols ...columns.Column
 				sqlQuery = fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (%s) OPTIONS (expiration_timestamp = TIMESTAMP("%s"))`,
 					args.FqTableName, strings.Join(colSQLParts, ","), expiryString)
 			// Not enabled for constants.Snowflake yet
-			case constants.Snowflake, constants.SnowflakeStages:
+			case constants.Snowflake:
 				// TEMPORARY Table syntax - https://docs.snowflake.com/en/sql-reference/sql/create-table
 				// PURGE syntax - https://docs.snowflake.com/en/sql-reference/sql/copy-into-table#purging-files-after-loading
 				// FIELD_OPTIONALLY_ENCLOSED_BY - is needed because CSV will try to escape any values that have `"`

--- a/lib/destination/ddl/ddl_test.go
+++ b/lib/destination/ddl/ddl_test.go
@@ -60,7 +60,7 @@ func (d *DDLTestSuite) Test_DropTemporaryTable() {
 
 	for _, _dwh := range []destination.DataWarehouse{d.bigQueryStore, d.snowflakeStagesStore} {
 		var fakeStore *mocks.FakeStore
-		if _dwh.Label() == constants.Snowflake || _dwh.Label() == constants.SnowflakeStages {
+		if _dwh.Label() == constants.Snowflake {
 			fakeStore = d.fakeSnowflakeStagesStore
 		} else if _dwh.Label() == constants.BigQuery {
 			fakeStore = d.fakeBigQueryStore

--- a/lib/destination/ddl/errors.go
+++ b/lib/destination/ddl/errors.go
@@ -16,7 +16,7 @@ func ColumnAlreadyExistErr(err error, kind constants.DestinationKind) bool {
 		// Error ends up looking like something like this: Column already exists: _string at [1:39]
 		return strings.Contains(err.Error(), "Column already exists")
 
-	case constants.Snowflake, constants.SnowflakeStages, constants.Redshift:
+	case constants.Snowflake, constants.Redshift:
 		// Snowflake doesn't have column mutations (IF NOT EXISTS)
 		// Redshift's error: ERROR: column "foo" of relation "statement" already exists
 		return strings.Contains(err.Error(), "already exists")

--- a/lib/destination/dml/merge_parts_test.go
+++ b/lib/destination/dml/merge_parts_test.go
@@ -15,7 +15,6 @@ import (
 func (m *MergeTestSuite) TestMergeStatementPartsValidation() {
 	for _, arg := range []*MergeArgument{
 		{DestKind: constants.Snowflake},
-		{DestKind: constants.SnowflakeStages},
 		{DestKind: constants.BigQuery},
 	} {
 		parts, err := MergeStatementParts(m.ctx, arg)

--- a/lib/destination/utils/load.go
+++ b/lib/destination/utils/load.go
@@ -53,7 +53,7 @@ func DataWarehouse(ctx context.Context, store *db.Store) destination.DataWarehou
 			Fake: mocks.FakeStore{},
 		})
 		return snowflake.LoadSnowflake(ctx, &store)
-	case constants.Snowflake, constants.SnowflakeStages:
+	case constants.Snowflake:
 		s := snowflake.LoadSnowflake(ctx, store)
 		if err := s.Sweep(ctx); err != nil {
 			logger.FromContext(ctx).WithError(err).Fatalf("failed to clean up snowflake")

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -174,7 +174,6 @@ func (o *OptimizationTestSuite) TestNewTableData_TableName() {
 		}, testCase.tableName)
 		assert.Equal(o.T(), testCase.expectedName, td.RawName(), testCase.name)
 		assert.Equal(o.T(), testCase.expectedName, td.name, testCase.name)
-		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.SnowflakeStages, true, ""), testCase.name)
 		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.Snowflake, true, ""), testCase.name)
 		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true, bqProjectID), testCase.name)
 		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true, bqProjectID), testCase.name)

--- a/lib/typing/columns/wrapper_test.go
+++ b/lib/typing/columns/wrapper_test.go
@@ -58,7 +58,7 @@ func (c *ColumnsTestSuite) TestWrapper_Complete() {
 		assert.Equal(c.T(), testCase.expectedEscapedNameBQ, w.EscapedName(), testCase.name)
 		assert.Equal(c.T(), testCase.expectedRawName, w.RawName(), testCase.name)
 
-		for _, destKind := range []constants.DestinationKind{constants.Snowflake, constants.SnowflakeStages, constants.BigQuery} {
+		for _, destKind := range []constants.DestinationKind{constants.Snowflake, constants.BigQuery} {
 			w = NewWrapper(c.ctx, NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
 				Escape:   false,
 				DestKind: destKind,

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -172,7 +172,7 @@ func ParseValue(ctx context.Context, key string, optionalSchema map[string]KindD
 
 func KindToDWHType(kd KindDetails, dwh constants.DestinationKind) string {
 	switch dwh {
-	case constants.Snowflake, constants.SnowflakeStages:
+	case constants.Snowflake:
 		return kindToSnowflake(kd)
 	case constants.BigQuery:
 		return kindToBigQuery(kd)


### PR DESCRIPTION
We should standardize everything on `snowflake` and not have to chain if statements everywhere

### Note to folks upgrading

All you'll need to do is update your `outputSource` from `snowflake_stage` to `snowflake`