### PR TITLE
Explicitly pass in create temporary table flag

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -36,9 +36,8 @@ type Store struct {
 	db.Store
 }
 
-func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, _ types.AdditionalSettings) error {
-	// Create a temporary table
-	if tableData.Mode() != config.History {
+func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, _ types.AdditionalSettings, createTempTable bool) error {
+	if createTempTable {
 		tempAlterTableArgs := ddl.AlterTableArgs{
 			Dwh:               s,
 			Tc:                tableConfig,

--- a/clients/mssql/staging.go
+++ b/clients/mssql/staging.go
@@ -3,8 +3,6 @@ package mssql
 import (
 	"fmt"
 
-	"github.com/artie-labs/transfer/lib/config"
-
 	mssql "github.com/microsoft/go-mssqldb"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -13,8 +11,8 @@ import (
 	"github.com/artie-labs/transfer/lib/optimization"
 )
 
-func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, _ types.AdditionalSettings) error {
-	if tableData.Mode() != config.History {
+func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, _ types.AdditionalSettings, createTempTable bool) error {
+	if createTempTable {
 		tempAlterTableArgs := ddl.AlterTableArgs{
 			Dwh:               s,
 			Tc:                tableConfig,

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -15,7 +15,8 @@ import (
 	"github.com/artie-labs/transfer/lib/s3lib"
 )
 
-func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, _ types.AdditionalSettings) error {
+func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, _ types.AdditionalSettings, _ bool) error {
+	// Redshift always creates a temporary table.
 	tempAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:               s,
 		Tc:                tableConfig,

--- a/clients/shared/append.go
+++ b/clients/shared/append.go
@@ -57,5 +57,5 @@ func Append(dwh destination.DataWarehouse, tableData *optimization.TableData, cf
 		AdditionalCopyClause: opts.AdditionalCopyClause,
 	}
 
-	return dwh.PrepareTemporaryTable(tableData, tableConfig, opts.TempTableName, additionalSettings)
+	return dwh.PrepareTemporaryTable(tableData, tableConfig, opts.TempTableName, additionalSettings, false)
 }

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -74,7 +74,7 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, cfg
 	tableConfig.AuditColumnsToDelete(srcKeysMissing)
 	tableData.MergeColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 	temporaryTableName := fmt.Sprintf("%s_%s", dwh.ToFullyQualifiedName(tableData, false), tableData.TempTableSuffix())
-	if err = dwh.PrepareTemporaryTable(tableData, tableConfig, temporaryTableName, types.AdditionalSettings{}); err != nil {
+	if err = dwh.PrepareTemporaryTable(tableData, tableConfig, temporaryTableName, types.AdditionalSettings{}, true); err != nil {
 		return fmt.Errorf("failed to prepare temporary table: %w", err)
 	}
 

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/artie-labs/transfer/lib/config"
-
 	"github.com/artie-labs/transfer/lib/typing/values"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -36,8 +34,8 @@ func castColValStaging(colVal any, colKind columns.Column, additionalDateFmts []
 // 3) Runs PUT to upload CSV to Snowflake staging (auto-compression with GZIP)
 // 4) Runs COPY INTO with the columns specified into temporary table
 // 5) Deletes CSV generated from (2)
-func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, additionalSettings types.AdditionalSettings) error {
-	if tableData.Mode() != config.History {
+func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, additionalSettings types.AdditionalSettings, createTempTable bool) error {
+	if createTempTable {
 		tempAlterTableArgs := ddl.AlterTableArgs{
 			Dwh:               s,
 			Tc:                tableConfig,

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -7,14 +7,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/artie-labs/transfer/lib/typing/values"
-
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/artie-labs/transfer/lib/typing/values"
 )
 
 // castColValStaging - takes `colVal` any and `colKind` typing.Column and converts the value into a string value

--- a/lib/destination/dwh.go
+++ b/lib/destination/dwh.go
@@ -21,7 +21,7 @@ type DataWarehouse interface {
 	IsRetryableError(err error) bool
 	ToFullyQualifiedName(tableData *optimization.TableData, escape bool) string
 	GetTableConfig(tableData *optimization.TableData) (*types.DwhTableConfig, error)
-	PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, additionalSettings types.AdditionalSettings) error
+	PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, additionalSettings types.AdditionalSettings, createTempTable bool) error
 }
 
 type Baseline interface {


### PR DESCRIPTION
Instead of doing a check to see which mode it is to determine whether or not to create a temporary table, we can just have the caller specify it.

* When you run MERGE, you'll want a temporary table.
* When you run APPEND, you don't want a temporary table.[1]

[1] Exception here is Redshift, where you don't want to append directly to the table, you'll want to create a temporary table and then run `ALTER TABLE APPEND` which does a zero copy clone.

By doing this, it allows Reader to call Append for backfills.