### PR TITLE
Removing `context.Context` from MERGE and APPEND

### DIFF
--- a/clients/bigquery/append.go
+++ b/clients/bigquery/append.go
@@ -1,12 +1,11 @@
 package bigquery
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/artie-labs/transfer/lib/optimization"
 )
 
-func (s *Store) Append(ctx context.Context, tableData *optimization.TableData) error {
+func (s *Store) Append(tableData *optimization.TableData) error {
 	return fmt.Errorf("bigquery: did not implement this yet")
 }

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -1,7 +1,6 @@
 package bigquery
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 
@@ -26,7 +25,7 @@ func (r *Row) Save() (map[string]bigquery.Value, string, error) {
 	return r.data, bigquery.NoDedupeID, nil
 }
 
-func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
+func (s *Store) Merge(tableData *optimization.TableData) error {
 	var additionalEqualityStrings []string
 	if tableData.TopicConfig.BigQueryPartitionSettings != nil {
 		additionalDateFmts := s.config.SharedTransferConfig.TypingSettings.AdditionalDateFormats

--- a/clients/redshift/append.go
+++ b/clients/redshift/append.go
@@ -1,7 +1,6 @@
 package redshift
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 
@@ -12,7 +11,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
-func (s *Store) Append(ctx context.Context, tableData *optimization.TableData) error {
+func (s *Store) Append(tableData *optimization.TableData) error {
 	if tableData.ShouldSkipUpdate() {
 		return nil
 	}

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -1,7 +1,6 @@
 package redshift
 
 import (
-	"context"
 	"fmt"
 
 	_ "github.com/lib/pq"
@@ -42,7 +41,7 @@ func (s *Store) Label() constants.DestinationKind {
 	return constants.Redshift
 }
 
-func (s *Store) Merge(_ context.Context, tableData *optimization.TableData) error {
+func (s *Store) Merge(tableData *optimization.TableData) error {
 	return shared.Merge(s, tableData, s.config, types.MergeOpts{
 		UseMergeParts: true,
 		// We are adding SELECT DISTINCT here for the temporary table as an extra guardrail.

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -63,9 +63,9 @@ func (s *Store) ObjectPrefix(tableData *optimization.TableData) string {
 	return strings.Join([]string{fqTableName, yyyyMMDDFormat}, "/")
 }
 
-func (s *Store) Append(ctx context.Context, tableData *optimization.TableData) error {
+func (s *Store) Append(tableData *optimization.TableData) error {
 	// There's no difference in appending or merging for S3.
-	return s.Merge(ctx, tableData)
+	return s.Merge(tableData)
 }
 
 // Merge - will take tableData, write it into a particular file in the specified format, in these steps:
@@ -73,7 +73,7 @@ func (s *Store) Append(ctx context.Context, tableData *optimization.TableData) e
 // 2. Load the temporary file, under this format: s3://bucket/optionalS3Prefix/fullyQualifiedTableName/YYYY-MM-DD/{{unix_timestamp}}.parquet.gz
 // 3. It will then upload this to S3
 // 4. Delete the temporary file
-func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
+func (s *Store) Merge(tableData *optimization.TableData) error {
 	if tableData.ShouldSkipUpdate() {
 		return nil
 	}
@@ -146,7 +146,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		}
 	}()
 
-	if _, err = s3lib.UploadLocalFileToS3(ctx, s3lib.UploadArgs{
+	if _, err = s3lib.UploadLocalFileToS3(context.Background(), s3lib.UploadArgs{
 		Bucket:                     s.config.S3.Bucket,
 		OptionalS3Prefix:           s.ObjectPrefix(tableData),
 		FilePath:                   fp,
@@ -159,7 +159,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 	return nil
 }
 
-func (s *Store) IsRetryableError(err error) bool {
+func (s *Store) IsRetryableError(_ error) bool {
 	return false // not supported for S3
 }
 

--- a/clients/snowflake/append.go
+++ b/clients/snowflake/append.go
@@ -1,7 +1,6 @@
 package snowflake
 
 import (
-	"context"
 	"log/slog"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -12,13 +11,13 @@ import (
 	"github.com/artie-labs/transfer/lib/optimization"
 )
 
-func (s *Store) Append(ctx context.Context, tableData *optimization.TableData) error {
+func (s *Store) Append(tableData *optimization.TableData) error {
 	// TODO: Implement max retry count
 	err := s.append(tableData)
 	if IsAuthExpiredError(err) {
 		slog.Warn("Authentication has expired, will reload the Snowflake store and retry appending", slog.Any("err", err))
 		s.reestablishConnection()
-		return s.Append(ctx, tableData)
+		return s.Append(tableData)
 	}
 
 	return err

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -1,7 +1,6 @@
 package snowflake
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 
@@ -62,13 +61,13 @@ func (s *Store) GetConfigMap() *types.DwhToTablesConfigMap {
 	return s.configMap
 }
 
-func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
+func (s *Store) Merge(tableData *optimization.TableData) error {
 	// TODO: Implement max retry count
 	err := shared.Merge(s, tableData, s.config, types.MergeOpts{})
 	if IsAuthExpiredError(err) {
 		slog.Warn("Authentication has expired, will reload the Snowflake store and retry merging", slog.Any("err", err))
 		s.reestablishConnection()
-		return s.Merge(ctx, tableData)
+		return s.Merge(tableData)
 	}
 
 	return err

--- a/lib/destination/dwh.go
+++ b/lib/destination/dwh.go
@@ -1,7 +1,6 @@
 package destination
 
 import (
-	"context"
 	"database/sql"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -11,8 +10,8 @@ import (
 
 type DataWarehouse interface {
 	Label() constants.DestinationKind
-	Merge(ctx context.Context, tableData *optimization.TableData) error
-	Append(ctx context.Context, tableData *optimization.TableData) error
+	Merge(tableData *optimization.TableData) error
+	Append(tableData *optimization.TableData) error
 	Exec(query string, args ...any) (sql.Result, error)
 	Query(query string, args ...any) (*sql.Rows, error)
 	Begin() (*sql.Tx, error)
@@ -27,7 +26,7 @@ type DataWarehouse interface {
 
 type Baseline interface {
 	Label() constants.DestinationKind
-	Merge(ctx context.Context, tableData *optimization.TableData) error
-	Append(ctx context.Context, tableData *optimization.TableData) error
+	Merge(tableData *optimization.TableData) error
+	Append(tableData *optimization.TableData) error
 	IsRetryableError(err error) bool
 }

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -89,10 +89,10 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 			action := "merge"
 			// Merge or Append depending on the mode.
 			if _tableData.Mode() == config.History {
-				err = dest.Append(ctx, _tableData.TableData)
+				err = dest.Append(_tableData.TableData)
 				action = "append"
 			} else {
-				err = dest.Merge(ctx, _tableData.TableData)
+				err = dest.Merge(_tableData.TableData)
 			}
 
 			if err != nil {

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -25,11 +25,11 @@ func (m MockDestination) Label() constants.DestinationKind {
 	return "mock"
 }
 
-func (m MockDestination) Merge(ctx context.Context, tableData *optimization.TableData) error {
+func (m MockDestination) Merge(tableData *optimization.TableData) error {
 	return fmt.Errorf("should not be called")
 }
 
-func (m MockDestination) Append(ctx context.Context, tableData *optimization.TableData) error {
+func (m MockDestination) Append(tableData *optimization.TableData) error {
 	return fmt.Errorf("should not be called")
 }
 


### PR DESCRIPTION
## Changes

Let's remove `context.Context` from MERGE and APPEND since it's no longer required.