### PR TITLE
[Redshift] Improve Sweep query

### DIFF
--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -73,6 +73,7 @@ func (s *Store) Sweep() error {
 		return err
 	}
 
+	// `relkind` will filter for only ordinary tables and exclude sequences, views, etc.
 	queryFunc := func(dbAndSchemaPair kafkalib.DatabaseSchemaPair) (string, []any) {
 		return `
 SELECT 
@@ -82,7 +83,7 @@ FROM
 JOIN 
     PG_CATALOG.PG_NAMESPACE n ON n.oid = c.relnamespace
 WHERE 
-    n.nspname = $1 AND c.relname ILIKE $2;`, []any{dbAndSchemaPair.Schema, "%" + constants.ArtiePrefix + "%"}
+    n.nspname = $1 AND c.relname ILIKE $2 AND c.relkind = 'r';`, []any{dbAndSchemaPair.Schema, "%" + constants.ArtiePrefix + "%"}
 	}
 
 	return shared.Sweep(s, tcs, queryFunc)

--- a/lib/destination/ddl/expiry.go
+++ b/lib/destination/ddl/expiry.go
@@ -19,7 +19,7 @@ func ShouldDeleteFromName(name string) bool {
 func shouldDeleteUnix(unixString string) bool {
 	unix, err := strconv.Atoi(unixString)
 	if err != nil {
-		slog.Warn("Failed to parse unix string", slog.Any("err", err), slog.String("unixString", unixString))
+		slog.Error("Failed to parse unix string", slog.Any("err", err), slog.String("unixString", unixString))
 		return false
 	}
 

--- a/lib/destination/ddl/expiry.go
+++ b/lib/destination/ddl/expiry.go
@@ -13,13 +13,10 @@ func ShouldDeleteFromName(name string) bool {
 		return false
 	}
 
-	return shouldDeleteUnix(nameParts[len(nameParts)-1])
-}
-
-func shouldDeleteUnix(unixString string) bool {
+	unixString := nameParts[len(nameParts)-1]
 	unix, err := strconv.Atoi(unixString)
 	if err != nil {
-		slog.Error("Failed to parse unix string", slog.Any("err", err), slog.String("unixString", unixString))
+		slog.Error("Failed to parse unix string", slog.Any("err", err), slog.String("tableName", name), slog.String("unixString", unixString))
 		return false
 	}
 


### PR DESCRIPTION
The current sweep query picks up sequences from the primary key for the temporary table. This PR makes it so that we filter on `relkind`.

Also changing `Failed to parse unix string` to log an error so that we can see it in Sentry.