### PR TITLE
Combining Redshift and Snowflake's Cast Value

### DIFF
--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -79,7 +79,7 @@ type _testCase struct {
 func evaluateTestCase(t *testing.T, store *Store, testCase _testCase) {
 	actualString, actualErr := store.CastColValStaging(testCase.colVal, testCase.colKind, nil)
 	if len(testCase.errorMessage) > 0 {
-		assert.Contains(t, actualErr.Error(), testCase.errorMessage, testCase.name)
+		assert.ErrorContains(t, actualErr, testCase.errorMessage, testCase.name)
 	} else {
 		assert.NoError(t, actualErr, testCase.name)
 		assert.Equal(t, testCase.expectedString, actualString, testCase.name)

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -3,9 +3,7 @@ package redshift
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"testing"
-	"time"
 
 	"github.com/artie-labs/transfer/lib/stringutil"
 
@@ -13,15 +11,9 @@ import (
 
 	"github.com/artie-labs/transfer/lib/config"
 
-	"github.com/artie-labs/transfer/lib/ptr"
-
-	"github.com/artie-labs/transfer/lib/typing/decimal"
-
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
-
-	"github.com/artie-labs/transfer/lib/typing/ext"
 
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/stretchr/testify/assert"
@@ -81,292 +73,16 @@ type _testCase struct {
 	colKind columns.Column
 
 	expectedString string
-	expectErr      bool
+	errorMessage   string
 }
 
 func evaluateTestCase(t *testing.T, store *Store, testCase _testCase) {
 	actualString, actualErr := store.CastColValStaging(testCase.colVal, testCase.colKind, nil)
-	if testCase.expectErr {
-		assert.Error(t, actualErr, testCase.name)
+	if len(testCase.errorMessage) > 0 {
+		assert.Contains(t, actualErr.Error(), testCase.errorMessage, testCase.name)
 	} else {
 		assert.NoError(t, actualErr, testCase.name)
-	}
-	assert.Equal(t, testCase.expectedString, actualString, testCase.name)
-}
-
-func (r *RedshiftTestSuite) TestCastColValStaging_Basic() {
-	testCases := []_testCase{
-		{
-			name:   "float",
-			colVal: float32(15333599),
-			colKind: columns.Column{
-				KindDetails: typing.Integer,
-			},
-			expectedString: "15333599",
-		},
-		{
-			name:   "float",
-			colVal: 1533358,
-			colKind: columns.Column{
-				KindDetails: typing.Integer,
-			},
-			expectedString: "1533358",
-		},
-		{
-			name:   "empty string",
-			colVal: "",
-			colKind: columns.Column{
-				KindDetails: typing.String,
-			},
-			expectedString: "",
-		},
-		{
-			name:   "null value (string, not that it matters)",
-			colVal: nil,
-			colKind: columns.Column{
-				KindDetails: typing.String,
-			},
-
-			expectedString: `\N`,
-		},
-		{
-			name:   "string",
-			colVal: "foo",
-			colKind: columns.Column{
-				KindDetails: typing.String,
-			},
-
-			expectedString: "foo",
-		},
-		{
-			name:   "integer",
-			colVal: 7,
-			colKind: columns.Column{
-				KindDetails: typing.Integer,
-			},
-			expectedString: "7",
-		},
-		{
-			name:   "boolean",
-			colVal: true,
-			colKind: columns.Column{
-				KindDetails: typing.Boolean,
-			},
-			expectedString: "true",
-		},
-		{
-			name:   "array",
-			colVal: []string{"hello", "there"},
-			colKind: columns.Column{
-				KindDetails: typing.Array,
-			},
-			expectedString: `["hello","there"]`,
-		},
-		{
-			name:   "array (string with interface type)",
-			colVal: []interface{}{"hello", "there", "world"},
-			colKind: columns.Column{
-				KindDetails: typing.String,
-			},
-			expectedString: `["hello","there","world"]`,
-		},
-		{
-			name:   "JSON string",
-			colVal: `{"hello": "world"}`,
-			colKind: columns.Column{
-				KindDetails: typing.Struct,
-			},
-			expectedString: `{"hello": "world"}`,
-		},
-		{
-			name:   "JSON struct",
-			colVal: map[string]string{"hello": "world"},
-			colKind: columns.Column{
-				KindDetails: typing.Struct,
-			},
-			expectedString: `{"hello":"world"}`,
-		},
-		{
-			name:   "numeric data types (backwards compatibility)",
-			colVal: decimal.NewDecimal(2, ptr.ToInt(5), big.NewFloat(55.22)),
-			colKind: columns.Column{
-				KindDetails: typing.Float,
-			},
-
-			expectedString: "55.22",
-		},
-		{
-			name:   "numeric data types (float)",
-			colVal: 123.45,
-			colKind: columns.Column{
-				KindDetails: typing.EDecimal,
-			},
-			expectedString: "123.45",
-		},
-		{
-			name:   "numeric data types (string)",
-			colVal: "123.45",
-			colKind: columns.Column{
-				KindDetails: typing.EDecimal,
-			},
-			expectedString: "123.45",
-		},
-		{
-			name:   "numeric data types",
-			colVal: decimal.NewDecimal(2, ptr.ToInt(38), big.NewFloat(585692791691858.25)),
-			colKind: columns.Column{
-				KindDetails: typing.EDecimal,
-			},
-			expectedString: "585692791691858.25",
-		},
-	}
-
-	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.store, testCase)
-	}
-}
-
-func (r *RedshiftTestSuite) TestCastColValStaging_Array() {
-	testCases := []_testCase{
-		{
-			name:   "array w/ numbers",
-			colVal: []int{1, 2, 3, 4, 5},
-			colKind: columns.Column{
-				KindDetails: typing.Array,
-			},
-			expectedString: `[1,2,3,4,5]`,
-		},
-		{
-			name: "array w/ nested objects (JSON)",
-			colKind: columns.Column{
-				KindDetails: typing.Array,
-			},
-			colVal: []map[string]interface{}{
-				{
-					"dusty": "the mini aussie",
-				},
-				{
-					"robin": "tang",
-				},
-				{
-					"foo": "bar",
-				},
-			},
-			expectedString: `[{"dusty":"the mini aussie"},{"robin":"tang"},{"foo":"bar"}]`,
-		},
-		{
-			name: "array w/ bools",
-			colKind: columns.Column{
-				KindDetails: typing.Array,
-			},
-			colVal: []bool{
-				true,
-				true,
-				false,
-				false,
-				true,
-			},
-			expectedString: `[true,true,false,false,true]`,
-		},
-		{
-			name: "json object, but this is inferred as a string",
-			colVal: map[string]interface{}{
-				"foo": "bar",
-			},
-			colKind: columns.Column{
-				KindDetails: typing.String,
-			},
-			expectedString: `{"foo":"bar"}`,
-		},
-		{
-			name: "list of json object, but this is inferred as a string",
-			colVal: []map[string]interface{}{
-				{
-					"foo": "bar",
-				},
-				{
-					"hello": "world",
-				},
-			},
-			colKind: columns.Column{
-				KindDetails: typing.String,
-			},
-			expectedString: `[{"foo":"bar"},{"hello":"world"}]`,
-		},
-		{
-			name:   "string",
-			colVal: "hello world",
-			colKind: columns.Column{
-				KindDetails: typing.String,
-			},
-			expectedString: "hello world",
-		},
-	}
-
-	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.store, testCase)
-	}
-}
-
-// TestCastColValStaging_Time - will test all the variants of date, time and date time.
-func (r *RedshiftTestSuite) TestCastColValStaging_Time() {
-	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
-	// date
-	dateKind := typing.ETime
-	dateKind.ExtendedTimeDetails = &ext.Date
-	// time
-	timeKind := typing.ETime
-	timeKind.ExtendedTimeDetails = &ext.Time
-	// date time
-	dateTimeKind := typing.ETime
-	dateTimeKind.ExtendedTimeDetails = &ext.DateTime
-
-	birthdate, err := ext.NewExtendedTime(birthday, dateKind.ExtendedTimeDetails.Type, "")
-	assert.NoError(r.T(), err)
-
-	birthTime, err := ext.NewExtendedTime(birthday, timeKind.ExtendedTimeDetails.Type, "")
-	assert.NoError(r.T(), err)
-
-	birthDateTime, err := ext.NewExtendedTime(birthday, dateTimeKind.ExtendedTimeDetails.Type, "")
-	assert.NoError(r.T(), err)
-
-	testCases := []_testCase{
-		{
-			name:   "date",
-			colVal: birthdate,
-			colKind: columns.Column{
-				KindDetails: dateKind,
-			},
-			expectedString: "2022-09-06",
-		},
-		{
-			name:   "date (but value is datetime)",
-			colVal: birthDateTime,
-			colKind: columns.Column{
-				KindDetails: dateKind,
-			},
-			expectedString: "2022-09-06",
-		},
-		{
-			name:   "time",
-			colVal: birthTime,
-			colKind: columns.Column{
-				KindDetails: timeKind,
-			},
-			expectedString: "03:19:24.942",
-		},
-		{
-			name:   "datetime",
-			colVal: birthDateTime,
-			colKind: columns.Column{
-				KindDetails: dateTimeKind,
-			},
-			expectedString: "2022-09-06T03:19:24.942Z",
-		},
-	}
-
-	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.store, testCase)
+		assert.Equal(t, testCase.expectedString, actualString, testCase.name)
 	}
 }
 

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/typing/values"
+
 	"github.com/artie-labs/transfer/clients/utils"
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -19,6 +21,17 @@ import (
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing/columns"
 )
