### PR TITLE
Kafka Message Fields - Don't use ptrs

### DIFF
--- a/lib/artie/message.go
+++ b/lib/artie/message.go
@@ -29,7 +29,7 @@ type Message struct {
 	PubSub   *pubsubWrapper
 }
 
-func KafkaMsgLogFields(msg *kafka.Message) []any {
+func KafkaMsgLogFields(msg kafka.Message) []any {
 	return []any{
 		slog.String("topic", msg.Topic),
 		slog.Int64("offset", msg.Offset),

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -112,12 +112,12 @@ func StartConsumer(ctx context.Context) {
 			for {
 				kafkaMsg, err := kafkaConsumer.FetchMessage(ctx)
 				if err != nil {
-					slog.With(artie.KafkaMsgLogFields(&kafkaMsg)...).Warn("failed to read kafka message", slog.Any("err", err))
+					slog.With(artie.KafkaMsgLogFields(kafkaMsg)...).Warn("failed to read kafka message", slog.Any("err", err))
 					continue
 				}
 
 				if len(kafkaMsg.Value) == 0 {
-					slog.Info("found a tombstone message, skipping...", artie.KafkaMsgLogFields(&kafkaMsg)...)
+					slog.Info("found a tombstone message, skipping...", artie.KafkaMsgLogFields(kafkaMsg)...)
 					continue
 				}
 
@@ -131,7 +131,7 @@ func StartConsumer(ctx context.Context) {
 				msg.EmitIngestionLag(ctx, kafkaConsumer.Config().GroupID, tableName)
 				msg.EmitRowLag(ctx, kafkaConsumer.Config().GroupID, tableName)
 				if processErr != nil {
-					slog.With(artie.KafkaMsgLogFields(&kafkaMsg)...).Warn("skipping message...", slog.Any("err", processErr))
+					slog.With(artie.KafkaMsgLogFields(kafkaMsg)...).Warn("skipping message...", slog.Any("err", processErr))
 				}
 			}
 		}(topic)


### PR DESCRIPTION
Following this PR: https://github.com/artie-labs/transfer/pull/286

We shouldn't need pointers for `kafka.Message`, so let's remove it.