### PR TITLE
Fix Microsoft SQL Server booleans

### DIFF
--- a/clients/mssql/staging.go
+++ b/clients/mssql/staging.go
@@ -61,7 +61,6 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 				return castErr
 			}
 
-			fmt.Println("castedValue", castedValue, "colKind", colKind.KindDetails, "colName", colKind.RawName())
 			row = append(row, castedValue)
 		}
 

--- a/clients/mssql/staging.go
+++ b/clients/mssql/staging.go
@@ -61,8 +61,6 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 				return castErr
 			}
 
-			fmt.Println("castedValue", castedValue, "col", colKind.RawName(), colKind.KindDetails.Kind)
-
 			row = append(row, castedValue)
 		}
 

--- a/clients/mssql/staging.go
+++ b/clients/mssql/staging.go
@@ -61,6 +61,8 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 				return castErr
 			}
 
+			fmt.Println("castedValue", castedValue, "col", colKind.RawName(), colKind.KindDetails.Kind)
+
 			row = append(row, castedValue)
 		}
 

--- a/clients/mssql/staging.go
+++ b/clients/mssql/staging.go
@@ -61,6 +61,7 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 				return castErr
 			}
 
+			fmt.Println("castedValue", castedValue, "colKind", colKind.KindDetails, "colName", colKind.RawName())
 			row = append(row, castedValue)
 		}
 

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -88,12 +88,21 @@ func parseValue(colVal any, colKind columns.Column, additionalDateFmts []string)
 
 		return colVal, nil
 	case typing.Boolean.Kind:
-		// If it's already a boolean, return it. Else, convert it.
+		// We need to convert boolean into a bit for Microsoft SQL Server.
 		if val, isOk := colVal.(bool); isOk {
-			return val, nil
+			if val {
+				return 1, nil
+			} else {
+				return 0, nil
+			}
 		}
 
-		return strconv.ParseBool(colValString)
+		val, err := strconv.ParseBool(colValString)
+		if err != nil {
+			return nil, err
+		}
+
+		return parseValue(val, colKind, additionalDateFmts)
 	case typing.EDecimal.Kind:
 		if val, isOk := colVal.(*decimal.Decimal); isOk {
 			return val.String(), nil

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -100,17 +100,12 @@ func parseValue(colVal any, colKind columns.Column, additionalDateFmts []string)
 
 		return colVal, nil
 	case typing.Boolean.Kind:
-		_, isString := colVal.(string)
-		if isString {
-			val, err := strconv.ParseBool(colValString)
-			if err != nil {
-				return nil, err
-			}
-
-			return booleanToBit(val), nil
+		// If it's already a boolean, return it. Else, convert it.
+		if val, isOk := colVal.(bool); isOk {
+			return val, nil
 		}
 
-		return colVal, nil
+		return strconv.ParseBool(colValString)
 	case typing.EDecimal.Kind:
 		if val, isOk := colVal.(*decimal.Decimal); isOk {
 			return val.String(), nil

--- a/clients/mssql/values_test.go
+++ b/clients/mssql/values_test.go
@@ -56,19 +56,19 @@ func TestParseValue(t *testing.T) {
 		// Booleans
 		val, err := parseValue(true, columns.NewColumn("bool", typing.Boolean), nil)
 		assert.NoError(t, err)
-		assert.True(t, val.(bool))
+		assert.Equal(t, 1, val)
 
 		val, err = parseValue(false, columns.NewColumn("bool", typing.Boolean), nil)
 		assert.NoError(t, err)
-		assert.False(t, val.(bool))
+		assert.Equal(t, 0, val)
 
 		// Should be able to handle string booleans
 		val, err = parseValue("true", columns.NewColumn("bool", typing.Boolean), nil)
 		assert.NoError(t, err)
-		assert.True(t, val.(bool))
+		assert.Equal(t, 1, val)
 
 		val, err = parseValue("false", columns.NewColumn("bool", typing.Boolean), nil)
 		assert.NoError(t, err)
-		assert.False(t, val.(bool))
+		assert.Equal(t, 0, val)
 	}
 }

--- a/clients/mssql/values_test.go
+++ b/clients/mssql/values_test.go
@@ -53,22 +53,27 @@ func TestParseValue(t *testing.T) {
 		assert.Equal(t, 1234.5678, val)
 	}
 	{
-		// Booleans
-		val, err := parseValue(true, columns.NewColumn("bool", typing.Boolean), nil)
+		// Boolean, but the column is an integer column.
+		val, err := parseValue(true, columns.NewColumn("bigint", typing.Integer), nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, val)
 
+		// Booleans
+		val, err = parseValue(true, columns.NewColumn("bool", typing.Boolean), nil)
+		assert.NoError(t, err)
+		assert.True(t, val.(bool))
+
 		val, err = parseValue(false, columns.NewColumn("bool", typing.Boolean), nil)
 		assert.NoError(t, err)
-		assert.Equal(t, 0, val)
+		assert.False(t, val.(bool))
 
 		// Should be able to handle string booleans
 		val, err = parseValue("true", columns.NewColumn("bool", typing.Boolean), nil)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, val)
+		assert.True(t, val.(bool))
 
 		val, err = parseValue("false", columns.NewColumn("bool", typing.Boolean), nil)
 		assert.NoError(t, err)
-		assert.Equal(t, 0, val)
+		assert.False(t, val.(bool))
 	}
 }


### PR DESCRIPTION
Solving for data indigestion.

Because Microsoft SQL Server doesn't support BOOLEANs, some data replication tools will create `BIGINT` as opposed to `BIT` columns.

Transfer then tries to load `boolean` values into a `BIGINT` column which fails the typecheck. We can safely load `boolean` values into a `BIT` column because the underlying Microsoft SQL driver expects and will cast `boolean` values into `BIT` values.