### PR TITLE
Remove `context` from `lib/typing` - Part 4

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -93,7 +93,8 @@ func LoadBigQuery(ctx context.Context, _store *db.Store) *Store {
 	if _store != nil {
 		// Used for tests.
 		return &Store{
-			Store:             *_store,
+			Store: *_store,
+
 			projectID:         settings.Config.BigQuery.ProjectID,
 			uppercaseEscNames: settings.Config.SharedDestinationConfig.UppercaseEscapedNames,
 			configMap:         &types.DwhToTablesConfigMap{},
@@ -110,7 +111,8 @@ func LoadBigQuery(ctx context.Context, _store *db.Store) *Store {
 	}
 
 	return &Store{
-		Store:             db.Open(ctx, "bigquery", settings.Config.BigQuery.DSN()),
+		Store: db.Open(ctx, "bigquery", settings.Config.BigQuery.DSN()),
+
 		configMap:         &types.DwhToTablesConfigMap{},
 		batchSize:         settings.Config.BigQuery.BatchSize,
 		projectID:         settings.Config.BigQuery.ProjectID,

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -114,12 +114,13 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	fqName := tableData.ToFqName(s.Label(), true, s.uppercaseEscNames, s.projectID)
 	createAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:         s,
-		Tc:          tableConfig,
-		FqTableName: fqName,
-		CreateTable: tableConfig.CreateTable(),
-		ColumnOp:    constants.Add,
-		CdcTime:     tableData.LatestCDCTs,
+		Dwh:               s,
+		Tc:                tableConfig,
+		FqTableName:       fqName,
+		CreateTable:       tableConfig.CreateTable(),
+		ColumnOp:          constants.Add,
+		CdcTime:           tableData.LatestCDCTs,
+		UppercaseEscNames: &s.uppercaseEscNames,
 	}
 
 	// Keys that exist in CDC stream, but not in BigQuery
@@ -140,6 +141,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		ColumnOp:               constants.Delete,
 		ContainOtherOperations: tableData.ContainOtherOperations(),
 		CdcTime:                tableData.LatestCDCTs,
+		UppercaseEscNames:      &s.uppercaseEscNames,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)
@@ -155,12 +157,13 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 	// Start temporary table creation
 	tempAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:            s,
-		Tc:             tableConfig,
-		FqTableName:    fmt.Sprintf("%s_%s", tableData.ToFqName(s.Label(), false, s.uppercaseEscNames, s.projectID), tableData.TempTableSuffix()),
-		CreateTable:    true,
-		TemporaryTable: true,
-		ColumnOp:       constants.Add,
+		Dwh:               s,
+		Tc:                tableConfig,
+		FqTableName:       fmt.Sprintf("%s_%s", tableData.ToFqName(s.Label(), false, s.uppercaseEscNames, s.projectID), tableData.TempTableSuffix()),
+		CreateTable:       true,
+		TemporaryTable:    true,
+		ColumnOp:          constants.Add,
+		UppercaseEscNames: &s.uppercaseEscNames,
 	}
 
 	if err = ddl.AlterTable(ctx, tempAlterTableArgs, tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -228,7 +228,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		additionalEqualityStrings = []string{mergeString}
 	}
 
-	mergeArg := &dml.MergeArgument{
+	mergeArg := dml.MergeArgument{
 		FqTableName:               fqName,
 		AdditionalEqualityStrings: additionalEqualityStrings,
 		SubQuery:                  tempAlterTableArgs.FqTableName,

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -228,20 +228,19 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		additionalEqualityStrings = []string{mergeString}
 	}
 
-	mergeQuery, err := dml.MergeStatement(ctx, &dml.MergeArgument{
+	mergeArg := &dml.MergeArgument{
 		FqTableName:               fqName,
 		AdditionalEqualityStrings: additionalEqualityStrings,
 		SubQuery:                  tempAlterTableArgs.FqTableName,
 		IdempotentKey:             tableData.TopicConfig.IdempotentKey,
-		PrimaryKeys: tableData.PrimaryKeys(ctx, &sql.NameArgs{
-			Escape:   true,
-			DestKind: s.Label(),
-		}),
-		ColumnsToTypes: *tableData.ReadOnlyInMemoryCols(),
-		SoftDelete:     tableData.TopicConfig.SoftDelete,
-		DestKind:       s.Label(),
-	})
+		PrimaryKeys:               tableData.PrimaryKeys(s.uppercaseEscNames, &sql.NameArgs{Escape: true, DestKind: s.Label()}),
+		ColumnsToTypes:            *tableData.ReadOnlyInMemoryCols(),
+		SoftDelete:                tableData.TopicConfig.SoftDelete,
+		DestKind:                  s.Label(),
+		UppercaseEscNames:         &s.uppercaseEscNames,
+	}
 
+	mergeQuery, err := mergeArg.GetStatement()
 	if err != nil {
 		return err
 	}

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -28,17 +28,18 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	log := logger.FromContext(ctx)
-	fqName := tableData.ToFqName(ctx, s.Label(), true, "")
+	fqName := tableData.ToFqName(s.Label(), true, s.uppercaseEscNames, "")
 	// Check if all the columns exist in Redshift
 	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
 		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt)
 	createAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:         s,
-		Tc:          tableConfig,
-		FqTableName: fqName,
-		CreateTable: tableConfig.CreateTable(),
-		ColumnOp:    constants.Add,
-		CdcTime:     tableData.LatestCDCTs,
+		Dwh:               s,
+		Tc:                tableConfig,
+		FqTableName:       fqName,
+		CreateTable:       tableConfig.CreateTable(),
+		ColumnOp:          constants.Add,
+		CdcTime:           tableData.LatestCDCTs,
+		UppercaseEscNames: &s.uppercaseEscNames,
 	}
 
 	// Keys that exist in CDC stream, but not in Redshift
@@ -59,6 +60,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		ColumnOp:               constants.Delete,
 		ContainOtherOperations: tableData.ContainOtherOperations(),
 		CdcTime:                tableData.LatestCDCTs,
+		UppercaseEscNames:      &s.uppercaseEscNames,
 	}
 
 	err = ddl.AlterTable(ctx, deleteAlterTableArgs, srcKeysMissing...)
@@ -71,7 +73,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	tableData.MergeColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 
 	// Temporary tables cannot specify schemas, so we just prefix it instead.
-	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(ctx, s.Label(), false, ""), tableData.TempTableSuffix())
+	temporaryTableName := fmt.Sprintf("%s_%s", tableData.ToFqName(s.Label(), false, s.uppercaseEscNames, ""), tableData.TempTableSuffix())
 	if err = s.prepareTempTable(ctx, tableData, tableConfig, temporaryTableName); err != nil {
 		return err
 	}

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -94,7 +94,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		})
 	}
 
