### PR TITLE
[BigQuery] Escape Project ID for fully qualified name

### DIFF
--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -208,7 +208,7 @@ func (t *TableData) ToFqName(kind constants.DestinationKind, escape bool, upperc
 		}))
 	case constants.BigQuery:
 		// The fully qualified name for BigQuery is: project_id.dataset.tableName.
-		return fmt.Sprintf("%s.%s.%s", opts.BigQueryProjectID, t.TopicConfig.Database, t.Name(uppercaseEscNames, &sql.NameArgs{
+		return fmt.Sprintf("`%s`.%s.%s", opts.BigQueryProjectID, t.TopicConfig.Database, t.Name(uppercaseEscNames, &sql.NameArgs{
 			Escape:   escape,
 			DestKind: kind,
 		}))

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -208,7 +208,8 @@ func (t *TableData) ToFqName(kind constants.DestinationKind, escape bool, upperc
 		}))
 	case constants.BigQuery:
 		// The fully qualified name for BigQuery is: project_id.dataset.tableName.
-		return fmt.Sprintf("`%s`.%s.%s", opts.BigQueryProjectID, t.TopicConfig.Database, t.Name(uppercaseEscNames, &sql.NameArgs{
+		// We are escaping the project_id and dataset because there could be special characters.
+		return fmt.Sprintf("`%s`.`%s`.%s", opts.BigQueryProjectID, t.TopicConfig.Database, t.Name(uppercaseEscNames, &sql.NameArgs{
 			Escape:   escape,
 			DestKind: kind,
 		}))

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -136,7 +136,7 @@ func TestNewTableData_TableName(t *testing.T) {
 
 			expectedName:            "food",
 			expectedSnowflakeFqName: "db.public.food",
-			expectedBigQueryFqName:  "artie.db.food",
+			expectedBigQueryFqName:  "`artie`.db.food",
 			expectedRedshiftFqName:  "public.food",
 			expectedS3FqName:        "db.public.food",
 		},

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -136,7 +136,7 @@ func TestNewTableData_TableName(t *testing.T) {
 
 			expectedName:            "food",
 			expectedSnowflakeFqName: "db.public.food",
-			expectedBigQueryFqName:  "`artie`.db.food",
+			expectedBigQueryFqName:  "`artie`.`db`.food",
 			expectedRedshiftFqName:  "public.food",
 			expectedS3FqName:        "db.public.food",
 		},


### PR DESCRIPTION
We need to escape the project ID since it could contain special characters.