### PR TITLE
[ExtTime] Enforce YYYY - Take two

### DIFF
--- a/lib/cdc/util/parse.go
+++ b/lib/cdc/util/parse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/artie-labs/transfer/lib/jsonutil"
 
@@ -64,6 +65,15 @@ func parseField(ctx context.Context, field debezium.Field, value interface{}) in
 				if err == nil {
 					return extendedTime
 				} else {
+					if strings.Contains(err.Error(), "is not valid") {
+						logger.FromContext(ctx).WithFields(map[string]interface{}{
+							"err":           err,
+							"supportedType": supportedType,
+							"val":           value,
+						}).Info("returning nil here instead")
+						return nil
+					}
+
 					logger.FromContext(ctx).WithFields(map[string]interface{}{
 						"err":           err,
 						"supportedType": supportedType,

--- a/lib/cdc/util/parse.go
+++ b/lib/cdc/util/parse.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/artie-labs/transfer/lib/jsonutil"
+	"github.com/artie-labs/transfer/lib/typing/ext"
 
 	"github.com/artie-labs/transfer/lib/debezium"
 	"github.com/artie-labs/transfer/lib/logger"
@@ -65,12 +65,12 @@ func parseField(ctx context.Context, field debezium.Field, value interface{}) in
 				if err == nil {
 					return extendedTime
 				} else {
-					if strings.Contains(err.Error(), "is not valid") {
+					if ext.IsInvalidErr(err) {
 						logger.FromContext(ctx).WithFields(map[string]interface{}{
 							"err":           err,
 							"supportedType": supportedType,
 							"val":           value,
-						}).Info("returning nil here instead")
+						}).Info("extTime is not valid, so returning nil here instead")
 						return nil
 					}
 

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -60,29 +60,38 @@ func RequiresSpecialTypeCasting(typeLabel string) (bool, SupportedDebeziumType) 
 	return false, Invalid
 }
 
+// FromDebeziumTypeToTime is implemented by following this spec: https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-temporal-types
 func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ext.ExtendedTime, error) {
-	// https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-temporal-types
+	var extTime *ext.ExtendedTime
+	var err error
 	switch supportedType {
 	case Timestamp, DateTimeKafkaConnect:
 		// Represents the number of milliseconds since the epoch, and does not include timezone information.
-		return ext.NewExtendedTime(time.UnixMilli(val).In(time.UTC), ext.DateTimeKindType, time.RFC3339Nano)
+		extTime, err = ext.NewExtendedTime(time.UnixMilli(val).In(time.UTC), ext.DateTimeKindType, time.RFC3339Nano)
 	case MicroTimestamp:
 		// Represents the number of microseconds since the epoch, and does not include timezone information.
-		return ext.NewExtendedTime(time.UnixMicro(val).In(time.UTC), ext.DateTimeKindType, time.RFC3339Nano)
+		extTime, err = ext.NewExtendedTime(time.UnixMicro(val).In(time.UTC), ext.DateTimeKindType, time.RFC3339Nano)
 	case Date, DateKafkaConnect:
 		unix := time.UnixMilli(0).In(time.UTC) // 1970-01-01
 		// Represents the number of days since the epoch.
-		return ext.NewExtendedTime(unix.AddDate(0, 0, int(val)), ext.DateKindType, "")
+		extTime, err = ext.NewExtendedTime(unix.AddDate(0, 0, int(val)), ext.DateKindType, "")
 	case Time, TimeKafkaConnect:
 		// Represents the number of milliseconds past midnight, and does not include timezone information.
-		return ext.NewExtendedTime(time.UnixMilli(val).In(time.UTC), ext.TimeKindType, "")
+		extTime, err = ext.NewExtendedTime(time.UnixMilli(val).In(time.UTC), ext.TimeKindType, "")
 	case TimeMicro:
 		// Represents the number of microseconds past midnight, and does not include timezone information.
-		return ext.NewExtendedTime(time.UnixMicro(val).In(time.UTC), ext.TimeKindType, "")
-
+		extTime, err = ext.NewExtendedTime(time.UnixMicro(val).In(time.UTC), ext.TimeKindType, "")
+	default:
+		return nil, fmt.Errorf("supportedType: %s, val: %v failed to be matched", supportedType, val)
 	}
 
-	return nil, fmt.Errorf("supportedType: %s, val: %v failed to be matched", supportedType, val)
+	if extTime != nil {
+		if !extTime.IsValid() {
+			return nil, fmt.Errorf("extTime is not valid, extTime: %v", extTime.String(""))
+		}
+	}
+
+	return extTime, err
 }
 
 // DecodeDecimal is used to handle `org.apache.kafka.connect.data.Decimal` where this would be emitted by Debezium when the `decimal.handling.mode` is `precise`

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -90,10 +90,8 @@ func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ex
 		return nil, err
 	}
 