-	mergArg := &dml.MergeArgument{
+	mergArg := dml.MergeArgument{
 		FqTableName: fqName,
 		// We are adding SELECT DISTINCT here for the temporary table as an extra guardrail.
 		// Redshift does not enforce any row uniqueness and there could be potential LOAD errors which will cause duplicate rows to arise.

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -78,6 +78,7 @@ func (s *Store) loadTemporaryTable(ctx context.Context, tableData *optimization.
 	if err != nil {
 		return "", err
 	}
+
 	defer file.Close()
 
 	gzipWriter := gzip.NewWriter(file) // Create a new gzip writer
@@ -89,12 +90,13 @@ func (s *Store) loadTemporaryTable(ctx context.Context, tableData *optimization.
 	additionalDateFmts := config.FromContext(ctx).Config.SharedTransferConfig.AdditionalDateFormats
 	for _, value := range tableData.RowsData() {
 		var row []string
-		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(ctx, nil) {
+		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(s.uppercaseEscNames, nil) {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			castedValue, castErr := s.CastColValStaging(value[col], colKind, additionalDateFmts)
 			if castErr != nil {
 				return "", castErr
 			}
+
 			row = append(row, castedValue)
 		}
 

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -147,7 +147,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	return os.RemoveAll(fp)
 }
 
-func LoadStore(_ context.Context, settings *config.S3Settings) (*Store, error) {
+func LoadStore(settings *config.S3Settings) (*Store, error) {
 	store := &Store{
 		Settings:          settings,
 		uppercaseEscNames: false,

--- a/clients/s3/s3_test.go
+++ b/clients/s3/s3_test.go
@@ -60,7 +60,7 @@ func (s *S3TestSuite) TestObjectPrefix() {
 	}
 
 	for _, tc := range testCases {
-		store, err := LoadStore(s.ctx, tc.config)
+		store, err := LoadStore(tc.config)
 		if tc.expectError {
 			assert.Error(s.T(), err, tc.name)
 		} else {

--- a/clients/s3/s3_test.go
+++ b/clients/s3/s3_test.go
@@ -65,7 +65,7 @@ func (s *S3TestSuite) TestObjectPrefix() {
 			assert.Error(s.T(), err, tc.name)
 		} else {
 			assert.NoError(s.T(), err, tc.name)
-			actualObjectPrefix := store.ObjectPrefix(s.ctx, tc.tableData)
+			actualObjectPrefix := store.ObjectPrefix(tc.tableData)
 			assert.Equal(s.T(), tc.expectedFormat, actualObjectPrefix, tc.name)
 		}
 	}

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -18,8 +18,9 @@ import (
 
 type Store struct {
 	db.Store
-	testDB    bool // Used for testing
-	configMap *types.DwhToTablesConfigMap
+	uppercaseEscNames bool
+	testDB            bool // Used for testing
+	configMap         *types.DwhToTablesConfigMap
 }
 
 const (
@@ -97,17 +98,21 @@ func (s *Store) reestablishConnection(ctx context.Context) {
 }
 
 func LoadSnowflake(ctx context.Context, _store *db.Store) *Store {
+	cfg := config.FromContext(ctx).Config
+
 	if _store != nil {
 		// Used for tests.
 		return &Store{
-			testDB:    true,
-			Store:     *_store,
-			configMap: &types.DwhToTablesConfigMap{},
+			testDB:            true,
+			uppercaseEscNames: cfg.SharedDestinationConfig.UppercaseEscapedNames,
+			configMap:         &types.DwhToTablesConfigMap{},
+			Store:             *_store,
 		}
 	}
 
 	s := &Store{
-		configMap: &types.DwhToTablesConfigMap{},
+		uppercaseEscNames: cfg.SharedDestinationConfig.UppercaseEscapedNames,
+		configMap:         &types.DwhToTablesConfigMap{},
 	}
 
 	s.reestablishConnection(ctx)

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -106,7 +106,8 @@ func LoadSnowflake(ctx context.Context, _store *db.Store) *Store {
 			testDB:            true,
 			uppercaseEscNames: cfg.SharedDestinationConfig.UppercaseEscapedNames,
 			configMap:         &types.DwhToTablesConfigMap{},
-			Store:             *_store,
+
+			Store: *_store,
 		}
 	}
 

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -110,7 +110,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		tableData.InsertRow(pk, row, false)
 	}
 
-	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(constants.Snowflake, true, s.stageStore.uppercaseEscNames, ""),
+	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.stageStore.Label(), true, s.stageStore.uppercaseEscNames, ""),
 		types.NewDwhTableConfig(&cols, nil, false, true))
 
 	s.fakeStageStore.ExecReturnsOnCall(0, nil, fmt.Errorf("390114: Authentication token has expired. The user must authenticate again."))

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -64,7 +64,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		anotherCols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, ""),
+	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.stageStore.Label(), true, s.stageStore.uppercaseEscNames, ""),
 		types.NewDwhTableConfig(&anotherCols, nil, false, true))
 
 	err := s.stageStore.Merge(s.ctx, tableData)
@@ -110,7 +110,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		tableData.InsertRow(pk, row, false)
 	}
 
-	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, ""),
+	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(constants.Snowflake, true, s.stageStore.uppercaseEscNames, ""),
 		types.NewDwhTableConfig(&cols, nil, false, true))
 
 	s.fakeStageStore.ExecReturnsOnCall(0, nil, fmt.Errorf("390114: Authentication token has expired. The user must authenticate again."))
@@ -160,7 +160,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 
 	var idx int
 
-	fqName := tableData.ToFqName(s.ctx, constants.Snowflake, true, "")
+	fqName := tableData.ToFqName(s.stageStore.Label(), true, s.stageStore.uppercaseEscNames, "")
 	s.stageStore.configMap.AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, true))
 	err := s.stageStore.Merge(s.ctx, tableData)
 	assert.Nil(s.T(), err)
@@ -242,7 +242,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 	sflkCols.AddColumn(columns.NewColumn("new", typing.String))
 	config := types.NewDwhTableConfig(&sflkCols, nil, false, true)
-	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, ""), config)
+	s.stageStore.configMap.AddTableToConfig(tableData.ToFqName(s.stageStore.Label(), true, s.stageStore.uppercaseEscNames, ""), config)
 
 	err := s.stageStore.Merge(s.ctx, tableData)
 	assert.Nil(s.T(), err)
