### PR TITLE
[Redshift] Addressing SUPER limitation

### DIFF
--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -26,6 +26,9 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 		expectedResult string
 	}
 
+	randomJSONString := fmt.Sprintf(`{"foo": "%s"}`, stringutil.Random(maxRedshiftVarCharLen+1))
+	randomArrayString := fmt.Sprintf(`["a", "%s"]`, stringutil.Random(maxRedshiftVarCharLen+1))
+
 	tcs := []_tc{
 		{
 			name:   "string",
@@ -50,6 +53,30 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 				KindDetails: typing.Struct,
 			},
 			expectedResult: fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker),
+		},
+		{
+			name:   "string, but the data type is a SUPER",
+			colVal: stringutil.Random(maxRedshiftVarCharLen + 1),
+			colKind: columns.Column{
+				KindDetails: typing.Struct,
+			},
+			expectedResult: fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker),
+		},
+		{
+			name:   "struct, exceeded 65k but under 1mb",
+			colVal: randomJSONString,
+			colKind: columns.Column{
+				KindDetails: typing.Struct,
+			},
+			expectedResult: randomJSONString,
+		},
+		{
+			name:   "array, exceeded 65k but under 1mb",
+			colVal: randomArrayString,
+			colKind: columns.Column{
+				KindDetails: typing.Struct,
+			},
+			expectedResult: randomArrayString,
 		},
 		{
 			name:   "struct - not masked",


### PR DESCRIPTION
## Motivation

We are currently applying the SUPER limitation the same regardless of whether the value is an array, object or string. This is not correct since string's limit is 2^16.

![image](https://github.com/artie-labs/transfer/assets/4412200/113f7737-6781-4dc4-8091-21af839bd791)


