### PR TITLE
Renaming `interface{}` to `any` Part 1

### DIFF
--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -15,7 +15,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func castColVal(colVal interface{}, colKind columns.Column, additionalDateFmts []string) (interface{}, error) {
+func castColVal(colVal any, colKind columns.Column, additionalDateFmts []string) (any, error) {
 	if colVal != nil {
 		switch colKind.KindDetails.Kind {
 		case typing.EDecimal.Kind:

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -36,7 +36,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 		cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
 
-	rowsData := map[string]map[string]interface{}{
+	rowsData := map[string]map[string]any{
 		"pk-1": {
 			"first_name": "bob",
 		},
@@ -90,10 +90,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
 
-	rowsData := make(map[string]map[string]interface{})
+	rowsData := make(map[string]map[string]any)
 
 	for i := 0; i < 5; i++ {
-		rowsData[fmt.Sprintf("pk-%d", i)] = map[string]interface{}{
+		rowsData[fmt.Sprintf("pk-%d", i)] = map[string]any{
 			"id":         fmt.Sprintf("pk-%d", i),
 			"created_at": time.Now().Format(time.RFC3339Nano),
 			"name":       fmt.Sprintf("Robin-%d", i),
@@ -138,10 +138,10 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 		cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
 
-	rowsData := make(map[string]map[string]interface{})
+	rowsData := make(map[string]map[string]any)
 
 	for i := 0; i < 5; i++ {
-		rowsData[fmt.Sprintf("pk-%d", i)] = map[string]interface{}{
+		rowsData[fmt.Sprintf("pk-%d", i)] = map[string]any{
 			"id":         fmt.Sprintf("pk-%d", i),
 			"created_at": time.Now().Format(time.RFC3339Nano),
 			"name":       fmt.Sprintf("Robin-%d", i),
@@ -204,9 +204,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		Schema:    "public",
 	}
 
-	rowsData := make(map[string]map[string]interface{})
+	rowsData := make(map[string]map[string]any)
 	for i := 0; i < 5; i++ {
-		rowsData[fmt.Sprintf("pk-%d", i)] = map[string]interface{}{
+		rowsData[fmt.Sprintf("pk-%d", i)] = map[string]any{
 			"id":         fmt.Sprintf("pk-%d", i),
 			"created_at": time.Now().Format(time.RFC3339Nano),
 			"name":       fmt.Sprintf("Robin-%d", i),

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -19,9 +19,9 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
-// castColValStaging - takes `colVal` interface{} and `colKind` typing.Column and converts the value into a string value
+// castColValStaging - takes `colVal` any and `colKind` typing.Column and converts the value into a string value
 // This is necessary because CSV writers require values to in `string`.
-func castColValStaging(colVal interface{}, colKind columns.Column, additionalDateFmts []string) (string, error) {
+func castColValStaging(colVal any, colKind columns.Column, additionalDateFmts []string) (string, error) {
 	if colVal == nil {
 		// \\N needs to match NULL_IF(...) from ddl.go
 		return `\\N`, nil

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -24,7 +24,7 @@ import (
 func (s *SnowflakeTestSuite) TestCastColValStaging() {
 	type _tc struct {
 		name    string
-		colVal  interface{}
+		colVal  any
 		colKind columns.Column
 
 		errorMessage  string
@@ -133,7 +133,7 @@ func generateTableData(rows int) (string, *optimization.TableData) {
 	td := optimization.NewTableData(cols, config.Replication, []string{"user_id"}, kafkalib.TopicConfig{}, "")
 	for i := 0; i < rows; i++ {
 		key := fmt.Sprint(i)
-		rowData := map[string]interface{}{
+		rowData := map[string]any{
 			"user_id":    key,
 			"first_name": fmt.Sprintf("first_name %d", i),
 			"last_name":  fmt.Sprintf("last_name %d", i),

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -9,7 +9,7 @@ import (
 	"github.com/artie-labs/transfer/lib/stringutil"
 )
 
-func InterfaceToArrayString(val interface{}, recastAsArray bool) ([]string, error) {
+func InterfaceToArrayString(val any, recastAsArray bool) ([]string, error) {
 	if val == nil {
 		return nil, nil
 	}
@@ -18,7 +18,7 @@ func InterfaceToArrayString(val interface{}, recastAsArray bool) ([]string, erro
 	if list.Kind() != reflect.Slice {
 		if recastAsArray {
 			// Since it's not a slice, let's cast it as a slice and re-enter this function.
-			return InterfaceToArrayString([]interface{}{val}, recastAsArray)
+			return InterfaceToArrayString([]any{val}, recastAsArray)
 		} else {
 			return nil, fmt.Errorf("wrong data type, kind: %v", list.Kind())
 		}
@@ -31,7 +31,7 @@ func InterfaceToArrayString(val interface{}, recastAsArray bool) ([]string, erro
 		value := list.Index(i).Interface()
 		var shouldParse bool
 		if kind == reflect.Interface {
-			valMap, isOk := value.(map[string]interface{})
+			valMap, isOk := value.(map[string]any)
 			if isOk {
 				value = valMap
 			}

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -21,7 +21,7 @@ func TestStringsJoinAddSingleQuotes(t *testing.T) {
 func TestToArrayString(t *testing.T) {
 	type _testCase struct {
 		name          string
-		val           interface{}
+		val           any
 		recastAsArray bool
 		expectedList  []string
 		expectedErr   error
@@ -54,7 +54,7 @@ func TestToArrayString(t *testing.T) {
 		},
 		{
 			name: "array of nested objects",
-			val: []map[string]interface{}{
+			val: []map[string]any{
 				{
 					"foo": "bar",
 				},

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -86,7 +86,7 @@ func (p *MongoTestSuite) TestSource_GetExecutionTime() {
 }
 
 func (p *MongoTestSuite) TestBsonTypes() {
-	var tsMap map[string]interface{}
+	var tsMap map[string]any
 	bsonData := []byte(`
 {"_id": {"$numberLong": "10004"}, "order_date": {"$date": 1456012800000},"purchaser_id": {"$numberLong": "1003"},"quantity": 1,"product_id": {"$numberLong": "107"}}
 `)
@@ -169,7 +169,7 @@ func (p *MongoTestSuite) TestMongoDBEventCustomer() {
 
 	evt, err := p.Debezium.GetEventFromBytes(typing.Settings{}, []byte(payload))
 	assert.NoError(p.T(), err)
-	evtData := evt.GetData(map[string]interface{}{"_id": 1003}, &kafkalib.TopicConfig{})
+	evtData := evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{})
 	_, isOk := evtData[constants.UpdateColumnMarker]
 	assert.False(p.T(), isOk)
 	assert.Equal(p.T(), evtData["_id"], 1003)
@@ -177,11 +177,11 @@ func (p *MongoTestSuite) TestMongoDBEventCustomer() {
 	assert.Equal(p.T(), evtData["last_name"], "Tang")
 	assert.Equal(p.T(), evtData["email"], "robin@artie.so")
 
-	evtDataWithIncludedAt := evt.GetData(map[string]interface{}{"_id": 1003}, &kafkalib.TopicConfig{})
+	evtDataWithIncludedAt := evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{})
 	_, isOk = evtDataWithIncludedAt[constants.UpdateColumnMarker]
 	assert.False(p.T(), isOk)
 
-	evtDataWithIncludedAt = evt.GetData(map[string]interface{}{"_id": 1003}, &kafkalib.TopicConfig{
+	evtDataWithIncludedAt = evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{
 		IncludeDatabaseUpdatedAt: true,
 		IncludeArtieUpdatedAt:    true,
 	})
@@ -190,7 +190,7 @@ func (p *MongoTestSuite) TestMongoDBEventCustomer() {
 	_, err = time.Parse(ext.ISO8601, evtDataWithIncludedAt[constants.UpdateColumnMarker].(string))
 	assert.NoError(p.T(), err, evtDataWithIncludedAt[constants.UpdateColumnMarker])
 
-	var nestedData map[string]interface{}
+	var nestedData map[string]any
 	err = json.Unmarshal([]byte(evtData["nested"].(string)), &nestedData)
 	assert.NoError(p.T(), err)
 
@@ -235,7 +235,7 @@ func (p *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 
 	evt, err := p.Debezium.GetEventFromBytes(typing.Settings{}, []byte(payload))
 	assert.NoError(p.T(), err)
-	evtData := evt.GetData(map[string]interface{}{"_id": 1003}, &kafkalib.TopicConfig{})
+	evtData := evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{})
 	assert.Equal(p.T(), "customers123", evt.GetTableName())
 	_, isOk := evtData[constants.UpdateColumnMarker]
 	assert.False(p.T(), isOk)
@@ -245,7 +245,7 @@ func (p *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 		time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC))
 	assert.Equal(p.T(), true, evt.DeletePayload())
 
-	evtData = evt.GetData(map[string]interface{}{"_id": 1003}, &kafkalib.TopicConfig{
+	evtData = evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{
 		IncludeArtieUpdatedAt: true,
 	})
 	_, isOk = evtData[constants.UpdateColumnMarker]

--- a/lib/cdc/util/geometry.go
+++ b/lib/cdc/util/geometry.go
@@ -28,7 +28,7 @@ type GeometricShapes string
 
 const Point GeometricShapes = "Point"
 
-// ParseGeometry takes in a map[string]interface{} and returns a GeoJSON string.
+// ParseGeometry takes in a map[string]any and returns a GeoJSON string.
 // This function does not use WKB or SRID and leverages X, Y.
 // https://debezium.io/documentation/reference/stable/connectors/postgresql.html#:~:text=io.debezium.data.geometry.Point
 func parseGeometryPoint(value any) (string, error) {

--- a/lib/cdc/util/geometry.go
+++ b/lib/cdc/util/geometry.go
@@ -10,9 +10,9 @@ import (
 )
 
 type GeoJSON struct {
-	Type       GeoJSONType            `json:"type"`
-	Geometry   Geometry               `json:"geometry"`
-	Properties map[string]interface{} `json:"properties,omitempty"`
+	Type       GeoJSONType    `json:"type"`
+	Geometry   Geometry       `json:"geometry"`
+	Properties map[string]any `json:"properties,omitempty"`
 }
 
 type GeoJSONType string
@@ -21,7 +21,7 @@ const FeatureType GeoJSONType = "Feature"
 
 type Geometry struct {
 	Type        GeometricShapes `json:"type"`
-	Coordinates interface{}     `json:"coordinates"`
+	Coordinates any             `json:"coordinates"`
 }
 
 type GeometricShapes string
@@ -31,10 +31,10 @@ const Point GeometricShapes = "Point"
 // ParseGeometry takes in a map[string]interface{} and returns a GeoJSON string.
 // This function does not use WKB or SRID and leverages X, Y.
 // https://debezium.io/documentation/reference/stable/connectors/postgresql.html#:~:text=io.debezium.data.geometry.Point
-func parseGeometryPoint(value interface{}) (string, error) {
-	valMap, isOk := value.(map[string]interface{})
+func parseGeometryPoint(value any) (string, error) {
+	valMap, isOk := value.(map[string]any)
 	if !isOk {
-		return "", fmt.Errorf("value is not map[string]interface{} type")
+		return "", fmt.Errorf("value is not map[string]any type")
 	}
 
 	x, isOk := valMap["x"]
@@ -51,7 +51,7 @@ func parseGeometryPoint(value interface{}) (string, error) {
 		Type: FeatureType,
 		Geometry: Geometry{
 			Type:        Point,
-			Coordinates: []interface{}{x, y},
+			Coordinates: []any{x, y},
 		},
 	}
 
@@ -64,10 +64,10 @@ func parseGeometryPoint(value interface{}) (string, error) {
 }
 
 // parseGeometry will take in an object with b64 encoded wkb and return a GeoJSON string.
-func parseGeometry(value interface{}) (string, error) {
-	valMap, isOk := value.(map[string]interface{})
+func parseGeometry(value any) (string, error) {
+	valMap, isOk := value.(map[string]any)
 	if !isOk {
-		return "", fmt.Errorf("value is not map[string]interface{} type")
+		return "", fmt.Errorf("value is not map[string]any type")
 	}
 
 	wkbVal, isOk := valMap["wkb"]

--- a/lib/cdc/util/parse.go
+++ b/lib/cdc/util/parse.go
@@ -11,8 +11,8 @@ import (
 	"github.com/artie-labs/transfer/lib/debezium"
 )
 
-// ParseField returns a `parsedValue` as type interface{}
-func parseField(field debezium.Field, value interface{}) interface{} {
+// ParseField returns a `parsedValue` as type any
+func parseField(field debezium.Field, value any) interface{} {
 	// TODO: We should surface the errors from `parseField`.
 	if value == nil {
 		return nil

--- a/lib/cdc/util/parse.go
+++ b/lib/cdc/util/parse.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ParseField returns a `parsedValue` as type any
-func parseField(field debezium.Field, value any) interface{} {
+func parseField(field debezium.Field, value any) any {
 	// TODO: We should surface the errors from `parseField`.
 	if value == nil {
 		return nil

--- a/lib/cdc/util/parse_test.go
+++ b/lib/cdc/util/parse_test.go
@@ -12,8 +12,8 @@ func TestParseField(t *testing.T) {
 	type _testCase struct {
 		name          string
 		field         debezium.Field
-		value         interface{}
-		expectedValue interface{}
+		value         any
+		expectedValue any
 
 		expectedDecimal bool
 	}
@@ -41,7 +41,7 @@ func TestParseField(t *testing.T) {
 			name: "decimal",
 			field: debezium.Field{
 				DebeziumType: string(debezium.KafkaDecimalType),
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"scale":                           "0",
 					debezium.KafkaDecimalPrecisionKey: "5",
 				},
@@ -54,7 +54,7 @@ func TestParseField(t *testing.T) {
 			name: "numeric",
 			field: debezium.Field{
 				DebeziumType: string(debezium.KafkaDecimalType),
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"scale":                           "2",
 					debezium.KafkaDecimalPrecisionKey: "5",
 				},
@@ -67,7 +67,7 @@ func TestParseField(t *testing.T) {
 			name: "money",
 			field: debezium.Field{
 				DebeziumType: string(debezium.KafkaDecimalType),
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"scale": "2",
 				},
 			},
@@ -79,11 +79,11 @@ func TestParseField(t *testing.T) {
 			name: "variable decimal",
 			field: debezium.Field{
 				DebeziumType: string(debezium.KafkaVariableNumericType),
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"scale": "2",
 				},
 			},
-			value: map[string]interface{}{
+			value: map[string]any{
 				"scale": 2,
 				"value": "MDk=",
 			},
@@ -95,7 +95,7 @@ func TestParseField(t *testing.T) {
 			field: debezium.Field{
 				DebeziumType: string(debezium.GeometryType),
 			},
-			value: map[string]interface{}{
+			value: map[string]any{
 				"srid": nil,
 				"wkb":  "AQEAAAAAAAAAAADwPwAAAAAAABRA",
 			},
@@ -106,7 +106,7 @@ func TestParseField(t *testing.T) {
 			field: debezium.Field{
 				DebeziumType: string(debezium.GeometryType),
 			},
-			value: map[string]interface{}{
+			value: map[string]any{
 				"srid": 4326,
 				"wkb":  "AQEAACDmEAAAAAAAAAAA8D8AAAAAAAAYQA==",
 			},
@@ -117,7 +117,7 @@ func TestParseField(t *testing.T) {
 			field: debezium.Field{
 				DebeziumType: string(debezium.GeographyType),
 			},
-			value: map[string]interface{}{
+			value: map[string]any{
 				"srid": 4326,
 				"wkb":  "AQEAACDmEAAAAAAAAADAXkAAAAAAAIBDwA==",
 			},

--- a/lib/jsonutil/jsonutil.go
+++ b/lib/jsonutil/jsonutil.go
@@ -5,13 +5,13 @@ import (
 )
 
 // SanitizePayload will take in a JSON string, and return a JSON string that has been sanitized (removed duplicate keys)
-func SanitizePayload(val interface{}) (interface{}, error) {
+func SanitizePayload(val any) (any, error) {
 	valString, isOk := val.(string)
 	if !isOk {
 		return val, nil
 	}
 
-	var obj interface{}
+	var obj any
 	err := json.Unmarshal([]byte(valString), &obj)
 	if err == nil {
 		valBytes, err := json.Marshal(obj)

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -23,9 +23,9 @@ type TableData struct {
 	inMemoryColumns *columns.Columns // list of columns
 
 	// rowsData is used for replication
-	rowsData map[string]map[string]interface{} // pk -> { col -> val }
+	rowsData map[string]map[string]any // pk -> { col -> val }
 	// rows is used for history mode, since it's append only.
-	rows []map[string]interface{}
+	rows []map[string]any
 
 	primaryKeys []string
 
@@ -112,7 +112,7 @@ func NewTableData(inMemoryColumns *columns.Columns, mode config.Mode, primaryKey
 	return &TableData{
 		mode:            mode,
 		inMemoryColumns: inMemoryColumns,
-		rowsData:        map[string]map[string]interface{}{},
+		rowsData:        map[string]map[string]any{},
 		primaryKeys:     primaryKeys,
 		TopicConfig:     topicConfig,
 		// temporaryTableSuffix is being set in `ResetTempTableSuffix`
@@ -125,7 +125,7 @@ func NewTableData(inMemoryColumns *columns.Columns, mode config.Mode, primaryKey
 // InsertRow creates a single entrypoint for how rows get added to TableData
 // This is important to avoid concurrent r/w, but also the ability for us to add or decrement row size by keeping a running total
 // With this, we are able to reduce the latency by 500x+ on a 5k row table. See event_bench_test.go vs. size_bench_test.go
-func (t *TableData) InsertRow(pk string, rowData map[string]interface{}, delete bool) {
+func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 	if t.mode == config.History {
 		t.rows = append(t.rows, rowData)
 		t.approxSize += size.GetApproxSize(rowData)
@@ -167,8 +167,8 @@ func (t *TableData) InsertRow(pk string, rowData map[string]interface{}, delete 
 }
 
 // Rows returns a read only slice of tableData's rows or rowsData depending on mode
-func (t *TableData) Rows() []map[string]interface{} {
-	var rows []map[string]interface{}
+func (t *TableData) Rows() []map[string]any {
+	var rows []map[string]any
 
 	if t.Mode() == config.History {
 		// History mode, the data is stored under `rows`
@@ -183,7 +183,7 @@ func (t *TableData) Rows() []map[string]interface{} {
 }
 
 // RowsData will create a read-only map of `rowsData`, this should be strictly used for testing only.
-func (t *TableData) RowsData() map[string]map[string]interface{} {
+func (t *TableData) RowsData() map[string]map[string]any {
 	return maps.Clone(t.rowsData)
 }
 

--- a/lib/size/size_bench_test.go
+++ b/lib/size/size_bench_test.go
@@ -9,7 +9,7 @@ import (
 func BenchmarkGetApproxSize_TallTable(b *testing.B) {
 	rowsData := make(map[string]interface{})
 	for i := 0; i < 5000; i++ {
-		rowsData[fmt.Sprint(i)] = map[string]interface{}{
+		rowsData[fmt.Sprint(i)] = map[string]any{
 			"id":   i,
 			"name": "Robin",
 			"dog":  "dusty the mini aussie",
@@ -22,9 +22,9 @@ func BenchmarkGetApproxSize_TallTable(b *testing.B) {
 }
 
 func BenchmarkGetApproxSize_WideTable(b *testing.B) {
-	rowsData := make(map[string]interface{})
+	rowsData := make(map[string]any)
 	for i := 0; i < 5000; i++ {
-		rowsData[fmt.Sprint(i)] = map[string]interface{}{
+		rowsData[fmt.Sprint(i)] = map[string]any{
 			"id":                 i,
 			"name":               "Robin",
 			"dog":                "dusty the mini aussie",
@@ -37,16 +37,16 @@ func BenchmarkGetApproxSize_WideTable(b *testing.B) {
 			"created_at":         time.Now(),
 			"updated_at":         time.Now(),
 			"negative_number":    -500,
-			"nestedObject": map[string]interface{}{
+			"nestedObject": map[string]any{
 				"foo": "bar",
 				"abc": "def",
 			},
-			"array_of_objects": []map[string]interface{}{
+			"array_of_objects": []map[string]any{
 				{
 					"foo": "bar",
 				},
 				{
-					"foo_nested": map[string]interface{}{
+					"foo_nested": map[string]any{
 						"foo_foo": "bar_bar",
 					},
 				},


### PR DESCRIPTION
* Taking over this PR: https://github.com/artie-labs/transfer/pull/354
* `any` is an alias of `interface{}` 
