### PR TITLE
Reducing `store` from LoadStore(...)

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -148,18 +148,8 @@ func (s *Store) putTable(ctx context.Context, dataset, tableName string, rows []
 	return nil
 }
 
-func LoadBigQuery(cfg config.Config, _store *db.Store) *Store {
+func LoadBigQuery(cfg config.Config) *Store {
 	cfg.BigQuery.LoadDefaultValues()
-	if _store != nil {
-		// Used for tests.
-		return &Store{
-			Store: *_store,
-
-			configMap: &types.DwhToTablesConfigMap{},
-			config:    cfg,
-		}
-	}
-
 	if credPath := cfg.BigQuery.PathToCredentials; credPath != "" {
 		// If the credPath is set, let's set it into the env var.
 		slog.Debug("Writing the path to BQ credentials to env var for google auth")

--- a/clients/bigquery/bigquery_suite_test.go
+++ b/clients/bigquery/bigquery_suite_test.go
@@ -24,8 +24,8 @@ func (b *BigQueryTestSuite) SetupTest() {
 	}
 
 	b.fakeStore = &mocks.FakeStore{}
-	store := db.Store(b.fakeStore)
-	b.store = LoadBigQuery(cfg, &store)
+	b.store = LoadBigQuery(cfg)
+	b.store.Store = db.Store(b.fakeStore)
 }
 
 func TestBigQueryTestSuite(t *testing.T) {

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -173,9 +173,8 @@ func (r *RedshiftTestSuite) TestCastColValStaging_ExceededValues() {
 		},
 	}
 
-	store := db.Store(r.fakeStore)
-	skipLargeRowsStore := LoadRedshift(cfg, &store)
-
+	skipLargeRowsStore := LoadRedshift(cfg)
+	skipLargeRowsStore.Store = db.Store(r.fakeStore)
 	for _, testCase := range testCases {
 		evaluateTestCase(r.T(), skipLargeRowsStore, testCase)
 	}

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -70,18 +70,7 @@ func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTab
 	})
 }
 
-func LoadRedshift(cfg config.Config, _store *db.Store) *Store {
-	if _store != nil {
-		// Used for tests.
-		return &Store{
-			configMap:  &types.DwhToTablesConfigMap{},
-			skipLgCols: cfg.Redshift.SkipLgCols,
-			config:     cfg,
-
-			Store: *_store,
-		}
-	}
-
+func LoadRedshift(cfg config.Config) *Store {
 	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=require",
 		cfg.Redshift.Host, cfg.Redshift.Port, cfg.Redshift.Username,
 		cfg.Redshift.Password, cfg.Redshift.Database)

--- a/clients/redshift/redshift_suite_test.go
+++ b/clients/redshift/redshift_suite_test.go
@@ -21,8 +21,8 @@ func (r *RedshiftTestSuite) SetupTest() {
 	}
 
 	r.fakeStore = &mocks.FakeStore{}
-	store := db.Store(r.fakeStore)
-	r.store = LoadRedshift(cfg, &store)
+	r.store = LoadRedshift(cfg)
+	r.store.Store = db.Store(r.fakeStore)
 	r.store.skipLgCols = true
 }
 

--- a/lib/destination/ddl/ddl_suite_test.go
+++ b/lib/destination/ddl/ddl_suite_test.go
@@ -39,17 +39,17 @@ func (d *DDLTestSuite) SetupTest() {
 	}
 
 	d.fakeBigQueryStore = &mocks.FakeStore{}
-	bqStore := db.Store(d.fakeBigQueryStore)
 
-	d.bigQueryStore = bigquery.LoadBigQuery(d.bigQueryCfg, &bqStore)
+	d.bigQueryStore = bigquery.LoadBigQuery(d.bigQueryCfg)
+	d.bigQueryStore.Store = db.Store(d.fakeBigQueryStore)
 
 	d.fakeSnowflakeStagesStore = &mocks.FakeStore{}
 	snowflakeStagesStore := db.Store(d.fakeSnowflakeStagesStore)
 	d.snowflakeStagesStore = snowflake.LoadSnowflake(cfg, &snowflakeStagesStore)
 
 	d.fakeRedshiftStore = &mocks.FakeStore{}
-	redshiftStore := db.Store(d.fakeRedshiftStore)
-	d.redshiftStore = redshift.LoadRedshift(cfg, &redshiftStore)
+	d.redshiftStore = redshift.LoadRedshift(cfg)
+	d.redshiftStore.Store = db.Store(d.fakeRedshiftStore)
 }
 
 func TestDDLTestSuite(t *testing.T) {

--- a/lib/destination/utils/load.go
+++ b/lib/destination/utils/load.go
@@ -55,9 +55,9 @@ func DataWarehouse(cfg config.Config, store *db.Store) destination.DataWarehouse
 		}
 		return s
 	case constants.BigQuery:
-		return bigquery.LoadBigQuery(cfg, store)
+		return bigquery.LoadBigQuery(cfg)
 	case constants.Redshift:
-		s := redshift.LoadRedshift(cfg, store)
+		s := redshift.LoadRedshift(cfg)
 		if err := s.Sweep(); err != nil {
 			logger.Panic("Failed to clean up redshift", slog.Any("err", err))
 		}


### PR DESCRIPTION
We don't need to specify `store` as a 2nd parameter for `LoadStore(...)`.

* Tests can directly inject a `Store` dependency, which is what this PR did.
* Snowflake still needs it as we support `test` as a valid destination