### PR TITLE
[debezium] Add `io.debezium.time.MicroDuration` type

### DIFF
--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -100,7 +100,7 @@ func (f Field) ToKindDetails() typing.KindDetails {
 		return typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType)
 	case Date, DateKafkaConnect:
 		return typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType)
-	case Time, TimeMicro, TimeKafkaConnect, TimeWithTimezone:
+	case Time, MicroTime, TimeKafkaConnect, TimeWithTimezone:
 		return typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType)
 	case JSON, GeometryPointType, GeometryType, GeographyType:
 		return typing.Struct

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -280,7 +280,7 @@ func TestField_ToKindDetails(t *testing.T) {
 		{
 			name: "Time Micro",
 			field: Field{
-				DebeziumType: TimeMicro,
+				DebeziumType: MicroTime,
 			},
 			expectedKindDetails: typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType),
 		},

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -26,10 +26,11 @@ const (
 	MicroTimestamp       SupportedDebeziumType = "io.debezium.time.MicroTimestamp"
 	Date                 SupportedDebeziumType = "io.debezium.time.Date"
 	Time                 SupportedDebeziumType = "io.debezium.time.Time"
-	TimeMicro            SupportedDebeziumType = "io.debezium.time.MicroTime"
+	MicroTime            SupportedDebeziumType = "io.debezium.time.MicroTime"
 	Year                 SupportedDebeziumType = "io.debezium.time.Year"
 	TimeWithTimezone     SupportedDebeziumType = "io.debezium.time.ZonedTime"
 	DateTimeWithTimezone SupportedDebeziumType = "io.debezium.time.ZonedTimestamp"
+	MicroDuration        SupportedDebeziumType = "io.debezium.time.MicroDuration"
 	DateKafkaConnect     SupportedDebeziumType = "org.apache.kafka.connect.data.Date"
 	TimeKafkaConnect     SupportedDebeziumType = "org.apache.kafka.connect.data.Time"
 	DateTimeKafkaConnect SupportedDebeziumType = "org.apache.kafka.connect.data.Timestamp"
@@ -50,7 +51,7 @@ var typesThatRequireTypeCasting = []SupportedDebeziumType{
 	MicroTimestamp,
 	Date,
 	Time,
-	TimeMicro,
+	MicroTime,
 	DateKafkaConnect,
 	TimeKafkaConnect,
 	DateTimeKafkaConnect,
@@ -91,7 +92,7 @@ func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ex
 	case Time, TimeKafkaConnect:
 		// Represents the number of milliseconds past midnight, and does not include timezone information.
 		extTime, err = ext.NewExtendedTime(time.UnixMilli(val).In(time.UTC), ext.TimeKindType, "")
-	case TimeMicro:
+	case MicroTime:
 		// Represents the number of microseconds past midnight, and does not include timezone information.
 		extTime, err = ext.NewExtendedTime(time.UnixMicro(val).In(time.UTC), ext.TimeKindType, "")
 	default:


### PR DESCRIPTION
Also renamed `TimeMicro` to `MicroTime` for consistency.