### PR TITLE
[Redshift] Simplifying casting values

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -10,31 +10,18 @@ import (
 )
 
 const (
-	maxRedshiftVarCharLen = 65535
-	maxRedshiftSuperLen   = 1 * 1024 * 1024 // 1 MB
+	maxRedshiftLength = 65535
 )
 
 // replaceExceededValues - takes `colVal` any and `colKind` columns.Column and replaces the value with an empty string if it exceeds the max length.
 // This currently only works for STRING and SUPER data types.
 func replaceExceededValues(colVal string, colKind columns.Column) string {
-	numOfChars := len(colVal)
-	switch colKind.KindDetails.Kind {
-	// Assuming this corresponds to SUPER type in Redshift
-	case typing.Struct.Kind:
-		shouldReplace := numOfChars > maxRedshiftSuperLen
-		potentiallyReplace := numOfChars > maxRedshiftVarCharLen
-
-		// If the data value is a string, there's still a 2^16 character limit despite it being a SUPER data type.
-		// https://docs.aws.amazon.com/redshift/latest/dg/limitations-super.html
-		if !shouldReplace && potentiallyReplace && !typing.IsJSON(colVal) {
-			shouldReplace = true
-		}
-
-		if shouldReplace {
+	structOrString := colKind.KindDetails.Kind == typing.Struct.Kind || colKind.KindDetails.Kind == typing.String.Kind
+	shouldReplace := len(colVal) > maxRedshiftLength
+	if structOrString && shouldReplace {
+		if colKind.KindDetails.Kind == typing.Struct.Kind {
 			return fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker)
-		}
-	case typing.String.Kind:
-		if numOfChars > maxRedshiftVarCharLen {
+		} else {
 			return constants.ExceededValueMarker
 		}
 	}

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -9,9 +9,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/values"
 )
 
-const (
-	maxRedshiftLength = 65535
-)
+const maxRedshiftLength = 65535
 
 // replaceExceededValues - takes `colVal` any and `colKind` columns.Column and replaces the value with an empty string if it exceeds the max length.
 // This currently only works for STRING and SUPER data types.

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -17,11 +17,12 @@ const (
 // This currently only works for STRING and SUPER data types.
 func replaceExceededValues(colVal string, colKind columns.Column) string {
 	structOrString := colKind.KindDetails.Kind == typing.Struct.Kind || colKind.KindDetails.Kind == typing.String.Kind
-	shouldReplace := len(colVal) > maxRedshiftLength
-	if structOrString && shouldReplace {
-		if colKind.KindDetails.Kind == typing.Struct.Kind {
-			return fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker)
-		} else {
+	if structOrString {
+		if shouldReplace := len(colVal) > maxRedshiftLength; shouldReplace {
+			if colKind.KindDetails.Kind == typing.Struct.Kind {
+				return fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker)
+			}
+
 			return constants.ExceededValueMarker
 		}
 	}

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -26,13 +26,10 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 		expectedResult string
 	}
 
-	randomJSONString := fmt.Sprintf(`{"foo": "%s"}`, stringutil.Random(maxRedshiftVarCharLen+1))
-	randomArrayString := fmt.Sprintf(`["a", "%s"]`, stringutil.Random(maxRedshiftVarCharLen+1))
-
 	tcs := []_tc{
 		{
 			name:   "string",
-			colVal: stringutil.Random(maxRedshiftVarCharLen + 1),
+			colVal: stringutil.Random(maxRedshiftLength + 1),
 			colKind: columns.Column{
 				KindDetails: typing.String,
 			},
@@ -48,7 +45,7 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 		},
 		{
 			name:   "struct",
-			colVal: fmt.Sprintf(`{"foo": "%s"}`, stringutil.Random(maxRedshiftSuperLen+1)),
+			colVal: fmt.Sprintf(`{"foo": "%s"}`, stringutil.Random(maxRedshiftLength+1)),
 			colKind: columns.Column{
 				KindDetails: typing.Struct,
 			},
@@ -56,27 +53,11 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 		},
 		{
 			name:   "string, but the data type is a SUPER",
-			colVal: stringutil.Random(maxRedshiftVarCharLen + 1),
+			colVal: stringutil.Random(maxRedshiftLength + 1),
 			colKind: columns.Column{
 				KindDetails: typing.Struct,
 			},
 			expectedResult: fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker),
-		},
-		{
-			name:   "struct, exceeded 65k but under 1mb",
-			colVal: randomJSONString,
-			colKind: columns.Column{
-				KindDetails: typing.Struct,
-			},
-			expectedResult: randomJSONString,
-		},
-		{
-			name:   "array, exceeded 65k but under 1mb",
-			colVal: randomArrayString,
-			colKind: columns.Column{
-				KindDetails: typing.Struct,
-			},
-			expectedResult: randomArrayString,
 		},
 		{
 			name:   "struct - not masked",
@@ -112,30 +93,11 @@ func evaluateTestCase(t *testing.T, store *Store, testCase _testCase) {
 	}
 }
 
-func (r *RedshiftTestSuite) TestCastColValStaging_TOAST() {
-	// Toast only really matters for JSON blobs since it'll return a STRING value that's not a JSON object.
-	// We're testing that we're casting the unavailable value correctly into a JSON object so that it can compile.
-	testCases := []_testCase{
-		{
-			name:   "struct with TOAST value",
-			colVal: constants.ToastUnavailableValuePlaceholder,
-			colKind: columns.Column{
-				KindDetails: typing.Struct,
-			},
-			expectedString: fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder),
-		},
-	}
-
-	for _, testCase := range testCases {
-		evaluateTestCase(r.T(), r.store, testCase)
-	}
-}
-
 func (r *RedshiftTestSuite) TestCastColValStaging_ExceededValues() {
 	testCases := []_testCase{
 		{
 			name:   "string",
-			colVal: stringutil.Random(maxRedshiftVarCharLen + 1),
+			colVal: stringutil.Random(maxRedshiftLength + 1),
 			colKind: columns.Column{
 				KindDetails: typing.String,
 			},
@@ -151,7 +113,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_ExceededValues() {
 		},
 		{
 			name:   "struct",
-			colVal: map[string]any{"foo": stringutil.Random(maxRedshiftSuperLen + 1)},
+			colVal: map[string]any{"foo": stringutil.Random(maxRedshiftLength + 1)},
 			colKind: columns.Column{
 				KindDetails: typing.Struct,
 			},
@@ -159,7 +121,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging_ExceededValues() {
 		},
 		{
 			name:   "struct",
-			colVal: map[string]any{"foo": stringutil.Random(maxRedshiftSuperLen + 1)},
+			colVal: map[string]any{"foo": stringutil.Random(maxRedshiftLength + 1)},
 			colKind: columns.Column{
 				KindDetails: typing.Struct,
 			},

--- a/clients/redshift/redshift_bench_test.go
+++ b/clients/redshift/redshift_bench_test.go
@@ -34,13 +34,13 @@ func replaceExceededValuesOld(colVal any, colKind columns.Column) any {
 	colValString := fmt.Sprint(colVal)
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind:
-		if len(colValString) > maxRedshiftSuperLen {
+		if len(colValString) > maxRedshiftLength {
 			return map[string]any{
 				"key": constants.ExceededValueMarker,
 			}
 		}
 	case typing.String.Kind:
-		if len(colValString) > maxRedshiftVarCharLen {
+		if len(colValString) > maxRedshiftLength {
 			return constants.ExceededValueMarker
 		}
 	}
@@ -53,13 +53,13 @@ func replaceExceededValuesNew(colVal any, colKind columns.Column) any {
 	colValBytes := len(colValString)
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind:
-		if colValBytes > maxRedshiftSuperLen {
+		if colValBytes > maxRedshiftLength {
 			return map[string]any{
 				"key": constants.ExceededValueMarker,
 			}
 		}
 	case typing.String.Kind:
-		if colValBytes > maxRedshiftVarCharLen {
+		if colValBytes > maxRedshiftLength {
 			return constants.ExceededValueMarker
 		}
 	}


### PR DESCRIPTION
## Problem

The documentation for Redshift is incorrect regarding JSON objects within a SUPER data type. They are subject to the same character limit as STRINGs.

This PR uses the STRING limit for both STRING and SUPER along with simplifying the current codepath.