### PR TITLE
Change Sentry logging to Error

### DIFF
--- a/lib/logger/log.go
+++ b/lib/logger/log.go
@@ -28,7 +28,7 @@ func NewLogger(settings *config.Settings) (*slog.Logger, bool) {
 		} else {
 			handler = slogmulti.Fanout(
 				handler,
-				slogsentry.Option{Level: slog.LevelWarn}.NewSentryHandler(),
+				slogsentry.Option{Level: slog.LevelError}.NewSentryHandler(),
 			)
 			loggingToSentry = true
 		}


### PR DESCRIPTION
We were previously using `WARN` which gets spammy. Let's use `ERROR` instead.