### PR TITLE
[Typing] `parseField` to start emitting an error

### DIFF
--- a/lib/cdc/util/parse.go
+++ b/lib/cdc/util/parse.go
@@ -2,102 +2,50 @@ package util
 
 import (
 	"fmt"
-	"log/slog"
 	"strconv"
 
-	"github.com/artie-labs/transfer/lib/jsonutil"
-	"github.com/artie-labs/transfer/lib/typing/ext"
-
 	"github.com/artie-labs/transfer/lib/debezium"
+	"github.com/artie-labs/transfer/lib/jsonutil"
 )
 
-// ParseField returns a `parsedValue` as type any
-func parseField(field debezium.Field, value any) any {
-	// TODO: We should surface the errors from `parseField`.
+func parseField(field debezium.Field, value any) (any, error) {
 	if value == nil {
-		return nil
+		return nil, nil
 	}
 
 	// Check if the field is an integer and requires us to cast it as such.
 	if field.IsInteger() {
 		valFloat, isOk := value.(float64)
-		if isOk {
-			return int(valFloat)
+		if !isOk {
+			return nil, fmt.Errorf("failed to cast value to float64")
 		}
+
+		return int(valFloat), nil
 	}
 
 	if valid, supportedType := debezium.RequiresSpecialTypeCasting(field.DebeziumType); valid {
 		switch debezium.SupportedDebeziumType(field.DebeziumType) {
 		case debezium.JSON:
-			valString, err := jsonutil.SanitizePayload(value)
-			if err == nil {
-				return valString
-			}
+			return jsonutil.SanitizePayload(value)
 		case debezium.GeometryType, debezium.GeographyType:
-			geometryString, err := parseGeometry(value)
-			if err == nil {
-				return geometryString
-			}
+			return parseGeometry(value)
 		case debezium.GeometryPointType:
-			geometryString, err := parseGeometryPoint(value)
-			if err == nil {
-				return geometryString
-			}
+			return parseGeometryPoint(value)
 		case debezium.KafkaDecimalType:
-			decimalVal, err := field.DecodeDecimal(fmt.Sprint(value))
-			if err == nil {
-				return decimalVal
-			} else {
-				slog.Debug("Skipped casting dbz type due to an error",
-					slog.Any("err", err),
-					slog.Any("supportedType", supportedType),
-					slog.Any("val", value),
-				)
-			}
+			return field.DecodeDecimal(fmt.Sprint(value))
 		case debezium.KafkaVariableNumericType:
-			variableNumericVal, err := field.DecodeDebeziumVariableDecimal(value)
-			if err == nil {
-				return variableNumericVal
-			} else {
-				slog.Debug("Skipped casting dbz type due to an error",
-					slog.Any("err", err),
-					slog.Any("supportedType", supportedType),
-					slog.Any("val", value),
-				)
-			}
+			return field.DecodeDebeziumVariableDecimal(value)
 		default:
 			// Need to cast this as a FLOAT first because the number may come out in scientific notation
 			// ParseFloat is apt to handle it, and ParseInt is not, see: https://github.com/golang/go/issues/19288
 			floatVal, castErr := strconv.ParseFloat(fmt.Sprint(value), 64)
-			if castErr == nil {
-				extendedTime, err := debezium.FromDebeziumTypeToTime(supportedType, int64(floatVal))
-				if err == nil {
-					return extendedTime
-				} else {
-					if ext.IsInvalidErr(err) {
-						slog.Info("ExtTime is not valid, so returning nil here instead",
-							slog.Any("err", err),
-							slog.Any("supportedType", supportedType),
-							slog.Any("val", value),
-						)
-						return nil
-					}
-
-					slog.Debug("Skipped casting dbz type due to an error",
-						slog.Any("err", err),
-						slog.Any("supportedType", supportedType),
-						slog.Any("val", value),
-					)
-				}
-			} else {
-				slog.Debug("Skipped casting because we failed to parse the float",
-					slog.Any("err", castErr),
-					slog.Any("supportedType", supportedType),
-					slog.Any("val", value),
-				)
+			if castErr != nil {
+				return nil, castErr
 			}
+
+			return debezium.FromDebeziumTypeToTime(supportedType, int64(floatVal))
 		}
 	}
 
-	return value
+	return value, nil
 }

--- a/lib/cdc/util/parse_test.go
+++ b/lib/cdc/util/parse_test.go
@@ -158,7 +158,8 @@ func TestParseField(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualField := parseField(testCase.field, testCase.value)
+		actualField, err := parseField(testCase.field, testCase.value)
+		assert.NoError(t, err, testCase.name)
 		if testCase.expectedDecimal {
 			decVal, isOk := actualField.(*decimal.Decimal)
 			assert.True(t, isOk)

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -99,7 +99,7 @@ func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ex
 	}
 
 	if extTime != nil && !extTime.IsValid() {
-		return nil, fmt.Errorf("%s, extTime: %v", ext.InvalidErrPrefix, extTime)
+		return nil, fmt.Errorf("extTime is invalid: %v", extTime)
 	}
 
 	return extTime, err

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -1,7 +1,6 @@
 package ext
 
 import (
-	"strings"
 	"time"
 )
 
@@ -40,16 +39,6 @@ var (
 type ExtendedTime struct {
 	time.Time
 	NestedKind NestedKind
-}
-
-const InvalidErrPrefix = "extTime is not valid"
-
-func IsInvalidErr(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	return strings.HasPrefix(err.Error(), InvalidErrPrefix)
 }
 
 func (e *ExtendedTime) IsValid() bool {


### PR DESCRIPTION
## Context

Previously, `parseField` would not emit an error and if the translation failed, it would just return the original value. However, this masked the actual translation error from the caller which makes it hard for other codepaths to reliably call this function.