+
+// castColValStaging - takes `colVal` interface{} and `colKind` typing.Column and converts the value into a string value
+// This is necessary because CSV writers require values to in `string`.
+func castColValStaging(colVal interface{}, colKind columns.Column, additionalDateFmts []string) (string, error) {
+	if colVal == nil {
+		// \\N needs to match NULL_IF(...) from ddl.go
+		return `\\N`, nil
+	}
+
+	return values.ToString(colVal, colKind, additionalDateFmts)
+}
 
 // prepareTempTable does the following:
 // 1) Create the temporary table

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -21,6 +21,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func (s *SnowflakeTestSuite) TestCastColValStaging() {
+	type _tc struct {
+		name    string
+		colVal  interface{}
+		colKind columns.Column
+
+		errorMessage  string
+		expectedValue string
+	}
+
+	tcs := []_tc{
+		{
+			name:   "null value (string, not that it matters)",
+			colVal: nil,
+			colKind: columns.Column{
+				KindDetails: typing.String,
+			},
+
+			expectedValue: `\\N`,
+		},
+	}
+
+	for _, tc := range tcs {
+		actualValue, err := castColValStaging(tc.colVal, tc.colKind, nil)
+
+		if len(tc.errorMessage) > 0 {
+			assert.Contains(s.T(), err.Error(), tc.errorMessage, tc.name)
+		} else {
+			assert.NoError(s.T(), err, tc.name)
+			assert.Equal(s.T(), tc.expectedValue, actualValue, tc.name)
+		}
+	}
+}
+
 func (s *SnowflakeTestSuite) TestBackfillColumn() {
 	fqTableName := "db.public.tableName"
 	type _testCase struct {

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -42,9 +42,10 @@ func ToString(colVal interface{}, colKind columns.Column, additionalDateFmts []s
 
 		return colValString, nil
 	case typing.String.Kind:
+		// If the values is an array, let's convert it to a string.
 		list, convErr := array.InterfaceToArrayString(colVal, false)
 		if convErr == nil {
-			colValString = "[" + strings.Join(list, ",") + "]"
+			return "[" + strings.Join(list, ",") + "]", nil
 		}
 
 		// This should also check if the colValString contains Go's internal string representation of a map[string]interface{}

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/artie-labs/transfer/lib/stringutil"
 
-	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
@@ -42,15 +41,11 @@ func ToString(colVal interface{}, colKind columns.Column, additionalDateFmts []s
 
 		return colValString, nil
 	case typing.String.Kind:
-		// If the values is an array, let's convert it to a string.
-		list, convErr := array.InterfaceToArrayString(colVal, false)
-		if convErr == nil {
-			return "[" + strings.Join(list, ",") + "]", nil
-		}
+		isArray := reflect.ValueOf(colVal).Kind() == reflect.Slice
+		_, isMap := colVal.(map[string]interface{})
 
-		// This should also check if the colValString contains Go's internal string representation of a map[string]interface{}
-		_, isOk := colVal.(map[string]interface{})
-		if isOk {
+		// If colVal is either an array or a JSON object, we should run JSON parse.
+		if isMap || isArray {
 			colValBytes, err := json.Marshal(colVal)
 			if err != nil {
 				return "", err

--- a/lib/typing/values/string_test.go
+++ b/lib/typing/values/string_test.go
@@ -21,14 +21,14 @@ type _testCase struct {
 	colVal  interface{}
 	colKind columns.Column
 
+	errorMessage   string
 	expectedString string
-	expectErr      bool
 }
 
 func evaluateTestCase(t *testing.T, testCase _testCase) {
 	actualString, actualErr := ToString(testCase.colVal, testCase.colKind, nil)
-	if testCase.expectErr {
-		assert.Error(t, actualErr, testCase.name)
+	if len(testCase.errorMessage) > 0 {
+		assert.Contains(t, actualErr.Error(), testCase.errorMessage, testCase.name)
 	} else {
 		assert.NoError(t, actualErr, testCase.name)
 		assert.Equal(t, testCase.expectedString, actualString, testCase.name)
@@ -38,9 +38,9 @@ func evaluateTestCase(t *testing.T, testCase _testCase) {
 func TestCastColValStaging_Basic(t *testing.T) {
 	testCases := []_testCase{
 		{
-			name:      "null value",
-			colVal:    nil,
-			expectErr: true,
+			name:         "null value",
+			colVal:       nil,
+			errorMessage: "colVal is nil",
 		},
 		{
 			name:   "colKind = string, colVal = JSON (this happens because of schema inference)",
@@ -118,6 +118,7 @@ func TestCastColValStaging_Basic(t *testing.T) {
 
 			expectedString: "55.22",
 		},
+		// Indigestion stuff
 		{
 			name:   "numeric data types (string)",
 			colVal: "123.45",

--- a/lib/typing/values/string_test.go
+++ b/lib/typing/values/string_test.go
@@ -153,6 +153,14 @@ func TestCastColValStaging_Basic(t *testing.T) {
 func TestCastColValStaging_Array(t *testing.T) {
 	testCases := []_testCase{
 		{
+			name:   "array w/ numbers - but type is STRING",
+			colVal: []int{1, 2, 3, 4, 5},
+			colKind: columns.Column{
+				KindDetails: typing.String,
+			},
+			expectedString: `[1,2,3,4,5]`,
+		},
+		{
 			name:   "array w/ numbers",
 			colVal: []int{1, 2, 3, 4, 5},
 			colKind: columns.Column{

--- a/lib/typing/values/string_test.go
+++ b/lib/typing/values/string_test.go
@@ -28,7 +28,7 @@ type _testCase struct {
 func evaluateTestCase(t *testing.T, testCase _testCase) {
 	actualString, actualErr := ToString(testCase.colVal, testCase.colKind, nil)
 	if len(testCase.errorMessage) > 0 {
-		assert.Contains(t, actualErr.Error(), testCase.errorMessage, testCase.name)
+		assert.ErrorContains(t, actualErr, testCase.errorMessage, testCase.name)
 	} else {
 		assert.NoError(t, actualErr, testCase.name)
 		assert.Equal(t, testCase.expectedString, actualString, testCase.name)


### PR DESCRIPTION
## Changes

Both are using compressed CSVs to upload into their respective destinations. The codepath are basically the same, so this PR is combining the two.

## Checks
* [x] Snowflake [wraps values](https://github.com/artie-labs/transfer/blob/985d12be2f85fef6098c92db313896945aabc925/clients/snowflake/cast.go#L56C4-L56C48). Is this necessary? - I just checked and it doesn't seem necessary. I tested a string that needs to be escaped and a JSON string that also needs to be escaped.