### PR TITLE
Skipping tombstone messages

### DIFF
--- a/lib/artie/message.go
+++ b/lib/artie/message.go
@@ -3,6 +3,7 @@ package artie
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"cloud.google.com/go/pubsub"
@@ -26,6 +27,15 @@ type pubsubWrapper struct {
 type Message struct {
 	KafkaMsg *kafka.Message
 	PubSub   *pubsubWrapper
+}
+
+func KafkaMsgLogFields(msg *kafka.Message) []any {
+	return []any{
+		slog.String("topic", msg.Topic),
+		slog.Int64("offset", msg.Offset),
+		slog.String("key", string(msg.Key)),
+		slog.String("value", string(msg.Value)),
+	}
 }
 
 func NewMessage(kafkaMsg *kafka.Message, pubsubMsg *pubsub.Message, topic string) Message {

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -25,8 +25,7 @@ type Debezium string
 func (d *Debezium) GetEventFromBytes(typingSettings typing.Settings, bytes []byte) (cdc.Event, error) {
 	var schemaEventPayload SchemaEventPayload
 	if len(bytes) == 0 {
-		schemaEventPayload.Tombstone()
-		return &schemaEventPayload, nil
+		return nil, fmt.Errorf("empty message")
 	}
 
 	err := json.Unmarshal(bytes, &schemaEventPayload)

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -246,10 +246,8 @@ func (p *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 }
 
 func (p *MongoTestSuite) TestGetEventFromBytesTombstone() {
-	evt, err := p.Debezium.GetEventFromBytes(typing.Settings{}, nil)
-	assert.NoError(p.T(), err)
-	assert.Equal(p.T(), true, evt.DeletePayload())
-	assert.False(p.T(), evt.GetExecutionTime().IsZero())
+	_, err := p.Debezium.GetEventFromBytes(typing.Settings{}, nil)
+	assert.Error(p.T(), err)
 }
 
 func (p *MongoTestSuite) TestMongoDBEventWithSchema() {

--- a/lib/cdc/mongo/event.go
+++ b/lib/cdc/mongo/event.go
@@ -1,8 +1,6 @@
 package mongo
 
 import (
-	"time"
-
 	"github.com/artie-labs/transfer/lib/debezium"
 )
 
@@ -10,11 +8,6 @@ import (
 type SchemaEventPayload struct {
 	Schema  debezium.Schema `json:"schema"`
 	Payload payload         `json:"payload"`
-}
-
-func (s *SchemaEventPayload) Tombstone() {
-	s.Payload.Operation = "d"
-	s.Payload.Source.TsMs = time.Now().UnixMilli()
 }
 
 type payload struct {

--- a/lib/cdc/mysql/debezium.go
+++ b/lib/cdc/mysql/debezium.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/cdc/util"
@@ -16,8 +17,7 @@ type Debezium string
 func (d *Debezium) GetEventFromBytes(_ typing.Settings, bytes []byte) (cdc.Event, error) {
 	var event util.SchemaEventPayload
 	if len(bytes) == 0 {
-		event.Tombstone()
-		return &event, nil
+		return nil, fmt.Errorf("empty message")
 	}
 
 	err := json.Unmarshal(bytes, &event)

--- a/lib/cdc/mysql/debezium_test.go
+++ b/lib/cdc/mysql/debezium_test.go
@@ -12,10 +12,8 @@ import (
 )
 
 func (m *MySQLTestSuite) TestGetEventFromBytesTombstone() {
-	evt, err := m.GetEventFromBytes(typing.Settings{}, nil)
-	assert.NoError(m.T(), err)
-	assert.True(m.T(), evt.DeletePayload())
-	assert.False(m.T(), evt.GetExecutionTime().IsZero())
+	_, err := m.GetEventFromBytes(typing.Settings{}, nil)
+	assert.Error(m.T(), err)
 }
 
 func (m *MySQLTestSuite) TestGetEventFromBytes() {

--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/cdc/util"
@@ -16,8 +17,7 @@ type Debezium string
 func (d *Debezium) GetEventFromBytes(_ typing.Settings, bytes []byte) (cdc.Event, error) {
 	var event util.SchemaEventPayload
 	if len(bytes) == 0 {
-		event.Tombstone()
-		return &event, nil
+		return nil, fmt.Errorf("empty message")
 	}
 
 	err := json.Unmarshal(bytes, &event)

--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -15,10 +15,8 @@ var validTc = &kafkalib.TopicConfig{
 }
 
 func (p *PostgresTestSuite) TestGetEventFromBytesTombstone() {
-	evt, err := p.GetEventFromBytes(typing.Settings{}, nil)
-	assert.NoError(p.T(), err)
-	assert.True(p.T(), evt.DeletePayload())
-	assert.False(p.T(), evt.GetExecutionTime().IsZero())
+	_, err := p.GetEventFromBytes(typing.Settings{}, nil)
+	assert.Error(p.T(), err)
 }
 
 func (p *PostgresTestSuite) TestGetPrimaryKey() {

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -35,12 +35,6 @@ type Source struct {
 	Table     string `json:"table"`
 }
 
-// Tombstone - This function is filling out the necessary metadata needed for a Kafka tombstone event.
-func (s *SchemaEventPayload) Tombstone() {
-	s.Payload.Operation = "d"
-	s.Payload.Source.TsMs = time.Now().UnixMilli()
-}
-
 func (s *SchemaEventPayload) GetColumns() *columns.Columns {
 	fieldsObject := s.Schema.GetSchemaFromLabel(cdc.After)
 	if fieldsObject == nil {

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -124,6 +124,11 @@ func StartConsumer(ctx context.Context) {
 					continue
 				}
 
+				if len(msg.Value()) == 0 {
+					slog.With(logFields...).Info("found a tombstone message, skipping...")
+					continue
+				}
+
 				tableName, processErr := processMessage(ctx, ProcessArgs{
 					Msg:                    msg,
 					GroupID:                kafkaConsumer.Config().GroupID,

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -111,14 +111,13 @@ func StartConsumer(ctx context.Context) {
 			topicToConsumer.Add(topic, kafkaConsumer)
 			for {
 				kafkaMsg, err := kafkaConsumer.FetchMessage(ctx)
-				logFields := artie.KafkaMsgLogFields(&kafkaMsg)
 				if err != nil {
-					slog.With(logFields...).Warn("failed to read kafka message", slog.Any("err", err))
+					slog.With(artie.KafkaMsgLogFields(&kafkaMsg)...).Warn("failed to read kafka message", slog.Any("err", err))
 					continue
 				}
 
 				if len(kafkaMsg.Value) == 0 {
-					slog.Info("found a tombstone message, skipping...", logFields...)
+					slog.Info("found a tombstone message, skipping...", artie.KafkaMsgLogFields(&kafkaMsg)...)
 					continue
 				}
 
@@ -132,7 +131,7 @@ func StartConsumer(ctx context.Context) {
 				msg.EmitIngestionLag(ctx, kafkaConsumer.Config().GroupID, tableName)
 				msg.EmitRowLag(ctx, kafkaConsumer.Config().GroupID, tableName)
 				if processErr != nil {
-					slog.With(logFields...).Warn("skipping message...", slog.Any("err", processErr))
+					slog.With(artie.KafkaMsgLogFields(&kafkaMsg)...).Warn("skipping message...", slog.Any("err", processErr))
 				}
 			}
 		}(topic)

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -108,7 +108,6 @@ func TestProcessMessageFailures(t *testing.T) {
 	})
 
 	vals := []string{
-		"",
 		`{
 	"schema": {
 		"type": "struct",
@@ -189,14 +188,7 @@ func TestProcessMessageFailures(t *testing.T) {
 	}
 
 	td := memoryDB.GetOrCreateTableData(table)
-
-	// Tombstone means deletion
 	val, isOk := td.RowsData()["_id=1"][constants.DeleteColumnMarker]
-	assert.True(t, isOk)
-	assert.True(t, val.(bool))
-
-	// Non tombstone = no delete.
-	val, isOk = td.RowsData()["_id=2"][constants.DeleteColumnMarker]
 	assert.True(t, isOk)
 	assert.False(t, val.(bool))
 


### PR DESCRIPTION
## Context

Depending on how Debezium is configured - it may emit a Kafka tombstone message upon each delete. Previously Artie Transfer was treating it as a delete event. This is redundant and could cause issues when we want to start emitting the database updated timestamp (since the Kafka message will be `nil`).


## Changes

Delete a row only when the database says to delete the row. Skip tombstone messages altogether. 