### PR TITLE
MongoDB making before/after maps private

### DIFF
--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -40,7 +40,7 @@ func (d *Debezium) GetEventFromBytes(typingSettings typing.Settings, bytes []byt
 			return nil, err
 		}
 
-		schemaEventPayload.Payload.BeforeMap = before
+		schemaEventPayload.Payload.beforeMap = before
 	}
 
 	if schemaEventPayload.Payload.After != nil {
@@ -62,7 +62,7 @@ func (d *Debezium) GetEventFromBytes(typingSettings typing.Settings, bytes []byt
 			}
 		}
 
-		schemaEventPayload.Payload.AfterMap = after
+		schemaEventPayload.Payload.afterMap = after
 	}
 
 	return &schemaEventPayload, nil
@@ -151,7 +151,7 @@ func (s *SchemaEventPayload) GetColumns() *columns.Columns {
 
 func (s *SchemaEventPayload) GetData(pkMap map[string]interface{}, tc *kafkalib.TopicConfig) map[string]interface{} {
 	var retMap map[string]interface{}
-	if len(s.Payload.AfterMap) == 0 {
+	if len(s.Payload.afterMap) == 0 {
 		// This is a delete event, so mark it as deleted.
 		// And we need to reconstruct the data bit since it will be empty.
 		// We _can_ rely on *before* since even without running replicate identity, it will still copy over
@@ -169,7 +169,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]interface{}, tc *kafkalib.
 			retMap[tc.IdempotentKey] = s.GetExecutionTime().Format(ext.ISO8601)
 		}
 	} else {
-		retMap = s.Payload.AfterMap
+		retMap = s.Payload.afterMap
 		// We need this because there's an edge case with Debezium
 		// Where _id gets rewritten as id in the partition key.
 		for k, v := range pkMap {

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -73,8 +73,8 @@ func (p *MongoTestSuite) TestSource_GetExecutionTime() {
 	schemaEvtPayload := &SchemaEventPayload{Payload: Payload{
 		Before:    nil,
 		After:     nil,
-		BeforeMap: nil,
-		AfterMap:  nil,
+		beforeMap: nil,
+		afterMap:  nil,
 		Source: Source{
 			Connector: "mongodb",
 			TsMs:      1668753321000, // Tue Oct 11 2022 03:19:24

--- a/lib/cdc/mongo/event.go
+++ b/lib/cdc/mongo/event.go
@@ -11,12 +11,13 @@ type SchemaEventPayload struct {
 }
 
 type Payload struct {
-	Before    *string `json:"before"`
-	After     *string `json:"after"`
-	BeforeMap map[string]interface{}
-	AfterMap  map[string]interface{}
-	Source    Source `json:"source"`
-	Operation string `json:"op"`
+	Before *string `json:"before"`
+	After  *string `json:"after"`
+
+	BeforeMap map[string]interface{} `json:"beforeMap,omitempty"`
+	AfterMap  map[string]interface{} `json:"afterMap,omitempty"`
+	Source    Source                 `json:"source"`
+	Operation string                 `json:"op"`
 }
 
 type Source struct {

--- a/lib/cdc/mongo/event.go
+++ b/lib/cdc/mongo/event.go
@@ -17,7 +17,7 @@ type Payload struct {
 	Source    Source `json:"source"`
 	Operation string `json:"op"`
 
-	// These maps are used to store the before and after JSONE as a map as opposed to a string.
+	// These maps are used to store the before and after JSONE as a map, since `before` and `after` come in as a JSONE string.
 	beforeMap map[string]interface{}
 	afterMap  map[string]interface{}
 }

--- a/lib/cdc/mongo/event.go
+++ b/lib/cdc/mongo/event.go
@@ -14,10 +14,12 @@ type Payload struct {
 	Before *string `json:"before"`
 	After  *string `json:"after"`
 
-	BeforeMap map[string]interface{} `json:"beforeMap,omitempty"`
-	AfterMap  map[string]interface{} `json:"afterMap,omitempty"`
-	Source    Source                 `json:"source"`
-	Operation string                 `json:"op"`
+	Source    Source `json:"source"`
+	Operation string `json:"op"`
+
+	// These maps are used to store the before and after JSONE as a map as opposed to a string.
+	beforeMap map[string]interface{}
+	afterMap  map[string]interface{}
 }
 
 type Source struct {


### PR DESCRIPTION
Making these private since `before/after maps` are JSONE representation of the `after` and `before` strings.

As you can see from the event below, `after` is a JSONE string.


```json
{
    "schema": {
        "type": "",
        "fields": null
    },
    "payload": {
        "before": null,
        "after": "{\"email\":\"pemett7@oaic.gov.au\",\"_id\":{\"$oid\":\"640127e4beeb1ccfc821c261\"},\"name\":\"Portie Emett\"}",
        "BeforeMap": null,
        "AfterMap": null,
        "source": {
            "connector": "",
            "ts_ms": 1707868641463,
            "db": "myFirstDatabase",
            "collection": "customers"
        },
        "op": "r"
    }
}
```