### PR TITLE
Address mixed precision handling indigestion

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -41,6 +41,7 @@ func replaceExceededValues(colVal string, colKind columns.Column) string {
 // CastColValStaging - takes `colVal` interface{} and `colKind` typing.Column and converts the value into a string value
 // This is necessary because CSV writers require values to in `string`.
 func (s *Store) CastColValStaging(colVal interface{}, colKind columns.Column, additionalDateFmts []string) (string, error) {
+	// TODO: We should consolidate Snowflake and Redshift functions together.
 	if colVal == nil {
 		if colKind.KindDetails == typing.Struct {
 			// Returning empty here because if it's a struct, it will go through JSON PARSE and JSON_PARSE("") = null
@@ -124,7 +125,8 @@ func (s *Store) CastColValStaging(colVal interface{}, colKind columns.Column, ad
 		}
 
 		switch castedColVal := colVal.(type) {
-		// It's okay if it's not a *decimal.Decimal, so long as it's a float.
+		// It's okay if it's not a *decimal.Decimal, so long as it's a float or string.
+		// By having the flexibility of handling both *decimal.Decimal and float64/float32/string values within the same batch will increase our ability for data digestion.
 		case float64, float32:
 			return fmt.Sprint(castedColVal), nil
 		case string:

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -196,6 +196,22 @@ func (r *RedshiftTestSuite) TestCastColValStaging_Basic() {
 			expectedString: "55.22",
 		},
 		{
+			name:   "numeric data types (float)",
+			colVal: 123.45,
+			colKind: columns.Column{
+				KindDetails: typing.EDecimal,
+			},
+			expectedString: "123.45",
+		},
+		{
+			name:   "numeric data types (string)",
+			colVal: "123.45",
+			colKind: columns.Column{
+				KindDetails: typing.EDecimal,
+			},
+			expectedString: "123.45",
+		},
+		{
 			name:   "numeric data types",
 			colVal: decimal.NewDecimal(2, ptr.ToInt(38), big.NewFloat(585692791691858.25)),
 			colKind: columns.Column{

--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -86,7 +86,8 @@ func castColValStaging(colVal interface{}, colKind columns.Column, additionalDat
 		}
 
 		switch castedColVal := colVal.(type) {
-		// It's okay if it's not a *decimal.Decimal, so long as it's a float.
+		// It's okay if it's not a *decimal.Decimal, so long as it's a float or string.
+		// By having the flexibility of handling both *decimal.Decimal and float64/float32/string values within the same batch will increase our ability for data digestion.
 		case float64, float32:
 			return fmt.Sprint(castedColVal), nil
 		case string:

--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -81,17 +81,19 @@ func castColValStaging(colVal interface{}, colKind columns.Column, additionalDat
 		colValString = string(colValBytes)
 	case typing.EDecimal.Kind:
 		val, isOk := colVal.(*decimal.Decimal)
-		if !isOk {
-			switch castedColVal := colVal.(type) {
-			// It's okay if it's not a *decimal.Decimal, so long as it's a float.
-			case float64, float32:
-				return fmt.Sprint(castedColVal), nil
-			}
-
-			return "", fmt.Errorf("colVal is not *decimal.Decimal type, type is: %T", colVal)
+		if isOk {
+			return val.String(), nil
 		}
 
-		return val.String(), nil
+		switch castedColVal := colVal.(type) {
+		// It's okay if it's not a *decimal.Decimal, so long as it's a float.
+		case float64, float32:
+			return fmt.Sprint(castedColVal), nil
+		case string:
+			return castedColVal, nil
+		}
+
+		return "", fmt.Errorf("colVal is not *decimal.Decimal type, type is: %T", colVal)
 	}
 
 	return colValString, nil

--- a/clients/snowflake/cast.go
+++ b/clients/snowflake/cast.go
@@ -82,7 +82,13 @@ func castColValStaging(colVal interface{}, colKind columns.Column, additionalDat
 	case typing.EDecimal.Kind:
 		val, isOk := colVal.(*decimal.Decimal)
 		if !isOk {
-			return "", fmt.Errorf("colVal is not *decimal.Decimal type")
+			switch castedColVal := colVal.(type) {
+			// It's okay if it's not a *decimal.Decimal, so long as it's a float.
+			case float64, float32:
+				return fmt.Sprint(castedColVal), nil
+			}
+
+			return "", fmt.Errorf("colVal is not *decimal.Decimal type, type is: %T", colVal)
 		}
 
 		return val.String(), nil

--- a/clients/snowflake/cast_test.go
+++ b/clients/snowflake/cast_test.go
@@ -127,6 +127,22 @@ func (s *SnowflakeTestSuite) TestCastColValStaging_Basic() {
 			expectedString: "55.22",
 		},
 		{
+			name:   "numeric data types (string)",
+			colVal: "123.45",
+			colKind: columns.Column{
+				KindDetails: typing.EDecimal,
+			},
+			expectedString: "123.45",
+		},
+		{
+			name:   "numeric data types (float)",
+			colVal: 123.45,
+			colKind: columns.Column{
+				KindDetails: typing.EDecimal,
+			},
+			expectedString: "123.45",
+		},
+		{
 			name:   "numeric data types",
 			colVal: decimal.NewDecimal(2, ptr.ToInt(38), big.NewFloat(585692791691858.25)),
 			colKind: columns.Column{


### PR DESCRIPTION
# Problem

Debezium allows you to configure [decimal.handling.mode](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-property-decimal-handling-mode). Transfer currently supports all 3, but it does not support if you change handling mode during streaming.

Today, there is a breaking change if you go from `precise` to `double` or `string`.  This PR alleviates that by being compatible towards the two other handling modes.