### PR TITLE
Pass `TableData` to `ToFullyQualifiedName` and `Dedupe`

### DIFF
--- a/clients/bigquery/append.go
+++ b/clients/bigquery/append.go
@@ -8,6 +8,6 @@ import (
 
 func (s *Store) Append(tableData *optimization.TableData) error {
 	return shared.Append(s, tableData, s.config, types.AppendOpts{
-		TempTableName: s.ToFullyQualifiedName(tableData.TableIdentifier(), true),
+		TempTableName: s.ToFullyQualifiedName(tableData, true),
 	})
 }

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -78,8 +78,8 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 	return s.putTable(context.Background(), tableData.TopicConfig.Database, tempTableName, rows)
 }
 
-func (s *Store) ToFullyQualifiedName(tableID optimization.TableIdentifier, escape bool) string {
-	return tableID.FqName(s.Label(), escape, s.config.SharedDestinationConfig.UppercaseEscapedNames,
+func (s *Store) ToFullyQualifiedName(tableData *optimization.TableData, escape bool) string {
+	return tableData.TableIdentifier().FqName(s.Label(), escape, s.config.SharedDestinationConfig.UppercaseEscapedNames,
 		optimization.FqNameOpts{BigQueryProjectID: s.config.BigQuery.ProjectID})
 }
 
@@ -87,7 +87,7 @@ func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTab
 	query := fmt.Sprintf("SELECT column_name, data_type, description FROM `%s.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS` WHERE table_name = ?;", tableData.TopicConfig.Database)
 	return shared.GetTableCfgArgs{
 		Dwh:                s,
-		FqName:             s.ToFullyQualifiedName(tableData.TableIdentifier(), true),
+		FqName:             s.ToFullyQualifiedName(tableData, true),
 		ConfigMap:          s.configMap,
 		Query:              query,
 		Args:               []any{tableData.RawName()},
@@ -149,8 +149,8 @@ func (s *Store) putTable(ctx context.Context, dataset, tableName string, rows []
 	return nil
 }
 
-func (s *Store) Dedupe(tableID optimization.TableIdentifier) error {
-	fqTableName := s.ToFullyQualifiedName(tableID, true)
+func (s *Store) Dedupe(tableData *optimization.TableData) error {
+	fqTableName := s.ToFullyQualifiedName(tableData, true)
 	_, err := s.Exec(fmt.Sprintf("CREATE OR REPLACE TABLE %s AS SELECT DISTINCT * FROM %s", fqTableName, fqTableName))
 	return err
 }

--- a/clients/bigquery/bigquery_test.go
+++ b/clients/bigquery/bigquery_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/artie-labs/transfer/lib/config"
+	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/stretchr/testify/assert"
 )
@@ -30,7 +31,7 @@ func (b *BigQueryTestSuite) TestTableRelName() {
 }
 
 func TestFullyQualifiedName(t *testing.T) {
-	tableID := optimization.NewTableIdentifier("database", "schema", "table")
+	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "database", Schema: "schema"}, "table")
 
 	{
 		// With UppercaseEscapedNames: true
@@ -44,8 +45,8 @@ func TestFullyQualifiedName(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, "`project`.`database`.`TABLE`", store.ToFullyQualifiedName(tableID, true), "escaped")
-		assert.Equal(t, "`project`.`database`.table", store.ToFullyQualifiedName(tableID, false), "unescaped")
+		assert.Equal(t, "`project`.`database`.`TABLE`", store.ToFullyQualifiedName(tableData, true), "escaped")
+		assert.Equal(t, "`project`.`database`.table", store.ToFullyQualifiedName(tableData, false), "unescaped")
 	}
 	{
 		// With UppercaseEscapedNames: false
@@ -59,7 +60,7 @@ func TestFullyQualifiedName(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, "`project`.`database`.`table`", store.ToFullyQualifiedName(tableID, true), "escaped")
-		assert.Equal(t, "`project`.`database`.table", store.ToFullyQualifiedName(tableID, false), "unescaped")
+		assert.Equal(t, "`project`.`database`.`table`", store.ToFullyQualifiedName(tableData, true), "escaped")
+		assert.Equal(t, "`project`.`database`.table", store.ToFullyQualifiedName(tableData, false), "unescaped")
 	}
 }

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -44,11 +44,12 @@ func (s *Store) Merge(tableData *optimization.TableData) error {
 
 func (s *Store) Append(tableData *optimization.TableData) error {
 	return shared.Append(s, tableData, s.config, types.AppendOpts{
-		TempTableName: s.ToFullyQualifiedName(tableData.TableIdentifier(), true),
+		TempTableName: s.ToFullyQualifiedName(tableData, true),
 	})
 }
 
-func (s *Store) ToFullyQualifiedName(tableID optimization.TableIdentifier, escape bool) string {
+func (s *Store) ToFullyQualifiedName(tableData *optimization.TableData, escape bool) string {
+	tableID := tableData.TableIdentifier()
 	return tableID.FqName(s.Label(), escape, s.config.SharedDestinationConfig.UppercaseEscapedNames, optimization.FqNameOpts{
 		MsSQLSchemaOverride: s.Schema(tableID),
 	})
@@ -67,7 +68,7 @@ func (s *Store) Sweep() error {
 	return shared.Sweep(s, tcs, queryFunc)
 }
 
-func (s *Store) Dedupe(_ optimization.TableIdentifier) error {
+func (s *Store) Dedupe(_ *optimization.TableData) error {
 	return nil // dedupe is not necessary for MS SQL
 }
 
@@ -82,7 +83,7 @@ func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTab
 	query, args := describeTableQuery(s.Schema(tableData.TableIdentifier()), tableData.RawName())
 	return shared.GetTableCfgArgs{
 		Dwh:                s,
-		FqName:             s.ToFullyQualifiedName(tableData.TableIdentifier(), true),
+		FqName:             s.ToFullyQualifiedName(tableData, true),
 		ConfigMap:          s.configMap,
 		Query:              query,
 		Args:               args,

--- a/clients/mssql/store_test.go
+++ b/clients/mssql/store_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/artie-labs/transfer/lib/config"
+	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFullyQualifiedName(t *testing.T) {
-	tableID := optimization.NewTableIdentifier("database", "schema", "table")
+	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "database", Schema: "schema"}, "table")
 
 	{
 		// With UppercaseEscapedNames: true
@@ -20,8 +21,8 @@ func TestFullyQualifiedName(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, `schema."TABLE"`, store.ToFullyQualifiedName(tableID, true), "escaped")
-		assert.Equal(t, "schema.table", store.ToFullyQualifiedName(tableID, false), "unescaped")
+		assert.Equal(t, `schema."TABLE"`, store.ToFullyQualifiedName(tableData, true), "escaped")
+		assert.Equal(t, "schema.table", store.ToFullyQualifiedName(tableData, false), "unescaped")
 	}
 	{
 		// With UppercaseEscapedNames: false
@@ -32,7 +33,7 @@ func TestFullyQualifiedName(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, `schema."table"`, store.ToFullyQualifiedName(tableID, true), "escaped")
-		assert.Equal(t, "schema.table", store.ToFullyQualifiedName(tableID, false), "unescaped")
+		assert.Equal(t, `schema."table"`, store.ToFullyQualifiedName(tableData, true), "escaped")
+		assert.Equal(t, "schema.table", store.ToFullyQualifiedName(tableData, false), "unescaped")
 	}
 }

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -29,8 +29,8 @@ type Store struct {
 	db.Store
 }
 
-func (s *Store) ToFullyQualifiedName(tableID optimization.TableIdentifier, escape bool) string {
-	return tableID.FqName(s.Label(), escape, s.config.SharedDestinationConfig.UppercaseEscapedNames, optimization.FqNameOpts{})
+func (s *Store) ToFullyQualifiedName(tableData *optimization.TableData, escape bool) string {
+	return tableData.TableIdentifier().FqName(s.Label(), escape, s.config.SharedDestinationConfig.UppercaseEscapedNames, optimization.FqNameOpts{})
 }
 
 func (s *Store) GetConfigMap() *types.DwhToTablesConfigMap {
@@ -59,7 +59,7 @@ func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTab
 
 	return shared.GetTableCfgArgs{
 		Dwh:                s,
-		FqName:             s.ToFullyQualifiedName(tableData.TableIdentifier(), true),
+		FqName:             s.ToFullyQualifiedName(tableData, true),
 		ConfigMap:          s.configMap,
 		Query:              query,
 		Args:               args,
@@ -93,9 +93,9 @@ WHERE
 	return shared.Sweep(s, tcs, queryFunc)
 }
 
-func (s *Store) Dedupe(tableID optimization.TableIdentifier) error {
-	fqTableName := s.ToFullyQualifiedName(tableID, true)
-	stagingTableName := shared.TempTableName(s, tableID, strings.ToLower(stringutil.Random(5)))
+func (s *Store) Dedupe(tableData *optimization.TableData) error {
+	fqTableName := s.ToFullyQualifiedName(tableData, true)
+	stagingTableName := shared.TempTableName(s, tableData, strings.ToLower(stringutil.Random(5)))
 
 	query := fmt.Sprintf(`
 CREATE TABLE %s AS SELECT DISTINCT * FROM %s;

--- a/clients/redshift/redshift_test.go
+++ b/clients/redshift/redshift_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/artie-labs/transfer/lib/config"
+	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFullyQualifiedName(t *testing.T) {
-	tableID := optimization.NewTableIdentifier("database", "schema", "table")
+	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "database", Schema: "schema"}, "table")
 
 	{
 		// With UppercaseEscapedNames: true
@@ -20,8 +21,8 @@ func TestFullyQualifiedName(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, `schema."TABLE"`, store.ToFullyQualifiedName(tableID, true), "escaped")
-		assert.Equal(t, "schema.table", store.ToFullyQualifiedName(tableID, false), "unescaped")
+		assert.Equal(t, `schema."TABLE"`, store.ToFullyQualifiedName(tableData, true), "escaped")
+		assert.Equal(t, "schema.table", store.ToFullyQualifiedName(tableData, false), "unescaped")
 	}
 	{
 		// With UppercaseEscapedNames: false
@@ -32,7 +33,7 @@ func TestFullyQualifiedName(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, `schema."table"`, store.ToFullyQualifiedName(tableID, true), "escaped")
-		assert.Equal(t, "schema.table", store.ToFullyQualifiedName(tableID, false), "unescaped")
+		assert.Equal(t, `schema."table"`, store.ToFullyQualifiedName(tableData, true), "escaped")
+		assert.Equal(t, "schema.table", store.ToFullyQualifiedName(tableData, false), "unescaped")
 	}
 }

--- a/clients/redshift/writes.go
+++ b/clients/redshift/writes.go
@@ -11,12 +11,12 @@ import (
 func (s *Store) Append(tableData *optimization.TableData) error {
 	// Redshift is slightly different, we'll load and create the temporary table via shared.Append
 	// Then, we'll invoke `ALTER TABLE target APPEND FROM staging` to combine the diffs.
-	temporaryTableName := shared.TempTableName(s, tableData.TableIdentifier(), tableData.TempTableSuffix())
+	temporaryTableName := shared.TempTableName(s, tableData, tableData.TempTableSuffix())
 	if err := shared.Append(s, tableData, s.config, types.AppendOpts{TempTableName: temporaryTableName}); err != nil {
 		return err
 	}
 
-	_, err := s.Exec(fmt.Sprintf(`ALTER TABLE %s APPEND FROM %s;`, s.ToFullyQualifiedName(tableData.TableIdentifier(), true), temporaryTableName))
+	_, err := s.Exec(fmt.Sprintf(`ALTER TABLE %s APPEND FROM %s;`, s.ToFullyQualifiedName(tableData, true), temporaryTableName))
 	return err
 }
 

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -49,15 +49,15 @@ func (s *Store) Label() constants.DestinationKind {
 	return constants.S3
 }
 
-func (s *Store) ToFullyQualifiedName(tableID optimization.TableIdentifier) string {
-	return tableID.FqName(s.Label(), false, s.uppercaseEscNames, optimization.FqNameOpts{})
+func (s *Store) ToFullyQualifiedName(tableData *optimization.TableData) string {
+	return tableData.TableIdentifier().FqName(s.Label(), false, s.uppercaseEscNames, optimization.FqNameOpts{})
 }
 
 // ObjectPrefix - this will generate the exact right prefix that we need to write into S3.
 // It will look like something like this:
 // > optionalPrefix/fullyQualifiedTableName/YYYY-MM-DD
 func (s *Store) ObjectPrefix(tableData *optimization.TableData) string {
-	fqTableName := s.ToFullyQualifiedName(tableData.TableIdentifier())
+	fqTableName := s.ToFullyQualifiedName(tableData)
 	yyyyMMDDFormat := tableData.LatestCDCTs.Format(ext.PostgresDateFormat)
 
 	if len(s.config.S3.OptionalPrefix) > 0 {

--- a/clients/s3/s3_test.go
+++ b/clients/s3/s3_test.go
@@ -71,7 +71,7 @@ func TestObjectPrefix(t *testing.T) {
 }
 
 func TestFullyQualifiedName(t *testing.T) {
-	tableID := optimization.NewTableIdentifier("database", "schema", "table")
+	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "database", Schema: "schema"}, "table")
 
 	{
 		// With UppercaseEscapedNames: true
@@ -82,7 +82,7 @@ func TestFullyQualifiedName(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, "database.schema.table", store.ToFullyQualifiedName(tableID), "unescaped")
+		assert.Equal(t, "database.schema.table", store.ToFullyQualifiedName(tableData), "unescaped")
 	}
 	{
 		// With UppercaseEscapedNames: false
@@ -93,6 +93,6 @@ func TestFullyQualifiedName(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, "database.schema.table", store.ToFullyQualifiedName(tableID), "unescaped")
+		assert.Equal(t, "database.schema.table", store.ToFullyQualifiedName(tableData), "unescaped")
 	}
 }

--- a/clients/shared/append.go
+++ b/clients/shared/append.go
@@ -22,7 +22,7 @@ func Append(dwh destination.DataWarehouse, tableData *optimization.TableData, cf
 		return nil
 	}
 
-	fqName := dwh.ToFullyQualifiedName(tableData.TableIdentifier(), true)
+	fqName := dwh.ToFullyQualifiedName(tableData, true)
 	tableConfig, err := dwh.GetTableConfig(tableData)
 	if err != nil {
 		return err

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -34,7 +34,7 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, cfg
 		tableData.TopicConfig.SoftDelete, tableData.TopicConfig.IncludeArtieUpdatedAt,
 		tableData.TopicConfig.IncludeDatabaseUpdatedAt, tableData.Mode())
 
-	fqName := dwh.ToFullyQualifiedName(tableData.TableIdentifier(), true)
+	fqName := dwh.ToFullyQualifiedName(tableData, true)
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:               dwh,
 		Tc:                tableConfig,
@@ -71,7 +71,7 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, cfg
 
 	tableConfig.AuditColumnsToDelete(srcKeysMissing)
 	tableData.MergeColumnsFromDestination(tableConfig.Columns().GetColumns()...)
-	temporaryTableName := TempTableName(dwh, tableData.TableIdentifier(), tableData.TempTableSuffix())
+	temporaryTableName := TempTableName(dwh, tableData, tableData.TempTableSuffix())
 	if err = dwh.PrepareTemporaryTable(tableData, tableConfig, temporaryTableName, types.AdditionalSettings{}, true); err != nil {
 		return fmt.Errorf("failed to prepare temporary table: %w", err)
 	}

--- a/clients/shared/temp_table.go
+++ b/clients/shared/temp_table.go
@@ -10,10 +10,10 @@ import (
 	"github.com/artie-labs/transfer/lib/optimization"
 )
 
-func TempTableName(dwh destination.DataWarehouse, tableID optimization.TableIdentifier, suffix string) string {
+func TempTableName(dwh destination.DataWarehouse, tableData *optimization.TableData, suffix string) string {
 	return fmt.Sprintf(
 		"%s_%s_%s_%d",
-		dwh.ToFullyQualifiedName(tableID, false),
+		dwh.ToFullyQualifiedName(tableData, false),
 		constants.ArtiePrefix,
 		suffix,
 		time.Now().Add(constants.TemporaryTableTTL).Unix(),

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -31,12 +31,12 @@ const (
 	describeCommentCol = "comment"
 )
 
-func (s *Store) ToFullyQualifiedName(tableID optimization.TableIdentifier, escape bool) string {
-	return tableID.FqName(s.Label(), escape, s.config.SharedDestinationConfig.UppercaseEscapedNames, optimization.FqNameOpts{})
+func (s *Store) ToFullyQualifiedName(tableData *optimization.TableData, escape bool) string {
+	return tableData.TableIdentifier().FqName(s.Label(), escape, s.config.SharedDestinationConfig.UppercaseEscapedNames, optimization.FqNameOpts{})
 }
 
 func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTableConfig, error) {
-	fqName := s.ToFullyQualifiedName(tableData.TableIdentifier(), true)
+	fqName := s.ToFullyQualifiedName(tableData, true)
 	return shared.GetTableCfgArgs{
 		Dwh:                s,
 		FqName:             fqName,
@@ -115,8 +115,8 @@ func (s *Store) reestablishConnection() error {
 	return nil
 }
 
-func (s *Store) Dedupe(tableID optimization.TableIdentifier) error {
-	fqTableName := s.ToFullyQualifiedName(tableID, true)
+func (s *Store) Dedupe(tableData *optimization.TableData) error {
+	fqTableName := s.ToFullyQualifiedName(tableData, true)
 	_, err := s.Exec(fmt.Sprintf("CREATE OR REPLACE TABLE %s AS SELECT DISTINCT * FROM %s", fqTableName, fqTableName))
 	return err
 }

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -290,7 +290,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeExitEarly() {
 }
 
 func TestFullyQualifiedName(t *testing.T) {
-	tableID := optimization.NewTableIdentifier("database", "schema", "table")
+	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "database", Schema: "schema"}, "table")
 
 	{
 		// With UppercaseEscapedNames: true
@@ -301,8 +301,8 @@ func TestFullyQualifiedName(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, `database.schema."TABLE"`, store.ToFullyQualifiedName(tableID, true), "escaped")
-		assert.Equal(t, "database.schema.table", store.ToFullyQualifiedName(tableID, false), "unescaped")
+		assert.Equal(t, `database.schema."TABLE"`, store.ToFullyQualifiedName(tableData, true), "escaped")
+		assert.Equal(t, "database.schema.table", store.ToFullyQualifiedName(tableData, false), "unescaped")
 	}
 	{
 		// With UppercaseEscapedNames: false
@@ -313,7 +313,7 @@ func TestFullyQualifiedName(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, `database.schema."table"`, store.ToFullyQualifiedName(tableID, true), "escaped")
-		assert.Equal(t, "database.schema.table", store.ToFullyQualifiedName(tableID, false), "unescaped")
+		assert.Equal(t, `database.schema."table"`, store.ToFullyQualifiedName(tableData, true), "escaped")
+		assert.Equal(t, "database.schema.table", store.ToFullyQualifiedName(tableData, false), "unescaped")
 	}
 }

--- a/clients/snowflake/writes.go
+++ b/clients/snowflake/writes.go
@@ -26,7 +26,7 @@ func (s *Store) Append(tableData *optimization.TableData) error {
 
 		// TODO: For history mode - in the future, we could also have a separate stage name for history mode so we can enable parallel processing.
 		err = shared.Append(s, tableData, s.config, types.AppendOpts{
-			TempTableName:        s.ToFullyQualifiedName(tableData.TableIdentifier(), true),
+			TempTableName:        s.ToFullyQualifiedName(tableData, true),
 			AdditionalCopyClause: `FILE_FORMAT = (TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE) PURGE = TRUE`,
 		})
 	}

--- a/lib/destination/dwh.go
+++ b/lib/destination/dwh.go
@@ -12,7 +12,7 @@ type DataWarehouse interface {
 	Label() constants.DestinationKind
 	Merge(tableData *optimization.TableData) error
 	Append(tableData *optimization.TableData) error
-	Dedupe(tableID optimization.TableIdentifier) error
+	Dedupe(tableID *optimization.TableData) error
 	Exec(query string, args ...any) (sql.Result, error)
 	Query(query string, args ...any) (*sql.Rows, error)
 	Begin() (*sql.Tx, error)
@@ -20,7 +20,7 @@ type DataWarehouse interface {
 	// Helper functions for merge
 
 	IsRetryableError(err error) bool
-	ToFullyQualifiedName(tableID optimization.TableIdentifier, escape bool) string
+	ToFullyQualifiedName(tableData *optimization.TableData, escape bool) string
 	GetTableConfig(tableData *optimization.TableData) (*types.DwhTableConfig, error)
 	PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableName string, additionalSettings types.AdditionalSettings, createTempTable bool) error
 }


### PR DESCRIPTION
Basically just reverts #444. Instead of having a shared `TableIdentifier` struct we'll have a per-data-warehouse struct. This is a prerequisite in order to make that possible.