### PR TITLE
Return `Duration` from `Jitter()`

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -190,7 +190,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 			if TableUpdateQuotaErr(err) {
 				err = nil
 				attempts += 1
-				time.Sleep(jitter.Jitter(1500, 3500, attempts))
+				time.Sleep(jitter.Jitter(1500, jitter.DefaultMaxMs, attempts))
 			} else {
 				return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v", col.RawName(), col.RawDefaultValue(), err)
 			}

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -190,7 +190,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 			if TableUpdateQuotaErr(err) {
 				err = nil
 				attempts += 1
-				time.Sleep(time.Duration(jitter.JitterMs(1500, attempts)) * time.Millisecond)
+				time.Sleep(jitter.Jitter(1500, 3500, attempts))
 			} else {
 				return fmt.Errorf("failed to backfill col: %v, default value: %v, err: %v", col.RawName(), col.RawDefaultValue(), err)
 			}

--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -12,7 +12,6 @@ import (
 const (
 	maxAttempts = 3
 	sleepBaseMs = 500
-	sleepMaxMs  = 3500
 )
 
 type Store interface {
@@ -30,7 +29,7 @@ func (s *storeWrapper) Exec(query string, args ...any) (sql.Result, error) {
 	var err error
 	for attempts := 0; attempts < maxAttempts; attempts++ {
 		if attempts > 0 {
-			sleepDuration := jitter.Jitter(sleepBaseMs, sleepMaxMs, attempts-1)
+			sleepDuration := jitter.Jitter(sleepBaseMs, jitter.DefaultMaxMs, attempts-1)
 			slog.Warn("Failed to execute the query, retrying...",
 				slog.Any("err", err),
 				slog.Duration("sleep", sleepDuration),

--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	maxAttempts     = 3
-	sleepIntervalMs = 500
+	maxAttempts = 3
+	sleepBaseMs = 500
+	sleepMaxMs  = 3500
 )
 
 type Store interface {
@@ -29,7 +30,7 @@ func (s *storeWrapper) Exec(query string, args ...any) (sql.Result, error) {
 	var err error
 	for attempts := 0; attempts < maxAttempts; attempts++ {
 		if attempts > 0 {
-			sleepDuration := jitter.Jitter(sleepIntervalMs, 3500, attempts-1)
+			sleepDuration := jitter.Jitter(sleepBaseMs, sleepMaxMs, attempts-1)
 			slog.Warn("Failed to execute the query, retrying...",
 				slog.Any("err", err),
 				slog.Duration("sleep", sleepDuration),

--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -29,13 +29,13 @@ func (s *storeWrapper) Exec(query string, args ...any) (sql.Result, error) {
 	var err error
 	for attempts := 0; attempts < maxAttempts; attempts++ {
 		if attempts > 0 {
-			sleepDurationMs := jitter.JitterMs(sleepIntervalMs, attempts-1)
+			sleepDuration := jitter.Jitter(sleepIntervalMs, 3500, attempts-1)
 			slog.Warn("Failed to execute the query, retrying...",
 				slog.Any("err", err),
-				slog.Int("sleepDurationMs", sleepDurationMs),
+				slog.Duration("sleep", sleepDuration),
 				slog.Int("attempts", attempts),
 			)
-			time.Sleep(time.Duration(sleepDurationMs) * time.Millisecond)
+			time.Sleep(sleepDuration)
 		}
 
 		result, err = s.DB.Exec(query, args...)

--- a/lib/destination/types/table_config_test.go
+++ b/lib/destination/types/table_config_test.go
@@ -115,7 +115,7 @@ func (t *TypesTestSuite) TestDwhTableConfig_ReadOnlyColumnsToDelete() {
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
-			time.Sleep(time.Duration(jitter.JitterMs(50, 1)) * time.Millisecond)
+			time.Sleep(jitter.Jitter(50, 3500, 1))
 			defer wg.Done()
 			actualColsToDelete := tc.ReadOnlyColumnsToDelete()
 			assert.Equal(t.T(), colsToDelete, actualColsToDelete)

--- a/lib/destination/types/table_config_test.go
+++ b/lib/destination/types/table_config_test.go
@@ -1,14 +1,13 @@
 package types
 
 import (
+	"math/rand"
 	"sort"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/columns"
-
-	"github.com/artie-labs/transfer/lib/jitter"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 
@@ -115,7 +114,7 @@ func (t *TypesTestSuite) TestDwhTableConfig_ReadOnlyColumnsToDelete() {
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
-			time.Sleep(jitter.Jitter(50, 3500, 1))
+			time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
 			defer wg.Done()
 			actualColsToDelete := tc.ReadOnlyColumnsToDelete()
 			assert.Equal(t.T(), colsToDelete, actualColsToDelete)

--- a/lib/destination/types/types_test.go
+++ b/lib/destination/types/types_test.go
@@ -51,7 +51,7 @@ func (t *TypesTestSuite) TestDwhToTablesConfigMap_Concurrency() {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 1000; i++ {
-			time.Sleep(time.Duration(jitter.JitterMs(5, 1)) * time.Millisecond)
+			time.Sleep(jitter.Jitter(5, 3500, 1))
 			dwh.AddTableToConfig(fqName, dwhTableCfg)
 		}
 	}()
@@ -61,7 +61,7 @@ func (t *TypesTestSuite) TestDwhToTablesConfigMap_Concurrency() {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 1000; i++ {
-			time.Sleep(time.Duration(jitter.JitterMs(5, 1)) * time.Millisecond)
+			time.Sleep(jitter.Jitter(5, 3500, 1))
 			assert.Equal(t.T(), *dwhTableCfg, *dwh.TableConfig(fqName))
 		}
 

--- a/lib/destination/types/types_test.go
+++ b/lib/destination/types/types_test.go
@@ -1,12 +1,11 @@
 package types
 
 import (
+	"math/rand"
 	"sync"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/columns"
-
-	"github.com/artie-labs/transfer/lib/jitter"
 
 	"github.com/stretchr/testify/assert"
 
@@ -51,7 +50,7 @@ func (t *TypesTestSuite) TestDwhToTablesConfigMap_Concurrency() {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 1000; i++ {
-			time.Sleep(jitter.Jitter(5, 3500, 1))
+			time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
 			dwh.AddTableToConfig(fqName, dwhTableCfg)
 		}
 	}()
@@ -61,7 +60,7 @@ func (t *TypesTestSuite) TestDwhToTablesConfigMap_Concurrency() {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 1000; i++ {
-			time.Sleep(jitter.Jitter(5, 3500, 1))
+			time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
 			assert.Equal(t.T(), *dwhTableCfg, *dwh.TableConfig(fqName))
 		}
 

--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -2,13 +2,13 @@ package jitter
 
 import (
 	"math/rand"
+	"time"
 )
 
-const maxMilliSeconds = 3500
-
-func JitterMs(baseMilliSeconds, attempts int) int {
+func Jitter(baseMs, maxMs, attempts int) time.Duration {
 	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 	// sleep = random_between(0, min(cap, base * 2 ** attempt))
 	// 2 ** x == 1 << x
-	return rand.Intn(min(maxMilliSeconds, baseMilliSeconds*(1<<attempts)))
+	ms := rand.Intn(min(maxMs, baseMs*(1<<attempts)))
+	return time.Duration(ms) * time.Millisecond
 }

--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const DefaultMaxMs = 3500
+
 func Jitter(baseMs, maxMs, attempts int) time.Duration {
 	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 	// sleep = random_between(0, min(cap, base * 2 ** attempt))


### PR DESCRIPTION
Also remove hardcoded `maxMs` and require callers to pass one in. This way we can reuse this function in [reader.](https://github.com/artie-labs/reader/)