### PR TITLE
[Redshift] Supporting Append only

### DIFF
--- a/clients/redshift/append.go
+++ b/clients/redshift/append.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
-	"github.com/artie-labs/transfer/lib/typing/columns"
-
 	"github.com/artie-labs/transfer/lib/optimization"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
 func (s *Store) Append(ctx context.Context, tableData *optimization.TableData) error {

--- a/clients/redshift/append.go
+++ b/clients/redshift/append.go
@@ -2,11 +2,47 @@ package redshift
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/destination/ddl"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 
 	"github.com/artie-labs/transfer/lib/optimization"
 )
 
 func (s *Store) Append(ctx context.Context, tableData *optimization.TableData) error {
-	return fmt.Errorf("redshift: did not implement this yet")
+	if tableData.ShouldSkipUpdate() {
+		return nil
+	}
+
+	tableConfig, err := s.getTableConfig(tableData)
+	if err != nil {
+		return err
+	}
+
+	fqName := tableData.ToFqName(s.Label(), true, s.config.SharedDestinationConfig.UppercaseEscapedNames, "")
+	// Check if all the columns exist in Redshift
+	_, targetKeysMissing := columns.Diff(tableData.ReadOnlyInMemoryCols(), tableConfig.Columns(),
+		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt, tableData.TopicConfig.IncludeDatabaseUpdatedAt, tableData.Mode())
+
+	createAlterTableArgs := ddl.AlterTableArgs{
+		Dwh:               s,
+		Tc:                tableConfig,
+		FqTableName:       fqName,
+		CreateTable:       tableConfig.CreateTable(),
+		ColumnOp:          constants.Add,
+		CdcTime:           tableData.LatestCDCTs,
+		UppercaseEscNames: &s.config.SharedDestinationConfig.UppercaseEscapedNames,
+	}
+
+	// Keys that exist in CDC stream, but not in Redshift
+	err = ddl.AlterTable(createAlterTableArgs, targetKeysMissing...)
+	if err != nil {
+		slog.Warn("Failed to apply alter table", slog.Any("err", err))
+		return err
+	}
+
+	tableData.MergeColumnsFromDestination(tableConfig.Columns().GetColumns()...)
+	return s.prepareTempTable(ctx, tableData, tableConfig, fqName)
 }

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -10,15 +10,12 @@ import (
 	"time"
 
 	"github.com/artie-labs/transfer/lib/config"
-
-	"github.com/artie-labs/transfer/lib/typing"
-
-	"github.com/artie-labs/transfer/lib/s3lib"
-
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/optimization"
+	"github.com/artie-labs/transfer/lib/s3lib"
+	"github.com/artie-labs/transfer/lib/typing"
 )
 
 func (s *Store) prepareTempTable(ctx context.Context, tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string) error {

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
 	"github.com/artie-labs/transfer/lib/destination/types"
@@ -19,26 +18,24 @@ import (
 )
 
 func (s *Store) prepareTempTable(ctx context.Context, tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string) error {
-	if tableData.Mode() != config.History {
-		tempAlterTableArgs := ddl.AlterTableArgs{
-			Dwh:               s,
-			Tc:                tableConfig,
-			FqTableName:       tempTableName,
-			CreateTable:       true,
-			TemporaryTable:    true,
-			ColumnOp:          constants.Add,
-			UppercaseEscNames: &s.config.SharedDestinationConfig.UppercaseEscapedNames,
-		}
+	tempAlterTableArgs := ddl.AlterTableArgs{
+		Dwh:               s,
+		Tc:                tableConfig,
+		FqTableName:       tempTableName,
+		CreateTable:       true,
+		TemporaryTable:    true,
+		ColumnOp:          constants.Add,
+		UppercaseEscNames: &s.config.SharedDestinationConfig.UppercaseEscapedNames,
+	}
 
-		if err := ddl.AlterTable(tempAlterTableArgs, tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {
-			return fmt.Errorf("failed to create temp table: %w", err)
-		}
+	if err := ddl.AlterTable(tempAlterTableArgs, tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {
+		return fmt.Errorf("failed to create temp table: %w", err)
+	}
 
-		expiryString := typing.ExpiresDate(time.Now().UTC().Add(ddl.TempTableTTL))
-		// Now add a comment to the temporary table.
-		if _, err := s.Exec(fmt.Sprintf(`COMMENT ON TABLE %s IS '%s';`, tempTableName, ddl.ExpiryComment(expiryString))); err != nil {
-			return fmt.Errorf("failed to add comment to table %s: %w", tempTableName, err)
-		}
+	expiryString := typing.ExpiresDate(time.Now().UTC().Add(ddl.TempTableTTL))
+	// Now add a comment to the temporary table.
+	if _, err := s.Exec(fmt.Sprintf(`COMMENT ON TABLE %s IS '%s';`, tempTableName, ddl.ExpiryComment(expiryString))); err != nil {
+		return fmt.Errorf("failed to add comment to table %s: %w", tempTableName, err)
 	}
 
 	fp, err := s.loadTemporaryTable(tableData, tempTableName)

--- a/clients/snowflake/append.go
+++ b/clients/snowflake/append.go
@@ -55,6 +55,8 @@ func (s *Store) append(tableData *optimization.TableData) error {
 		return err
 	}
 
+	tableData.MergeColumnsFromDestination(tableConfig.Columns().GetColumns()...)
+
 	// TODO: For history mode - in the future, we could also have a separate stage name for history mode so we can enable parallel processing.
 	return s.prepareTempTable(tableData, tableConfig, fqName,
 		`FILE_FORMAT = (TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE) PURGE = TRUE`)


### PR DESCRIPTION
## Motivation

This will enable History Mode for Redshift Append

## Strategy

1. Apply necessary DDLs to the target table
2. Create staging table
3. Run `ALTER TABLE target APPEND staging` https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE_APPEND.html