### PR TITLE
[MSSQL] Typing library adding `typing.Float`

### DIFF
--- a/lib/typing/mssql.go
+++ b/lib/typing/mssql.go
@@ -67,6 +67,8 @@ func kindToMSSQL(kd KindDetails, isPk bool) string {
 	const maxVarCharLengthForPrimaryKey = 900
 
 	switch kd.Kind {
+	case Float.Kind:
+		return "float"
 	case Integer.Kind:
 		return "bigint"
 	case Struct.Kind, Array.Kind:


### PR DESCRIPTION
We didn't include `Float.Kind`, it didn't break anything because the default statement will return `kd.Kind` which is a Float, but this makes it explicit.