@@ -250,10 +250,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	assert.Equal(s.T(), s.fakeStageStore.ExecCallCount(), 5, "called merge")
 
 	// Check the temp deletion table now.
-	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, "")).ReadOnlyColumnsToDelete()), 1,
-		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, "")).ReadOnlyColumnsToDelete())
+	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.stageStore.Label(), true, s.stageStore.uppercaseEscNames, "")).ReadOnlyColumnsToDelete()), 1,
+		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.stageStore.Label(), true, s.stageStore.uppercaseEscNames, "")).ReadOnlyColumnsToDelete())
 
-	_, isOk := s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, "")).ReadOnlyColumnsToDelete()["new"]
+	_, isOk := s.stageStore.configMap.TableConfig(tableData.ToFqName(s.stageStore.Label(), true, s.stageStore.uppercaseEscNames, "")).ReadOnlyColumnsToDelete()["new"]
 	assert.True(s.T(), isOk)
 
 	// Now try to execute merge where 1 of the rows have the column now
@@ -274,8 +274,8 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	assert.Equal(s.T(), s.fakeStageStore.ExecCallCount(), 10, "called merge again")
 
 	// Caught up now, so columns should be 0.
-	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, "")).ReadOnlyColumnsToDelete()), 0,
-		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.ctx, constants.Snowflake, true, "")).ReadOnlyColumnsToDelete())
+	assert.Equal(s.T(), len(s.stageStore.configMap.TableConfig(tableData.ToFqName(s.stageStore.Label(), true, s.stageStore.uppercaseEscNames, "")).ReadOnlyColumnsToDelete()), 0,
+		s.stageStore.configMap.TableConfig(tableData.ToFqName(s.stageStore.Label(), true, s.stageStore.uppercaseEscNames, "")).ReadOnlyColumnsToDelete())
 }
 
 func (s *SnowflakeTestSuite) TestExecuteMergeExitEarly() {

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -185,7 +185,7 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		})
 	}
 
-	mergeArg := &dml.MergeArgument{
+	mergeArg := dml.MergeArgument{
 		FqTableName:       fqName,
 		SubQuery:          temporaryTableName,
 		IdempotentKey:     tableData.TopicConfig.IdempotentKey,
@@ -195,7 +195,6 @@ func (s *Store) mergeWithStages(ctx context.Context, tableData *optimization.Tab
 		UppercaseEscNames: &s.uppercaseEscNames,
 	}
 
-	// Prepare merge statement
 	mergeQuery, err := mergeArg.GetStatement()
 	if err != nil {
 		return fmt.Errorf("failed to generate merge statement, err: %v", err)

--- a/clients/utils/utils.go
+++ b/clients/utils/utils.go
@@ -31,7 +31,8 @@ func BackfillColumn(ctx context.Context, dwh destination.DataWarehouse, column c
 		return fmt.Errorf("failed to escape default value, err: %v", err)
 	}
 
-	escapedCol := column.Name(ctx, &sql.NameArgs{Escape: true, DestKind: dwh.Label()})
+	uppercaseEscNames := config.FromContext(ctx).Config.SharedDestinationConfig.UppercaseEscapedNames
+	escapedCol := column.Name(uppercaseEscNames, &sql.NameArgs{Escape: true, DestKind: dwh.Label()})
 
 	// TODO: This is added because `default` is not technically a column that requires escaping, but it is required when it's in the where clause.
 	// Once we escape everything by default, we can remove this patch of code.

--- a/lib/destination/ddl/ddl_alter_delete_test.go
+++ b/lib/destination/ddl/ddl_alter_delete_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/artie-labs/transfer/lib/config"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -60,6 +62,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: true,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts,
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -80,6 +83,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: true,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts,
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -100,6 +104,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: true,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts,
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -134,6 +139,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: false,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts,
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -154,6 +160,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: false,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts,
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -174,6 +181,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: false,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts,
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -210,6 +218,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: true,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts,
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -226,6 +235,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: true,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts,
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -242,6 +252,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: true,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts,
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -266,6 +277,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: true,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts.Add(2 * constants.DeletionConfidencePadding),
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -280,6 +292,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: true,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts.Add(2 * constants.DeletionConfidencePadding),
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err = ddl.AlterTable(d.ctx, alterTableArgs, column)
@@ -294,6 +307,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			ContainOtherOperations: true,
 			ColumnOp:               constants.Delete,
 			CdcTime:                ts.Add(2 * constants.DeletionConfidencePadding),
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err = ddl.AlterTable(d.ctx, alterTableArgs, column)

--- a/lib/destination/ddl/ddl_alter_delete_test.go
+++ b/lib/destination/ddl/ddl_alter_delete_test.go
@@ -31,9 +31,9 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	}, "tableName")
 
 	originalColumnLength := len(cols.GetColumns())
-	bqName := td.ToFqName(d.bqCtx, constants.BigQuery, true, config.FromContext(d.bqCtx).Config.BigQuery.ProjectID)
-	redshiftName := td.ToFqName(d.ctx, constants.Redshift, true, "")
-	snowflakeName := td.ToFqName(d.ctx, constants.Snowflake, true, "")
+	bqName := td.ToFqName(constants.BigQuery, true, false, config.FromContext(d.bqCtx).Config.BigQuery.ProjectID)
+	redshiftName := td.ToFqName(constants.Redshift, true, false, "")
+	snowflakeName := td.ToFqName(constants.Snowflake, true, false, "")
 
 	// Testing 3 scenarios here
 	// 1. DropDeletedColumns = false, ContainOtherOperations = true, don't delete ever.

--- a/lib/destination/ddl/ddl_bq_test.go
+++ b/lib/destination/ddl/ddl_bq_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/artie-labs/transfer/lib/config"
 
 	artieSQL "github.com/artie-labs/transfer/lib/sql"
@@ -61,6 +63,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 			ColumnOp:               constants.Delete,
 			ContainOtherOperations: true,
 			CdcTime:                ts,
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
@@ -83,6 +86,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 			ColumnOp:               constants.Delete,
 			ContainOtherOperations: true,
 			CdcTime:                ts.Add(2 * constants.DeletionConfidencePadding),
+			UppercaseEscNames:      ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
@@ -135,12 +139,13 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)
 	for name, kind := range newCols {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:         d.bigQueryStore,
-			Tc:          tc,
-			FqTableName: fqName,
-			CreateTable: tc.CreateTable(),
-			ColumnOp:    constants.Add,
-			CdcTime:     ts,
+			Dwh:               d.bigQueryStore,
+			Tc:                tc,
+			FqTableName:       fqName,
+			CreateTable:       tc.CreateTable(),
+			ColumnOp:          constants.Add,
+			CdcTime:           ts,
+			UppercaseEscNames: ptr.ToBool(false),
 		}
 
 		col := columns.NewColumn(name, kind)
