### PR TITLE
[Relational Data] Include the Before object

### DIFF
--- a/lib/cdc/postgres/debezium.go
+++ b/lib/cdc/postgres/debezium.go
@@ -20,8 +20,7 @@ func (d *Debezium) GetEventFromBytes(_ typing.Settings, bytes []byte) (cdc.Event
 		return nil, fmt.Errorf("empty message")
 	}
 
-	err := json.Unmarshal(bytes, &event)
-	if err != nil {
+	if err := json.Unmarshal(bytes, &event); err != nil {
 		return nil, err
 	}
 

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -130,6 +130,7 @@ func (s *SchemaEventPayload) parseAndMutateMapInPlace(retMap map[string]any, kin
 			if val, parseErr := field.ParseValue(fieldVal); parseErr == nil {
 				retMap[field.FieldName] = val
 			} else {
+				// TODO: Make this a hard failure, confirm this with Datadog logs.
 				slog.Warn("Failed to parse field, using original value", slog.Any("err", parseErr),
 					slog.String("field", field.FieldName), slog.Any("value", fieldVal))
 			}

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -121,17 +121,17 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 func (s *SchemaEventPayload) parseValues(retMap map[string]any, kind cdc.FieldLabelKind) map[string]any {
 	if schemaObject := s.Schema.GetSchemaFromLabel(kind); schemaObject != nil {
 		for _, field := range schemaObject.Fields {
-			_, isOk := retMap[field.FieldName]
+			fieldVal, isOk := retMap[field.FieldName]
 			if !isOk {
 				continue
 			}
 
-			val, parseErr := field.ParseValue(retMap[field.FieldName])
+			val, parseErr := field.ParseValue(fieldVal)
 			if parseErr == nil {
 				retMap[field.FieldName] = val
 			} else {
 				slog.Warn("Failed to parse field, using original value", slog.Any("err", parseErr),
-					slog.String("field", field.FieldName), slog.Any("value", retMap[field.FieldName]))
+					slog.String("field", field.FieldName), slog.Any("value", fieldVal))
 			}
 		}
 	}

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -118,8 +118,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 
 func (s *SchemaEventPayload) parseValues(retMap map[string]any, kind cdc.FieldLabelKind) map[string]any {
 	// Iterate over the schema and identify if there are any fields that require extra care.
-	schemaObject := s.Schema.GetSchemaFromLabel(kind)
-	if schemaObject != nil {
+	if schemaObject := s.Schema.GetSchemaFromLabel(kind); schemaObject != nil {
 		for _, field := range schemaObject.Fields {
 			_, isOk := retMap[field.FieldName]
 			if !isOk {

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -127,8 +127,7 @@ func (s *SchemaEventPayload) parseAndMutateMapInPlace(retMap map[string]any, kin
 				continue
 			}
 
-			val, parseErr := field.ParseValue(fieldVal)
-			if parseErr == nil {
+			if val, parseErr := field.ParseValue(fieldVal); parseErr == nil {
 				retMap[field.FieldName] = val
 			} else {
 				slog.Warn("Failed to parse field, using original value", slog.Any("err", parseErr),

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -82,14 +82,16 @@ func (s *SchemaEventPayload) GetTableName() string {
 func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicConfig) map[string]any {
 	var retMap map[string]any
 	if len(s.Payload.After) == 0 {
+		if len(s.Payload.Before) > 0 {
+			retMap = s.Payload.Before
+		} else {
+			retMap = make(map[string]any)
+		}
 		// This is a delete payload, so mark it as deleted.
 		// And we need to reconstruct the data bit since it will be empty.
 		// We _can_ rely on *before* since even without running replicate identity, it will still copy over
 		// the PK. We can explore simplifying this interface in the future by leveraging before.
-		retMap = map[string]any{
-			constants.DeleteColumnMarker: true,
-		}
-
+		retMap[constants.DeleteColumnMarker] = true
 		for k, v := range pkMap {
 			retMap[k] = v
 		}

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -116,13 +116,13 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 	return retMap
 }
 
+// parseValues will take `retMap` and `kind` (which part of the schema should we be inspecting) and then parse the values accordingly.
+// This will unpack any Debezium-specific values and convert them back into their original types.
 func (s *SchemaEventPayload) parseValues(retMap map[string]any, kind cdc.FieldLabelKind) map[string]any {
-	// Iterate over the schema and identify if there are any fields that require extra care.
 	if schemaObject := s.Schema.GetSchemaFromLabel(kind); schemaObject != nil {
 		for _, field := range schemaObject.Fields {
 			_, isOk := retMap[field.FieldName]
 			if !isOk {
-				// Skipping b/c envelope mismatch with the actual request body
 				continue
 			}
 

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -134,10 +134,11 @@ func TestGetData_TestDelete(t *testing.T) {
 	}
 
 	expectedKeyValues := map[string]any{
-		"id":         1004,
-		"first_name": "Anne",
-		"last_name":  "Kretchmar",
-		"email":      "annek@noanswer.org",
+		"id":                         1004,
+		"first_name":                 "Anne",
+		"last_name":                  "Kretchmar",
+		"email":                      "annek@noanswer.org",
+		constants.DeleteColumnMarker: true,
 	}
 
 	kvMap := map[string]any{"pk": 1004}

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -134,14 +133,6 @@ func TestGetData_TestDelete(t *testing.T) {
 		IdempotentKey: "updated_at",
 	}
 
-	kvMap := map[string]any{"pk": 1004}
-	var schemaEventPayload SchemaEventPayload
-	assert.NoError(t, json.Unmarshal([]byte(PostgresDelete), &schemaEventPayload))
-
-	assert.True(t, schemaEventPayload.DeletePayload())
-	data := schemaEventPayload.GetData(kvMap, tc)
-	fmt.Println("data", data)
-
 	expectedKeyValues := map[string]any{
 		"id":         1004,
 		"first_name": "Anne",
@@ -149,10 +140,30 @@ func TestGetData_TestDelete(t *testing.T) {
 		"email":      "annek@noanswer.org",
 	}
 
-	for expectedKey, expectedValue := range expectedKeyValues {
-		value, isOk := data[expectedKey]
-		assert.True(t, isOk)
-		assert.Equal(t, expectedValue, value)
+	kvMap := map[string]any{"pk": 1004}
+	{
+		// Postgres
+		var schemaEventPayload SchemaEventPayload
+		assert.NoError(t, json.Unmarshal([]byte(PostgresDelete), &schemaEventPayload))
+		assert.True(t, schemaEventPayload.DeletePayload())
+		data := schemaEventPayload.GetData(kvMap, tc)
+		for expectedKey, expectedValue := range expectedKeyValues {
+			value, isOk := data[expectedKey]
+			assert.True(t, isOk)
+			assert.Equal(t, expectedValue, value)
+		}
+	}
+	{
+		// MySQL
+		var schemaEventPayload SchemaEventPayload
+		assert.NoError(t, json.Unmarshal([]byte(MySQLDelete), &schemaEventPayload))
+		assert.True(t, schemaEventPayload.DeletePayload())
+		data := schemaEventPayload.GetData(kvMap, tc)
+		for expectedKey, expectedValue := range expectedKeyValues {
+			value, isOk := data[expectedKey]
+			assert.True(t, isOk)
+			assert.Equal(t, expectedValue, value)
+		}
 	}
 }
 

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -2,10 +2,9 @@ package util
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
-
-	"github.com/artie-labs/transfer/lib/typing/ext"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -130,37 +129,31 @@ func TestGetDataTestInsert(t *testing.T) {
 	assert.True(t, isOk)
 }
 
-func TestGetDataTestDelete(t *testing.T) {
+func TestGetData_TestDelete(t *testing.T) {
 	tc := &kafkalib.TopicConfig{
 		IdempotentKey: "updated_at",
 	}
 
-	now := time.Now().UTC()
-	schemaEventPayload := SchemaEventPayload{
-		Payload: Payload{
-			Before:    nil,
-			After:     nil,
-			Operation: "c",
-			Source:    Source{TsMs: now.UnixMilli()},
-		},
+	kvMap := map[string]any{"pk": 1004}
+	var schemaEventPayload SchemaEventPayload
+	assert.NoError(t, json.Unmarshal([]byte(PostgresDelete), &schemaEventPayload))
+
+	assert.True(t, schemaEventPayload.DeletePayload())
+	data := schemaEventPayload.GetData(kvMap, tc)
+	fmt.Println("data", data)
+
+	expectedKeyValues := map[string]any{
+		"id":         1004,
+		"first_name": "Anne",
+		"last_name":  "Kretchmar",
+		"email":      "annek@noanswer.org",
 	}
 
-	assert.False(t, schemaEventPayload.DeletePayload())
-
-	kvMap := map[string]any{"pk": 1}
-	evtData := schemaEventPayload.GetData(kvMap, tc)
-	shouldDelete, isOk := evtData[constants.DeleteColumnMarker]
-	assert.True(t, isOk)
-	assert.True(t, shouldDelete.(bool))
-
-	assert.Equal(t, 3, len(evtData), evtData)
-	assert.Equal(t, evtData["pk"], 1)
-	assert.Equal(t, evtData[tc.IdempotentKey], now.Format(ext.ISO8601))
-
-	tc.IdempotentKey = ""
-	evtData = schemaEventPayload.GetData(kvMap, tc)
-	_, isOk = evtData[tc.IdempotentKey]
-	assert.False(t, isOk, evtData)
+	for expectedKey, expectedValue := range expectedKeyValues {
+		value, isOk := data[expectedKey]
+		assert.True(t, isOk)
+		assert.Equal(t, expectedValue, value)
+	}
 }
 
 func TestGetDataTestUpdate(t *testing.T) {


### PR DESCRIPTION
## Changes

Today, for our deletes - we do not pass the `before` object through. Which has worked fine, for hard deletes - we only need the primary keys and an indicator on whether the row has been deleted anyways.

However, if we want to use merge predicates which can speed up [merges](https://select.dev/posts/snowflake-merges#:~:text=This%20is%20known%20as%20dynamic%20pruning%2C%20because%20Snowflake%20is%20determining%20which%20micro%2Dpartitions%20to%20prune%20(avoid%20scanning)%20while%20during%20the%20query%20execution%20after%20it%20has%20read%20the%20values%20in%20the%20source%20table.), we'll need to be able to join on non-primary key values such as `created_at`.

This PR opens up the ability to pass through the before state for relational sources. Once this works well, we'll also add this for MongoDB.