### PR TITLE
Add `WithTable` methods to `TableIdentifier`s

### DIFF
--- a/clients/bigquery/tableid.go
+++ b/clients/bigquery/tableid.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
@@ -27,6 +28,10 @@ func (ti TableIdentifier) Dataset() string {
 
 func (ti TableIdentifier) Table() string {
 	return ti.table
+}
+
+func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
+	return NewTableIdentifier(ti.projectID, ti.dataset, table)
 }
 
 func (ti TableIdentifier) FullyQualifiedName(escape, uppercaseEscNames bool) string {

--- a/clients/bigquery/tableid_test.go
+++ b/clients/bigquery/tableid_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTableIdentifier_WithTable(t *testing.T) {
+	tableID := NewTableIdentifier("project", "dataset", "foo")
+	tableID2 := tableID.WithTable("bar")
+	typedTableID2, ok := tableID2.(TableIdentifier)
+	assert.True(t, ok)
+	assert.Equal(t, "project", typedTableID2.ProjectID())
+	assert.Equal(t, "dataset", typedTableID2.Dataset())
+	assert.Equal(t, "bar", tableID2.Table())
+}
+
 func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	{
 		// Table name that does not need escaping:

--- a/clients/mssql/tableid.go
+++ b/clients/mssql/tableid.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
@@ -22,6 +23,10 @@ func (ti TableIdentifier) Schema() string {
 
 func (ti TableIdentifier) Table() string {
 	return ti.table
+}
+
+func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
+	return NewTableIdentifier(ti.schema, table)
 }
 
 func (ti TableIdentifier) FullyQualifiedName(escape, uppercaseEscNames bool) string {

--- a/clients/mssql/tableid_test.go
+++ b/clients/mssql/tableid_test.go
@@ -6,6 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTableIdentifier_WithTable(t *testing.T) {
+	tableID := NewTableIdentifier("schema", "foo")
+	tableID2 := tableID.WithTable("bar")
+	typedTableID2, ok := tableID2.(TableIdentifier)
+	assert.True(t, ok)
+	assert.Equal(t, "schema", typedTableID2.Schema())
+	assert.Equal(t, "bar", tableID2.Table())
+}
+
 func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	{
 		// Table name that does not need escaping:

--- a/clients/redshift/tableid.go
+++ b/clients/redshift/tableid.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
@@ -22,6 +23,10 @@ func (ti TableIdentifier) Schema() string {
 
 func (ti TableIdentifier) Table() string {
 	return ti.table
+}
+
+func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
+	return NewTableIdentifier(ti.schema, table)
 }
 
 func (ti TableIdentifier) FullyQualifiedName(escape, uppercaseEscNames bool) string {

--- a/clients/redshift/tableid_test.go
+++ b/clients/redshift/tableid_test.go
@@ -6,6 +6,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTableIdentifier_WithTable(t *testing.T) {
+	tableID := NewTableIdentifier("schema", "foo")
+	tableID2 := tableID.WithTable("bar")
+	typedTableID2, ok := tableID2.(TableIdentifier)
+	assert.True(t, ok)
+	assert.Equal(t, "schema", typedTableID2.Schema())
+	assert.Equal(t, "bar", tableID2.Table())
+}
+
 func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	{
 		// Table name that does not need escaping:

--- a/clients/s3/tableid.go
+++ b/clients/s3/tableid.go
@@ -2,6 +2,8 @@ package s3
 
 import (
 	"fmt"
+
+	"github.com/artie-labs/transfer/lib/destination/types"
 )
 
 type TableIdentifier struct {
@@ -24,6 +26,10 @@ func (ti TableIdentifier) Schema() string {
 
 func (ti TableIdentifier) Table() string {
 	return ti.table
+}
+
+func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
+	return NewTableIdentifier(ti.database, ti.schema, table)
 }
 
 func (ti TableIdentifier) FullyQualifiedName(_, _ bool) string {

--- a/clients/s3/tableid_test.go
+++ b/clients/s3/tableid_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTableIdentifier_WithTable(t *testing.T) {
+	tableID := NewTableIdentifier("database", "schema", "foo")
+	tableID2 := tableID.WithTable("bar")
+	typedTableID2, ok := tableID2.(TableIdentifier)
+	assert.True(t, ok)
+	assert.Equal(t, "database", typedTableID2.Database())
+	assert.Equal(t, "schema", typedTableID2.Schema())
+	assert.Equal(t, "bar", tableID2.Table())
+}
+
 func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	// S3 doesn't escape the table name.
 	tableID := NewTableIdentifier("database", "schema", "table")

--- a/clients/shared/table_config_test.go
+++ b/clients/shared/table_config_test.go
@@ -78,8 +78,9 @@ func (MockDWH) ShouldUppercaseEscapedNames() bool { return true }
 
 type MockTableIdentifier struct{ fqName string }
 
-func (MockTableIdentifier) Table() string                         { panic("not implemented") }
-func (m MockTableIdentifier) FullyQualifiedName(_, _ bool) string { return m.fqName }
+func (MockTableIdentifier) Table() string                                { panic("not implemented") }
+func (MockTableIdentifier) WithTable(table string) types.TableIdentifier { panic("not implemented") }
+func (m MockTableIdentifier) FullyQualifiedName(_, _ bool) string        { return m.fqName }
 
 func TestGetTableConfig(t *testing.T) {
 	// Return early because table is found in configMap.

--- a/clients/snowflake/tableid.go
+++ b/clients/snowflake/tableid.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
@@ -27,6 +28,10 @@ func (ti TableIdentifier) Schema() string {
 
 func (ti TableIdentifier) Table() string {
 	return ti.table
+}
+
+func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
+	return NewTableIdentifier(ti.database, ti.schema, table)
 }
 
 func (ti TableIdentifier) FullyQualifiedName(escape, uppercaseEscNames bool) string {

--- a/clients/snowflake/tableid_test.go
+++ b/clients/snowflake/tableid_test.go
@@ -6,6 +6,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTableIdentifier_WithTable(t *testing.T) {
+	tableID := NewTableIdentifier("database", "schema", "foo")
+	tableID2 := tableID.WithTable("bar")
+	assert.IsType(t, TableIdentifier{}, tableID2)
+	typedTableID2, ok := tableID2.(TableIdentifier)
+	assert.True(t, ok)
+	assert.Equal(t, "database", typedTableID2.Database())
+	assert.Equal(t, "schema", typedTableID2.Schema())
+	assert.Equal(t, "bar", tableID2.Table())
+}
+
 func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	{
 		// Table name that does not need escaping:

--- a/clients/snowflake/tableid_test.go
+++ b/clients/snowflake/tableid_test.go
@@ -9,7 +9,6 @@ import (
 func TestTableIdentifier_WithTable(t *testing.T) {
 	tableID := NewTableIdentifier("database", "schema", "foo")
 	tableID2 := tableID.WithTable("bar")
-	assert.IsType(t, TableIdentifier{}, tableID2)
 	typedTableID2, ok := tableID2.(TableIdentifier)
 	assert.True(t, ok)
 	assert.Equal(t, "database", typedTableID2.Database())

--- a/lib/destination/types/types.go
+++ b/lib/destination/types/types.go
@@ -61,5 +61,6 @@ func (a AppendOpts) Validate() error {
 
 type TableIdentifier interface {
 	Table() string
+	WithTable(table string) TableIdentifier
 	FullyQualifiedName(escape, uppercaseEscNames bool) string
 }


### PR DESCRIPTION
The idea being that we can use these methods to change just the table of an identifier while preserving the schema/database/dataset/project. This will be used for the function that creates temporary table names so that it can return a `TableIdentifier` rather than a fully qualified table name string.