### PR TITLE
[debezium] Support decoding decimals from `[]byte`

### DIFF
--- a/lib/cdc/util/parse.go
+++ b/lib/cdc/util/parse.go
@@ -32,7 +32,11 @@ func parseField(field debezium.Field, value any) (any, error) {
 		case debezium.GeometryPointType:
 			return parseGeometryPoint(value)
 		case debezium.KafkaDecimalType:
-			return field.DecodeDecimal(fmt.Sprint(value))
+			bytes, err := debezium.ToBytes(value)
+			if err != nil {
+				return nil, nil
+			}
+			return field.DecodeDecimal(bytes)
 		case debezium.KafkaVariableNumericType:
 			return field.DecodeDebeziumVariableDecimal(value)
 		default:

--- a/lib/cdc/util/parse.go
+++ b/lib/cdc/util/parse.go
@@ -34,7 +34,7 @@ func parseField(field debezium.Field, value any) (any, error) {
 		case debezium.KafkaDecimalType:
 			bytes, err := debezium.ToBytes(value)
 			if err != nil {
-				return nil, nil
+				return nil, err
 			}
 			return field.DecodeDecimal(bytes)
 		case debezium.KafkaVariableNumericType:

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -68,12 +68,12 @@ func DecodeDecimal(data []byte, precision *int, scale int) (*decimal.Decimal, er
 	bigFloat := new(big.Float).SetInt(bigInt)
 
 	// Compute divisor as 10^scale with big.Int's Exp, then convert to big.Float
-	scaleInt := big.NewInt(int64(scale))
+	scaleInt := big.NewInt(int64(results.Scale))
 	ten := big.NewInt(10)
 	divisorInt := new(big.Int).Exp(ten, scaleInt, nil)
 	divisorFloat := new(big.Float).SetInt(divisorInt)
 
 	// Perform the division
 	bigFloat.Quo(bigFloat, divisorFloat)
-	return decimal.NewDecimal(precision, scale, bigFloat), nil
+	return decimal.NewDecimal(results.Precision, results.Scale, bigFloat), nil
 }

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -68,12 +68,12 @@ func DecodeDecimal(data []byte, precision *int, scale int) (*decimal.Decimal, er
 	bigFloat := new(big.Float).SetInt(bigInt)
 
 	// Compute divisor as 10^scale with big.Int's Exp, then convert to big.Float
-	scaleInt := big.NewInt(int64(results.Scale))
+	scaleInt := big.NewInt(int64(scale))
 	ten := big.NewInt(10)
 	divisorInt := new(big.Int).Exp(ten, scaleInt, nil)
 	divisorFloat := new(big.Float).SetInt(divisorInt)
 
 	// Perform the division
 	bigFloat.Quo(bigFloat, divisorFloat)
-	return decimal.NewDecimal(results.Precision, results.Scale, bigFloat), nil
+	return decimal.NewDecimal(precision, scale, bigFloat), nil
 }

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -46,7 +46,7 @@ func EncodeDecimal(value string, scale int) []byte {
 }
 
 // DecodeDecimal is used to decode `org.apache.kafka.connect.data.Decimal`.
-func DecodeDecimal(data []byte, precision *int, scale int) (*decimal.Decimal, error) {
+func DecodeDecimal(data []byte, precision *int, scale int) *decimal.Decimal {
 	bigInt := new(big.Int)
 
 	// If the data represents a negative number, the sign bit will be set.
@@ -75,5 +75,5 @@ func DecodeDecimal(data []byte, precision *int, scale int) (*decimal.Decimal, er
 
 	// Perform the division
 	bigFloat.Quo(bigFloat, divisorFloat)
-	return decimal.NewDecimal(precision, scale, bigFloat), nil
+	return decimal.NewDecimal(precision, scale, bigFloat)
 }

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -6,6 +6,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 )
 
+// EncodeDecimal is used to encode a string representation of a number to `org.apache.kafka.connect.data.Decimal`.
 func EncodeDecimal(value string, scale int) []byte {
 	scaledValue := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
 	bigFloatValue := new(big.Float)
@@ -44,11 +45,7 @@ func EncodeDecimal(value string, scale int) []byte {
 	return data
 }
 
-// DecodeDecimal is used to handle `org.apache.kafka.connect.data.Decimal` where this would be emitted by Debezium when the `decimal.handling.mode` is `precise`
-// * Data - takes a slice of bytes
-// * Parameters - which contains:
-//   - `scale` (number of digits following decimal point)
-//   - `connect.decimal.precision` which is an optional parameter. (If -1, then it's variable and .Value() will be in STRING).
+// DecodeDecimal is used to decode `org.apache.kafka.connect.data.Decimal`.
 func DecodeDecimal(data []byte, precision *int, scale int) (*decimal.Decimal, error) {
 	bigInt := new(big.Int)
 

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -1,0 +1,82 @@
+package debezium
+
+import (
+	"math/big"
+
+	"github.com/artie-labs/transfer/lib/typing/decimal"
+)
+
+func EncodeDecimal(value string, scale int) []byte {
+	scaledValue := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
+	bigFloatValue := new(big.Float)
+	bigFloatValue.SetString(value)
+	bigFloatValue.Mul(bigFloatValue, new(big.Float).SetInt(scaledValue))
+
+	// Extract the scaled integer value.
+	bigIntValue, _ := bigFloatValue.Int(nil)
+	data := bigIntValue.Bytes()
+	if bigIntValue.Sign() < 0 {
+		// Convert to two's complement if the number is negative
+		bigIntValue = bigIntValue.Neg(bigIntValue)
+		data = bigIntValue.Bytes()
+
+		// Inverting bits for two's complement.
+		for i := range data {
+			data[i] = ^data[i]
+		}
+
+		// Adding one to complete two's complement.
+		twoComplement := new(big.Int).SetBytes(data)
+		twoComplement.Add(twoComplement, big.NewInt(1))
+
+		data = twoComplement.Bytes()
+		if data[0]&0x80 == 0 {
+			// 0xff is -1 in Java
+			// https://stackoverflow.com/questions/1677957/why-byte-b-byte-0xff-is-equals-to-integer-1
+			data = append([]byte{0xff}, data...)
+		}
+	} else {
+		// For positive values, prepend a zero if the highest bit is set to ensure it's interpreted as positive.
+		if len(data) > 0 && data[0]&0x80 != 0 {
+			data = append([]byte{0x00}, data...)
+		}
+	}
+	return data
+}
+
+// DecodeDecimal is used to handle `org.apache.kafka.connect.data.Decimal` where this would be emitted by Debezium when the `decimal.handling.mode` is `precise`
+// * Data - takes a slice of bytes
+// * Parameters - which contains:
+//   - `scale` (number of digits following decimal point)
+//   - `connect.decimal.precision` which is an optional parameter. (If -1, then it's variable and .Value() will be in STRING).
+func DecodeDecimal(data []byte, precision *int, scale int) (*decimal.Decimal, error) {
+	bigInt := new(big.Int)
+
+	// If the data represents a negative number, the sign bit will be set.
+	if len(data) > 0 && data[0] >= 0x80 {
+		// To convert the data to a two's complement integer, we need to invert the bytes and add one.
+		for i := range data {
+			data[i] = ^data[i]
+		}
+
+		bigInt.SetBytes(data)
+		// We are adding this because Debezium (Java) encoded this value and uses two's complement binary representation for negative numbers
+		bigInt.Add(bigInt, big.NewInt(1))
+		bigInt.Neg(bigInt)
+	} else {
+		bigInt.SetBytes(data)
+	}
+
+	// Convert the big integer to a big float
+	bigFloat := new(big.Float).SetInt(bigInt)
+
+	// Compute divisor as 10^scale with big.Int's Exp, then convert to big.Float
+	scaleInt := big.NewInt(int64(scale))
+	ten := big.NewInt(10)
+	divisorInt := new(big.Int).Exp(ten, scaleInt, nil)
+	divisorFloat := new(big.Float).SetInt(divisorInt)
+
+	// Perform the division
+	bigFloat.Quo(bigFloat, divisorFloat)
+	return decimal.NewDecimal(precision, scale, bigFloat), nil
+}

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -1,0 +1,77 @@
+package debezium
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeDecimal(t *testing.T) {
+	type _tc struct {
+		name  string
+		value string
+		scale int
+	}
+
+	tcs := []_tc{
+		{
+			name:  "0 scale",
+			value: "5",
+		},
+		{
+			name:  "2 scale",
+			value: "23131319.99",
+			scale: 2,
+		},
+		{
+			name:  "5 scale",
+			value: "9.12345",
+			scale: 5,
+		},
+		{
+			name:  "negative number",
+			value: "-105.2813669",
+			scale: 7,
+		},
+		// Longitude #1
+		{
+			name:  "long 1",
+			value: "-75.765611",
+			scale: 6,
+		},
+		// Latitude #1
+		{
+			name:  "lat",
+			value: "40.0335495",
+			scale: 7,
+		},
+		// Long #2
+		{
+			name:  "long 2",
+			value: "-119.65575",
+			scale: 5,
+		},
+		{
+			name:  "lat 2",
+			value: "36.3303",
+			scale: 4,
+		},
+		{
+			name:  "long 3",
+			value: "-81.76254098",
+			scale: 8,
+		},
+		{
+			name:  "amount",
+			value: "6408.355",
+			scale: 3,
+		},
+	}
+
+	for _, tc := range tcs {
+		actualEncodedValue := EncodeDecimal(tc.value, tc.scale)
+		decodedValue, err := DecodeDecimal(actualEncodedValue, nil, tc.scale)
+		assert.NoError(t, err, tc.name)
+		assert.Equal(t, tc.value, decodedValue.String(), tc.name)
+	}
+}

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -69,9 +69,8 @@ func TestEncodeDecimal(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		actualEncodedValue := EncodeDecimal(tc.value, tc.scale)
-		decodedValue, err := DecodeDecimal(actualEncodedValue, nil, tc.scale)
-		assert.NoError(t, err, tc.name)
+		encodedValue := EncodeDecimal(tc.value, tc.scale)
+		decodedValue := DecodeDecimal(encodedValue, nil, tc.scale)
 		assert.Equal(t, tc.value, decodedValue.String(), tc.name)
 	}
 }

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -87,9 +87,9 @@ func ToBytes(value any) ([]byte, error) {
 		stringVal = typedValue
 	default:
 		// TODO: Make this a hard error if we don't observe this happening.
-		slog.Error("Expected string/[]byte, falling back to string",
+		slog.Error("Expected string/[]byte, falling back to fmt.Sprint(value)",
 			slog.String("type", fmt.Sprintf("%T", value)),
-			slog.Any("value", fmt.Sprintf("%T", value)),
+			slog.Any("value", value),
 		)
 		stringVal = fmt.Sprint(value)
 	}

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -148,7 +148,7 @@ func (f Field) DecodeDecimal(encoded []byte) (*decimal.Decimal, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get scale and/or precision: %w", err)
 	}
-	return DecodeDecimal(encoded, results.Precision, results.Scale)
+	return DecodeDecimal(encoded, results.Precision, results.Scale), nil
 }
 
 func (f Field) DecodeDebeziumVariableDecimal(value any) (*decimal.Decimal, error) {

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -139,6 +139,11 @@ func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ex
 	return extTime, err
 }
 
+// DecodeDecimal is used to handle `org.apache.kafka.connect.data.Decimal` where this would be emitted by Debezium when the `decimal.handling.mode` is `precise`
+// * Data - takes a slice of bytes
+// * Parameters - which contains:
+//   - `scale` (number of digits following decimal point)
+//   - `connect.decimal.precision` which is an optional parameter. (If -1, then it's variable and .Value() will be in STRING).
 func (f Field) DecodeDecimal(encoded []byte) (*decimal.Decimal, error) {
 	results, err := f.GetScaleAndPrecision()
 	if err != nil {

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -73,7 +73,7 @@ func RequiresSpecialTypeCasting(typeLabel SupportedDebeziumType) (bool, Supporte
 	return false, Invalid
 }
 
-// toBytes attempts to convert a value of unknown type to a slice of bytes.
+// ToBytes attempts to convert a value of unknown type to a slice of bytes.
 // - If value is already a slice of bytes it will be directly returned.
 // - If value is a string we will attempt to base64 decode it.
 // - If value is any other type we will convert it to a string and then attempt to base64 decode it.

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -172,6 +172,7 @@ func (f Field) DecodeDebeziumVariableDecimal(value any) (*decimal.Decimal, error
 		return nil, err
 	}
 
+	// TODO: Could probably just call [DecodeDecimal] directly with scale and -1.
 	f.Parameters = map[string]any{
 		"scale":                  scale,
 		KafkaDecimalPrecisionKey: "-1",

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -140,7 +140,7 @@ func FromDebeziumTypeToTime(supportedType SupportedDebeziumType, val int64) (*ex
 }
 
 // DecodeDecimal is used to handle `org.apache.kafka.connect.data.Decimal` where this would be emitted by Debezium when the `decimal.handling.mode` is `precise`
-// * Data - takes a slice of bytes
+// * Encoded - takes the encoded value as a slice of bytes
 // * Parameters - which contains:
 //   - `scale` (number of digits following decimal point)
 //   - `connect.decimal.precision` which is an optional parameter. (If -1, then it's variable and .Value() will be in STRING).

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -78,14 +78,14 @@ func RequiresSpecialTypeCasting(typeLabel SupportedDebeziumType) (bool, Supporte
 // - If value is a string we will attempt to base64 decode it.
 // - If value is any other type we will convert it to a string and then attempt to base64 decode it.
 func ToBytes(value any) ([]byte, error) {
-	if bytes, ok := value.([]byte); ok {
-		return bytes, nil
-	}
-
 	var stringVal string
-	if str, ok := value.(string); ok {
-		stringVal = str
-	} else {
+
+	switch typedValue := value.(type) {
+	case []byte:
+		return typedValue, nil
+	case string:
+		stringVal = typedValue
+	default:
 		// TODO: Make this a hard error if we don't observe this happening.
 		slog.Error("Expected string/[]byte, falling back to string",
 			slog.String("type", fmt.Sprintf("%T", value)),

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 
 	"github.com/artie-labs/transfer/lib/maputil"
@@ -173,5 +172,10 @@ func (f Field) DecodeDebeziumVariableDecimal(value any) (*decimal.Decimal, error
 		return nil, err
 	}
 
-	return DecodeDecimal(bytes, ptr.ToInt(-1), scale)
+	f.Parameters = map[string]any{
+		"scale":                  scale,
+		KafkaDecimalPrecisionKey: "-1",
+	}
+
+	return f.DecodeDecimal(bytes)
 }

--- a/lib/debezium/types_bench_test.go
+++ b/lib/debezium/types_bench_test.go
@@ -15,7 +15,9 @@ func BenchmarkDecodeDecimal_P64_S10(b *testing.B) {
 	}
 	field := Field{Parameters: parameters}
 	for i := 0; i < b.N; i++ {
-		dec, err := field.DecodeDecimal("AwBGAw8m9GLXrCGifrnVP/8jPHrNEtd1r4rS")
+		bytes, err := ToBytes("AwBGAw8m9GLXrCGifrnVP/8jPHrNEtd1r4rS")
+		assert.NoError(b, err)
+		dec, err := field.DecodeDecimal(bytes)
 		assert.NoError(b, err)
 		assert.Equal(b, "123456789012345678901234567890123456789012345678901234.1234567889", dec.Value())
 		require.NoError(b, err)
@@ -29,7 +31,9 @@ func BenchmarkDecodeDecimal_P38_S2(b *testing.B) {
 	}
 	field := Field{Parameters: parameters}
 	for i := 0; i < b.N; i++ {
-		dec, err := field.DecodeDecimal(`AMCXznvJBxWzS58P/////w==`)
+		bytes, err := ToBytes(`AMCXznvJBxWzS58P/////w==`)
+		assert.NoError(b, err)
+		dec, err := field.DecodeDecimal(bytes)
 		assert.NoError(b, err)
 		assert.Equal(b, "9999999999999999999999999999999999.99", dec.String())
 	}
@@ -43,7 +47,9 @@ func BenchmarkDecodeDecimal_P5_S2(b *testing.B) {
 
 	field := Field{Parameters: parameters}
 	for i := 0; i < b.N; i++ {
-		dec, err := field.DecodeDecimal(`AOHJ`)
+		bytes, err := ToBytes(`AOHJ`)
+		assert.NoError(b, err)
+		dec, err := field.DecodeDecimal(bytes)
 		assert.NoError(b, err)
 		assert.Equal(b, "578.01", dec.String())
 	}

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -293,7 +293,7 @@ func TestDecodeDebeziumVariableDecimal(t *testing.T) {
 			value: map[string]any{
 				"scale": "foo",
 			},
-			expectedErr: "key: scale is not type integer:",
+			expectedErr: "key: scale is not type integer",
 		},
 		{
 			name: "value exists (scale 3)",

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -20,8 +20,8 @@ func TestToBytes(t *testing.T) {
 	testCases := []_testCase{
 		{
 			name:          "[]byte",
-			value:         []byte{byte(40), byte(39), byte(38)},
-			expectedValue: []byte{byte(40), byte(39), byte(38)},
+			value:         []byte{40, 39, 38},
+			expectedValue: []byte{40, 39, 38},
 		},
 		{
 			name:          "base64 encoded string",

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -270,29 +270,30 @@ func TestDecodeDecimal(t *testing.T) {
 
 func TestDecodeDebeziumVariableDecimal(t *testing.T) {
 	type _testCase struct {
-		name        string
-		value       any
-		expectValue string
-		expectError string
-		expectScale int
+		name  string
+		value any
+
+		expectedValue string
+		expectedScale int
+		expectedErr   string
 	}
 
 	testCases := []_testCase{
 		{
 			name:        "empty val (nil)",
-			expectError: "value is not map[string]any type",
+			expectedErr: "value is not map[string]any type",
 		},
 		{
 			name:        "empty map",
 			value:       map[string]any{},
-			expectError: "object is empty",
+			expectedErr: "object is empty",
 		},
 		{
 			name: "scale is not an integer",
 			value: map[string]any{
 				"scale": "foo",
 			},
-			expectError: "key: scale is not type integer:",
+			expectedErr: "key: scale is not type integer:",
 		},
 		{
 			name: "value exists (scale 3)",
@@ -300,8 +301,8 @@ func TestDecodeDebeziumVariableDecimal(t *testing.T) {
 				"scale": 3,
 				"value": "SOx4FQ==",
 			},
-			expectValue: "1223456.789",
-			expectScale: 3,
+			expectedValue: "1223456.789",
+			expectedScale: 3,
 		},
 		{
 			name: "value exists (scale 2)",
@@ -309,8 +310,8 @@ func TestDecodeDebeziumVariableDecimal(t *testing.T) {
 				"scale": 2,
 				"value": "MDk=",
 			},
-			expectValue: "123.45",
-			expectScale: 2,
+			expectedValue: "123.45",
+			expectedScale: 2,
 		},
 		{
 			name: "negative numbers (scale 7)",
@@ -318,8 +319,8 @@ func TestDecodeDebeziumVariableDecimal(t *testing.T) {
 				"scale": 7,
 				"value": "wT9Wmw==",
 			},
-			expectValue: "-105.2813669",
-			expectScale: 7,
+			expectedValue: "-105.2813669",
+			expectedScale: 7,
 		},
 		{
 			name: "malformed base64 value",
@@ -327,7 +328,7 @@ func TestDecodeDebeziumVariableDecimal(t *testing.T) {
 				"scale": 7,
 				"value": "==wT9Wmw==",
 			},
-			expectError: "failed to base64 decode",
+			expectedErr: "failed to base64 decode",
 		},
 		{
 			name: "[]byte value",
@@ -335,16 +336,16 @@ func TestDecodeDebeziumVariableDecimal(t *testing.T) {
 				"scale": 7,
 				"value": []byte{193, 63, 86, 155},
 			},
-			expectValue: "-105.2813669",
-			expectScale: 7,
+			expectedValue: "-105.2813669",
+			expectedScale: 7,
 		},
 	}
 
 	for _, testCase := range testCases {
 		field := Field{}
 		dec, err := field.DecodeDebeziumVariableDecimal(testCase.value)
-		if testCase.expectError != "" {
-			assert.ErrorContains(t, err, testCase.expectError, testCase.name)
+		if testCase.expectedErr != "" {
+			assert.ErrorContains(t, err, testCase.expectedErr, testCase.name)
 			continue
 		}
 
@@ -356,8 +357,8 @@ func TestDecodeDebeziumVariableDecimal(t *testing.T) {
 		_, isOk = dec.Value().(string)
 		assert.True(t, isOk, testCase.name)
 		assert.Equal(t, -1, *dec.Precision(), testCase.name)
-		assert.Equal(t, testCase.expectScale, dec.Scale(), testCase.name)
-		assert.Equal(t, testCase.expectValue, dec.Value(), testCase.name)
+		assert.Equal(t, testCase.expectedScale, dec.Scale(), testCase.name)
+		assert.Equal(t, testCase.expectedValue, dec.Value(), testCase.name)
 	}
 
 }

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -8,6 +8,49 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestToBytes(t *testing.T) {
+	type _testCase struct {
+		name  string
+		value any
+
+		expectedValue []byte
+		expectedErr   string
+	}
+
+	testCases := []_testCase{
+		{
+			name:          "[]byte",
+			value:         []byte{byte(40), byte(39), byte(38)},
+			expectedValue: []byte{byte(40), byte(39), byte(38)},
+		},
+		{
+			name:          "base64 encoded string",
+			value:         "aGVsbG8gd29ybGQK",
+			expectedValue: []byte{0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0xa},
+		},
+		{
+			name:        "malformed string",
+			value:       "asdf$$$",
+			expectedErr: "failed to base64 decode",
+		},
+		{
+			name:        "type that isn't a string or []byte",
+			value:       map[string]any{},
+			expectedErr: "failed to base64 decode",
+		},
+	}
+
+	for _, testCase := range testCases {
+		actual, err := ToBytes(testCase.value)
+
+		if testCase.expectedErr == "" {
+			assert.Equal(t, testCase.expectedValue, actual, testCase.name)
+		} else {
+			assert.ErrorContains(t, err, testCase.expectedErr, testCase.name)
+		}
+	}
+}
+
 func TestFromDebeziumTypeToTime(t *testing.T) {
 	dt, err := FromDebeziumTypeToTime(Date, int64(19401))
 	assert.Equal(t, "2023-02-13", dt.String(""))

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -201,7 +201,10 @@ func TestDecodeDecimal(t *testing.T) {
 			Parameters: testCase.params,
 		}
 
-		dec, err := field.DecodeDecimal(testCase.encoded)
+		bytes, err := ToBytes(testCase.encoded)
+		assert.NoError(t, err)
+
+		dec, err := field.DecodeDecimal(bytes)
 		if testCase.expectError {
 			assert.Error(t, err, testCase.name)
 			continue


### PR DESCRIPTION
- Support decoding decimals that are either `string` or `[]byte`
- Pull out the logic from `Field.DecodeDecimal` to a new function in `lib/debezium/decimal`
- Add `EncodeDecimal` [from reader](https://github.com/artie-labs/reader/blob/529d2f3181db4586c97be641ad3f520a0ed9ea27/lib/debezium/converters/decimal.go#L11) so that `reader` can just import it and the encoder can live next to the decoder