### PR TITLE
Pull out jitter upper bounds computation

### DIFF
--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-const DefaultMaxMs = int64(3500)
+const DefaultMaxMs = 3500
 
 func computeJitterUpperBoundMs(baseMs, maxMs, attempts int) int {
 	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/

--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -5,14 +5,14 @@ import (
 	"time"
 )
 
-const DefaultMaxMs = 3500
+const DefaultMaxMs = int64(3500)
 
-func Jitter(baseMs, maxMs, attempts int) time.Duration {
+func computeJitterUpperBoundMs(baseMs, maxMs, attempts int) int {
 	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 	// sleep = random_between(0, min(cap, base * 2 ** attempt))
 	// 2 ** x == 1 << x
 	if maxMs <= 0 {
-		return time.Duration(0)
+		return 0
 	}
 
 	// Check for overflows when computing base * 2 ** attempts.
@@ -20,6 +20,13 @@ func Jitter(baseMs, maxMs, attempts int) time.Duration {
 		maxMs = min(maxMs, attemptsMaxMs)
 	}
 
-	ms := rand.Intn(maxMs)
-	return time.Duration(ms) * time.Millisecond
+	return maxMs
+}
+
+func Jitter(baseMs, maxMs, attempts int) time.Duration {
+	upperBoundMs := computeJitterUpperBoundMs(baseMs, maxMs, attempts)
+	if upperBoundMs <= 0 {
+		return time.Duration(0)
+	}
+	return time.Duration(rand.Intn(upperBoundMs)) * time.Millisecond
 }

--- a/lib/jitter/sleep_test.go
+++ b/lib/jitter/sleep_test.go
@@ -8,12 +8,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestComputeJitterUpperBoundMs(t *testing.T) {
+	// A maxMs that is <= 0 returns 0.
+	assert.Equal(t, 0, computeJitterUpperBoundMs(0, 0, 0))
+	assert.Equal(t, 0, computeJitterUpperBoundMs(10, 0, 0))
+	assert.Equal(t, 0, computeJitterUpperBoundMs(10, 0, 100))
+	assert.Equal(t, 0, computeJitterUpperBoundMs(10, -1, 0))
+	assert.Equal(t, 0, computeJitterUpperBoundMs(10, -1, 100))
+
+	// Increasing attempts with a baseMs of 10 and essentially no maxMs.
+	assert.Equal(t, 10, computeJitterUpperBoundMs(10, math.MaxInt, 0))
+	assert.Equal(t, 20, computeJitterUpperBoundMs(10, math.MaxInt, 1))
+	assert.Equal(t, 40, computeJitterUpperBoundMs(10, math.MaxInt, 2))
+	assert.Equal(t, 80, computeJitterUpperBoundMs(10, math.MaxInt, 3))
+	assert.Equal(t, 160, computeJitterUpperBoundMs(10, math.MaxInt, 4))
+
+	// Large inputs do not panic.
+	assert.Equal(t, 100, computeJitterUpperBoundMs(10, 100, 200))
+	assert.Equal(t, 100, computeJitterUpperBoundMs(10, 100, math.MaxInt))
+	assert.Equal(t, math.MaxInt, computeJitterUpperBoundMs(math.MaxInt, math.MaxInt, math.MaxInt))
+}
+
 func TestJitter(t *testing.T) {
-	// maxMs <= 0 returns time.Duration(0)
-	assert.Equal(t, time.Duration(0), Jitter(10, 0, 0))
-	assert.Equal(t, time.Duration(0), Jitter(10, 0, 100))
-	assert.Equal(t, time.Duration(0), Jitter(10, -1, 0))
-	assert.Equal(t, time.Duration(0), Jitter(10, -1, 100))
+	// An upper bounds of 0 does not cause a [rand.Intn] panic.
+	assert.Equal(t, time.Duration(0), Jitter(0, 0, 0))
+	assert.Equal(t, time.Duration(0), Jitter(-1, -1, -1))
 
 	{
 		// A large number of attempts does not panic.


### PR DESCRIPTION
This way we can test the upper bound values before they pass through `rand.Intn`.