### PR TITLE
Clean up `computeJitterUpperBoundMs`

### DIFF
--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -15,7 +15,7 @@ func safePowerOfTwo(n int64) int64 {
 	} else if n > 62 {
 		return math.MaxInt64 // 2 ** n will overflow
 	}
-	return 1 << n // 2 ** n == 1 << n
+	return 1 << n // equal to 2 ** n
 }
 
 // computeJitterUpperBoundMs calculates min(maxMs, baseMs * 2 ** attempt).

--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -13,8 +13,7 @@ func safePowerOfTwo(n int64) int64 {
 	if n < 0 {
 		return 0
 	} else if n > 62 {
-		// 2 ** n will overflow, return [math.MaxInt64] instead.
-		return math.MaxInt64
+		return math.MaxInt64 // 2 ** n will overflow
 	}
 	return 1 << n // 2 ** n == 1 << n
 }

--- a/lib/jitter/sleep.go
+++ b/lib/jitter/sleep.go
@@ -1,11 +1,23 @@
 package jitter
 
 import (
+	"math"
 	"math/rand"
 	"time"
 )
 
 const DefaultMaxMs = 3500
+
+// safePowerOfTwo calculates 2 ** n without panicking for values of n below 0 or above 62.
+func safePowerOfTwo(n int64) int64 {
+	if n < 0 {
+		return 0
+	} else if n > 62 {
+		// 2 ** n will overflow, return [math.MaxInt64] instead.
+		return math.MaxInt64
+	}
+	return 1 << n // 2 ** n == 1 << n
+}
 
 // computeJitterUpperBoundMs calculates min(maxMs, baseMs * 2 ** attempt).
 func computeJitterUpperBoundMs(baseMs, maxMs, attempts int64) int64 {
@@ -13,13 +25,11 @@ func computeJitterUpperBoundMs(baseMs, maxMs, attempts int64) int64 {
 		return 0
 	}
 
-	// Check for overflows when computing base * 2 ** attempts.
-	// 2 ** x == 1 << x
-	if attemptsMaxMs := baseMs * (1 << attempts); attemptsMaxMs > 0 {
-		maxMs = min(maxMs, attemptsMaxMs)
+	powerOfTwo := safePowerOfTwo(attempts)
+	if powerOfTwo > math.MaxInt64/baseMs { // check for overflow
+		return maxMs
 	}
-
-	return maxMs
+	return min(maxMs, baseMs*powerOfTwo)
 }
 
 // Jitter implements exponential backoff + jitter.

--- a/lib/jitter/sleep_test.go
+++ b/lib/jitter/sleep_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSafePowerOfTwo(t *testing.T) {
+	assert.Equal(t, int64(0), safePowerOfTwo(-2))
+	assert.Equal(t, int64(0), safePowerOfTwo(-1))
+	assert.Equal(t, int64(1), safePowerOfTwo(0))
+	assert.Equal(t, int64(2), safePowerOfTwo(1))
+	assert.Equal(t, int64(4), safePowerOfTwo(2))
+	assert.Equal(t, int64(4611686018427387904), safePowerOfTwo(62))
+	assert.Equal(t, int64(math.MaxInt64), safePowerOfTwo(63))
+	assert.Equal(t, int64(math.MaxInt64), safePowerOfTwo(64))
+	assert.Equal(t, int64(math.MaxInt64), safePowerOfTwo(100))
+}
+
 func TestComputeJitterUpperBoundMs(t *testing.T) {
 	// A maxMs that is <= 0 returns 0.
 	assert.Equal(t, int64(0), computeJitterUpperBoundMs(0, 0, 0))


### PR DESCRIPTION
Inspired by https://github.com/artie-labs/transfer/pull/397, adds a function to safely compute a power of two.