### PR TITLE
Support Debezium Maps

### DIFF
--- a/lib/cdc/mysql/debezium_test.go
+++ b/lib/cdc/mysql/debezium_test.go
@@ -140,7 +140,19 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 				"type": "int64",
 				"optional": false,
 				"field": "abcDEF"
-			}],
+			}, {
+                "type": "map",
+                "keys": {
+                    "type": "string",
+                    "optional": false
+                },
+                "values": {
+                    "type": "string",
+                    "optional": true
+                },
+                "optional": false,
+                "field": "custom_fields"
+            }],
 			"optional": true,
 			"name": "mysql1.inventory.customers.Value",
 			"field": "after"
@@ -307,6 +319,9 @@ func (m *MySQLTestSuite) TestGetEventFromBytes() {
 	assert.NoError(m.T(), err)
 	assert.Equal(m.T(), time.Date(2023, time.March, 13, 19, 19, 24, 0, time.UTC), evt.GetExecutionTime())
 	assert.Equal(m.T(), "customers", evt.GetTableName())
+
+	schema := evt.GetOptionalSchema(ctx)
+	assert.Equal(m.T(), typing.Struct, schema["custom_fields"])
 
 	kvMap := map[string]interface{}{
 		"id": 1001,

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -107,6 +107,8 @@ func (f Field) ToKindDetails() typing.KindDetails {
 	}
 
 	switch f.Type {
+	case "map":
+		return typing.Struct
 	case "int16", "int32", "int64":
 		return typing.Integer
 	case "float", "double":

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -329,6 +329,14 @@ func TestField_ToKindDetails(t *testing.T) {
 			},
 			expectedKindDetails: eDecimal,
 		},
+		{
+			name: "Debezium Map",
+			field: Field{
+				DebeziumType: "",
+				Type:         "map",
+			},
+			expectedKindDetails: typing.Struct,
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
This is what it looks like from Debezium:

```json
{
    "type": "struct",
    "fields": [
        {
            "type": "struct",
            "fields": [
                {
                    "type": "int32",
                    "optional": false,
                    "default": 0,
                    "field": "id"
                },
                {
                    "type": "string",
                    "optional": false,
                    "field": "first_name"
                },
                {
                    "type": "string",
                    "optional": false,
                    "field": "last_name"
                },
                {
                    "type": "string",
                    "optional": false,
                    "field": "email"
                },
                {
                    "type": "map",
                    "keys": {
                        "type": "string",
                        "optional": false
                    },
                    "values": {
                        "type": "string",
                        "optional": true
                    },
                    "optional": false,
                    "field": "custom_fields"
                }
            ],
            "optional": true,
            "name": "dbserver1.inventory.customers.Value",
            "field": "before"
        }
    ]
}
```