### PR TITLE
Mongo - Adding getter/setter for `afterMap` and `beforeMap`

### DIFF
--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -151,7 +151,7 @@ func (s *SchemaEventPayload) GetColumns() *columns.Columns {
 
 func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicConfig) map[string]any {
 	var retMap map[string]any
-	if len(s.Payload.afterMap) == 0 {
+	if len(s.Payload.GetAfterMap()) == 0 {
 		// This is a delete event, so mark it as deleted.
 		// And we need to reconstruct the data bit since it will be empty.
 		// We _can_ rely on *before* since even without running replicate identity, it will still copy over
@@ -169,7 +169,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 			retMap[tc.IdempotentKey] = s.GetExecutionTime().Format(ext.ISO8601)
 		}
 	} else {
-		retMap = s.Payload.afterMap
+		retMap = s.Payload.GetAfterMap()
 		// We need this because there's an edge case with Debezium
 		// Where _id gets rewritten as id in the partition key.
 		for k, v := range pkMap {

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -40,7 +40,7 @@ func (d *Debezium) GetEventFromBytes(typingSettings typing.Settings, bytes []byt
 			return nil, err
 		}
 
-		schemaEventPayload.Payload.beforeMap = before
+		schemaEventPayload.Payload.SetBeforeMap(before)
 	}
 
 	if schemaEventPayload.Payload.After != nil {
@@ -62,7 +62,7 @@ func (d *Debezium) GetEventFromBytes(typingSettings typing.Settings, bytes []byt
 			}
 		}
 
-		schemaEventPayload.Payload.afterMap = after
+		schemaEventPayload.Payload.SetAfterMap(after)
 	}
 
 	return &schemaEventPayload, nil

--- a/lib/cdc/mongo/event.go
+++ b/lib/cdc/mongo/event.go
@@ -22,6 +22,22 @@ type Payload struct {
 	afterMap  map[string]any
 }
 
+func (p *Payload) SetAfterMap(afterMap map[string]any) {
+	p.afterMap = afterMap
+}
+
+func (p *Payload) GetAfterMap() map[string]any {
+	return p.afterMap
+}
+
+func (p *Payload) SetBeforeMap(beforeMap map[string]any) {
+	p.beforeMap = beforeMap
+}
+
+func (p *Payload) GetBeforeMap() map[string]any {
+	return p.beforeMap
+}
+
 type Source struct {
 	Connector  string `json:"connector"`
 	TsMs       int64  `json:"ts_ms"`


### PR DESCRIPTION
We need access to these methods in Reader