### PR TITLE
[debezium] Use `toInt64` to parse time values

### DIFF
--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -152,11 +152,6 @@ func (f Field) ParseValue(value any) (any, error) {
 		TimeKafkaConnect,
 		DateTimeKafkaConnect:
 
-		int64Value, err := toInt64(value)
-		if err != nil {
-			return nil, err
-		}
-
 		switch f.Type {
 		case Int16, Int32, Int64:
 			// These are the types we expect.
@@ -170,6 +165,10 @@ func (f Field) ParseValue(value any) (any, error) {
 			)
 		}
 
+		int64Value, err := toInt64(value)
+		if err != nil {
+			return nil, err
+		}
 		return FromDebeziumTypeToTime(f.DebeziumType, int64Value)
 	}
 

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -153,18 +152,9 @@ func (f Field) ParseValue(value any) (any, error) {
 		TimeKafkaConnect,
 		DateTimeKafkaConnect:
 
-		switch value.(type) {
-		case float64:
-			// This value is coming from Kafka, and will have been marshaled to a JSON string, so when it is
-			// unmarshalled it will be a float64
-			// -> Pass.
-		case int64:
-			// This value is coming from reader.
-			// -> Pass.
-		default:
-			// Value should always be a float64/int64, but let's check this if this assumption holds and if so clean up
-			// the code below so that we aren't doing float -> string -> float.
-			slog.Error(fmt.Sprintf("Expected float64 received %T with value '%v'", value, value))
+		int64Value, err := toInt64(value)
+		if err != nil {
+			return nil, err
 		}
 
 		switch f.Type {
@@ -180,26 +170,7 @@ func (f Field) ParseValue(value any) (any, error) {
 			)
 		}
 
-		// Need to cast this as a FLOAT first because the number may come out in scientific notation
-		// ParseFloat is apt to handle it, and ParseInt is not, see: https://github.com/golang/go/issues/19288
-		floatVal, castErr := strconv.ParseFloat(fmt.Sprint(value), 64)
-		if castErr != nil {
-			return nil, castErr
-		}
-		int64Val := int64(floatVal)
-
-		int64ValFromFunc, err := toInt64(value)
-		if err != nil {
-			slog.Error("Unable to call toInt64", slog.Any("err", err), slog.Any("value", value))
-		} else if int64Val != int64ValFromFunc {
-			slog.Error("int64Val is different from int64ValFromFunc",
-				slog.Int64("int64Val", int64Val),
-				slog.Int64("int64ValFromFunc", int64ValFromFunc),
-				slog.Any("value", value),
-			)
-		}
-
-		return FromDebeziumTypeToTime(f.DebeziumType, int64Val)
+		return FromDebeziumTypeToTime(f.DebeziumType, int64Value)
 	}
 
 	if bytes, ok := value.([]byte); ok {

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -313,14 +313,8 @@ func TestField_ParseValue(t *testing.T) {
 				Type:         Int64,
 				DebeziumType: MicroTimestamp,
 			},
-			value: "1712609795827000",
-			expectedValue: &ext.ExtendedTime{
-				Time: time.Date(2024, time.April, 8, 20, 56, 35, 827000000, time.UTC),
-				NestedKind: ext.NestedKind{
-					Type:   ext.DateTimeKindType,
-					Format: "2006-01-02T15:04:05.999999999Z07:00",
-				},
-			},
+			value:       "1712609795827000",
+			expectedErr: "failed to cast value '1712609795827000' with type 'string' to int64",
 		},
 		{
 			name: "[]byte",

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -308,7 +308,7 @@ func TestField_ParseValue(t *testing.T) {
 			},
 		},
 		{
-			name: "string micro-timestamp",
+			name: "string micro-timestamp - should error",
 			field: Field{
 				Type:         Int64,
 				DebeziumType: MicroTimestamp,


### PR DESCRIPTION
We've been running https://github.com/artie-labs/transfer/pull/434 for a day with no errors logged, so the old parsing code seems safe to remove.