### PR TITLE
[Topic Config] Remove support for `skippedDelete`

### DIFF
--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -2,7 +2,6 @@ package kafkalib
 
 import (
 	"fmt"
-	"log/slog"
 	"slices"
 	"strings"
 
@@ -35,17 +34,15 @@ func GetUniqueDatabaseAndSchema(tcs []*TopicConfig) []DatabaseSchemaPair {
 }
 
 type TopicConfig struct {
-	Database           string `yaml:"db"`
-	TableName          string `yaml:"tableName"`
-	Schema             string `yaml:"schema"`
-	Topic              string `yaml:"topic"`
-	IdempotentKey      string `yaml:"idempotentKey"`
-	CDCFormat          string `yaml:"cdcFormat"`
-	CDCKeyFormat       string `yaml:"cdcKeyFormat"`
-	DropDeletedColumns bool   `yaml:"dropDeletedColumns"`
-	SoftDelete         bool   `yaml:"softDelete"`
-	// TODO: Deprecate SkipDelete in the next version and add it to the Release Notes.
-	SkipDelete                bool                        `yaml:"skipDelete"`
+	Database                  string                      `yaml:"db"`
+	TableName                 string                      `yaml:"tableName"`
+	Schema                    string                      `yaml:"schema"`
+	Topic                     string                      `yaml:"topic"`
+	IdempotentKey             string                      `yaml:"idempotentKey"`
+	CDCFormat                 string                      `yaml:"cdcFormat"`
+	CDCKeyFormat              string                      `yaml:"cdcKeyFormat"`
+	DropDeletedColumns        bool                        `yaml:"dropDeletedColumns"`
+	SoftDelete                bool                        `yaml:"softDelete"`
 	SkippedOperations         string                      `yaml:"skippedOperations"`
 	IncludeArtieUpdatedAt     bool                        `yaml:"includeArtieUpdatedAt"`
 	IncludeDatabaseUpdatedAt  bool                        `yaml:"includeDatabaseUpdatedAt"`
@@ -73,12 +70,6 @@ func (t *TopicConfig) Load() {
 	for _, op := range strings.Split(t.SkippedOperations, ",") {
 		// Lowercase and trim space.
 		t.opsToSkipMap[strings.ToLower(strings.TrimSpace(op))] = true
-	}
-
-	// TODO: For backwards compatibility, remove in a later version.
-	if t.SkipDelete {
-		slog.Warn("skipDelete is deprecated, use skippedOperations instead")
-		t.opsToSkipMap["d"] = true
 	}
 }
 

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -145,18 +145,6 @@ func TestTopicConfig_Validate(t *testing.T) {
 
 func TestTopicConfig_Load_ShouldSkip(t *testing.T) {
 	{
-		// Test backwards compat
-		tc := TopicConfig{
-			SkipDelete: true,
-		}
-
-		tc.Load()
-		assert.True(t, tc.ShouldSkip("d"), tc.String())
-		for _, op := range []string{"c", "r", "u"} {
-			assert.False(t, tc.ShouldSkip(op), tc.String())
-		}
-	}
-	{
 		tc := TopicConfig{
 			SkippedOperations: "c, r, u",
 		}

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -266,14 +266,14 @@ func TestProcessMessageSkip(t *testing.T) {
 	})
 
 	tc := &kafkalib.TopicConfig{
-		Database:      db,
-		TableName:     table,
-		Schema:        schema,
-		Topic:         msg.Topic(),
-		IdempotentKey: "",
-		CDCFormat:     "",
-		CDCKeyFormat:  "org.apache.kafka.connect.storage.StringConverter",
-		SkipDelete:    true,
+		Database:          db,
+		TableName:         table,
+		Schema:            schema,
+		Topic:             msg.Topic(),
+		IdempotentKey:     "",
+		CDCFormat:         "",
+		CDCKeyFormat:      "org.apache.kafka.connect.storage.StringConverter",
+		SkippedOperations: "d",
 	}
 	tc.Load()
 


### PR DESCRIPTION
## Changes

Previously, we already introduced `skippedOperations` which enables the ability to skip all operations with a comma separated string.

* This PR removes the old option `skippedDelete`.
* To maintain the ability for `skippedDelete` to work, make sure to set `skippedOperations = d`