### PR TITLE
[Snowflake] Max Retries for Append and Merge

### DIFF
--- a/clients/snowflake/append.go
+++ b/clients/snowflake/append.go
@@ -14,13 +14,16 @@ import (
 func (s *Store) Append(tableData *optimization.TableData) error {
 	var err error
 	for i := 0; i < maxRetries; i++ {
-		err = s.append(tableData)
-		if IsAuthExpiredError(err) {
-			slog.Warn("Authentication has expired, will reload the Snowflake store and retry appending", slog.Any("err", err))
-			s.reestablishConnection()
-		} else {
-			break
+		if i > 0 {
+			if IsAuthExpiredError(err) {
+				slog.Warn("Authentication has expired, will reload the Snowflake store and retry appending", slog.Any("err", err))
+				s.reestablishConnection()
+			} else {
+				break
+			}
 		}
+
+		err = s.append(tableData)
 	}
 
 	return err

--- a/clients/snowflake/append.go
+++ b/clients/snowflake/append.go
@@ -12,12 +12,15 @@ import (
 )
 
 func (s *Store) Append(tableData *optimization.TableData) error {
-	// TODO: Implement max retry count
-	err := s.append(tableData)
-	if IsAuthExpiredError(err) {
-		slog.Warn("Authentication has expired, will reload the Snowflake store and retry appending", slog.Any("err", err))
-		s.reestablishConnection()
-		return s.Append(tableData)
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		err = s.append(tableData)
+		if IsAuthExpiredError(err) {
+			slog.Warn("Authentication has expired, will reload the Snowflake store and retry appending", slog.Any("err", err))
+			s.reestablishConnection()
+		} else {
+			break
+		}
 	}
 
 	return err

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -66,13 +66,16 @@ func (s *Store) GetConfigMap() *types.DwhToTablesConfigMap {
 func (s *Store) Merge(tableData *optimization.TableData) error {
 	var err error
 	for i := 0; i < maxRetries; i++ {
-		err = shared.Merge(s, tableData, s.config, types.MergeOpts{})
-		if IsAuthExpiredError(err) {
-			slog.Warn("Authentication has expired, will reload the Snowflake store and retry merging", slog.Any("err", err))
-			s.reestablishConnection()
-		} else {
-			break
+		if i > 0 {
+			if IsAuthExpiredError(err) {
+				slog.Warn("Authentication has expired, will reload the Snowflake store and retry merging", slog.Any("err", err))
+				s.reestablishConnection()
+			} else {
+				break
+			}
 		}
+
+		err = shared.Merge(s, tableData, s.config, types.MergeOpts{})
 	}
 	return err
 }

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -16,6 +16,8 @@ import (
 	"github.com/artie-labs/transfer/lib/ptr"
 )
 
+const maxRetries = 10
+
 type Store struct {
 	db.Store
 	testDB    bool // Used for testing
@@ -62,14 +64,16 @@ func (s *Store) GetConfigMap() *types.DwhToTablesConfigMap {
 }
 
 func (s *Store) Merge(tableData *optimization.TableData) error {
-	// TODO: Implement max retry count
-	err := shared.Merge(s, tableData, s.config, types.MergeOpts{})
-	if IsAuthExpiredError(err) {
-		slog.Warn("Authentication has expired, will reload the Snowflake store and retry merging", slog.Any("err", err))
-		s.reestablishConnection()
-		return s.Merge(tableData)
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		err = shared.Merge(s, tableData, s.config, types.MergeOpts{})
+		if IsAuthExpiredError(err) {
+			slog.Warn("Authentication has expired, will reload the Snowflake store and retry merging", slog.Any("err", err))
+			s.reestablishConnection()
+		} else {
+			break
+		}
 	}
-
 	return err
 }
 


### PR DESCRIPTION
Setting the max retries to be 10 for Snowflake MERGE and APPEND upon a retryable auth error.