@@ -198,12 +203,13 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 		// BQ returning the same error because the column already exists.
 		d.fakeBigQueryStore.ExecReturnsOnCall(0, sqlResult, errors.New("Column already exists: _string at [1:39]"))
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:         d.bigQueryStore,
-			Tc:          tc,
-			FqTableName: fqName,
-			CreateTable: tc.CreateTable(),
-			ColumnOp:    constants.Add,
-			CdcTime:     ts,
+			Dwh:               d.bigQueryStore,
+			Tc:                tc,
+			FqTableName:       fqName,
+			CreateTable:       tc.CreateTable(),
+			ColumnOp:          constants.Add,
+			CdcTime:           ts,
+			UppercaseEscNames: ptr.ToBool(false),
 		}
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 		assert.NoError(d.T(), err)
@@ -254,12 +260,13 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 	assert.Equal(d.T(), 0, len(d.bigQueryStore.GetConfigMap().TableConfig(fqName).ReadOnlyColumnsToDelete()), d.bigQueryStore.GetConfigMap().TableConfig(fqName).ReadOnlyColumnsToDelete())
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:         d.bigQueryStore,
-			Tc:          tc,
-			FqTableName: fqName,
-			CreateTable: tc.CreateTable(),
-			ColumnOp:    constants.Delete,
-			CdcTime:     ts,
+			Dwh:               d.bigQueryStore,
+			Tc:                tc,
+			FqTableName:       fqName,
+			CreateTable:       tc.CreateTable(),
+			ColumnOp:          constants.Delete,
+			CdcTime:           ts,
+			UppercaseEscNames: ptr.ToBool(false),
 		}
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 		assert.NoError(d.T(), err)
@@ -271,12 +278,13 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 	// Now try to delete again and with an increased TS. It should now be all deleted.
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:         d.bigQueryStore,
-			Tc:          tc,
-			FqTableName: fqName,
-			CreateTable: tc.CreateTable(),
-			ColumnOp:    constants.Delete,
-			CdcTime:     ts.Add(2 * constants.DeletionConfidencePadding),
+			Dwh:               d.bigQueryStore,
+			Tc:                tc,
+			FqTableName:       fqName,
+			CreateTable:       tc.CreateTable(),
+			ColumnOp:          constants.Delete,
+			CdcTime:           ts.Add(2 * constants.DeletionConfidencePadding),
+			UppercaseEscNames: ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)

--- a/lib/destination/ddl/ddl_bq_test.go
+++ b/lib/destination/ddl/ddl_bq_test.go
@@ -45,7 +45,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 	}
 
 	bqProjectID := config.FromContext(d.bqCtx).Config.BigQuery.ProjectID
-	fqName := td.ToFqName(d.bqCtx, constants.BigQuery, true, bqProjectID)
+	fqName := td.ToFqName(d.bigQueryStore.Label(), true, false, bqProjectID)
 	originalColumnLength := len(cols.GetColumns())
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, true))
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)
@@ -88,7 +88,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", fqName, column.Name(d.ctx, &artieSQL.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s drop COLUMN %s", fqName, column.Name(false, &artieSQL.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		})), query)
@@ -148,7 +148,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, col)
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, col.Name(d.ctx, &artieSQL.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, col.Name(false, &artieSQL.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		}),
@@ -208,7 +208,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 		err := ddl.AlterTable(d.bqCtx, alterTableArgs, column)
 		assert.NoError(d.T(), err)
 		query, _ := d.fakeBigQueryStore.ExecArgsForCall(callIdx)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(d.ctx, &artieSQL.NameArgs{
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s %s COLUMN %s %s", fqName, constants.Add, column.Name(false, &artieSQL.NameArgs{
 			Escape:   true,
 			DestKind: d.bigQueryStore.Label(),
 		}), typing.KindToDWHType(column.KindDetails, d.bigQueryStore.Label())), query)
@@ -245,7 +245,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 	}
 
 	bqProjectID := config.FromContext(d.bqCtx).Config.BigQuery.ProjectID
-	fqName := td.ToFqName(d.bqCtx, constants.BigQuery, true, bqProjectID)
+	fqName := td.ToFqName(d.bigQueryStore.Label(), true, false, bqProjectID)
 	originalColumnLength := len(columnNameToKindDetailsMap)
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, false))
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)

--- a/lib/destination/ddl/ddl_create_table_test.go
+++ b/lib/destination/ddl/ddl_create_table_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -42,11 +44,12 @@ func (d *DDLTestSuite) Test_CreateTable() {
 		},
 	} {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:         dwhTc._dwh,
-			Tc:          dwhTc._tableConfig,
-			FqTableName: fqName,
-			CreateTable: dwhTc._tableConfig.CreateTable(),
-			ColumnOp:    constants.Add,
+			Dwh:               dwhTc._dwh,
+			Tc:                dwhTc._tableConfig,
+			FqTableName:       fqName,
+			CreateTable:       dwhTc._tableConfig.CreateTable(),
+			ColumnOp:          constants.Add,
+			UppercaseEscNames: ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, columns.NewColumn("name", typing.String))
@@ -107,12 +110,13 @@ func (d *DDLTestSuite) TestCreateTable() {
 		tc := d.snowflakeStagesStore.GetConfigMap().TableConfig(fqTable)
 
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:         d.snowflakeStagesStore,
-			Tc:          tc,
-			FqTableName: fqTable,
-			CreateTable: tc.CreateTable(),
-			ColumnOp:    constants.Add,
-			CdcTime:     time.Now().UTC(),
+			Dwh:               d.snowflakeStagesStore,
+			Tc:                tc,
+			FqTableName:       fqTable,
+			CreateTable:       tc.CreateTable(),
+			ColumnOp:          constants.Add,
+			CdcTime:           time.Now().UTC(),
+			UppercaseEscNames: ptr.ToBool(false),
 		}
 
 		err := ddl.AlterTable(d.ctx, alterTableArgs, testCase.cols...)

