### PR TITLE
Redshift ignoring table deletes

### DIFF
--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -121,14 +121,15 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, cfg
 	}
 
 	mergeArg := dml.MergeArgument{
-		FqTableName:       fqName,
-		SubQuery:          subQuery,
-		IdempotentKey:     tableData.TopicConfig.IdempotentKey,
-		PrimaryKeys:       tableData.PrimaryKeys(cfg.SharedDestinationConfig.UppercaseEscapedNames, &sql.NameArgs{Escape: true, DestKind: dwh.Label()}),
-		ColumnsToTypes:    *tableData.ReadOnlyInMemoryCols(),
-		SoftDelete:        tableData.TopicConfig.SoftDelete,
-		DestKind:          dwh.Label(),
-		UppercaseEscNames: &cfg.SharedDestinationConfig.UppercaseEscapedNames,
+		FqTableName:         fqName,
+		SubQuery:            subQuery,
+		IdempotentKey:       tableData.TopicConfig.IdempotentKey,
+		PrimaryKeys:         tableData.PrimaryKeys(cfg.SharedDestinationConfig.UppercaseEscapedNames, &sql.NameArgs{Escape: true, DestKind: dwh.Label()}),
+		ColumnsToTypes:      *tableData.ReadOnlyInMemoryCols(),
+		SoftDelete:          tableData.TopicConfig.SoftDelete,
+		DestKind:            dwh.Label(),
+		UppercaseEscNames:   &cfg.SharedDestinationConfig.UppercaseEscapedNames,
+		ContainsHardDeletes: ptr.ToBool(tableData.ContainsHardDeletes()),
 	}
 
 	if len(opts.AdditionalEqualityStrings) > 0 {
@@ -147,6 +148,7 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, cfg
 		}
 
 		for _, mergeQuery := range mergeParts {
+			fmt.Println("Executing: ", mergeQuery)
 			_, err = tx.Exec(mergeQuery)
 			if err != nil {
 				return fmt.Errorf("failed to merge, query: %v, err: %w", mergeQuery, err)

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -148,7 +148,6 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, cfg
 		}
 
 		for _, mergeQuery := range mergeParts {
-			fmt.Println("Executing: ", mergeQuery)
 			_, err = tx.Exec(mergeQuery)
 			if err != nil {
 				return fmt.Errorf("failed to merge, query: %v, err: %w", mergeQuery, err)

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -41,7 +41,7 @@ type MergeArgument struct {
 	SoftDelete bool
 	// ContainsHardDeletes is only used for Redshift and MergeStatementParts,
 	// where we do not issue a DELETE statement if there are no hard deletes in the batch
-	ContainsHardDeletes bool
+	ContainsHardDeletes *bool
 
 	UppercaseEscNames *bool
 }
@@ -77,6 +77,11 @@ func (m *MergeArgument) Valid() error {
 func (m *MergeArgument) GetParts() ([]string, error) {
 	if err := m.Valid(); err != nil {
 		return nil, err
+	}
+
+	// ContainsHardDeletes is only used for Redshift, so we'll validate it now
+	if m.ContainsHardDeletes == nil {
+		return nil, fmt.Errorf("containsHardDeletes cannot be nil")
 	}
 
 	if m.DestKind != constants.Redshift {
@@ -176,7 +181,7 @@ func (m *MergeArgument) GetParts() ([]string, error) {
 		),
 	}
 
-	if m.ContainsHardDeletes {
+	if *m.ContainsHardDeletes {
 		parts = append(parts,
 			// DELETE
 			fmt.Sprintf(`DELETE FROM %s WHERE (%s) IN (SELECT %s FROM %s as cc WHERE cc.%s = true);`,

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -79,13 +79,13 @@ func (m *MergeArgument) GetParts() ([]string, error) {
 		return nil, err
 	}
 
+	if m.DestKind != constants.Redshift {
+		return nil, fmt.Errorf("err - this is meant for redshift only")
+	}
+
 	// ContainsHardDeletes is only used for Redshift, so we'll validate it now
 	if m.ContainsHardDeletes == nil {
 		return nil, fmt.Errorf("containsHardDeletes cannot be nil")
-	}
-
-	if m.DestKind != constants.Redshift {
-		return nil, fmt.Errorf("err - this is meant for redshift only")
 	}
 
 	// We should not need idempotency key for DELETE

--- a/lib/destination/dml/merge_parts_test.go
+++ b/lib/destination/dml/merge_parts_test.go
@@ -79,7 +79,7 @@ func TestMergeStatementParts_SkipDelete(t *testing.T) {
 		PrimaryKeys:         res.PrimaryKeys,
 		ColumnsToTypes:      res.ColumnsToTypes,
 		DestKind:            constants.Redshift,
-		ContainsHardDeletes: false,
+		ContainsHardDeletes: ptr.ToBool(false),
 		UppercaseEscNames:   ptr.ToBool(false),
 	}
 
@@ -101,13 +101,14 @@ func TestMergeStatementPartsSoftDelete(t *testing.T) {
 	tempTableName := "public.tableName__temp"
 	res := getBasicColumnsForTest(false, false)
 	mergeArg := &MergeArgument{
-		FqTableName:       fqTableName,
-		SubQuery:          tempTableName,
-		PrimaryKeys:       res.PrimaryKeys,
-		ColumnsToTypes:    res.ColumnsToTypes,
-		DestKind:          constants.Redshift,
-		SoftDelete:        true,
-		UppercaseEscNames: ptr.ToBool(false),
+		FqTableName:         fqTableName,
+		SubQuery:            tempTableName,
+		PrimaryKeys:         res.PrimaryKeys,
+		ColumnsToTypes:      res.ColumnsToTypes,
+		DestKind:            constants.Redshift,
+		SoftDelete:          true,
+		UppercaseEscNames:   ptr.ToBool(false),
+		ContainsHardDeletes: ptr.ToBool(false),
 	}
 
 	parts, err := mergeArg.GetParts()
@@ -140,13 +141,14 @@ func TestMergeStatementPartsSoftDeleteComposite(t *testing.T) {
 	tempTableName := "public.tableName__temp"
 	res := getBasicColumnsForTest(true, false)
 	mergeArg := &MergeArgument{
-		FqTableName:       fqTableName,
-		SubQuery:          tempTableName,
-		PrimaryKeys:       res.PrimaryKeys,
-		ColumnsToTypes:    res.ColumnsToTypes,
-		DestKind:          constants.Redshift,
-		SoftDelete:        true,
-		UppercaseEscNames: ptr.ToBool(false),
+		FqTableName:         fqTableName,
+		SubQuery:            tempTableName,
+		PrimaryKeys:         res.PrimaryKeys,
+		ColumnsToTypes:      res.ColumnsToTypes,
+		DestKind:            constants.Redshift,
+		SoftDelete:          true,
+		UppercaseEscNames:   ptr.ToBool(false),
+		ContainsHardDeletes: ptr.ToBool(false),
 	}
 
 	parts, err := mergeArg.GetParts()
@@ -187,7 +189,7 @@ func TestMergeStatementParts(t *testing.T) {
 		PrimaryKeys:         res.PrimaryKeys,
 		ColumnsToTypes:      res.ColumnsToTypes,
 		DestKind:            constants.Redshift,
-		ContainsHardDeletes: true,
+		ContainsHardDeletes: ptr.ToBool(true),
 		UppercaseEscNames:   ptr.ToBool(false),
 	}
 
@@ -214,7 +216,7 @@ func TestMergeStatementParts(t *testing.T) {
 		ColumnsToTypes:      res.ColumnsToTypes,
 		DestKind:            constants.Redshift,
 		IdempotentKey:       "created_at",
-		ContainsHardDeletes: true,
+		ContainsHardDeletes: ptr.ToBool(true),
 		UppercaseEscNames:   ptr.ToBool(false),
 	}
 
@@ -245,7 +247,7 @@ func TestMergeStatementPartsCompositeKey(t *testing.T) {
 		PrimaryKeys:         res.PrimaryKeys,
 		ColumnsToTypes:      res.ColumnsToTypes,
 		DestKind:            constants.Redshift,
-		ContainsHardDeletes: true,
+		ContainsHardDeletes: ptr.ToBool(true),
 		UppercaseEscNames:   ptr.ToBool(false),
 	}
 
@@ -271,7 +273,7 @@ func TestMergeStatementPartsCompositeKey(t *testing.T) {
 		PrimaryKeys:         res.PrimaryKeys,
 		ColumnsToTypes:      res.ColumnsToTypes,
 		DestKind:            constants.Redshift,
-		ContainsHardDeletes: true,
+		ContainsHardDeletes: ptr.ToBool(true),
 		IdempotentKey:       "created_at",
 		UppercaseEscNames:   ptr.ToBool(false),
 	}

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -56,7 +56,6 @@ func SetKafkaConsumer(_topicToConsumer map[string]kafkalib.Consumer) {
 
 func StartConsumer(ctx context.Context, cfg config.Config, inMemDB *models.DatabaseData, dest destination.Baseline, metricsClient base.Client) {
 	slog.Info("Starting Kafka consumer...", slog.Any("config", cfg.Kafka))
-
 	dialer := &kafka.Dialer{
 		Timeout:   10 * time.Second,
 		DualStack: true,

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -68,6 +68,21 @@ func ProcessMessage(ctx context.Context, cfg config.Config, inMemDB *models.Data
 	// Table name is only available after event has been cast
 	tags["table"] = evt.Table
 
+	possibleIDs := []float64{
+		1551002,
+		1551000,
+		1551062,
+		1551040,
+		1551042,
+		1551022,
+	}
+
+	for _, possibleID := range possibleIDs {
+		if evt.PrimaryKeyMap["id"] == possibleID {
+			fmt.Println("keys", evt.PrimaryKeyMap, evt.Data, "value", string(processArgs.Msg.Value()), "shouldSkip", topicConfig.tc.ShouldSkip(_event.Operation()))
+		}
+	}
+
 	if topicConfig.tc.ShouldSkip(_event.Operation()) {
 		// Check to see if we should skip first
 		// This way, we can emit a specific tag to be more clear

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -68,21 +68,6 @@ func ProcessMessage(ctx context.Context, cfg config.Config, inMemDB *models.Data
 	// Table name is only available after event has been cast
 	tags["table"] = evt.Table
 
-	possibleIDs := []float64{
-		1551002,
-		1551000,
-		1551062,
-		1551040,
-		1551042,
-		1551022,
-	}
-
-	for _, possibleID := range possibleIDs {
-		if evt.PrimaryKeyMap["id"] == possibleID {
-			fmt.Println("keys", evt.PrimaryKeyMap, evt.Data, "value", string(processArgs.Msg.Value()), "shouldSkip", topicConfig.tc.ShouldSkip(_event.Operation()))
-		}
-	}
-
 	if topicConfig.tc.ShouldSkip(_event.Operation()) {
 		// Check to see if we should skip first
 		// This way, we can emit a specific tag to be more clear


### PR DESCRIPTION
## Changes

Our merge consolidation a few weeks ago accidentally missed `containsHardDeletes` flag from the Redshift merge: https://github.com/artie-labs/transfer/pull/343/files#diff-87c1374c50373010ae6b2a9951ae46abee85163c403b39b0f1ac32d8bac54c61

This was not caught because the previous flag was a type `bool`. I changed it to a pointer so that we can validate that it has been set.