### PR TITLE
Skipping Operations Improvement

### DIFF
--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -97,14 +97,14 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		FqTableName: fqName,
 		// We are adding SELECT DISTINCT here for the temporary table as an extra guardrail.
 		// Redshift does not enforce any row uniqueness and there could be potential LOAD errors which will cause duplicate rows to arise.
-		SubQuery:          fmt.Sprintf(`( SELECT DISTINCT *  FROM %s )`, temporaryTableName),
-		IdempotentKey:     tableData.TopicConfig.IdempotentKey,
-		PrimaryKeys:       tableData.PrimaryKeys(s.config.SharedDestinationConfig.UppercaseEscapedNames, &sql.NameArgs{Escape: true, DestKind: s.Label()}),
-		ColumnsToTypes:    *tableData.ReadOnlyInMemoryCols(),
-		SkipDelete:        tableData.TopicConfig.SkipDelete,
-		SoftDelete:        tableData.TopicConfig.SoftDelete,
-		DestKind:          s.Label(),
-		UppercaseEscNames: &s.config.SharedDestinationConfig.UppercaseEscapedNames,
+		SubQuery:            fmt.Sprintf(`( SELECT DISTINCT *  FROM %s )`, temporaryTableName),
+		IdempotentKey:       tableData.TopicConfig.IdempotentKey,
+		PrimaryKeys:         tableData.PrimaryKeys(s.config.SharedDestinationConfig.UppercaseEscapedNames, &sql.NameArgs{Escape: true, DestKind: s.Label()}),
+		ColumnsToTypes:      *tableData.ReadOnlyInMemoryCols(),
+		ContainsHardDeletes: tableData.ContainsHardDeletes(),
+		SoftDelete:          tableData.TopicConfig.SoftDelete,
+		DestKind:            s.Label(),
+		UppercaseEscNames:   &s.config.SharedDestinationConfig.UppercaseEscapedNames,
 	}
 
 	// Prepare merge statement

