### PR TITLE
[Snowflake] Temporary table fix

### DIFF
--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -22,7 +22,7 @@ import (
 // It has a safety check to make sure the tableName contains the `constants.ArtiePrefix` key.
 // Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(10)
 func DropTemporaryTable(dwh destination.DataWarehouse, fqTableName string, shouldReturnError bool) error {
-	if strings.Contains(fqTableName, constants.ArtiePrefix) {
+	if strings.Contains(strings.ToLower(fqTableName), constants.ArtiePrefix) {
 		_, err := dwh.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", fqTableName))
 		if err != nil {
 			slog.Warn("Failed to drop temporary table, it will get garbage collected by the TTL...", slog.Any("err", err))

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -20,7 +20,7 @@ import (
 
 // DropTemporaryTable - this will drop the temporary table from Snowflake w/ stages and BigQuery
 // It has a safety check to make sure the tableName contains the `constants.ArtiePrefix` key.
-// Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(10)
+// Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(5)_expiryUnixTs
 func DropTemporaryTable(dwh destination.DataWarehouse, fqTableName string, shouldReturnError bool) error {
 	if strings.Contains(strings.ToLower(fqTableName), constants.ArtiePrefix) {
 		_, err := dwh.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", fqTableName))


### PR DESCRIPTION
This PR: https://github.com/artie-labs/transfer/pull/361 which has not been deployed yet consolidates our sweeping logic.

However, when the sweep query runs, the table names from Snowflake are returned in uppercase format which fails the `strings.Contains(...)` logic and the temporary table does not get deleted.

