### PR TITLE
Fix panic when calling `Jitter` with a large number of attempts

### DIFF
--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -15,7 +15,7 @@ func Jitter(baseMs, maxMs, attempts int) time.Duration {
 		return time.Duration(0)
 	}
 
-	// Check for overflows when computing base * 2 ** attempts
+	// Check for overflows when computing base * 2 ** attempts.
 	if attemptsMaxMs := baseMs * (1 << attempts); attemptsMaxMs > 0 {
 		maxMs = min(maxMs, attemptsMaxMs)
 	}

--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -14,6 +14,12 @@ func Jitter(baseMs, maxMs, attempts int) time.Duration {
 	if maxMs <= 0 {
 		return time.Duration(0)
 	}
-	ms := rand.Intn(min(maxMs, baseMs*(1<<attempts)))
+
+	// Check for overflows when computing 2 ** x
+	if attemptsMaxMs := baseMs * (1 << attempts); attemptsMaxMs > 0 {
+		maxMs = min(maxMs, attemptsMaxMs)
+	}
+
+	ms := rand.Intn(maxMs)
 	return time.Duration(ms) * time.Millisecond
 }

--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -15,7 +15,7 @@ func Jitter(baseMs, maxMs, attempts int) time.Duration {
 		return time.Duration(0)
 	}
 
-	// Check for overflows when computing 2 ** x
+	// Check for overflows when computing base * 2 ** attempts
 	if attemptsMaxMs := baseMs * (1 << attempts); attemptsMaxMs > 0 {
 		maxMs = min(maxMs, attemptsMaxMs)
 	}

--- a/lib/jitter/sleep_test.go
+++ b/lib/jitter/sleep_test.go
@@ -14,6 +14,10 @@ func TestJitter(t *testing.T) {
 	assert.Equal(t, time.Duration(0), Jitter(10, -1, 0))
 	assert.Equal(t, time.Duration(0), Jitter(10, -1, 100))
 
-	// A large number of attempts does not panic
-	assert.GreaterOrEqual(t, time.Duration(10)*time.Millisecond, Jitter(10, 100, 200))
+	{
+		// A large number of attempts does not panic
+		value := Jitter(10, 100, 200)
+		assert.GreaterOrEqual(t, value, time.Duration(10)*time.Millisecond)
+		assert.LessOrEqual(t, value, time.Duration(100)*time.Millisecond)
+	}
 }

--- a/lib/jitter/sleep_test.go
+++ b/lib/jitter/sleep_test.go
@@ -1,6 +1,7 @@
 package jitter
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -17,7 +18,11 @@ func TestJitter(t *testing.T) {
 	{
 		// A large number of attempts does not panic
 		value := Jitter(10, 100, 200)
-		assert.GreaterOrEqual(t, value, time.Duration(10)*time.Millisecond)
+		assert.LessOrEqual(t, value, time.Duration(100)*time.Millisecond)
+	}
+	{
+		// A very large number of attempts does not panic
+		value := Jitter(10, 100, math.MaxInt)
 		assert.LessOrEqual(t, value, time.Duration(100)*time.Millisecond)
 	}
 }

--- a/lib/jitter/sleep_test.go
+++ b/lib/jitter/sleep_test.go
@@ -16,12 +16,12 @@ func TestJitter(t *testing.T) {
 	assert.Equal(t, time.Duration(0), Jitter(10, -1, 100))
 
 	{
-		// A large number of attempts does not panic
+		// A large number of attempts does not panic.
 		value := Jitter(10, 100, 200)
 		assert.LessOrEqual(t, value, time.Duration(100)*time.Millisecond)
 	}
 	{
-		// A very large number of attempts does not panic
+		// A very large number of attempts does not panic.
 		value := Jitter(10, 100, math.MaxInt)
 		assert.LessOrEqual(t, value, time.Duration(100)*time.Millisecond)
 	}

--- a/lib/jitter/sleep_test.go
+++ b/lib/jitter/sleep_test.go
@@ -1,0 +1,19 @@
+package jitter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJitter(t *testing.T) {
+	// maxMs <= 0 returns time.Duration(0)
+	assert.Equal(t, time.Duration(0), Jitter(10, 0, 0))
+	assert.Equal(t, time.Duration(0), Jitter(10, 0, 100))
+	assert.Equal(t, time.Duration(0), Jitter(10, -1, 0))
+	assert.Equal(t, time.Duration(0), Jitter(10, -1, 100))
+
+	// A large number of attempts does not panic
+	assert.GreaterOrEqual(t, time.Duration(10)*time.Millisecond, Jitter(10, 100, 200))
+}


### PR DESCRIPTION
When `baseMs` and `attempts` are large enough `baseMs * attempts **2` will overflow and become negative, which then causes `rand.Intn` to panic.