--- a/clients/snowflake/sweep_test.go
+++ b/clients/snowflake/sweep_test.go
@@ -9,6 +9,30 @@ import (
 )
 
 func (s *SnowflakeTestSuite) TestSweep() {
+	tcs := []*kafkalib.TopicConfig{
+		{
+
+			Database:     "db",
+			Schema:       "schema",
+			TableName:    "table1",
+			Topic:        "topic1",
+			CDCFormat:    constants.DBZPostgresFormat,
+			CDCKeyFormat: kafkalib.JSONKeyFmt,
+		},
+		{
+			Database:     "db",
+			Schema:       "schema",
+			TableName:    "table2",
+			Topic:        "topic2",
+			CDCFormat:    constants.DBZPostgresFormat,
+			CDCKeyFormat: kafkalib.JSONKeyFmt,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc.Load()
+	}
+
 	s.stageStore.config = config.Config{
 		Queue:                constants.Kafka,
 		Output:               constants.Snowflake,
@@ -18,25 +42,7 @@ func (s *SnowflakeTestSuite) TestSweep() {
 		Kafka: &config.Kafka{
 			GroupID:         "artie",
 			BootstrapServer: "localhost:9092",
-			TopicConfigs: []*kafkalib.TopicConfig{
-				{
-
-					Database:     "db",
-					Schema:       "schema",
-					TableName:    "table1",
-					Topic:        "topic1",
-					CDCFormat:    constants.DBZPostgresFormat,
-					CDCKeyFormat: kafkalib.JSONKeyFmt,
-				},
-				{
-					Database:     "db",
-					Schema:       "schema",
-					TableName:    "table2",
-					Topic:        "topic2",
-					CDCFormat:    constants.DBZPostgresFormat,
-					CDCKeyFormat: kafkalib.JSONKeyFmt,
-				},
-			},
+			TopicConfigs:    tcs,
 		},
 	}
 

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -119,10 +119,6 @@ func (k *Kafka) String() string {
 }
 
 func (c Config) TopicConfigs() ([]*kafkalib.TopicConfig, error) {
-	if err := c.Validate(); err != nil {
-		return nil, err
-	}
-
 	switch c.Queue {
 	case constants.Kafka:
 		return c.Kafka.TopicConfigs, nil

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -134,14 +134,15 @@ bufferRows: 10
 	assert.Equal(t, config.FlushIntervalSeconds, 15)
 	assert.Equal(t, int(config.BufferRows), 10)
 
-	assert.Nil(t, config.Validate())
-
 	tcs, err := config.TopicConfigs()
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(tcs))
 	for _, tc := range tcs {
+		tc.Load()
 		assert.Equal(t, "customer", tc.Database)
 	}
+
+	assert.Nil(t, config.Validate())
 }
 
 func TestOutputSourceInvalid(t *testing.T) {
@@ -251,6 +252,12 @@ kafka:
 
 	assert.Equal(t, config.FlushIntervalSeconds, defaultFlushTimeSeconds)
 	assert.Equal(t, int(config.BufferRows), bufferPoolSizeEnd)
+
+	tcs, err := config.TopicConfigs()
+	assert.NoError(t, err)
+	for _, tc := range tcs {
+		tc.Load()
+	}
 
 	assert.ErrorContains(t, config.Validate(), "kafka settings is invalid")
 	for _, tc := range config.Kafka.TopicConfigs {
@@ -490,6 +497,8 @@ func TestConfig_Validate(t *testing.T) {
 		Schema:    "schema",
 		Topic:     "topic",
 	}
+
+	tc.Load()
 
 	pubsub.TopicConfigs = []*kafkalib.TopicConfig{&tc}
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -415,11 +415,11 @@ reporting:
 		}
 	}
 
-	assert.True(t, config.Kafka.TopicConfigs[orderIdx].ShouldSkip("d"))
-	assert.True(t, config.Kafka.TopicConfigs[customerIdx].ShouldSkip("c"))
-
 	assert.True(t, customerIdx >= 0)
 	assert.True(t, orderIdx >= 0)
+
+	assert.True(t, config.Kafka.TopicConfigs[orderIdx].ShouldSkip("d"))
+	assert.True(t, config.Kafka.TopicConfigs[customerIdx].ShouldSkip("c"))
 
 	// Verify Snowflake config
 	assert.Equal(t, snowflakeUser, config.Snowflake.Username)

--- a/lib/config/context.go
+++ b/lib/config/context.go
@@ -33,10 +33,6 @@ func LoadSettings(args []string, loadConfig bool) (*Settings, error) {
 			return nil, fmt.Errorf("failed to parse config file. Please check your config, err: %w", err)
 		}
 
-		if err = config.Validate(); err != nil {
-			return nil, fmt.Errorf("failed to validate config, err: %w", err)
-		}
-
 		tcs, err := config.TopicConfigs()
 		if err != nil {
 			return nil, err
@@ -44,6 +40,10 @@ func LoadSettings(args []string, loadConfig bool) (*Settings, error) {
 
 		for _, tc := range tcs {
 			tc.Load()
+		}
+
+		if err = config.Validate(); err != nil {
+			return nil, fmt.Errorf("failed to validate config, err: %w", err)
 		}
 
 		settings.Config = *config

--- a/lib/config/context.go
+++ b/lib/config/context.go
@@ -11,8 +11,7 @@ type Settings struct {
 	VerboseLogging bool
 }
 
-// InitializeCfgIntoContext will take the flags and then parse
-// loadConfig is optional for testing purposes.
+// LoadSettings will take the flags and then parse, loadConfig is optional for testing purposes.
 func LoadSettings(args []string, loadConfig bool) (*Settings, error) {
 	var opts struct {
 		ConfigFilePath string `short:"c" long:"config" description:"path to the config file"`
@@ -36,6 +35,15 @@ func LoadSettings(args []string, loadConfig bool) (*Settings, error) {
 
 		if err = config.Validate(); err != nil {
 			return nil, fmt.Errorf("failed to validate config, err: %w", err)
+		}
+
+		tcs, err := config.TopicConfigs()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, tc := range tcs {
+			tc.Load()
 		}
 
 		settings.Config = *config

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -39,8 +39,9 @@ type MergeArgument struct {
 	*/
 	DestKind   constants.DestinationKind
 	SoftDelete bool
-	// SkipDelete is only used for Redshift and MergeStatementParts
-	SkipDelete bool
+	// ContainsHardDeletes is only used for Redshift and MergeStatementParts,
+	// where we do not issue a DELETE statement if there are no hard deletes in the batch
+	ContainsHardDeletes bool
 
 	UppercaseEscNames *bool
 }
@@ -171,7 +172,7 @@ func (m *MergeArgument) GetParts() ([]string, error) {
 		),
 	}
 
-	if !m.SkipDelete {
+	if m.ContainsHardDeletes {
 		parts = append(parts,
 			// DELETE
 			fmt.Sprintf(`DELETE FROM %s WHERE (%s) IN (SELECT %s FROM %s as cc WHERE cc.%s = true);`,

--- a/lib/destination/dml/merge_parts_test.go
+++ b/lib/destination/dml/merge_parts_test.go
@@ -74,13 +74,13 @@ func TestMergeStatementParts_SkipDelete(t *testing.T) {
 	tempTableName := "public.tableName__temp"
 	res := getBasicColumnsForTest(false, false)
 	mergeArg := &MergeArgument{
-		FqTableName:       fqTableName,
-		SubQuery:          tempTableName,
-		PrimaryKeys:       res.PrimaryKeys,
-		ColumnsToTypes:    res.ColumnsToTypes,
-		DestKind:          constants.Redshift,
-		SkipDelete:        true,
-		UppercaseEscNames: ptr.ToBool(false),
+		FqTableName:         fqTableName,
+		SubQuery:            tempTableName,
+		PrimaryKeys:         res.PrimaryKeys,
+		ColumnsToTypes:      res.ColumnsToTypes,
+		DestKind:            constants.Redshift,
+		ContainsHardDeletes: false,
+		UppercaseEscNames:   ptr.ToBool(false),
 	}
 
 	parts, err := mergeArg.GetParts()
@@ -182,12 +182,13 @@ func TestMergeStatementParts(t *testing.T) {
 	tempTableName := "public.tableName__temp"
 	res := getBasicColumnsForTest(false, false)
 	mergeArg := &MergeArgument{
-		FqTableName:       fqTableName,
-		SubQuery:          tempTableName,
-		PrimaryKeys:       res.PrimaryKeys,
-		ColumnsToTypes:    res.ColumnsToTypes,
-		DestKind:          constants.Redshift,
-		UppercaseEscNames: ptr.ToBool(false),
+		FqTableName:         fqTableName,
+		SubQuery:            tempTableName,
+		PrimaryKeys:         res.PrimaryKeys,
+		ColumnsToTypes:      res.ColumnsToTypes,
+		DestKind:            constants.Redshift,
+		ContainsHardDeletes: true,
+		UppercaseEscNames:   ptr.ToBool(false),
 	}
 
 	parts, err := mergeArg.GetParts()
@@ -207,13 +208,14 @@ func TestMergeStatementParts(t *testing.T) {
 		parts[2])
 
 	mergeArg = &MergeArgument{
-		FqTableName:       fqTableName,
-		SubQuery:          tempTableName,
-		PrimaryKeys:       res.PrimaryKeys,
-		ColumnsToTypes:    res.ColumnsToTypes,
-		DestKind:          constants.Redshift,
-		IdempotentKey:     "created_at",
-		UppercaseEscNames: ptr.ToBool(false),
+		FqTableName:         fqTableName,
+		SubQuery:            tempTableName,
+		PrimaryKeys:         res.PrimaryKeys,
+		ColumnsToTypes:      res.ColumnsToTypes,
+		DestKind:            constants.Redshift,
+		IdempotentKey:       "created_at",
+		ContainsHardDeletes: true,
+		UppercaseEscNames:   ptr.ToBool(false),
 	}
 
 	parts, err = mergeArg.GetParts()
@@ -238,12 +240,13 @@ func TestMergeStatementPartsCompositeKey(t *testing.T) {
 	tempTableName := "public.tableName__temp"
 	res := getBasicColumnsForTest(true, false)
 	mergeArg := &MergeArgument{
-		FqTableName:       fqTableName,
-		SubQuery:          tempTableName,
-		PrimaryKeys:       res.PrimaryKeys,
-		ColumnsToTypes:    res.ColumnsToTypes,
-		DestKind:          constants.Redshift,
-		UppercaseEscNames: ptr.ToBool(false),
+		FqTableName:         fqTableName,
+		SubQuery:            tempTableName,
+		PrimaryKeys:         res.PrimaryKeys,
+		ColumnsToTypes:      res.ColumnsToTypes,
+		DestKind:            constants.Redshift,
+		ContainsHardDeletes: true,
+		UppercaseEscNames:   ptr.ToBool(false),
 	}
 
 	parts, err := mergeArg.GetParts()
@@ -263,13 +266,14 @@ func TestMergeStatementPartsCompositeKey(t *testing.T) {
 		parts[2])
 
 	mergeArg = &MergeArgument{
-		FqTableName:       fqTableName,
-		SubQuery:          tempTableName,
-		PrimaryKeys:       res.PrimaryKeys,
-		ColumnsToTypes:    res.ColumnsToTypes,
-		DestKind:          constants.Redshift,
-		IdempotentKey:     "created_at",
-		UppercaseEscNames: ptr.ToBool(false),
+		FqTableName:         fqTableName,
+		SubQuery:            tempTableName,
+		PrimaryKeys:         res.PrimaryKeys,
+		ColumnsToTypes:      res.ColumnsToTypes,
+		DestKind:            constants.Redshift,
+		ContainsHardDeletes: true,
+		IdempotentKey:       "created_at",
+		UppercaseEscNames:   ptr.ToBool(false),
 	}
 
 	parts, err = mergeArg.GetParts()

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/kafkalib/partition"
-	"github.com/artie-labs/transfer/lib/logger"
 )
 
 type DatabaseSchemaPair struct {
@@ -86,7 +85,7 @@ func (t *TopicConfig) Load() {
 
 func (t TopicConfig) ShouldSkip(op string) bool {
 	if t.opsToSkipMap == nil {
-		logger.Panic("opsToSkipMap is nil, Load() was never called")
+		panic("opsToSkipMap is nil, Load() was never called")
 	}
 
 	_, isOk := t.opsToSkipMap[op]

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -108,5 +108,9 @@ func (t TopicConfig) Validate() error {
 		return fmt.Errorf("invalid cdc key format: %s", t.CDCKeyFormat)
 	}
 
+	if t.opsToSkipMap == nil {
+		return fmt.Errorf("opsToSkipMap is nil, call Load() first")
+	}
+
 	return nil
 }

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -6,9 +6,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/artie-labs/transfer/lib/kafkalib/partition"
-
 	"github.com/artie-labs/transfer/lib/array"
+	"github.com/artie-labs/transfer/lib/kafkalib/partition"
+	"github.com/artie-labs/transfer/lib/logger"
 )
 
 type DatabaseSchemaPair struct {
@@ -73,18 +73,20 @@ func (t *TopicConfig) Load() {
 	t.opsToSkipMap = make(map[string]bool)
 	skippedOps := strings.Split(t.SkippedOperations, ",")
 	for _, op := range skippedOps {
-		t.opsToSkipMap[strings.TrimSpace(op)] = true
+		// Lowercase and trim space.
+		t.opsToSkipMap[strings.ToLower(strings.TrimSpace(op))] = true
 	}
 
 	// TODO: For backwards compatibility, remove in a later version.
 	if t.SkipDelete {
+		slog.Warn("skipDelete is deprecated, use skippedOperations instead")
 		t.opsToSkipMap["d"] = true
 	}
 }
 
 func (t TopicConfig) ShouldSkip(op string) bool {
 	if t.opsToSkipMap == nil {
-		slog.Warn("opsToSkipMap is nil, calling Load()")
+		logger.Panic("opsToSkipMap is nil, Load() was never called")
 	}
 
 	_, isOk := t.opsToSkipMap[op]

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -70,8 +70,7 @@ func (t *TopicConfig) Load() {
 	// 4. d - delete
 
 	t.opsToSkipMap = make(map[string]bool)
-	skippedOps := strings.Split(t.SkippedOperations, ",")
-	for _, op := range skippedOps {
+	for _, op := range strings.Split(t.SkippedOperations, ",") {
 		// Lowercase and trim space.
 		t.opsToSkipMap[strings.ToLower(strings.TrimSpace(op))] = true
 	}

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -172,4 +172,11 @@ func TestTopicConfig_Load_ShouldSkip(t *testing.T) {
 		tc.Load()
 		assert.True(t, tc.ShouldSkip("c"), tc.String())
 	}
+	{
+		tc := TopicConfig{
+			SkippedOperations: "d",
+		}
+		tc.Load()
+		assert.True(t, tc.ShouldSkip("d"), tc.String())
+	}
 }

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -128,6 +128,9 @@ func TestTopicConfig_Validate(t *testing.T) {
 		CDCKeyFormat: JSONKeyFmt,
 	}
 
+	assert.ErrorContains(t, tc.Validate(), "opsToSkipMap is nil, call Load() first")
+
+	tc.Load()
 	assert.NoError(t, tc.Validate(), tc.String())
 
 	tc.CDCKeyFormat = "non_existent"
@@ -137,4 +140,8 @@ func TestTopicConfig_Validate(t *testing.T) {
 		tc.CDCKeyFormat = validKeyFormat
 		assert.NoError(t, tc.Validate(), tc.String())
 	}
+}
+
+func TestTopicConfig_Load(t *testing.T) {
+
 }

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -142,6 +142,37 @@ func TestTopicConfig_Validate(t *testing.T) {
 	}
 }
 
-func TestTopicConfig_Load(t *testing.T) {
+func TestTopicConfig_Load_ShouldSkip(t *testing.T) {
+	{
+		// Test backwards compat
+		tc := TopicConfig{
+			SkipDelete: true,
+		}
 
+		// Before load, should be false.
+		assert.False(t, tc.ShouldSkip("d"), tc.String())
+
+		tc.Load()
+		assert.True(t, tc.ShouldSkip("d"), tc.String())
+		for _, op := range []string{"c", "r", "u"} {
+			assert.False(t, tc.ShouldSkip(op), tc.String())
+		}
+	}
+	{
+		tc := TopicConfig{
+			SkippedOperations: "c, r, u",
+		}
+		tc.Load()
+		for _, op := range []string{"c", "r", "u"} {
+			assert.True(t, tc.ShouldSkip(op), tc.String())
+		}
+		assert.False(t, tc.ShouldSkip("d"), tc.String())
+	}
+	{
+		tc := TopicConfig{
+			SkippedOperations: "c",
+		}
+		tc.Load()
+		assert.True(t, tc.ShouldSkip("c"), tc.String())
+	}
 }

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -149,9 +149,6 @@ func TestTopicConfig_Load_ShouldSkip(t *testing.T) {
 			SkipDelete: true,
 		}
 
-		// Before load, should be false.
-		assert.False(t, tc.ShouldSkip("d"), tc.String())
-
 		tc.Load()
 		assert.True(t, tc.ShouldSkip("d"), tc.String())
 		for _, op := range []string{"c", "r", "u"} {

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -275,7 +275,7 @@ func TestTableData_ContainsHardDeletes(t *testing.T) {
 
 		td.InsertRow("123", nil, true)
 		assert.Equal(t, 1, int(td.Rows()))
-		assert.True(t, td.containsHardDeletes)
+		assert.True(t, td.ContainsHardDeletes())
 	}
 	{
 		// TopicConfig has soft delete turned on, so hard delete = false
@@ -284,7 +284,7 @@ func TestTableData_ContainsHardDeletes(t *testing.T) {
 
 		td.InsertRow("123", nil, true)
 		assert.Equal(t, 1, int(td.Rows()))
-		assert.False(t, td.containsHardDeletes)
+		assert.False(t, td.ContainsHardDeletes())
 	}
 }
 

--- a/lib/optimization/event_test.go
+++ b/lib/optimization/event_test.go
@@ -267,6 +267,27 @@ func TestTableData_ShouldFlushRowLength(t *testing.T) {
 	assert.Equal(t, "rows", flushReason)
 }
 
+func TestTableData_ContainsHardDeletes(t *testing.T) {
+	{
+		// Hard delete = true
+		td := NewTableData(nil, nil, kafkalib.TopicConfig{}, "foo")
+		assert.Equal(t, 0, int(td.Rows()))
+
+		td.InsertRow("123", nil, true)
+		assert.Equal(t, 1, int(td.Rows()))
+		assert.True(t, td.containsHardDeletes)
+	}
+	{
+		// TopicConfig has soft delete turned on, so hard delete = false
+		td := NewTableData(nil, nil, kafkalib.TopicConfig{SoftDelete: true}, "foo")
+		assert.Equal(t, 0, int(td.Rows()))
+
+		td.InsertRow("123", nil, true)
+		assert.Equal(t, 1, int(td.Rows()))
+		assert.False(t, td.containsHardDeletes)
+	}
+}
+
 func TestTableData_ShouldFlushRowSize(t *testing.T) {
 	cfg := config.Config{
 		FlushSizeKb: 5,

--- a/main.go
+++ b/main.go
@@ -41,9 +41,8 @@ func main() {
 		slog.Int("flushPoolSizeKb", settings.Config.FlushSizeKb),
 	)
 
-	ctx := context.Background()
 	// Loading telemetry
-	ctx = metrics.LoadExporter(ctx, settings.Config)
+	ctx := metrics.LoadExporter(context.Background(), settings.Config)
 	var dest destination.Baseline
 	if utils.IsOutputBaseline(settings.Config) {
 		dest = utils.Baseline(settings.Config)

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -205,11 +205,3 @@ func (e *Event) Save(cfg config.Config, inMemDB *models.DatabaseData, topicConfi
 	flush, flushReason := td.ShouldFlush(cfg)
 	return flush, flushReason, nil
 }
-
-func (e *Event) ShouldSkip(skipDelete bool) bool {
-	if skipDelete && e.Deleted {
-		return true
-	}
-
-	return false
-}

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -140,45 +139,5 @@ func (e *EventsTestSuite) TestPrimaryKeyValueDeterministic() {
 
 	for i := 0; i < 500*1000; i++ {
 		assert.Equal(e.T(), evt.PrimaryKeyValue(), "aa=1bb=5dusty=mini aussiegg=artiezz=ff")
-	}
-}
-
-func (e *EventsTestSuite) TestShouldSkip() {
-	type _tc struct {
-		skipDelete     bool
-		deleted        bool
-		expectedResult bool
-	}
-
-	testCases := []_tc{
-		{
-			skipDelete:     false,
-			deleted:        false,
-			expectedResult: false,
-		},
-		{
-			skipDelete:     false,
-			deleted:        true,
-			expectedResult: false,
-		},
-		{
-			skipDelete:     true,
-			deleted:        false,
-			expectedResult: false,
-		},
-		{
-			skipDelete:     true,
-			deleted:        true,
-			expectedResult: true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		evt := &Event{
-			Deleted: testCase.deleted,
-		}
-
-		assert.Equal(e.T(), testCase.expectedResult, evt.ShouldSkip(testCase.skipDelete),
-			fmt.Sprintf("skipDelete: %v, deleted: %v", testCase.skipDelete, testCase.deleted))
 	}
 }

--- a/processes/consumer/flush_suite_test.go
+++ b/processes/consumer/flush_suite_test.go
@@ -28,21 +28,23 @@ func (f *FlushTestSuite) SetupTest() {
 	f.fakeStore = &mocks.FakeStore{}
 	store := db.Store(f.fakeStore)
 
+	tc := &kafkalib.TopicConfig{
+		Database:     "db",
+		Schema:       "schema",
+		Topic:        "topic",
+		CDCFormat:    constants.DBZPostgresFormat,
+		CDCKeyFormat: kafkalib.JSONKeyFmt,
+	}
+
+	tc.Load()
+
 	f.cfg = config.Config{
 		Kafka: &config.Kafka{
 			BootstrapServer: "foo",
 			GroupID:         "bar",
 			Username:        "user",
 			Password:        "abc",
-			TopicConfigs: []*kafkalib.TopicConfig{
-				{
-					Database:     "db",
-					Schema:       "schema",
-					Topic:        "topic",
-					CDCFormat:    constants.DBZPostgresFormat,
-					CDCKeyFormat: kafkalib.JSONKeyFmt,
-				},
-			},
+			TopicConfigs:    []*kafkalib.TopicConfig{tc},
 		},
 		Queue:                constants.Kafka,
 		Output:               "snowflake",

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -65,9 +65,9 @@ func processMessage(ctx context.Context, cfg config.Config, inMemDB *models.Data
 	// Table name is only available after event has been casted
 	tags["table"] = evt.Table
 
-	// Check to see if we should skip first
-	// This way, we can emit a specific tag to be more clear
-	if evt.ShouldSkip(topicConfig.tc.SkipDelete) {
+	if topicConfig.tc.ShouldSkip(_event.Operation()) {
+		// Check to see if we should skip first
+		// This way, we can emit a specific tag to be more clear
 		tags["skipped"] = "yes"
 		return evt.Table, nil
 	}

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -100,17 +100,20 @@ func TestProcessMessageFailures(t *testing.T) {
 	assert.Equal(t, 0, len(memDB.TableData()))
 	assert.Empty(t, tableName)
 
+	tc := &kafkalib.TopicConfig{
+		Database:      db,
+		TableName:     table,
+		Schema:        schema,
+		Topic:         msg.Topic(),
+		IdempotentKey: "",
+		CDCFormat:     "",
+		CDCKeyFormat:  "org.apache.kafka.connect.storage.StringConverter",
+	}
+	tc.Load()
+
 	// Add will just replace the prev setting.
 	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
-		tc: &kafkalib.TopicConfig{
-			Database:      db,
-			TableName:     table,
-			Schema:        schema,
-			Topic:         msg.Topic(),
-			IdempotentKey: "",
-			CDCFormat:     "",
-			CDCKeyFormat:  "org.apache.kafka.connect.storage.StringConverter",
-		},
+		tc:     tc,
 		Format: &mgo,
 	})
 

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -254,18 +254,21 @@ func TestProcessMessageSkip(t *testing.T) {
 		Format: &mgo,
 	})
 
+	tc := &kafkalib.TopicConfig{
+		Database:      db,
+		TableName:     table,
+		Schema:        schema,
+		Topic:         msg.Topic(),
+		IdempotentKey: "",
+		CDCFormat:     "",
+		CDCKeyFormat:  "org.apache.kafka.connect.storage.StringConverter",
+		SkipDelete:    true,
+	}
+	tc.Load()
+
 	// Add will just replace the prev setting.
 	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
-		tc: &kafkalib.TopicConfig{
-			Database:      db,
-			TableName:     table,
-			Schema:        schema,
-			Topic:         msg.Topic(),
-			IdempotentKey: "",
-			CDCFormat:     "",
-			CDCKeyFormat:  "org.apache.kafka.connect.storage.StringConverter",
-			SkipDelete:    true,
-		},
+		tc:     tc,
 		Format: &mgo,
 	})
 


### PR DESCRIPTION
## Changes

This PR adds the ability to skip operations other than deletes, such as:
* `r` - replication / backfill
* `u` - update
* `c` - create
* `d` - delete

This can be done by specifying at the `topicConfig` level:

```yaml
kafka:
  bootstrapServer: localhost:29092
  groupID: transfer4
  username: ""
  password: ""
  enableAWSMKSIAM: false
  topicConfigs:
    - db: customers
      tableName: users_test2
      schema: public
      skippedOperations: c, r, d
```


This also adds a backwards compatibility port from `skipDelete`.

We now have feature parity with Debezium's [skipped.operations](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-property-skipped-operations)