### PR TITLE
Clean up casing for MERGE.

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -165,7 +165,7 @@ outputSource: none
 
 	validErr := config.Validate()
 	assert.Error(t, validErr)
-	assert.True(t, strings.Contains(validErr.Error(), "is invalid"), validErr.Error())
+	assert.ErrorContains(t, validErr, "is invalid", validErr.Error())
 }
 
 func TestConfig_Validate_ErrorTopicConfigInvalid(t *testing.T) {

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -274,7 +274,7 @@ WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`
 	}
 
 	return fmt.Sprintf(`
-MERGE INTO %s c using %s AS cc ON %s
+MERGE INTO %s c USING %s AS cc ON %s
 WHEN MATCHED AND cc.%s THEN DELETE
 WHEN MATCHED AND IFNULL(cc.%s, false) = false %sTHEN UPDATE SET %s
 WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`,

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -244,7 +244,7 @@ func (m *MergeArgument) GetStatement() (string, error) {
 
 	if m.SoftDelete {
 		return fmt.Sprintf(`
-MERGE INTO %s c using %s as cc on %s
+MERGE INTO %s c using %s as cc ON %s
 WHEN MATCHED %sTHEN UPDATE SET %s
 WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`,
 			m.FqTableName, subQuery, strings.Join(equalitySQLParts, " and "),
@@ -274,7 +274,7 @@ WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`
 	}
 
 	return fmt.Sprintf(`
-MERGE INTO %s c using %s AS cc on %s
+MERGE INTO %s c using %s AS cc ON %s
 WHEN MATCHED AND cc.%s THEN DELETE
 WHEN MATCHED AND IFNULL(cc.%s, false) = false %sTHEN UPDATE SET %s
 WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`,

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -244,18 +244,10 @@ func (m *MergeArgument) GetStatement() (string, error) {
 
 	if m.SoftDelete {
 		return fmt.Sprintf(`
-			MERGE INTO %s c using %s as cc on %s
-				when matched %sthen UPDATE
-					SET %s
-				when not matched AND IFNULL(cc.%s, false) = false then INSERT
-					(
-						%s
-					)
-					VALUES
-					(
-						%s
-					);
-		`, m.FqTableName, subQuery, strings.Join(equalitySQLParts, " and "),
+MERGE INTO %s c using %s as cc on %s
+WHEN MATCHED %sTHEN UPDATE SET %s
+WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`,
+			m.FqTableName, subQuery, strings.Join(equalitySQLParts, " and "),
 			// Update + Soft Deletion
 			idempotentClause, columns.ColumnsUpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
 			// Insert
@@ -282,19 +274,11 @@ func (m *MergeArgument) GetStatement() (string, error) {
 	}
 
 	return fmt.Sprintf(`
-			MERGE INTO %s c using %s as cc on %s
-				when matched AND cc.%s then DELETE
-				when matched AND IFNULL(cc.%s, false) = false %sthen UPDATE
-					SET %s
-				when not matched AND IFNULL(cc.%s, false) = false then INSERT
-					(
-						%s
-					)
-					VALUES
-					(
-						%s
-					);
-		`, m.FqTableName, subQuery, strings.Join(equalitySQLParts, " and "),
+MERGE INTO %s c using %s AS cc on %s
+WHEN MATCHED AND cc.%s THEN DELETE
+WHEN MATCHED AND IFNULL(cc.%s, false) = false %sTHEN UPDATE SET %s
+WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`,
+		m.FqTableName, subQuery, strings.Join(equalitySQLParts, " and "),
 		// Delete
 		constants.DeleteColumnMarker,
 		// Update

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -244,7 +244,7 @@ func (m *MergeArgument) GetStatement() (string, error) {
 
 	if m.SoftDelete {
 		return fmt.Sprintf(`
-MERGE INTO %s c using %s as cc ON %s
+MERGE INTO %s c USING %s AS cc ON %s
 WHEN MATCHED %sTHEN UPDATE SET %s
 WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`,
 			m.FqTableName, subQuery, strings.Join(equalitySQLParts, " and "),

--- a/lib/destination/dml/merge_bigquery_test.go
+++ b/lib/destination/dml/merge_bigquery_test.go
@@ -29,7 +29,7 @@ func TestMergeStatement_TempTable(t *testing.T) {
 	mergeSQL, err := mergeArg.GetStatement()
 	assert.NoError(t, err)
 
-	assert.Contains(t, mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp as cc on c.order_id = cc.order_id", mergeSQL)
+	assert.Contains(t, mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp AS cc ON c.order_id = cc.order_id", mergeSQL)
 }
 
 func TestMergeStatement_JSONKey(t *testing.T) {
@@ -50,5 +50,5 @@ func TestMergeStatement_JSONKey(t *testing.T) {
 
 	mergeSQL, err := mergeArg.GetStatement()
 	assert.NoError(t, err)
-	assert.Contains(t, mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp as cc on TO_JSON_STRING(c.order_oid) = TO_JSON_STRING(cc.order_oid)", mergeSQL)
+	assert.Contains(t, mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp AS cc ON TO_JSON_STRING(c.order_oid) = TO_JSON_STRING(cc.order_oid)", mergeSQL)
 }

--- a/lib/destination/dml/merge_bigquery_test.go
+++ b/lib/destination/dml/merge_bigquery_test.go
@@ -29,7 +29,7 @@ func TestMergeStatement_TempTable(t *testing.T) {
 	mergeSQL, err := mergeArg.GetStatement()
 	assert.NoError(t, err)
 
-	assert.Contains(t, mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp AS cc ON c.order_id = cc.order_id", mergeSQL)
+	assert.Contains(t, mergeSQL, "MERGE INTO customers.orders c USING customers.orders_tmp AS cc ON c.order_id = cc.order_id", mergeSQL)
 }
 
 func TestMergeStatement_JSONKey(t *testing.T) {
@@ -50,5 +50,5 @@ func TestMergeStatement_JSONKey(t *testing.T) {
 
 	mergeSQL, err := mergeArg.GetStatement()
 	assert.NoError(t, err)
-	assert.Contains(t, mergeSQL, "MERGE INTO customers.orders c using customers.orders_tmp AS cc ON TO_JSON_STRING(c.order_oid) = TO_JSON_STRING(cc.order_oid)", mergeSQL)
+	assert.Contains(t, mergeSQL, "MERGE INTO customers.orders c USING customers.orders_tmp AS cc ON TO_JSON_STRING(c.order_oid) = TO_JSON_STRING(cc.order_oid)", mergeSQL)
 }

--- a/lib/destination/dml/merge_test.go
+++ b/lib/destination/dml/merge_test.go
@@ -196,9 +196,9 @@ func TestMergeStatementCompositeKey(t *testing.T) {
 
 	mergeSQL, err := mergeArg.GetStatement()
 	assert.NoError(t, err)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
-	assert.True(t, strings.Contains(mergeSQL, "cc on c.id = cc.id and c.another_id = cc.another_id"))
+	assert.Contains(t, mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable), mergeSQL)
+	assert.Contains(t, mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at"), fmt.Sprintf("Idempotency key: %s", mergeSQL))
+	assert.Contains(t, mergeSQL, "cc ON c.id = cc.id and c.another_id = cc.another_id", mergeSQL)
 }
 
 func TestMergeStatementEscapePrimaryKeys(t *testing.T) {
@@ -254,8 +254,7 @@ func TestMergeStatementEscapePrimaryKeys(t *testing.T) {
 	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
 	assert.False(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
 	// Check primary keys clause
-	assert.True(t, strings.Contains(mergeSQL, `as cc on c.id = cc.id and c."group" = cc."group"`), mergeSQL)
-
+	assert.Contains(t, mergeSQL, `AS cc ON c.id = cc.id and c."group" = cc."group"`, mergeSQL)
 	// Check setting for update
 	assert.True(t, strings.Contains(mergeSQL, `SET id=cc.id,"group"=cc."group",updated_at=cc.updated_at,"start"=cc."start"`), mergeSQL)
 	// Check for INSERT

--- a/lib/destination/dml/merge_test.go
+++ b/lib/destination/dml/merge_test.go
@@ -55,9 +55,9 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 
 		mergeSQL, err := mergeArg.GetStatement()
 		assert.NoError(t, err)
-		assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
+		assert.Contains(t, mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable), mergeSQL)
 		// Soft deletion flag being passed.
-		assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("%s=cc.%s", constants.DeleteColumnMarker, constants.DeleteColumnMarker)), mergeSQL)
+		assert.Contains(t, mergeSQL, fmt.Sprintf("%s=cc.%s", constants.DeleteColumnMarker, constants.DeleteColumnMarker), mergeSQL)
 
 		assert.Equal(t, len(idempotentKey) > 0, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")))
 	}
@@ -153,8 +153,8 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 
 	mergeSQL, err := mergeArg.GetStatement()
 	assert.NoError(t, err)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
+	assert.Contains(t, mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable), mergeSQL)
+	assert.Contains(t, mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at"), fmt.Sprintf("Idempotency key: %s", mergeSQL))
 }
 
 func TestMergeStatementCompositeKey(t *testing.T) {
@@ -251,13 +251,13 @@ func TestMergeStatementEscapePrimaryKeys(t *testing.T) {
 
 	mergeSQL, err := mergeArg.GetStatement()
 	assert.NoError(t, err)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
-	assert.False(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
+	assert.Contains(t, mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable), mergeSQL)
+	assert.NotContains(t, mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at"), fmt.Sprintf("Idempotency key: %s", mergeSQL))
 	// Check primary keys clause
 	assert.Contains(t, mergeSQL, `AS cc ON c.id = cc.id and c."group" = cc."group"`, mergeSQL)
 	// Check setting for update
-	assert.True(t, strings.Contains(mergeSQL, `SET id=cc.id,"group"=cc."group",updated_at=cc.updated_at,"start"=cc."start"`), mergeSQL)
+	assert.Contains(t, mergeSQL, `SET id=cc.id,"group"=cc."group",updated_at=cc.updated_at,"start"=cc."start"`, mergeSQL)
 	// Check for INSERT
-	assert.True(t, strings.Contains(mergeSQL, `id,"group",updated_at,"start"`), mergeSQL)
-	assert.True(t, strings.Contains(mergeSQL, `cc.id,cc."group",cc.updated_at,cc."start"`), mergeSQL)
+	assert.Contains(t, mergeSQL, `id,"group",updated_at,"start"`, mergeSQL)
+	assert.Contains(t, mergeSQL, `cc.id,cc."group",cc.updated_at,cc."start"`, mergeSQL)
 }

--- a/lib/destination/dml/merge_test.go
+++ b/lib/destination/dml/merge_test.go
@@ -105,16 +105,16 @@ func TestMergeStatement(t *testing.T) {
 
 	mergeSQL, err := mergeArg.GetStatement()
 	assert.NoError(t, err)
-	assert.True(t, strings.Contains(mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable)), mergeSQL)
-	assert.False(t, strings.Contains(mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at")), fmt.Sprintf("Idempotency key: %s", mergeSQL))
+	assert.Contains(t, mergeSQL, fmt.Sprintf("MERGE INTO %s", fqTable), mergeSQL)
+	assert.NotContains(t, mergeSQL, fmt.Sprintf("cc.%s >= c.%s", "updated_at", "updated_at"), fmt.Sprintf("Idempotency key: %s", mergeSQL))
 	// Check primary keys clause
-	assert.True(t, strings.Contains(mergeSQL, "as cc on c.id = cc.id"), mergeSQL)
+	assert.Contains(t, mergeSQL, "AS cc ON c.id = cc.id", mergeSQL)
 
 	// Check setting for update
-	assert.True(t, strings.Contains(mergeSQL, `SET id=cc.id,bar=cc.bar,updated_at=cc.updated_at,"start"=cc."start"`), mergeSQL)
+	assert.Contains(t, mergeSQL, `SET id=cc.id,bar=cc.bar,updated_at=cc.updated_at,"start"=cc."start"`, mergeSQL)
 	// Check for INSERT
-	assert.True(t, strings.Contains(mergeSQL, `id,bar,updated_at,"start"`), mergeSQL)
-	assert.True(t, strings.Contains(mergeSQL, `cc.id,cc.bar,cc.updated_at,cc."start"`), mergeSQL)
+	assert.Contains(t, mergeSQL, `id,bar,updated_at,"start"`, mergeSQL)
+	assert.Contains(t, mergeSQL, `cc.id,cc.bar,cc.updated_at,cc."start"`, mergeSQL)
 }
 
 func TestMergeStatementIdempotentKey(t *testing.T) {

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -3,7 +3,6 @@ package consumer
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -63,12 +62,12 @@ func TestProcessMessageFailures(t *testing.T) {
 	}
 
 	tableName, err := ProcessMessage(ctx, cfg, memDB, MockDestination{}, metrics.NullMetricsProvider{}, processArgs)
-	assert.True(t, strings.Contains(err.Error(), "failed to process, topicConfig is nil"), err.Error())
+	assert.ErrorContains(t, err, "failed to process, topicConfig is nil", err.Error())
 	assert.Empty(t, tableName)
 
 	processArgs.TopicToConfigFormatMap = NewTcFmtMap()
 	tableName, err = ProcessMessage(ctx, cfg, memDB, MockDestination{}, metrics.NullMetricsProvider{}, processArgs)
-	assert.True(t, strings.Contains(err.Error(), "failed to get topic"), err.Error())
+	assert.ErrorContains(t, err, "failed to get topic", err.Error())
 	assert.Equal(t, 0, len(memDB.TableData()))
 	assert.Empty(t, tableName)
 


### PR DESCRIPTION
Follow up to this PR: https://github.com/artie-labs/transfer/pull/365

## Changes
* Clean up casing for the default MERGE function
* Fixed tests to use `assert.Contains(...)` 