### PR TITLE
[MSSQL] Increasing the resiliency of INTs and FLOATs

### DIFF
--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -17,7 +17,6 @@ import (
 
 func parseValue(colVal interface{}, colKind columns.Column, additionalDateFmts []string) (any, error) {
 	if colVal == nil {
-		// TODO: Test nil
 		return colVal, nil
 	}
 
@@ -72,7 +71,21 @@ func parseValue(colVal interface{}, colKind columns.Column, additionalDateFmts [
 		}
 
 		return string(colValBytes), nil
-	case typing.Integer.Kind, typing.Float.Kind:
+	case typing.Integer.Kind:
+		_, isString := colVal.(string)
+		if isString {
+			// If the value is a string, convert it back into a number
+			return strconv.Atoi(colValString)
+		}
+
+		return colVal, nil
+	case typing.Float.Kind:
+		_, isString := colVal.(string)
+		if isString {
+			// If the value is a string, convert it back into a number
+			return strconv.ParseFloat(colValString, 64)
+		}
+
 		return colVal, nil
 	case typing.Boolean.Kind:
 		// If it's already a boolean, return it. Else, convert it.

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -15,7 +15,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
-func parseValue(colVal interface{}, colKind columns.Column, additionalDateFmts []string) (any, error) {
+func parseValue(colVal any, colKind columns.Column, additionalDateFmts []string) (any, error) {
 	if colVal == nil {
 		return colVal, nil
 	}
@@ -31,7 +31,7 @@ func parseValue(colVal interface{}, colKind columns.Column, additionalDateFmts [
 		return extTime.GetTime(), nil
 	case typing.String.Kind:
 		isArray := reflect.ValueOf(colVal).Kind() == reflect.Slice
-		_, isMap := colVal.(map[string]interface{})
+		_, isMap := colVal.(map[string]any)
 
 		// If colVal is either an array or a JSON object, we should run JSON parse.
 		if isMap || isArray {
@@ -50,7 +50,7 @@ func parseValue(colVal interface{}, colKind columns.Column, additionalDateFmts [
 	case typing.Struct.Kind:
 		if colKind.KindDetails == typing.Struct {
 			if strings.Contains(colValString, constants.ToastUnavailableValuePlaceholder) {
-				colVal = map[string]interface{}{
+				colVal = map[string]any{
 					"key": constants.ToastUnavailableValuePlaceholder,
 				}
 			}

--- a/clients/mssql/values_test.go
+++ b/clients/mssql/values_test.go
@@ -1,0 +1,74 @@
+package mssql
+
+import (
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/typing"
+
+	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseValue(t *testing.T) {
+	{
+		val, err := parseValue(nil, columns.Column{}, nil)
+		assert.NoError(t, err)
+		assert.Nil(t, val)
+	}
+	{
+		val, err := parseValue("string value", columns.NewColumn("foo", typing.String), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "string value", val)
+	}
+	{
+		val, err := parseValue(map[string]any{"foo": "bar"}, columns.NewColumn("json", typing.Struct), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"foo":"bar"}`, val)
+	}
+	{
+		val, err := parseValue([]any{"foo", "bar"}, columns.NewColumn("array", typing.Array), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, `["foo","bar"]`, val)
+	}
+	{
+		// Integers
+		val, err := parseValue(1234, columns.NewColumn("int", typing.Integer), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 1234, val)
+
+		// Should be able to handle string ints
+		val, err = parseValue("1234", columns.NewColumn("float", typing.Integer), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 1234, val)
+	}
+	{
+		// Floats
+		val, err := parseValue(1234.5678, columns.NewColumn("float", typing.Float), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 1234.5678, val)
+
+		// Should be able to handle string floats
+		val, err = parseValue("1234.5678", columns.NewColumn("float", typing.Float), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 1234.5678, val)
+	}
+	{
+		// Booleans
+		val, err := parseValue(true, columns.NewColumn("bool", typing.Boolean), nil)
+		assert.NoError(t, err)
+		assert.True(t, val.(bool))
+
+		val, err = parseValue(false, columns.NewColumn("bool", typing.Boolean), nil)
+		assert.NoError(t, err)
+		assert.False(t, val.(bool))
+
+		// Should be able to handle string booleans
+		val, err = parseValue("true", columns.NewColumn("bool", typing.Boolean), nil)
+		assert.NoError(t, err)
+		assert.True(t, val.(bool))
+
+		val, err = parseValue("false", columns.NewColumn("bool", typing.Boolean), nil)
+		assert.NoError(t, err)
+		assert.False(t, val.(bool))
+	}
+}


### PR DESCRIPTION
## Changes

1. Adding tests to `parseValue`
2. Ability to cast colVal back into a number if the destination is a number and value provided is in string.
3. Changing everything `parseValue` from `interface{}` -> `any`