### PR TITLE
[Snowflake] Standardize how we call tableData.

### DIFF
--- a/clients/redshift/append.go
+++ b/clients/redshift/append.go
@@ -2,11 +2,44 @@ package redshift
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/destination/ddl"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/optimization"
 )
 
 func (s *Store) Append(ctx context.Context, tableData *optimization.TableData) error {
-	return fmt.Errorf("redshift: did not implement this yet")
+	if tableData.ShouldSkipUpdate() {
+		return nil
+	}
+
+	fqName := tableData.ToFqName(s.Label(), true, s.config.SharedDestinationConfig.UppercaseEscapedNames, "")
+	tableConfig, err := s.getTableConfig(tableData)
+	if err != nil {
+		return err
+	}
+
+	// We don't care about srcKeysMissing because we don't drop columns when we append.
+	_, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
+		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt,
+		tableData.TopicConfig.IncludeDatabaseUpdatedAt, tableData.Mode())
+	createAlterTableArgs := ddl.AlterTableArgs{
+		Dwh:               s,
+		Tc:                tableConfig,
+		FqTableName:       fqName,
+		CreateTable:       tableConfig.CreateTable(),
+		ColumnOp:          constants.Add,
+		CdcTime:           tableData.LatestCDCTs,
+		UppercaseEscNames: &s.config.SharedDestinationConfig.UppercaseEscapedNames,
+	}
+
+	// Keys that exist in CDC stream, but not in Snowflake
+	err = ddl.AlterTable(createAlterTableArgs, targetKeysMissing...)
+	if err != nil {
+		slog.Warn("Failed to apply alter table", slog.Any("err", err))
+		return err
+	}
 }

--- a/clients/snowflake/append.go
+++ b/clients/snowflake/append.go
@@ -28,8 +28,7 @@ func (s *Store) append(tableData *optimization.TableData) error {
 		return nil
 	}
 
-	fqName := tableData.ToFqName(s.Label(), true, s.config.SharedDestinationConfig.UppercaseEscapedNames, "")
-	tableConfig, err := s.getTableConfig(fqName, tableData.TopicConfig.DropDeletedColumns)
+	tableConfig, err := s.getTableConfig(tableData)
 	if err != nil {
 		return err
 	}
@@ -38,6 +37,8 @@ func (s *Store) append(tableData *optimization.TableData) error {
 	_, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
 		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt,
 		tableData.TopicConfig.IncludeDatabaseUpdatedAt, tableData.Mode())
+
+	fqName := tableData.ToFqName(s.Label(), true, s.config.SharedDestinationConfig.UppercaseEscapedNames, "")
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:               s,
 		Tc:                tableConfig,

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/optimization"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -108,10 +111,19 @@ func (s *SnowflakeTestSuite) TestManipulateShouldDeleteColumn() {
 
 func (s *SnowflakeTestSuite) TestGetTableConfig() {
 	// If the table does not exist, snowflakeTableConfig should say so.
-	fqName := "customers.public.orders22"
-	s.fakeStageStore.QueryReturns(nil, fmt.Errorf("Table '%s' does not exist or not authorized", fqName))
+	s.fakeStageStore.QueryReturns(nil, fmt.Errorf("Table '%s' does not exist or not authorized", "customers.public.orders22"))
 
-	tableConfig, err := s.stageStore.getTableConfig(fqName, false)
+	tableData := &optimization.TableData{
+		TopicConfig: kafkalib.TopicConfig{
+			Database:  "customers",
+			Schema:    "public",
+			TableName: "orders22",
+		},
+		PartitionsToLastMessage: nil,
+		LatestCDCTs:             time.Time{},
+	}
+
+	tableConfig, err := s.stageStore.getTableConfig(tableData)
 	assert.NotNil(s.T(), tableConfig, "config is nil")
 	assert.NoError(s.T(), err)
 

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -31,7 +31,9 @@ const (
 	describeCommentCol = "comment"
 )
 
-func (s *Store) getTableConfig(fqName string, dropDeletedColumns bool) (*types.DwhTableConfig, error) {
+func (s *Store) getTableConfig(tableData *optimization.TableData) (*types.DwhTableConfig, error) {
+	fqName := tableData.ToFqName(s.Label(), true, s.config.SharedDestinationConfig.UppercaseEscapedNames, "")
+
 	return utils.GetTableConfig(utils.GetTableCfgArgs{
 		Dwh:                s,
 		FqName:             fqName,
@@ -41,7 +43,7 @@ func (s *Store) getTableConfig(fqName string, dropDeletedColumns bool) (*types.D
 		ColumnTypeLabel:    describeTypeCol,
 		ColumnDescLabel:    describeCommentCol,
 		EmptyCommentValue:  ptr.ToString("<nil>"),
-		DropDeletedColumns: dropDeletedColumns,
+		DropDeletedColumns: tableData.TopicConfig.DropDeletedColumns,
 	})
 }
 

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -137,8 +137,7 @@ func (s *Store) mergeWithStages(tableData *optimization.TableData) error {
 		return nil
 	}
 
-	fqName := tableData.ToFqName(s.Label(), true, s.config.SharedDestinationConfig.UppercaseEscapedNames, "")
-	tableConfig, err := s.getTableConfig(fqName, tableData.TopicConfig.DropDeletedColumns)
+	tableConfig, err := s.getTableConfig(tableData)
 	if err != nil {
 		return err
 	}
@@ -147,6 +146,8 @@ func (s *Store) mergeWithStages(tableData *optimization.TableData) error {
 	srcKeysMissing, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
 		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt,
 		tableData.TopicConfig.IncludeDatabaseUpdatedAt, tableData.Mode())
+
+	fqName := tableData.ToFqName(s.Label(), true, s.config.SharedDestinationConfig.UppercaseEscapedNames, "")
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:               s,
 		Tc:                tableConfig,


### PR DESCRIPTION
Redshift and BigQuery have the same function signature, this function is to align Snowflake to match.

```go
func (s *Store) getTableConfig(tableData *optimization.TableData) (*types.DwhTableConfig, error) {
	return utils.GetTableConfig(utils.GetTableCfgArgs{
		Dwh:       s,
		FqName:    tableData.ToFqName(s.Label(), true, s.config.SharedDestinationConfig.UppercaseEscapedNames, s.config.BigQuery.ProjectID),
		ConfigMap: s.configMap,
		Query: fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name='%s';",
			tableData.TopicConfig.Database, tableData.RawName()),
		ColumnNameLabel:    describeNameCol,
		ColumnTypeLabel:    describeTypeCol,
		ColumnDescLabel:    describeCommentCol,
		EmptyCommentValue:  ptr.ToString(""),
		DropDeletedColumns: tableData.TopicConfig.DropDeletedColumns,
	})
}
```