--- a/lib/destination/ddl/ddl_temp_test.go
+++ b/lib/destination/ddl/ddl_temp_test.go
@@ -3,6 +3,8 @@ package ddl_test
 import (
 	"time"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -14,8 +16,9 @@ import (
 
 func (d *DDLTestSuite) TestValidate_AlterTableArgs() {
 	a := &ddl.AlterTableArgs{
-		ColumnOp:    constants.Delete,
-		CreateTable: true,
+		ColumnOp:          constants.Delete,
+		CreateTable:       true,
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
 	assert.Contains(d.T(), a.Validate().Error(), "incompatible operation - cannot drop columns and create table at the same time")
@@ -31,13 +34,14 @@ func (d *DDLTestSuite) TestCreateTemporaryTable_Errors() {
 	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 	snowflakeTc := d.snowflakeStagesStore.GetConfigMap().TableConfig(fqName)
 	args := ddl.AlterTableArgs{
-		Dwh:            d.snowflakeStagesStore,
-		Tc:             snowflakeTc,
-		FqTableName:    fqName,
-		CreateTable:    true,
-		TemporaryTable: true,
-		ColumnOp:       constants.Add,
-		CdcTime:        time.Time{},
+		Dwh:               d.snowflakeStagesStore,
+		Tc:                snowflakeTc,
+		FqTableName:       fqName,
+		CreateTable:       true,
+		TemporaryTable:    true,
+		ColumnOp:          constants.Add,
+		CdcTime:           time.Time{},
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
 	err := ddl.AlterTable(d.ctx, args)
@@ -64,13 +68,14 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 	d.snowflakeStagesStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&columns.Columns{}, nil, true, true))
 	sflkStageTc := d.snowflakeStagesStore.GetConfigMap().TableConfig(fqName)
 	args := ddl.AlterTableArgs{
-		Dwh:            d.snowflakeStagesStore,
-		Tc:             sflkStageTc,
-		FqTableName:    fqName,
-		CreateTable:    true,
-		TemporaryTable: true,
-		ColumnOp:       constants.Add,
-		CdcTime:        time.Time{},
+		Dwh:               d.snowflakeStagesStore,
+		Tc:                sflkStageTc,
+		FqTableName:       fqName,
+		CreateTable:       true,
+		TemporaryTable:    true,
+		ColumnOp:          constants.Add,
+		CdcTime:           time.Time{},
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
 	err := ddl.AlterTable(d.ctx, args, columns.NewColumn("foo", typing.String), columns.NewColumn("bar", typing.Float), columns.NewColumn("start", typing.String))

--- a/lib/destination/dml/merge_bigquery_test.go
+++ b/lib/destination/dml/merge_bigquery_test.go
@@ -2,6 +2,7 @@ package dml
 
 import (
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
 	"github.com/stretchr/testify/assert"
@@ -14,15 +15,16 @@ func (m *MergeTestSuite) TestMergeStatement_TempTable() {
 	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
 	mergeArg := &MergeArgument{
-		FqTableName:    "customers.orders",
-		SubQuery:       "customers.orders_tmp",
-		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(m.ctx, columns.NewColumn("order_id", typing.Invalid), nil)},
-		ColumnsToTypes: cols,
-		DestKind:       constants.BigQuery,
-		SoftDelete:     false,
+		FqTableName:       "customers.orders",
+		SubQuery:          "customers.orders_tmp",
+		PrimaryKeys:       []columns.Wrapper{columns.NewWrapper(columns.NewColumn("order_id", typing.Invalid), false, nil)},
+		ColumnsToTypes:    cols,
+		DestKind:          constants.BigQuery,
+		SoftDelete:        false,
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
-	mergeSQL, err := MergeStatement(m.ctx, mergeArg)
+	mergeSQL, err := mergeArg.GetStatement()
 	assert.NoError(m.T(), err)
 
 	assert.Contains(m.T(), mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp as cc on c.order_id = cc.order_id", mergeSQL)
@@ -35,15 +37,16 @@ func (m *MergeTestSuite) TestMergeStatement_JSONKey() {
 	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
 	mergeArg := &MergeArgument{
-		FqTableName:    "customers.orders",
-		SubQuery:       "customers.orders_tmp",
-		PrimaryKeys:    []columns.Wrapper{columns.NewWrapper(m.ctx, columns.NewColumn("order_oid", typing.Invalid), nil)},
-		ColumnsToTypes: cols,
-		DestKind:       constants.BigQuery,
-		SoftDelete:     false,
+		FqTableName:       "customers.orders",
+		SubQuery:          "customers.orders_tmp",
+		PrimaryKeys:       []columns.Wrapper{columns.NewWrapper(columns.NewColumn("order_oid", typing.Invalid), false, nil)},
+		ColumnsToTypes:    cols,
+		DestKind:          constants.BigQuery,
+		SoftDelete:        false,
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
-	mergeSQL, err := MergeStatement(m.ctx, mergeArg)
+	mergeSQL, err := mergeArg.GetStatement()
 	assert.NoError(m.T(), err)
 	assert.Contains(m.T(), mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp as cc on TO_JSON_STRING(c.order_oid) = TO_JSON_STRING(cc.order_oid)", mergeSQL)
 }

--- a/lib/destination/dml/merge_parts_test.go
+++ b/lib/destination/dml/merge_parts_test.go
@@ -2,6 +2,7 @@ package dml
 
 import (
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/sql"
 
 	"github.com/artie-labs/transfer/lib/typing"
@@ -71,12 +72,13 @@ func (m *MergeTestSuite) TestMergeStatementParts_SkipDelete() {
 	tempTableName := "public.tableName__temp"
 	res := getBasicColumnsForTest(false, false)
 	mergeArg := &MergeArgument{
-		FqTableName:    fqTableName,
-		SubQuery:       tempTableName,
-		PrimaryKeys:    res.PrimaryKeys,
-		ColumnsToTypes: res.ColumnsToTypes,
-		DestKind:       constants.Redshift,
-		SkipDelete:     true,
+		FqTableName:       fqTableName,
+		SubQuery:          tempTableName,
+		PrimaryKeys:       res.PrimaryKeys,
+		ColumnsToTypes:    res.ColumnsToTypes,
+		DestKind:          constants.Redshift,
+		SkipDelete:        true,
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
 	parts, err := mergeArg.GetParts()
@@ -97,12 +99,13 @@ func (m *MergeTestSuite) TestMergeStatementPartsSoftDelete() {
 	tempTableName := "public.tableName__temp"
 	res := getBasicColumnsForTest(false, false)
 	mergeArg := &MergeArgument{
-		FqTableName:    fqTableName,
-		SubQuery:       tempTableName,
-		PrimaryKeys:    res.PrimaryKeys,
-		ColumnsToTypes: res.ColumnsToTypes,
-		DestKind:       constants.Redshift,
-		SoftDelete:     true,
+		FqTableName:       fqTableName,
+		SubQuery:          tempTableName,
+		PrimaryKeys:       res.PrimaryKeys,
+		ColumnsToTypes:    res.ColumnsToTypes,
+		DestKind:          constants.Redshift,
+		SoftDelete:        true,
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
 	parts, err := mergeArg.GetParts()
@@ -135,12 +138,13 @@ func (m *MergeTestSuite) TestMergeStatementPartsSoftDeleteComposite() {
 	tempTableName := "public.tableName__temp"
 	res := getBasicColumnsForTest(true, false)
 	mergeArg := &MergeArgument{
-		FqTableName:    fqTableName,
-		SubQuery:       tempTableName,
-		PrimaryKeys:    res.PrimaryKeys,
-		ColumnsToTypes: res.ColumnsToTypes,
-		DestKind:       constants.Redshift,
-		SoftDelete:     true,
+		FqTableName:       fqTableName,
+		SubQuery:          tempTableName,
+		PrimaryKeys:       res.PrimaryKeys,
+		ColumnsToTypes:    res.ColumnsToTypes,
+		DestKind:          constants.Redshift,
+		SoftDelete:        true,
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
 	parts, err := mergeArg.GetParts()
@@ -176,11 +180,12 @@ func (m *MergeTestSuite) TestMergeStatementParts() {
 	tempTableName := "public.tableName__temp"
 	res := getBasicColumnsForTest(false, false)
 	mergeArg := &MergeArgument{
-		FqTableName:    fqTableName,
-		SubQuery:       tempTableName,
-		PrimaryKeys:    res.PrimaryKeys,
-		ColumnsToTypes: res.ColumnsToTypes,
-		DestKind:       constants.Redshift,
+		FqTableName:       fqTableName,
+		SubQuery:          tempTableName,
+		PrimaryKeys:       res.PrimaryKeys,
+		ColumnsToTypes:    res.ColumnsToTypes,
+		DestKind:          constants.Redshift,
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
 	parts, err := mergeArg.GetParts()
@@ -200,12 +205,13 @@ func (m *MergeTestSuite) TestMergeStatementParts() {
 		parts[2])
 
 	mergeArg = &MergeArgument{
-		FqTableName:    fqTableName,
-		SubQuery:       tempTableName,
-		PrimaryKeys:    res.PrimaryKeys,
-		ColumnsToTypes: res.ColumnsToTypes,
-		DestKind:       constants.Redshift,
-		IdempotentKey:  "created_at",
+		FqTableName:       fqTableName,
+		SubQuery:          tempTableName,
+		PrimaryKeys:       res.PrimaryKeys,
+		ColumnsToTypes:    res.ColumnsToTypes,
+		DestKind:          constants.Redshift,
+		IdempotentKey:     "created_at",
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
 	parts, err = mergeArg.GetParts()
@@ -230,11 +236,12 @@ func (m *MergeTestSuite) TestMergeStatementPartsCompositeKey() {
 	tempTableName := "public.tableName__temp"
 	res := getBasicColumnsForTest(true, false)
 	mergeArg := &MergeArgument{
-		FqTableName:    fqTableName,
-		SubQuery:       tempTableName,
-		PrimaryKeys:    res.PrimaryKeys,
-		ColumnsToTypes: res.ColumnsToTypes,
-		DestKind:       constants.Redshift,
+		FqTableName:       fqTableName,
+		SubQuery:          tempTableName,
+		PrimaryKeys:       res.PrimaryKeys,
+		ColumnsToTypes:    res.ColumnsToTypes,
+		DestKind:          constants.Redshift,
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
 	parts, err := mergeArg.GetParts()
@@ -254,12 +261,13 @@ func (m *MergeTestSuite) TestMergeStatementPartsCompositeKey() {
 		parts[2])
 
 	mergeArg = &MergeArgument{
-		FqTableName:    fqTableName,
-		SubQuery:       tempTableName,
-		PrimaryKeys:    res.PrimaryKeys,
-		ColumnsToTypes: res.ColumnsToTypes,
-		DestKind:       constants.Redshift,
-		IdempotentKey:  "created_at",
+		FqTableName:       fqTableName,
+		SubQuery:          tempTableName,
+		PrimaryKeys:       res.PrimaryKeys,
+		ColumnsToTypes:    res.ColumnsToTypes,
+		DestKind:          constants.Redshift,
+		IdempotentKey:     "created_at",
+		UppercaseEscNames: ptr.ToBool(false),
 	}
 
 	parts, err = mergeArg.GetParts()

--- a/lib/destination/utils/context_test.go
+++ b/lib/destination/utils/context_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/config"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 
 	"github.com/artie-labs/transfer/clients/snowflake"
@@ -14,7 +16,11 @@ import (
 )
 
 func TestInjectDwhIntoCtx(t *testing.T) {
-	ctx := context.Background()
+	ctx := config.InjectSettingsIntoContext(context.Background(), &config.Settings{
+		Config: &config.Config{
+			SharedDestinationConfig: config.SharedDestinationConfig{UppercaseEscapedNames: true},
+		},
+	})
 
 	store := db.Store(&mock.DB{
 		Fake: mocks.FakeStore{},

--- a/lib/destination/utils/load.go
+++ b/lib/destination/utils/load.go
@@ -24,7 +24,7 @@ func Baseline(ctx context.Context) destination.Baseline {
 	settings := config.FromContext(ctx)
 	switch settings.Config.Output {
 	case constants.S3:
-		store, err := s3.LoadStore(ctx, settings.Config.S3)
+		store, err := s3.LoadStore(settings.Config.S3)
 		if err != nil {
 			logger.FromContext(ctx).WithError(err).Fatalf("failed to load s3")
 		}

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -47,11 +47,11 @@ func (t *TableData) ContainOtherOperations() bool {
 	return t.containOtherOperations
 }
 
-func (t *TableData) PrimaryKeys(ctx context.Context, args *sql.NameArgs) []columns.Wrapper {
+func (t *TableData) PrimaryKeys(uppercaseEscNames bool, args *sql.NameArgs) []columns.Wrapper {
 	var primaryKeysEscaped []columns.Wrapper
 	for _, pk := range t.primaryKeys {
 		col := columns.NewColumn(pk, typing.Invalid)
-		primaryKeysEscaped = append(primaryKeysEscaped, columns.NewWrapper(ctx, col, args))
+		primaryKeysEscaped = append(primaryKeysEscaped, columns.NewWrapper(col, uppercaseEscNames, args))
 	}
 
 	return primaryKeysEscaped

--- a/lib/optimization/event.go
+++ b/lib/optimization/event.go
@@ -61,8 +61,8 @@ func (t *TableData) RawName() string {
 	return t.name
 }
 
-func (t *TableData) Name(ctx context.Context, args *sql.NameArgs) string {
-	return sql.EscapeName(ctx, t.name, args)
+func (t *TableData) Name(uppercaseEscNames bool, args *sql.NameArgs) string {
+	return sql.EscapeName(t.name, uppercaseEscNames, args)
 }
 
 func (t *TableData) SetInMemoryColumns(columns *columns.Columns) {
@@ -141,29 +141,29 @@ func (t *TableData) RowsData() map[string]map[string]interface{} {
 	return _rowsData
 }
 
-func (t *TableData) ToFqName(ctx context.Context, kind constants.DestinationKind, escape bool, bigQueryProjectID string) string {
+func (t *TableData) ToFqName(kind constants.DestinationKind, escape bool, uppercaseEscNames bool, bigQueryProjectID string) string {
 	switch kind {
 	case constants.S3:
 		// S3 should be db.schema.tableName, but we don't need to escape, since it's not a SQL db.
-		return fmt.Sprintf("%s.%s.%s", t.TopicConfig.Database, t.TopicConfig.Schema, t.Name(ctx, &sql.NameArgs{
+		return fmt.Sprintf("%s.%s.%s", t.TopicConfig.Database, t.TopicConfig.Schema, t.Name(uppercaseEscNames, &sql.NameArgs{
 			Escape:   false,
 			DestKind: kind,
 		}))
 	case constants.Redshift:
 		// Redshift is Postgres compatible, so when establishing a connection, we'll specify a database.
 		// Thus, we only need to specify schema and table name here.
-		return fmt.Sprintf("%s.%s", t.TopicConfig.Schema, t.Name(ctx, &sql.NameArgs{
+		return fmt.Sprintf("%s.%s", t.TopicConfig.Schema, t.Name(uppercaseEscNames, &sql.NameArgs{
 			Escape:   escape,
 			DestKind: kind,
 		}))
 	case constants.BigQuery:
 		// The fully qualified name for BigQuery is: project_id.dataset.tableName.
-		return fmt.Sprintf("%s.%s.%s", bigQueryProjectID, t.TopicConfig.Database, t.Name(ctx, &sql.NameArgs{
+		return fmt.Sprintf("%s.%s.%s", bigQueryProjectID, t.TopicConfig.Database, t.Name(uppercaseEscNames, &sql.NameArgs{
 			Escape:   escape,
 			DestKind: kind,
 		}))
 	default:
-		return fmt.Sprintf("%s.%s.%s", t.TopicConfig.Database, t.TopicConfig.Schema, t.Name(ctx, &sql.NameArgs{
+		return fmt.Sprintf("%s.%s.%s", t.TopicConfig.Database, t.TopicConfig.Schema, t.Name(uppercaseEscNames, &sql.NameArgs{
 			Escape:   escape,
 			DestKind: kind,
 		}))

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -158,29 +158,20 @@ func (o *OptimizationTestSuite) TestNewTableData_TableName() {
 	}
 
 	bqProjectID := "artie"
-	ctx := config.InjectSettingsIntoContext(context.Background(), &config.Settings{
-		Config: &config.Config{
-			BigQuery: &config.BigQuery{
-				ProjectID: bqProjectID,
-			},
-		},
-	})
-
 	for _, testCase := range testCases {
-		td := NewTableData(nil, nil, kafkalib.TopicConfig{
-			Database:  testCase.db,
-			TableName: testCase.overrideName,
-			Schema:    testCase.schema,
-		}, testCase.tableName)
+		td := NewTableData(nil, nil,
+			kafkalib.TopicConfig{Database: testCase.db, TableName: testCase.overrideName, Schema: testCase.schema},
+			testCase.tableName)
+
 		assert.Equal(o.T(), testCase.expectedName, td.RawName(), testCase.name)
 		assert.Equal(o.T(), testCase.expectedName, td.name, testCase.name)
-		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(ctx, constants.Snowflake, true, ""), testCase.name)
-		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true, bqProjectID), testCase.name)
-		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(ctx, constants.BigQuery, true, bqProjectID), testCase.name)
+		assert.Equal(o.T(), testCase.expectedSnowflakeFqName, td.ToFqName(constants.Snowflake, true, false, ""), testCase.name)
+		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(constants.BigQuery, true, false, bqProjectID), testCase.name)
+		assert.Equal(o.T(), testCase.expectedBigQueryFqName, td.ToFqName(constants.BigQuery, true, false, bqProjectID), testCase.name)
 
 		// S3 does not escape, so let's test both to make sure.
-		assert.Equal(o.T(), testCase.expectedS3FqName, td.ToFqName(ctx, constants.S3, true, ""), testCase.name)
-		assert.Equal(o.T(), testCase.expectedS3FqName, td.ToFqName(ctx, constants.S3, false, ""), testCase.name)
+		assert.Equal(o.T(), testCase.expectedS3FqName, td.ToFqName(constants.S3, true, false, ""), testCase.name)
+		assert.Equal(o.T(), testCase.expectedS3FqName, td.ToFqName(constants.S3, false, false, ""), testCase.name)
 	}
 }
 

--- a/lib/sql/escape.go
+++ b/lib/sql/escape.go
@@ -1,12 +1,9 @@
 package sql
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/artie-labs/transfer/lib/config"
 
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -20,7 +17,7 @@ type NameArgs struct {
 // symbolsToEscape are additional keywords that we need to escape
 var symbolsToEscape = []string{":"}
 
-func EscapeName(ctx context.Context, name string, args *NameArgs) string {
+func EscapeName(name string, uppercaseEscNames bool, args *NameArgs) string {
 	if args == nil {
 		return name
 	}
@@ -52,7 +49,7 @@ func EscapeName(ctx context.Context, name string, args *NameArgs) string {
 	}
 
 	if args.Escape && needsEscaping {
-		if config.FromContext(ctx).Config.SharedDestinationConfig.UppercaseEscapedNames {
+		if uppercaseEscNames {
 			name = strings.ToUpper(name)
 		}
 

--- a/lib/sql/escape_test.go
+++ b/lib/sql/escape_test.go
@@ -1,7 +1,6 @@
 package sql
 
 import (
-	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/stretchr/testify/assert"
 )
@@ -132,11 +131,10 @@ func (s *SqlTestSuite) TestEscapeName() {
 	}
 
 	for _, testCase := range testCases {
-		actualName := EscapeName(s.ctx, testCase.nameToEscape, testCase.args)
+		actualName := EscapeName(testCase.nameToEscape, false, testCase.args)
 		assert.Equal(s.T(), testCase.expectedName, actualName, testCase.name)
 
-		upperCtx := config.InjectSettingsIntoContext(s.ctx, &config.Settings{Config: &config.Config{SharedDestinationConfig: config.SharedDestinationConfig{UppercaseEscapedNames: true}}})
-		actualUpperName := EscapeName(upperCtx, testCase.nameToEscape, testCase.args)
+		actualUpperName := EscapeName(testCase.nameToEscape, true, testCase.args)
 		assert.Equal(s.T(), testCase.expectedNameWhenUpperCfg, actualUpperName, testCase.name)
 	}
 }

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -169,15 +169,15 @@ func (c *ColumnsTestSuite) TestColumn_Name() {
 		}
 
 		assert.Equal(c.T(), testCase.expectedName, col.RawName(), testCase.colName)
-		assert.Equal(c.T(), testCase.expectedName, col.Name(c.ctx, &sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedName, col.Name(false, &sql.NameArgs{
 			Escape: false,
 		}), testCase.colName)
 
-		assert.Equal(c.T(), testCase.expectedNameEsc, col.Name(c.ctx, &sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedNameEsc, col.Name(false, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
 		}), testCase.colName)
-		assert.Equal(c.T(), testCase.expectedNameEscBq, col.Name(c.ctx, &sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedNameEscBq, col.Name(false, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.BigQuery,
 		}), testCase.colName)
@@ -240,17 +240,17 @@ func (c *ColumnsTestSuite) TestColumns_GetColumnsToUpdate() {
 			columns: testCase.cols,
 		}
 
-		assert.Equal(c.T(), testCase.expectedCols, cols.GetColumnsToUpdate(c.ctx, nil), testCase.name)
-		assert.Equal(c.T(), testCase.expectedCols, cols.GetColumnsToUpdate(c.ctx, &sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedCols, cols.GetColumnsToUpdate(false, nil), testCase.name)
+		assert.Equal(c.T(), testCase.expectedCols, cols.GetColumnsToUpdate(false, &sql.NameArgs{
 			Escape: false,
 		}), testCase.name)
 
-		assert.Equal(c.T(), testCase.expectedColsEsc, cols.GetColumnsToUpdate(c.ctx, &sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedColsEsc, cols.GetColumnsToUpdate(false, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
 		}), testCase.name)
 
-		assert.Equal(c.T(), testCase.expectedColsEscBq, cols.GetColumnsToUpdate(c.ctx, &sql.NameArgs{
+		assert.Equal(c.T(), testCase.expectedColsEscBq, cols.GetColumnsToUpdate(false, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.BigQuery,
 		}), testCase.name)
@@ -488,7 +488,7 @@ func (c *ColumnsTestSuite) TestColumnsUpdateQuery() {
 	}
 
 	for _, _testCase := range testCases {
-		actualQuery := ColumnsUpdateQuery(c.ctx, _testCase.columns, _testCase.columnsToTypes, _testCase.destKind)
+		actualQuery := ColumnsUpdateQuery(_testCase.columns, _testCase.columnsToTypes, _testCase.destKind, false)
 		assert.Equal(c.T(), _testCase.expectedString, actualQuery, _testCase.name)
 	}
 }

--- a/lib/typing/columns/wrapper.go
+++ b/lib/typing/columns/wrapper.go
@@ -1,8 +1,6 @@
 package columns
 
 import (
-	"context"
-
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
@@ -11,10 +9,10 @@ type Wrapper struct {
 	escapedName string
 }
 
-func NewWrapper(ctx context.Context, col Column, args *sql.NameArgs) Wrapper {
+func NewWrapper(col Column, uppercaseEscNames bool, args *sql.NameArgs) Wrapper {
 	return Wrapper{
 		name:        col.name,
-		escapedName: col.Name(ctx, args),
+		escapedName: col.Name(uppercaseEscNames, args),
 	}
 }
 

--- a/lib/typing/columns/wrapper_test.go
+++ b/lib/typing/columns/wrapper_test.go
@@ -41,7 +41,7 @@ func (c *ColumnsTestSuite) TestWrapper_Complete() {
 
 	for _, testCase := range testCases {
 		// Snowflake escape
-		w := NewWrapper(c.ctx, NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
+		w := NewWrapper(NewColumn(testCase.name, typing.Invalid), false, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.Snowflake,
 		})
@@ -50,7 +50,7 @@ func (c *ColumnsTestSuite) TestWrapper_Complete() {
 		assert.Equal(c.T(), testCase.expectedRawName, w.RawName(), testCase.name)
 
 		// BigQuery escape
-		w = NewWrapper(c.ctx, NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
+		w = NewWrapper(NewColumn(testCase.name, typing.Invalid), false, &sql.NameArgs{
 			Escape:   true,
 			DestKind: constants.BigQuery,
 		})
@@ -59,7 +59,7 @@ func (c *ColumnsTestSuite) TestWrapper_Complete() {
 		assert.Equal(c.T(), testCase.expectedRawName, w.RawName(), testCase.name)
 
 		for _, destKind := range []constants.DestinationKind{constants.Snowflake, constants.BigQuery} {
-			w = NewWrapper(c.ctx, NewColumn(testCase.name, typing.Invalid), &sql.NameArgs{
+			w = NewWrapper(NewColumn(testCase.name, typing.Invalid), false, &sql.NameArgs{
 				Escape:   false,
 				DestKind: destKind,
 			})
@@ -69,7 +69,7 @@ func (c *ColumnsTestSuite) TestWrapper_Complete() {
 		}
 
 		// Same if nil
-		w = NewWrapper(c.ctx, NewColumn(testCase.name, typing.Invalid), nil)
+		w = NewWrapper(NewColumn(testCase.name, typing.Invalid), false, nil)
 
 		assert.Equal(c.T(), testCase.expectedRawName, w.EscapedName(), testCase.name)
 		assert.Equal(c.T(), testCase.expectedRawName, w.RawName(), testCase.name)


### PR DESCRIPTION
As per title, this is the fourth (should be one more after) to remove `context `from the Typing library. This will bring more stability to external services that want to reference Transfer's typing library programmatically without hitting run-time panics.

## Changes
* `uppercaseEscName` is extracted when we load the data warehouse and injected as a private variable on the DWH object
* Refactored some merge functions to make it more ergonomic

## After
The last PR will be to remove `context` from being used in `ParseValue`