### PR TITLE
Pass `TableIdentifier` to `DataWarehouse.Dedupe`

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -149,7 +149,8 @@ func (s *Store) putTable(ctx context.Context, dataset, tableName string, rows []
 	return nil
 }
 
-func (s *Store) Dedupe(fqTableName string) error {
+func (s *Store) Dedupe(tableData *optimization.TableData) error {
+	fqTableName := s.ToFullyQualifiedName(tableData, true)
 	_, err := s.Exec(fmt.Sprintf("CREATE OR REPLACE TABLE %s AS SELECT DISTINCT * FROM %s", fqTableName, fqTableName))
 	return err
 }

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -149,8 +149,8 @@ func (s *Store) putTable(ctx context.Context, dataset, tableName string, rows []
 	return nil
 }
 
-func (s *Store) Dedupe(tableData *optimization.TableData) error {
-	fqTableName := s.ToFullyQualifiedName(tableData, true)
+func (s *Store) Dedupe(tableID optimization.TableIdentifier) error {
+	fqTableName := s.ToFullyQualifiedName(tableID, true)
 	_, err := s.Exec(fmt.Sprintf("CREATE OR REPLACE TABLE %s AS SELECT DISTINCT * FROM %s", fqTableName, fqTableName))
 	return err
 }

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -67,7 +67,7 @@ func (s *Store) Sweep() error {
 	return shared.Sweep(s, tcs, queryFunc)
 }
 
-func (s *Store) Dedupe(_ *optimization.TableData) error {
+func (s *Store) Dedupe(_ optimization.TableIdentifier) error {
 	return nil // dedupe is not necessary for MS SQL
 }
 

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -67,7 +67,7 @@ func (s *Store) Sweep() error {
 	return shared.Sweep(s, tcs, queryFunc)
 }
 
-func (s *Store) Dedupe(fqTableName string) error {
+func (s *Store) Dedupe(_ *optimization.TableData) error {
 	return nil // dedupe is not necessary for MS SQL
 }
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -90,7 +90,7 @@ WHERE
 	return shared.Sweep(s, tcs, queryFunc)
 }
 
-func (s *Store) Dedupe(fqTableName string) error {
+func (s *Store) Dedupe(tableData *optimization.TableData) error {
 	return fmt.Errorf("dedupe is not yet implemented")
 }
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -90,7 +90,7 @@ WHERE
 	return shared.Sweep(s, tcs, queryFunc)
 }
 
-func (s *Store) Dedupe(tableData *optimization.TableData) error {
+func (s *Store) Dedupe(_ optimization.TableIdentifier) error {
 	return fmt.Errorf("dedupe is not yet implemented")
 }
 

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -115,7 +115,8 @@ func (s *Store) reestablishConnection() error {
 	return nil
 }
 
-func (s *Store) Dedupe(fqTableName string) error {
+func (s *Store) Dedupe(tableData *optimization.TableData) error {
+	fqTableName := s.ToFullyQualifiedName(tableData, true)
 	_, err := s.Exec(fmt.Sprintf("CREATE OR REPLACE TABLE %s AS SELECT DISTINCT * FROM %s", fqTableName, fqTableName))
 	return err
 }

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -115,8 +115,8 @@ func (s *Store) reestablishConnection() error {
 	return nil
 }
 
-func (s *Store) Dedupe(tableData *optimization.TableData) error {
-	fqTableName := s.ToFullyQualifiedName(tableData, true)
+func (s *Store) Dedupe(tableID optimization.TableIdentifier) error {
+	fqTableName := s.ToFullyQualifiedName(tableID, true)
 	_, err := s.Exec(fmt.Sprintf("CREATE OR REPLACE TABLE %s AS SELECT DISTINCT * FROM %s", fqTableName, fqTableName))
 	return err
 }

--- a/lib/destination/dwh.go
+++ b/lib/destination/dwh.go
@@ -12,7 +12,7 @@ type DataWarehouse interface {
 	Label() constants.DestinationKind
 	Merge(tableData *optimization.TableData) error
 	Append(tableData *optimization.TableData) error
-	Dedupe(tableData *optimization.TableData) error
+	Dedupe(tableID optimization.TableIdentifier) error
 	Exec(query string, args ...any) (sql.Result, error)
 	Query(query string, args ...any) (*sql.Rows, error)
 	Begin() (*sql.Tx, error)

--- a/lib/destination/dwh.go
+++ b/lib/destination/dwh.go
@@ -12,7 +12,7 @@ type DataWarehouse interface {
 	Label() constants.DestinationKind
 	Merge(tableData *optimization.TableData) error
 	Append(tableData *optimization.TableData) error
-	Dedupe(fqTableName string) error
+	Dedupe(tableData *optimization.TableData) error
 	Exec(query string, args ...any) (sql.Result, error)
 	Query(query string, args ...any) (*sql.Rows, error)
 	Begin() (*sql.Tx, error)


### PR DESCRIPTION
That way we can use it to generate a temporary table name for Redshift dedupes.