### PR TITLE
Dropping staging files and temporary tables regardless of outcome

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -252,9 +252,5 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	_, err = s.Exec(mergeQuery)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/clients/redshift/merge.go
+++ b/clients/redshift/merge.go
@@ -98,7 +98,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		})
 	}
 
-	mergArg := dml.MergeArgument{
+	mergeArg := dml.MergeArgument{
 		FqTableName: fqName,
 		// We are adding SELECT DISTINCT here for the temporary table as an extra guardrail.
 		// Redshift does not enforce any row uniqueness and there could be potential LOAD errors which will cause duplicate rows to arise.
@@ -113,7 +113,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	// Prepare merge statement
-	mergeParts, err := mergArg.GetParts()
+	mergeParts, err := mergeArg.GetParts()
 	if err != nil {
 		return fmt.Errorf("failed to generate merge statement, err: %v", err)
 	}

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -135,6 +135,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	}
 
 	defer func() {
+		// Delete the file regardless of outcome to avoid fs build up.
 		if removeErr := os.RemoveAll(fp); removeErr != nil {
 			slog.Warn("Failed to delete temp file", slog.Any("err", removeErr), slog.String("filePath", fp))
 		}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -221,9 +221,5 @@ func (s *Store) mergeWithStages(tableData *optimization.TableData) error {
 
 	slog.Debug("Executing...", slog.String("query", mergeQuery))
 	_, err = s.Exec(mergeQuery)
-	if err != nil {
-		return err
-	}
-
 	return err
 }


### PR DESCRIPTION
# Overview

Today, we are only dropping tables and staging files upon a successful merge. This leaves temporary files and tables lingering around. 

Fortunately for temporary tables, we have a `Sweep(...)` process that will garbage collect old tables. 

## Changes

This PR implements a `defer` such that all temporary tables and files are removed regardless of outcome. We'll still need `Sweep`, but this will reduce our reliance on it.

