### PR TITLE
[Redshift] Fix edge cases for Kafka tombstone and number conversion

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -53,6 +53,12 @@ func (s *Store) CastColValStaging(colVal interface{}, colKind columns.Column, ad
 
 	colValString := fmt.Sprint(colVal)
 	switch colKind.KindDetails.Kind {
+	case typing.Integer.Kind:
+		switch colVal.(type) {
+		case float64, float32:
+			// Strip away the trailing zeros if the value is a float but the type is an integer in DWH
+			colValString = fmt.Sprintf("%.0f", colVal)
+		}
 	// All the other types do not need string wrapping.
 	case typing.ETime.Kind:
 		extTime, err := ext.ParseFromInterface(colVal, additionalDateFmts)

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -97,6 +97,22 @@ func evaluateTestCase(t *testing.T, store *Store, testCase _testCase) {
 func (r *RedshiftTestSuite) TestCastColValStaging_Basic() {
 	testCases := []_testCase{
 		{
+			name:   "float",
+			colVal: float32(15333599),
+			colKind: columns.Column{
+				KindDetails: typing.Integer,
+			},
+			expectedString: "15333599",
+		},
+		{
+			name:   "float",
+			colVal: 1533358,
+			colKind: columns.Column{
+				KindDetails: typing.Integer,
+			},
+			expectedString: "1533358",
+		},
+		{
 			name:   "empty string",
 			colVal: "",
 			colKind: columns.Column{

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -23,12 +23,13 @@ import (
 
 func (s *Store) prepareTempTable(ctx context.Context, tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string) error {
 	tempAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:            s,
-		Tc:             tableConfig,
-		FqTableName:    tempTableName,
-		CreateTable:    true,
-		TemporaryTable: true,
-		ColumnOp:       constants.Add,
+		Dwh:               s,
+		Tc:                tableConfig,
+		FqTableName:       tempTableName,
+		CreateTable:       true,
+		TemporaryTable:    true,
+		ColumnOp:          constants.Add,
+		UppercaseEscNames: &s.uppercaseEscNames,
 	}
 
 	if err := ddl.AlterTable(tempAlterTableArgs, tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {


### PR DESCRIPTION
* Missed `uppercaseEscName`
* Addressing Kafka tombstones for large integers in Redshift

TL;DR --
We rely on `parseField` to look at the CDC schema header and convert FLOATS into INTS if the schema tells us that the column is an integer.

However...
* Kafka tombstones doesn't have any metadata (no schema)
* JSON doesn't have a delineation between FLOATs and INTs, so it casts everything as a FLOAT
* Go's native print functionality will print large floats in scientific notation