-	if extTime != nil {
-		if !extTime.IsValid() {
-			return nil, fmt.Errorf("%s, extTime: %v", ext.InvalidErrPrefix, extTime)
-		}
+	if extTime != nil && !extTime.IsValid() {
+		return nil, fmt.Errorf("%s, extTime: %v", ext.InvalidErrPrefix, extTime)
 	}
 
 	return extTime, err

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -92,7 +92,7 @@ func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ex
 
 	if extTime != nil {
 		if !extTime.IsValid() {
-			return nil, fmt.Errorf("extTime is not valid, extTime: %v", extTime)
+			return nil, fmt.Errorf("%s, extTime: %v", ext.InvalidErrPrefix, extTime)
 		}
 	}
 

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -64,6 +64,7 @@ func RequiresSpecialTypeCasting(typeLabel string) (bool, SupportedDebeziumType) 
 func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ext.ExtendedTime, error) {
 	var extTime *ext.ExtendedTime
 	var err error
+
 	switch supportedType {
 	case Timestamp, DateTimeKafkaConnect:
 		// Represents the number of milliseconds since the epoch, and does not include timezone information.
@@ -85,9 +86,13 @@ func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ex
 		return nil, fmt.Errorf("supportedType: %s, val: %v failed to be matched", supportedType, val)
 	}
 
+	if err != nil {
+		return nil, err
+	}
+
 	if extTime != nil {
 		if !extTime.IsValid() {
-			return nil, fmt.Errorf("extTime is not valid, extTime: %v", extTime.String(""))
+			return nil, fmt.Errorf("extTime is not valid, extTime: %v", extTime)
 		}
 	}
 

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -315,8 +315,6 @@ func TestTableData_ShouldFlushRowSize(t *testing.T) {
 		},
 	}, false)
 
-	fmt.Println("####", td.approxSize)
-
 	shouldFlush, flushReason := td.ShouldFlush(ctx)
 	assert.True(t, shouldFlush)
 	assert.Equal(t, "size", flushReason)

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -1,6 +1,7 @@
 package ext
 
 import (
+	"strings"
 	"time"
 )
 
@@ -39,6 +40,16 @@ var (
 type ExtendedTime struct {
 	time.Time
 	NestedKind NestedKind
+}
+
+const InvalidErrPrefix = "extTime is not valid"
+
+func IsInvalidErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.HasPrefix(err.Error(), InvalidErrPrefix)
 }
 
 func (e *ExtendedTime) IsValid() bool {

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -1,6 +1,8 @@
 package ext
 
-import "time"
+import (
+	"time"
+)
 
 type ExtendedTimeKindType string
 

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -39,6 +39,15 @@ type ExtendedTime struct {
 	NestedKind NestedKind
 }
 
+func (e *ExtendedTime) IsValid() bool {
+	// This will make us feature-parity with Go: https://github.com/golang/go/blob/97daa6e94296980b4aa2dac93a938a5edd95ce93/src/time/format_rfc3339.go#L62
+	if e.Time.Year() > 9999 || e.Time.Year() < 0 {
+		return false
+	}
+
+	return true
+}
+
 func NewExtendedTime(t time.Time, kindType ExtendedTimeKindType, originalFormat string) (*ExtendedTime, error) {
 	if originalFormat == "" {
 		switch kindType {

--- a/lib/typing/ext/time_test.go
+++ b/lib/typing/ext/time_test.go
@@ -1,0 +1,28 @@
+package ext
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (e *ExtTestSuite) TestExtTimeIsValid() {
+	{
+		ext := ExtendedTime{
+			Time: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		assert.True(e.T(), ext.IsValid())
+	}
+	{
+		ext := ExtendedTime{
+			Time: time.Date(20020, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		assert.False(e.T(), ext.IsValid())
+	}
+	{
+		ext := ExtendedTime{
+			Time: time.Date(-1300, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		assert.False(e.T(), ext.IsValid())
+	}
+}


### PR DESCRIPTION
## Motivation

Bad data can come into Transfer, we should figure out a way to filter them, especially for `time.Time` objects where the year exceeds the YYYY format or in BC. They will get rejected by downstream destinations, so let's filter them out and not hard fail.

