### PR TITLE
[ExtTime] Enforce YYYY format

### DIFF
--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -61,6 +61,12 @@ func NewExtendedTime(t time.Time, kindType ExtendedTimeKindType, originalFormat 
 }
 
 func (e *ExtendedTime) String(overrideFormat string) string {
+	// This will make us feature-parity with Go: https://github.com/golang/go/blob/97daa6e94296980b4aa2dac93a938a5edd95ce93/src/time/format_rfc3339.go#L62
+	// If the year exceeds YYYY, or is in BC then we should return an empty string.
+	if e.Year() > 9999 || e.Year() < 0 {
+		return ""
+	}
+
 	if overrideFormat != "" {
 		return e.Time.Format(overrideFormat)
 	}

--- a/lib/typing/ext/time_test.go
+++ b/lib/typing/ext/time_test.go
@@ -1,0 +1,25 @@
+package ext
+
+import "time"
+
+func (e *ExtTestSuite) TestString() {
+	{
+		// Test DateTime
+		extendedTime, err := NewExtendedTime(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC), DateTimeKindType, "")
+		e.NoError(err)
+		e.Equal("2020-01-01T00:00:00Z", extendedTime.String(""))
+	}
+	{
+		// Test year 10k, should be empty string.
+		extendedTime, err := NewExtendedTime(time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC), DateTimeKindType, "")
+		e.NoError(err)
+		e.Equal("", extendedTime.String(""))
+	}
+
+	{
+		// Test year in BC, should also be empty string
+		extendedTime, err := NewExtendedTime(time.Date(-1, 1, 1, 0, 0, 0, 0, time.UTC), DateTimeKindType, "")
+		e.NoError(err)
+		e.Equal("", extendedTime.String(""))
+	}
+}


### PR DESCRIPTION
For `time.Time` where:
1. The year exceeds `YYYY` format, let's return empty string.
2. The year is in BC format, let's return empty string.

Most destinations has problems with this like Snowflake.