### PR TITLE
Minor code clean up

### DIFF
--- a/processes/consumer/configs.go
+++ b/processes/consumer/configs.go
@@ -39,12 +39,10 @@ type TopicConfigFormatter struct {
 }
 
 func commitOffset(ctx context.Context, topic string, partitionsToOffset map[string][]artie.Message) error {
-	var err error
 	for _, msgs := range partitionsToOffset {
 		for _, msg := range msgs {
 			if msg.KafkaMsg != nil {
-				err = topicToConsumer.Get(topic).CommitMessages(ctx, *msg.KafkaMsg)
-				if err != nil {
+				if err := topicToConsumer.Get(topic).CommitMessages(ctx, *msg.KafkaMsg); err != nil {
 					return err
 				}
 			}
@@ -55,5 +53,5 @@ func commitOffset(ctx context.Context, topic string, partitionsToOffset map[stri
 		}
 	}
 
-	return err
+	return nil
 }

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -116,12 +116,13 @@ func StartConsumer(ctx context.Context, cfg config.Config, inMemDB *models.Datab
 				}
 
 				msg := artie.NewMessage(&kafkaMsg, nil, kafkaMsg.Topic)
-				tableName, processErr := ProcessMessage(ctx, cfg, inMemDB, dest, metricsClient, ProcessArgs{
+				args := processArgs{
 					Msg:                    msg,
 					GroupID:                kafkaConsumer.Config().GroupID,
 					TopicToConfigFormatMap: tcFmtMap,
-				})
+				}
 
+				tableName, processErr := args.process(ctx, cfg, inMemDB, dest, metricsClient)
 				msg.EmitIngestionLag(metricsClient, cfg.Mode, kafkaConsumer.Config().GroupID, tableName)
 				msg.EmitRowLag(metricsClient, cfg.Mode, kafkaConsumer.Config().GroupID, tableName)
 				if processErr != nil {

--- a/processes/consumer/pubsub.go
+++ b/processes/consumer/pubsub.go
@@ -94,12 +94,13 @@ func StartSubscriber(ctx context.Context, cfg config.Config, inMemDB *models.Dat
 						slog.String("value", string(msg.Value())),
 					}
 
-					tableName, processErr := ProcessMessage(ctx, cfg, inMemDB, dest, metricsClient, ProcessArgs{
+					args := processArgs{
 						Msg:                    msg,
 						GroupID:                subName,
 						TopicToConfigFormatMap: tcFmtMap,
-					})
+					}
 
+					tableName, processErr := args.process(ctx, cfg, inMemDB, dest, metricsClient)
 					msg.EmitIngestionLag(metricsClient, cfg.Mode, subName, tableName)
 					if processErr != nil {
 						slog.With(logFields...).Warn("Skipping message...", slog.Any("err", processErr))


### PR DESCRIPTION
## Changes

We previously made `ProcessMessage(...)` public for Reader to import this function and directly call it from its codebase. However, this is at the wrong level. Reader would need to add additional overhead of marshaling the raw message into a Kafka message just to unmarshall it back out.

As such, I've changed the function back to private and made it slightly more idiomatic towards Go by having receiver methods.
