### PR TITLE
Removing context from `event.GetPrimaryKey(...)`

### DIFF
--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -13,7 +13,7 @@ import (
 
 type Format interface {
 	Labels() []string // Labels() to return a list of strings to maintain backward compatibility.
-	GetPrimaryKey(ctx context.Context, key []byte, tc *kafkalib.TopicConfig) (map[string]interface{}, error)
+	GetPrimaryKey(key []byte, tc *kafkalib.TopicConfig) (map[string]interface{}, error)
 	GetEventFromBytes(ctx context.Context, bytes []byte) (Event, error)
 }
 

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -74,7 +74,7 @@ func (d *Debezium) Labels() []string {
 	return []string{constants.DBZMongoFormat}
 }
 
-func (d *Debezium) GetPrimaryKey(ctx context.Context, key []byte, tc *kafkalib.TopicConfig) (map[string]interface{}, error) {
+func (d *Debezium) GetPrimaryKey(key []byte, tc *kafkalib.TopicConfig) (map[string]interface{}, error) {
 	kvMap, err := debezium.ParsePartitionKey(key, tc.CDCKeyFormat)
 	if err != nil {
 		return nil, err

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -50,7 +50,7 @@ func (p *MongoTestSuite) TestGetPrimaryKey() {
 	}
 
 	for _, tc := range tcs {
-		pkMap, err := p.GetPrimaryKey(p.ctx, tc.key, &kafkalib.TopicConfig{
+		pkMap, err := p.GetPrimaryKey(tc.key, &kafkalib.TopicConfig{
 			CDCKeyFormat: tc.keyFormat,
 		})
 

--- a/lib/cdc/mongo/mongo_bench_test.go
+++ b/lib/cdc/mongo/mongo_bench_test.go
@@ -1,7 +1,6 @@
 package mongo
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -14,12 +13,11 @@ import (
 
 func BenchmarkGetPrimaryKey(b *testing.B) {
 	var dbz Debezium
-	ctx := context.Background()
 
 	for i := 0; i < b.N; i++ {
 		newObjectID := primitive.NewObjectID().Hex()
 
-		pkMap, err := dbz.GetPrimaryKey(ctx, []byte(fmt.Sprintf(`{"schema":{"type":"struct","fields":[{"type":"string","optional":false,"field":"id"}],"optional":false,"name":"1a75f632-29d2-419b-9ffe-d18fa12d74d5.38d5d2db-870a-4a38-a76c-9891b0e5122d.myFirstDatabase.stock.Key"},"payload":{"id":"{\"$oid\": \"%s\"}"}}`, newObjectID)), &kafkalib.TopicConfig{
+		pkMap, err := dbz.GetPrimaryKey([]byte(fmt.Sprintf(`{"schema":{"type":"struct","fields":[{"type":"string","optional":false,"field":"id"}],"optional":false,"name":"1a75f632-29d2-419b-9ffe-d18fa12d74d5.38d5d2db-870a-4a38-a76c-9891b0e5122d.myFirstDatabase.stock.Key"},"payload":{"id":"{\"$oid\": \"%s\"}"}}`, newObjectID)), &kafkalib.TopicConfig{
 			CDCKeyFormat: debezium.KeyFormatJSON,
 		})
 

--- a/lib/cdc/mysql/debezium.go
+++ b/lib/cdc/mysql/debezium.go
@@ -32,6 +32,6 @@ func (d *Debezium) Labels() []string {
 	return []string{constants.DBZMySQLFormat}
 }
 
-func (d *Debezium) GetPrimaryKey(ctx context.Context, key []byte, tc *kafkalib.TopicConfig) (kvMap map[string]interface{}, err error) {
+func (d *Debezium) GetPrimaryKey(key []byte, tc *kafkalib.TopicConfig) (kvMap map[string]interface{}, err error) {
 	return debezium.ParsePartitionKey(key, tc.CDCKeyFormat)
 }

--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -32,6 +32,6 @@ func (d *Debezium) Labels() []string {
 	return []string{constants.DBZPostgresFormat, constants.DBZPostgresAltFormat}
 }
 
-func (d *Debezium) GetPrimaryKey(ctx context.Context, key []byte, tc *kafkalib.TopicConfig) (kvMap map[string]interface{}, err error) {
+func (d *Debezium) GetPrimaryKey(key []byte, tc *kafkalib.TopicConfig) (kvMap map[string]interface{}, err error) {
 	return debezium.ParsePartitionKey(key, tc.CDCKeyFormat)
 }

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -23,7 +23,7 @@ func (p *PostgresTestSuite) TestGetEventFromBytesTombstone() {
 
 func (p *PostgresTestSuite) TestGetPrimaryKey() {
 	valString := `{"id": 47}`
-	pkMap, err := p.GetPrimaryKey(p.ctx, []byte(valString), validTc)
+	pkMap, err := p.GetPrimaryKey([]byte(valString), validTc)
 	assert.NoError(p.T(), err)
 
 	val, isOk := pkMap["id"]
@@ -34,7 +34,7 @@ func (p *PostgresTestSuite) TestGetPrimaryKey() {
 
 func (p *PostgresTestSuite) TestGetPrimaryKeyUUID() {
 	valString := `{"uuid": "ca0cefe9-45cf-44fa-a2ab-ec5e7e5522a3"}`
-	pkMap, err := p.GetPrimaryKey(p.ctx, []byte(valString), validTc)
+	pkMap, err := p.GetPrimaryKey([]byte(valString), validTc)
 	val, isOk := pkMap["uuid"]
 	assert.True(p.T(), isOk)
 	assert.Equal(p.T(), val, "ca0cefe9-45cf-44fa-a2ab-ec5e7e5522a3")

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -44,7 +44,7 @@ func processMessage(ctx context.Context, processArgs ProcessArgs) (string, error
 	tags["database"] = topicConfig.tc.Database
 	tags["schema"] = topicConfig.tc.Schema
 
-	pkMap, err := topicConfig.GetPrimaryKey(ctx, processArgs.Msg.Key(), topicConfig.tc)
+	pkMap, err := topicConfig.GetPrimaryKey(processArgs.Msg.Key(), topicConfig.tc)
 	if err != nil {
 		tags["what"] = "marshall_pk_err"
 		return "", fmt.Errorf("cannot unmarshall key, key: %s, err: %v", string(processArgs.Msg.Key()), err)


### PR DESCRIPTION
The impl functions are not using `context`, so we can remove it from the impl and interface.