### PR TITLE
[Microsoft SQL Server] Boolean Improvement

### DIFF
--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -100,11 +100,6 @@ func parseValue(colVal any, colKind columns.Column, additionalDateFmts []string)
 
 		return colVal, nil
 	case typing.Boolean.Kind:
-		// If it's already a boolean, return it. Else, convert it.
-		if val, isOk := colVal.(bool); isOk {
-			return val, nil
-		}
-
 		return strconv.ParseBool(colValString)
 	case typing.EDecimal.Kind:
 		if val, isOk := colVal.(*decimal.Decimal); isOk {


### PR DESCRIPTION
After this PR: https://github.com/artie-labs/transfer/pull/388, `colVal` is already not a boolean, so there's no point in having this check.

`strconv.ParseBool(...)` will handles converting 0/1s into bools.