### PR TITLE
[BigQuery] Consolidate column backfills

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -6,10 +6,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/artie-labs/transfer/clients/utils"
-
 	"cloud.google.com/go/bigquery"
 
+	"github.com/artie-labs/transfer/clients/utils"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
 	"github.com/artie-labs/transfer/lib/destination/dml"

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/artie-labs/transfer/clients/utils"
+
 	"cloud.google.com/go/bigquery"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -54,45 +56,6 @@ func (s *Store) merge(tableData *optimization.TableData) ([]*Row, error) {
 	}
 
 	return rows, nil
-}
-
-// BackfillColumn will perform a backfill to the destination and also update the comment within a transaction.
-// Source: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#column_set_options_list
-func (s *Store) backfillColumn(column columns.Column, fqTableName string) error {
-	if !column.ShouldBackfill() {
-		// If we don't need to backfill, don't backfill.
-		return nil
-	}
-
-	additionalDateFmts := s.config.SharedTransferConfig.TypingSettings.AdditionalDateFormats
-
-	defaultVal, err := column.DefaultValue(&columns.DefaultValueArgs{Escape: true, DestKind: s.Label()}, additionalDateFmts)
-	if err != nil {
-		return fmt.Errorf("failed to escape default value: %w", err)
-	}
-
-	escapedCol := column.Name(s.config.SharedDestinationConfig.UppercaseEscapedNames, &sql.NameArgs{Escape: true, DestKind: s.Label()})
-	query := fmt.Sprintf(`UPDATE %s SET %s = %v WHERE %s IS NULL;`,
-		// UPDATE table SET col = default_val WHERE col IS NULL
-		fqTableName, escapedCol, defaultVal, escapedCol)
-
-	slog.Info(
-		"backfilling column",
-		slog.String("colName", column.RawName()),
-		slog.String("query", query),
-		slog.String("table", fqTableName),
-	)
-	_, err = s.Exec(query)
-	if err != nil {
-		return fmt.Errorf("failed to backfill, err: %w, query: %v", err, query)
-	}
-
-	query = fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET OPTIONS (description=`%s`);",
-		// ALTER TABLE table ALTER COLUMN col set OPTIONS (description=...)
-		fqTableName, escapedCol, `{"backfilled": true}`,
-	)
-	_, err = s.Exec(query)
-	return err
 }
 
 func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
@@ -178,7 +141,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 
 		var attempts int
 		for {
-			err = s.backfillColumn(col, fqName)
+			err = utils.BackfillColumn(s.config, s, col, fqName)
 			if err == nil {
 				tableConfig.Columns().UpsertColumn(col.RawName(), columns.UpsertColumnArg{
 					Backfilled: ptr.ToBool(true),

--- a/clients/bigquery/merge_test.go
+++ b/clients/bigquery/merge_test.go
@@ -1,6 +1,8 @@
 package bigquery
 
 import (
+	"github.com/artie-labs/transfer/clients/utils"
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
 	"github.com/stretchr/testify/assert"
@@ -59,7 +61,7 @@ func (b *BigQueryTestSuite) TestBackfillColumn() {
 
 	var index int
 	for _, testCase := range testCases {
-		err := b.store.backfillColumn(testCase.col, fqTableName)
+		err := utils.BackfillColumn(config.Config{}, b.store, testCase.col, fqTableName)
 		if testCase.expectErr {
 			assert.Error(b.T(), err, testCase.name)
 			continue


### PR DESCRIPTION
## Changes

Refactor `utils.BackfillColumn` to work with BigQuery as this is a pre-requisite in merge consolidation.
