### PR TITLE
Improving Columns Update Query

### DIFF
--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -131,7 +131,7 @@ func (m *MergeArgument) GetParts() ([]string, error) {
 			// UPDATE
 			fmt.Sprintf(`UPDATE %s as c SET %s FROM %s as cc WHERE %s%s;`,
 				// UPDATE table set col1 = cc. col1
-				m.FqTableName, columns.ColumnsUpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
+				m.FqTableName, columns.UpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
 				// FROM table (temp) WHERE join on PK(s)
 				m.SubQuery, strings.Join(equalitySQLParts, " and "), idempotentClause,
 			),
@@ -175,7 +175,7 @@ func (m *MergeArgument) GetParts() ([]string, error) {
 		// UPDATE
 		fmt.Sprintf(`UPDATE %s as c SET %s FROM %s as cc WHERE %s%s AND COALESCE(cc.%s, false) = false;`,
 			// UPDATE table set col1 = cc. col1
-			m.FqTableName, columns.ColumnsUpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
+			m.FqTableName, columns.UpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
 			// FROM staging WHERE join on PK(s)
 			m.SubQuery, strings.Join(equalitySQLParts, " and "), idempotentClause, constants.DeleteColumnMarker,
 		),
@@ -254,7 +254,7 @@ WHEN MATCHED %sTHEN UPDATE SET %s
 WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`,
 			m.FqTableName, subQuery, strings.Join(equalitySQLParts, " and "),
 			// Update + Soft Deletion
-			idempotentClause, columns.ColumnsUpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
+			idempotentClause, columns.UpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
 			// Insert
 			constants.DeleteColumnMarker, strings.Join(cols, ","),
 			array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
@@ -287,7 +287,7 @@ WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`
 		// Delete
 		constants.DeleteColumnMarker,
 		// Update
-		constants.DeleteColumnMarker, idempotentClause, columns.ColumnsUpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
+		constants.DeleteColumnMarker, idempotentClause, columns.UpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
 		// Insert
 		constants.DeleteColumnMarker, strings.Join(cols, ","),
 		array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
@@ -329,7 +329,7 @@ WHEN MATCHED %sTHEN UPDATE SET %s
 WHEN NOT MATCHED AND COALESCE(cc.%s, 0) = 0 THEN INSERT (%s) VALUES (%s);`,
 			m.FqTableName, m.SubQuery, strings.Join(equalitySQLParts, " and "),
 			// Update + Soft Deletion
-			idempotentClause, columns.ColumnsUpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
+			idempotentClause, columns.UpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
 			// Insert
 			constants.DeleteColumnMarker, strings.Join(cols, ","),
 			array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
@@ -363,7 +363,7 @@ WHEN NOT MATCHED AND COALESCE(cc.%s, 1) = 0 THEN INSERT (%s) VALUES (%s);`,
 		// Delete
 		constants.DeleteColumnMarker,
 		// Update
-		constants.DeleteColumnMarker, idempotentClause, columns.ColumnsUpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
+		constants.DeleteColumnMarker, idempotentClause, columns.UpdateQuery(cols, m.ColumnsToTypes, m.DestKind, *m.UppercaseEscNames),
 		// Insert
 		constants.DeleteColumnMarker, strings.Join(cols, ","),
 		array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -246,6 +246,7 @@ func (c *Columns) DeleteColumn(name string) {
 // bigQueryTypeCasting - We'll need to escape the column comparison if the column's a struct.
 // It then returns a list of strings like: cc.first_name=c.first_name,cc.last_name=c.last_name,cc.email=c.email
 func UpdateQuery(columns []string, columnsToTypes Columns, destKind constants.DestinationKind, uppercaseEscNames bool) string {
+	// TODO: We most likely don't need to pass in columns since we already have it from `Columns`.
 	columnsToTypes.EscapeName(uppercaseEscNames, &sql.NameArgs{
 		Escape:   true,
 		DestKind: destKind,

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -240,12 +240,12 @@ func (c *Columns) DeleteColumn(name string) {
 	}
 }
 
-// ColumnsUpdateQuery takes:
+// UpdateQuery takes:
 // columns - list of columns to iterate
 // columnsToTypes - given that list, provide the types (separate list because this list may contain invalid columns
 // bigQueryTypeCasting - We'll need to escape the column comparison if the column's a struct.
 // It then returns a list of strings like: cc.first_name=c.first_name,cc.last_name=c.last_name,cc.email=c.email
-func ColumnsUpdateQuery(columns []string, columnsToTypes Columns, destKind constants.DestinationKind, uppercaseEscNames bool) string {
+func UpdateQuery(columns []string, columnsToTypes Columns, destKind constants.DestinationKind, uppercaseEscNames bool) string {
 	columnsToTypes.EscapeName(uppercaseEscNames, &sql.NameArgs{
 		Escape:   true,
 		DestKind: destKind,

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -286,6 +286,7 @@ func processToastStructCol(colName string, destKind constants.DestinationKind) s
 		return fmt.Sprintf("%s= CASE WHEN COALESCE(cc.%s, {}) != {'key': '%s'} THEN cc.%s ELSE c.%s END",
 			colName, colName, constants.ToastUnavailableValuePlaceholder, colName, colName)
 	default:
+		// TODO: Change this to Snowflake and error out if the destKind isn't supported so we're explicit.
 		return fmt.Sprintf("%s= CASE WHEN COALESCE(cc.%s != {'key': '%s'}, true) THEN cc.%s ELSE c.%s END",
 			colName, colName, constants.ToastUnavailableValuePlaceholder, colName, colName)
 	}

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -273,18 +273,19 @@ func UpdateQuery(columns []string, columnsToTypes Columns, destKind constants.De
 }
 
 func processToastStructCol(colName string, destKind constants.DestinationKind) string {
-	if destKind == constants.BigQuery {
+	switch destKind {
+	case constants.BigQuery:
 		return fmt.Sprintf(`%s= CASE WHEN COALESCE(TO_JSON_STRING(cc.%s) != '{"key":"%s"}', true) THEN cc.%s ELSE c.%s END`,
 			colName, colName, constants.ToastUnavailableValuePlaceholder,
 			colName, colName)
-	} else if destKind == constants.Redshift {
+	case constants.Redshift:
 		return fmt.Sprintf(`%s= CASE WHEN COALESCE(cc.%s != JSON_PARSE('{"key":"%s"}'), true) THEN cc.%s ELSE c.%s END`,
 			colName, colName, constants.ToastUnavailableValuePlaceholder, colName, colName)
-	} else if destKind == constants.MSSQL {
+	case constants.MSSQL:
 		// Microsoft SQL Server doesn't allow boolean expressions to be in the COALESCE statement.
 		return fmt.Sprintf("%s= CASE WHEN COALESCE(cc.%s, {}) != {'key': '%s'} THEN cc.%s ELSE c.%s END",
 			colName, colName, constants.ToastUnavailableValuePlaceholder, colName, colName)
-	} else {
+	default:
 		return fmt.Sprintf("%s= CASE WHEN COALESCE(cc.%s != {'key': '%s'}, true) THEN cc.%s ELSE c.%s END",
 			colName, colName, constants.ToastUnavailableValuePlaceholder, colName, colName)
 	}

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -275,16 +275,11 @@ func UpdateQuery(columns []string, columnsToTypes Columns, destKind constants.De
 func processToastStructCol(colName string, destKind constants.DestinationKind) string {
 	if destKind == constants.BigQuery {
 		return fmt.Sprintf(`%s= CASE WHEN COALESCE(TO_JSON_STRING(cc.%s) != '{"key":"%s"}', true) THEN cc.%s ELSE c.%s END`,
-			// col CASE when TO_JSON_STRING(cc.col) != { 'key': TOAST_UNAVAILABLE_VALUE }
 			colName, colName, constants.ToastUnavailableValuePlaceholder,
-			// cc.col ELSE c.col END
 			colName, colName)
 	} else if destKind == constants.Redshift {
 		return fmt.Sprintf(`%s= CASE WHEN COALESCE(cc.%s != JSON_PARSE('{"key":"%s"}'), true) THEN cc.%s ELSE c.%s END`,
-			// col CASE when TO_JSON_STRING(cc.col) != { 'key': TOAST_UNAVAILABLE_VALUE }
-			colName, colName, constants.ToastUnavailableValuePlaceholder,
-			// cc.col ELSE c.col END
-			colName, colName)
+			colName, colName, constants.ToastUnavailableValuePlaceholder, colName, colName)
 	} else if destKind == constants.MSSQL {
 		// Microsoft SQL Server doesn't allow boolean expressions to be in the COALESCE statement.
 		return fmt.Sprintf("%s= CASE WHEN COALESCE(cc.%s, {}) != {'key': '%s'} THEN cc.%s ELSE c.%s END",
@@ -297,14 +292,11 @@ func processToastStructCol(colName string, destKind constants.DestinationKind) s
 
 func processToastCol(colName string, destKind constants.DestinationKind) string {
 	if destKind == constants.MSSQL {
+		// Microsoft SQL Server doesn't allow boolean expressions to be in the COALESCE statement.
 		return fmt.Sprintf("%s= CASE WHEN COALESCE(cc.%s, '') != '%s' THEN cc.%s ELSE c.%s END", colName, colName,
 			constants.ToastUnavailableValuePlaceholder, colName, colName)
 	} else {
-		// t.column3 = CASE WHEN t.column3 != '__debezium_unavailable_value' THEN t.column3 ELSE s.column3 END
 		return fmt.Sprintf("%s= CASE WHEN COALESCE(cc.%s != '%s', true) THEN cc.%s ELSE c.%s END",
-			// col = CASE WHEN cc.col != TOAST_UNAVAILABLE_VALUE
-			colName, colName, constants.ToastUnavailableValuePlaceholder,
-			// THEN cc.col ELSE c.col END
-			colName, colName)
+			colName, colName, constants.ToastUnavailableValuePlaceholder, colName, colName)
 	}
 }

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -489,7 +489,7 @@ func TestColumnsUpdateQuery(t *testing.T) {
 	}
 
 	for _, _testCase := range testCases {
-		actualQuery := ColumnsUpdateQuery(_testCase.columns, _testCase.columnsToTypes, _testCase.destKind, false)
+		actualQuery := UpdateQuery(_testCase.columns, _testCase.columnsToTypes, _testCase.destKind, false)
 		assert.Equal(t, _testCase.expectedString, actualQuery, _testCase.name)
 	}
 }

--- a/lib/typing/columns/columns_toast_test.go
+++ b/lib/typing/columns/columns_toast_test.go
@@ -1,0 +1,22 @@
+package columns
+
+import (
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessToastStructCol(t *testing.T) {
+	assert.Equal(t, `foo= CASE WHEN COALESCE(cc.foo != JSON_PARSE('{"key":"__debezium_unavailable_value"}'), true) THEN cc.foo ELSE c.foo END`, processToastStructCol("foo", constants.Redshift))
+	assert.Equal(t, `foo= CASE WHEN COALESCE(TO_JSON_STRING(cc.foo) != '{"key":"__debezium_unavailable_value"}', true) THEN cc.foo ELSE c.foo END`, processToastStructCol("foo", constants.BigQuery))
+	assert.Equal(t, `foo= CASE WHEN COALESCE(cc.foo != {'key': '__debezium_unavailable_value'}, true) THEN cc.foo ELSE c.foo END`, processToastStructCol("foo", constants.Snowflake))
+	assert.Equal(t, `foo= CASE WHEN COALESCE(cc.foo, {}) != {'key': '__debezium_unavailable_value'} THEN cc.foo ELSE c.foo END`, processToastStructCol("foo", constants.MSSQL))
+}
+
+func TestProcessToastCol(t *testing.T) {
+	assert.Equal(t, `bar= CASE WHEN COALESCE(cc.bar != '__debezium_unavailable_value', true) THEN cc.bar ELSE c.bar END`, processToastCol("bar", constants.Redshift))
+	assert.Equal(t, `bar= CASE WHEN COALESCE(cc.bar != '__debezium_unavailable_value', true) THEN cc.bar ELSE c.bar END`, processToastCol("bar", constants.BigQuery))
+	assert.Equal(t, `bar= CASE WHEN COALESCE(cc.bar != '__debezium_unavailable_value', true) THEN cc.bar ELSE c.bar END`, processToastCol("bar", constants.Snowflake))
+	assert.Equal(t, `bar= CASE WHEN COALESCE(cc.bar, '') != '__debezium_unavailable_value' THEN cc.bar ELSE c.bar END`, processToastCol("bar", constants.MSSQL))
+}


### PR DESCRIPTION
## Changes

1. Adding Microsoft SQL Server tests
2. Renaming `ColumnsUpdateQuery` -> `UpdateQuery` since the pkg name is `columns`
3. Breaking out `struct` and normal TOAST column handling into separate functions