### PR TITLE
Consolidate table name override.

### DIFF
--- a/clients/s3/s3_test.go
+++ b/clients/s3/s3_test.go
@@ -27,7 +27,7 @@ func TestObjectPrefix(t *testing.T) {
 		Database:  "db",
 		TableName: "table",
 		Schema:    "public",
-	}, "")
+	}, "table")
 
 	td.LatestCDCTs = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 	testCases := []_testCase{

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -48,8 +48,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	}
 
 	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
-	assert.Equal(s.T(), topicConfig.TableName, tableData.RawName(), "override is working")
-
+	assert.Equal(s.T(), "foo", tableData.RawName())
 	for pk, row := range rowsData {
 		tableData.InsertRow(pk, row, false)
 	}
@@ -147,13 +146,15 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 		}
 	}
 
+	tblName := "orders"
+
 	topicConfig := kafkalib.TopicConfig{
 		Database:  "customer",
-		TableName: "orders",
+		TableName: tblName,
 		Schema:    "public",
 	}
 
-	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, "foo")
+	tableData := optimization.NewTableData(&cols, []string{"id"}, topicConfig, tblName)
 	tableData.ResetTempTableSuffix()
 	for pk, row := range rowsData {
 		tableData.InsertRow(pk, row, false)

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -106,7 +106,7 @@ func NewTableData(inMemoryColumns *columns.Columns, primaryKeys []string, topicC
 		// temporaryTableSuffix is being set in `ResetTempTableSuffix`
 		temporaryTableSuffix:    "",
 		PartitionsToLastMessage: map[string][]artie.Message{},
-		name:                    stringutil.Override(name, topicConfig.TableName),
+		name:                    name,
 	}
 }
 

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -115,11 +115,10 @@ func slicesEqualUnordered(s1, s2 []string) bool {
 
 func TestNewTableData_TableName(t *testing.T) {
 	type _testCase struct {
-		name         string
-		tableName    string
-		overrideName string
-		schema       string
-		db           string
+		name      string
+		tableName string
+		schema    string
+		db        string
 
 		expectedName            string
 		expectedSnowflakeFqName string
@@ -141,26 +140,11 @@ func TestNewTableData_TableName(t *testing.T) {
 			expectedRedshiftFqName:  "public.food",
 			expectedS3FqName:        "db.public.food",
 		},
-		{
-			name:         "override is provided",
-			tableName:    "food",
-			schema:       "public",
-			overrideName: "drinks",
-			db:           "db",
-
-			expectedName:            "drinks",
-			expectedSnowflakeFqName: "db.public.drinks",
-			expectedBigQueryFqName:  "artie.db.drinks",
-			expectedRedshiftFqName:  "public.food",
-			expectedS3FqName:        "db.public.drinks",
-		},
 	}
 
 	bqProjectID := "artie"
 	for _, testCase := range testCases {
-		td := NewTableData(nil, nil,
-			kafkalib.TopicConfig{Database: testCase.db, TableName: testCase.overrideName, Schema: testCase.schema},
-			testCase.tableName)
+		td := NewTableData(nil, nil, kafkalib.TopicConfig{Database: testCase.db, Schema: testCase.schema}, testCase.tableName)
 
 		assert.Equal(t, testCase.expectedName, td.RawName(), testCase.name)
 		assert.Equal(t, testCase.expectedName, td.name, testCase.name)

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -64,7 +64,7 @@ func (e *EventsTestSuite) TestEvent_TableName() {
 	var f fakeEvent
 	// Don't pass in tableName.
 	evt := ToMemoryEvent(f, idMap, &kafkalib.TopicConfig{})
-	assert.Equal(e.T(), f.GetTableName(), evt.Table)
+	assert.Equal(e.T(), "foo", evt.Table)
 
 	// Now pass it in, it should override.
 	evt = ToMemoryEvent(f, idMap, &kafkalib.TopicConfig{


### PR DESCRIPTION
## Changes

We were previously doing table name override both in `ToMemoryEvent(...)` and in `NewTableData(...)`

The logic is the same, so let's consolidate.

Where we are doing this in `ToMemoryEvent` in `event.go` https://github.com/artie-labs/transfer/blob/fe8cfd99ebb7f728ef72a9c2c9fd15b0089e455a/models/event/event.go#L47

