### PR TITLE
[PostGIS] Supporting Point

### DIFF
--- a/lib/cdc/util/geometry.go
+++ b/lib/cdc/util/geometry.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 )
 
+// Note: Today, we are not doing anything about wkb and srid right now.
+
 type GeoJSON struct {
 	Type       GeoJSONType            `json:"type"`
 	Geometry   Geometry               `json:"geometry"`

--- a/lib/cdc/util/geometry.go
+++ b/lib/cdc/util/geometry.go
@@ -5,6 +5,16 @@ import (
 	"fmt"
 )
 
+type GeoJSON struct {
+	Type       GeoJSONType            `json:"type"`
+	Geometry   Geometry               `json:"geometry"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+type GeoJSONType string
+
+const Feature GeoJSONType = "Feature"
+
 type Geometry struct {
 	Type        GeometricShapes `json:"type"`
 	Coordinates interface{}     `json:"coordinates"`
@@ -12,9 +22,7 @@ type Geometry struct {
 
 type GeometricShapes string
 
-const (
-	Point GeometricShapes = "Point"
-)
+const Point GeometricShapes = "Point"
 
 func parseGeometryPoint(value interface{}) (string, error) {
 	valMap, isOk := value.(map[string]interface{})
@@ -32,12 +40,15 @@ func parseGeometryPoint(value interface{}) (string, error) {
 		return "", fmt.Errorf("y coordinate does not exist")
 	}
 
-	geometry := Geometry{
-		Type:        Point,
-		Coordinates: []interface{}{x, y},
+	geoJSON := GeoJSON{
+		Type: Feature,
+		Geometry: Geometry{
+			Type:        Point,
+			Coordinates: []interface{}{x, y},
+		},
 	}
 
-	bytes, err := json.Marshal(geometry)
+	bytes, err := json.Marshal(geoJSON)
 	if err != nil {
 		return "", err
 	}

--- a/lib/cdc/util/geometry.go
+++ b/lib/cdc/util/geometry.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Geometry struct {
+	Type        GeometricShapes `json:"type"`
+	Coordinates interface{}     `json:"coordinates"`
+}
+
+type GeometricShapes string
+
+const (
+	Point GeometricShapes = "Point"
+)
+
+func parseGeometryPoint(value interface{}) (string, error) {
+	valMap, isOk := value.(map[string]interface{})
+	if !isOk {
+		return "", fmt.Errorf("value is not map[string]interface{} type")
+	}
+
+	x, isOk := valMap["x"]
+	if !isOk {
+		return "", fmt.Errorf("x coordinate does not exist")
+	}
+
+	y, isOk := valMap["y"]
+	if !isOk {
+		return "", fmt.Errorf("y coordinate does not exist")
+	}
+
+	geometry := Geometry{
+		Type:        Point,
+		Coordinates: []interface{}{x, y},
+	}
+
+	bytes, err := json.Marshal(geometry)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}

--- a/lib/cdc/util/geometry_test.go
+++ b/lib/cdc/util/geometry_test.go
@@ -1,0 +1,17 @@
+package util
+
+import "github.com/stretchr/testify/assert"
+
+func (u *UtilTestSuite) TestParseGeometryPoint() {
+	{
+		geometry, err := parseGeometryPoint(map[string]interface{}{
+			"x":    2.2945,
+			"y":    48.8584,
+			"wkb":  "AQEAAABCYOXQIlsCQHZxGw3gbUhA",
+			"srid": nil,
+		})
+
+		assert.NoError(u.T(), err)
+		assert.Equal(u.T(), `{"type":"Point","coordinates":[2.2945,48.8584]}`, geometry)
+	}
+}

--- a/lib/cdc/util/geometry_test.go
+++ b/lib/cdc/util/geometry_test.go
@@ -4,7 +4,7 @@ import "github.com/stretchr/testify/assert"
 
 func (u *UtilTestSuite) TestParseGeometryPoint() {
 	{
-		geometry, err := parseGeometryPoint(map[string]interface{}{
+		geoJSONString, err := parseGeometryPoint(map[string]interface{}{
 			"x":    2.2945,
 			"y":    48.8584,
 			"wkb":  "AQEAAABCYOXQIlsCQHZxGw3gbUhA",
@@ -12,6 +12,6 @@ func (u *UtilTestSuite) TestParseGeometryPoint() {
 		})
 
 		assert.NoError(u.T(), err)
-		assert.Equal(u.T(), `{"type":"Point","coordinates":[2.2945,48.8584]}`, geometry)
+		assert.Equal(u.T(), `{"type":"Feature","geometry":{"type":"Point","coordinates":[2.2945,48.8584]}}`, geoJSONString)
 	}
 }

--- a/lib/cdc/util/parse.go
+++ b/lib/cdc/util/parse.go
@@ -33,6 +33,11 @@ func parseField(field debezium.Field, value interface{}) interface{} {
 			if err == nil {
 				return valString
 			}
+		case debezium.GeometryPointType:
+			geometryString, err := parseGeometryPoint(value)
+			if err == nil {
+				return geometryString
+			}
 		case debezium.KafkaDecimalType:
 			decimalVal, err := field.DecodeDecimal(fmt.Sprint(value))
 			if err == nil {

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -86,7 +86,7 @@ func (f Field) ToKindDetails() typing.KindDetails {
 		return typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType)
 	case string(Time), string(TimeMicro), string(TimeKafkaConnect), string(TimeWithTimezone):
 		return typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType)
-	case string(JSON):
+	case string(JSON), string(GeometryPointType):
 		return typing.Struct
 	case string(KafkaDecimalType):
 		scaleAndPrecision, err := f.GetScaleAndPrecision()

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -33,6 +33,9 @@ const (
 	KafkaDecimalType         SupportedDebeziumType = "org.apache.kafka.connect.data.Decimal"
 	KafkaVariableNumericType SupportedDebeziumType = "io.debezium.data.VariableScaleDecimal"
 
+	// PostGIS data types
+	GeometryPointType SupportedDebeziumType = "io.debezium.data.geometry.Point"
+
 	KafkaDecimalPrecisionKey = "connect.decimal.precision"
 )
 
@@ -48,6 +51,7 @@ var typesThatRequireTypeCasting = []SupportedDebeziumType{
 	KafkaDecimalType,
 	KafkaVariableNumericType,
 	JSON,
+	GeometryPointType,
 }
 
 func RequiresSpecialTypeCasting(typeLabel string) (bool, SupportedDebeziumType) {


### PR DESCRIPTION
## Changes

This is one of the first PRs to support PostGIS data type `Point`. We are then encoding this value into `GeoJSON`.

| Data in Postgres | GeoJSON Representation (in DWH) |
| -------- | -------------- |
| Point(2.2945, 48.8584) |<br>{<br> "type": "Feature",<br> "geometry": {<br> "type": "Point",<br> "coordinates": [2.2945, 48.8584]<br> }<br>}<br> |
