### PR TITLE
Optimize jitter function

### DIFF
--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -1,7 +1,6 @@
 package jitter
 
 import (
-	"math"
 	"math/rand"
 )
 
@@ -10,5 +9,6 @@ const maxMilliSeconds = 3500
 func JitterMs(baseMilliSeconds, attempts int) int {
 	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 	// sleep = random_between(0, min(cap, base * 2 ** attempt))
-	return rand.Intn(int(math.Min(maxMilliSeconds, float64(baseMilliSeconds)*math.Pow(2, float64(attempts)))))
+	// 2 ** x == 1 << x
+	return rand.Intn(min(maxMilliSeconds, baseMilliSeconds*(1<<attempts)))
 }


### PR DESCRIPTION
`2 ** x` is equivalent to `1 << x`, but doesn't require casting to `float64`. Proof https://go.dev/play/p/u2oW25Xes3Z