### PR TITLE
Default to lowercase temp table names

### DIFF
--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -22,14 +22,7 @@ import (
 // It has a safety check to make sure the tableName contains the `constants.ArtiePrefix` key.
 // Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(10)
 func DropTemporaryTable(dwh destination.DataWarehouse, fqTableName string, shouldReturnError bool) error {
-	if dwh.Label() != constants.BigQuery {
-		// BigQuery is case-sensitive, so lets no lower.
-		fqTableName = strings.ToLower(fqTableName)
-	}
-
 	if strings.Contains(fqTableName, constants.ArtiePrefix) {
-		// https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#drop_table_statement
-		// https://docs.snowflake.com/en/sql-reference/sql/drop-table
 		_, err := dwh.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", fqTableName))
 		if err != nil {
 			slog.Warn("Failed to drop temporary table, it will get garbage collected by the TTL...", slog.Any("err", err))

--- a/lib/destination/ddl/ddl_test.go
+++ b/lib/destination/ddl/ddl_test.go
@@ -15,7 +15,7 @@ func (d *DDLTestSuite) Test_DropTemporaryTableCaseSensitive() {
 	tablesToDrop := []string{
 		"foo",
 		"abcdef",
-		"gGghHH",
+		"gghh",
 	}
 
 	for _, dest := range []destination.DataWarehouse{d.bigQueryStore, d.snowflakeStagesStore} {
@@ -33,13 +33,7 @@ func (d *DDLTestSuite) Test_DropTemporaryTableCaseSensitive() {
 			// There should be the same number of DROP table calls as the number of tables to drop.
 			assert.Equal(d.T(), tableIndex+1, fakeStore.ExecCallCount())
 			query, _ := fakeStore.ExecArgsForCall(tableIndex)
-
-			if dest.Label() == constants.BigQuery {
-				// BigQuery should be case-sensitive.
-				assert.Equal(d.T(), fmt.Sprintf("DROP TABLE IF EXISTS %s", fullTableName), query)
-			} else {
-				assert.Equal(d.T(), fmt.Sprintf("DROP TABLE IF EXISTS %s", strings.ToLower(fullTableName)), query)
-			}
+			assert.Equal(d.T(), fmt.Sprintf("DROP TABLE IF EXISTS %s", strings.ToLower(fullTableName)), query)
 		}
 	}
 }

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -268,7 +268,8 @@ func (t *TableData) ResetTempTableSuffix() {
 		return
 	}
 
-	t.temporaryTableSuffix = fmt.Sprintf("%s_%s", constants.ArtiePrefix, stringutil.Random(5))
+	// Lowercase this because BigQuery is case-sensitive.
+	t.temporaryTableSuffix = strings.ToLower(fmt.Sprintf("%s_%s", constants.ArtiePrefix, stringutil.Random(5)))
 }
 
 func (t *TableData) TempTableSuffix() string {


### PR DESCRIPTION
## Changes

Temporary table names to be lowercase by default. This way, we don't need a separate IF statement in `DropTemporaryTable`