### PR TITLE
Remove `escape` argument from `FullyQualifiedName`

### DIFF
--- a/clients/bigquery/append.go
+++ b/clients/bigquery/append.go
@@ -9,6 +9,6 @@ import (
 func (s *Store) Append(tableData *optimization.TableData) error {
 	tableID := s.IdentifierFor(tableData.TopicConfig(), tableData.Name())
 	return shared.Append(s, tableData, s.config, types.AppendOpts{
-		TempTableName: tableID.FullyQualifiedName(true, s.ShouldUppercaseEscapedNames()),
+		TempTableName: tableID.FullyQualifiedName(s.ShouldUppercaseEscapedNames()),
 	})
 }

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -154,7 +154,7 @@ func (s *Store) putTable(ctx context.Context, dataset, tableName string, rows []
 }
 
 func (s *Store) Dedupe(tableID types.TableIdentifier) error {
-	fqTableName := tableID.FullyQualifiedName(true, s.ShouldUppercaseEscapedNames())
+	fqTableName := tableID.FullyQualifiedName(s.ShouldUppercaseEscapedNames())
 	_, err := s.Exec(fmt.Sprintf("CREATE OR REPLACE TABLE %s AS SELECT DISTINCT * FROM %s", fqTableName, fqTableName))
 	return err
 }

--- a/clients/bigquery/bigquery_test.go
+++ b/clients/bigquery/bigquery_test.go
@@ -47,6 +47,6 @@ func TestTempTableName(t *testing.T) {
 	store := &Store{config: config.Config{BigQuery: &config.BigQuery{ProjectID: "123454321"}}}
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
 	tableID := store.IdentifierFor(tableData.TopicConfig(), tableData.Name())
-	tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName(false, store.ShouldUppercaseEscapedNames())
+	tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName(store.ShouldUppercaseEscapedNames())
 	assert.Equal(t, "`123454321`.`db`.table___artie_sUfFiX", trimTTL(tempTableName))
 }

--- a/clients/bigquery/tableid.go
+++ b/clients/bigquery/tableid.go
@@ -34,13 +34,13 @@ func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
 	return NewTableIdentifier(ti.projectID, ti.dataset, table)
 }
 
-func (ti TableIdentifier) FullyQualifiedName(escape, uppercaseEscNames bool) string {
+func (ti TableIdentifier) FullyQualifiedName(uppercaseEscNames bool) string {
 	// The fully qualified name for BigQuery is: project_id.dataset.tableName.
 	// We are escaping the project_id and dataset because there could be special characters.
 	return fmt.Sprintf(
 		"`%s`.`%s`.%s",
 		ti.projectID,
 		ti.dataset,
-		sql.EscapeName(ti.table, uppercaseEscNames, &sql.NameArgs{Escape: escape, DestKind: constants.BigQuery}),
+		sql.EscapeName(ti.table, uppercaseEscNames, &sql.NameArgs{Escape: true, DestKind: constants.BigQuery}),
 	)
 }

--- a/clients/bigquery/tableid_test.go
+++ b/clients/bigquery/tableid_test.go
@@ -20,17 +20,13 @@ func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	{
 		// Table name that does not need escaping:
 		tableID := NewTableIdentifier("project", "dataset", "foo")
-		assert.Equal(t, "`project`.`dataset`.foo", tableID.FullyQualifiedName(true, false), "escaped")
-		assert.Equal(t, "`project`.`dataset`.foo", tableID.FullyQualifiedName(true, true), "escaped + upper")
-		assert.Equal(t, "`project`.`dataset`.foo", tableID.FullyQualifiedName(false, false), "unescaped")
-		assert.Equal(t, "`project`.`dataset`.foo", tableID.FullyQualifiedName(false, true), "unescaped + upper")
+		assert.Equal(t, "`project`.`dataset`.foo", tableID.FullyQualifiedName(false), "escaped")
+		assert.Equal(t, "`project`.`dataset`.foo", tableID.FullyQualifiedName(true), "escaped + upper")
 	}
 	{
 		// Table name that needs escaping:
 		tableID := NewTableIdentifier("project", "dataset", "table")
-		assert.Equal(t, "`project`.`dataset`.`table`", tableID.FullyQualifiedName(true, false), "escaped")
-		assert.Equal(t, "`project`.`dataset`.`TABLE`", tableID.FullyQualifiedName(true, true), "escaped + upper")
-		assert.Equal(t, "`project`.`dataset`.table", tableID.FullyQualifiedName(false, false), "unescaped")
-		assert.Equal(t, "`project`.`dataset`.table", tableID.FullyQualifiedName(false, true), "unescaped + upper")
+		assert.Equal(t, "`project`.`dataset`.`table`", tableID.FullyQualifiedName(false), "escaped")
+		assert.Equal(t, "`project`.`dataset`.`TABLE`", tableID.FullyQualifiedName(true), "escaped + upper")
 	}
 }

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -45,7 +45,7 @@ func (s *Store) Merge(tableData *optimization.TableData) error {
 func (s *Store) Append(tableData *optimization.TableData) error {
 	tableID := s.IdentifierFor(tableData.TopicConfig(), tableData.Name())
 	return shared.Append(s, tableData, s.config, types.AppendOpts{
-		TempTableName: tableID.FullyQualifiedName(true, s.ShouldUppercaseEscapedNames()),
+		TempTableName: tableID.FullyQualifiedName(s.ShouldUppercaseEscapedNames()),
 	})
 }
 

--- a/clients/mssql/store_test.go
+++ b/clients/mssql/store_test.go
@@ -28,14 +28,14 @@ func TestTempTableName(t *testing.T) {
 		// Schema is "schema":
 		tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
 		tableID := store.IdentifierFor(tableData.TopicConfig(), tableData.Name())
-		tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName(false, store.ShouldUppercaseEscapedNames())
+		tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName(store.ShouldUppercaseEscapedNames())
 		assert.Equal(t, "schema.table___artie_sUfFiX", trimTTL(tempTableName))
 	}
 	{
 		// Schema is "public" -> "dbo":
 		tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "public"}, "table")
 		tableID := store.IdentifierFor(tableData.TopicConfig(), tableData.Name())
-		tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName(false, store.ShouldUppercaseEscapedNames())
+		tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName(store.ShouldUppercaseEscapedNames())
 		assert.Equal(t, "dbo.table___artie_sUfFiX", trimTTL(tempTableName))
 	}
 }

--- a/clients/mssql/tableid.go
+++ b/clients/mssql/tableid.go
@@ -29,10 +29,10 @@ func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
 	return NewTableIdentifier(ti.schema, table)
 }
 
-func (ti TableIdentifier) FullyQualifiedName(escape, uppercaseEscNames bool) string {
+func (ti TableIdentifier) FullyQualifiedName(uppercaseEscNames bool) string {
 	return fmt.Sprintf(
 		"%s.%s",
 		ti.schema,
-		sql.EscapeName(ti.table, uppercaseEscNames, &sql.NameArgs{Escape: escape, DestKind: constants.MSSQL}),
+		sql.EscapeName(ti.table, uppercaseEscNames, &sql.NameArgs{Escape: true, DestKind: constants.MSSQL}),
 	)
 }

--- a/clients/mssql/tableid_test.go
+++ b/clients/mssql/tableid_test.go
@@ -19,17 +19,13 @@ func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	{
 		// Table name that does not need escaping:
 		tableID := NewTableIdentifier("schema", "foo")
-		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(true, false), "escaped")
-		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(true, true), "escaped + upper")
-		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(false, false), "unescaped")
-		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(false, true), "unescaped + upper")
+		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(false), "escaped")
+		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(true), "escaped + upper")
 	}
 	{
 		// Table name that needs escaping:
 		tableID := NewTableIdentifier("schema", "table")
-		assert.Equal(t, `schema."table"`, tableID.FullyQualifiedName(true, false), "escaped")
-		assert.Equal(t, `schema."TABLE"`, tableID.FullyQualifiedName(true, true), "escaped + upper")
-		assert.Equal(t, "schema.table", tableID.FullyQualifiedName(false, false), "unescaped")
-		assert.Equal(t, "schema.table", tableID.FullyQualifiedName(false, true), "unescaped + upper")
+		assert.Equal(t, `schema."table"`, tableID.FullyQualifiedName(false), "escaped")
+		assert.Equal(t, `schema."TABLE"`, tableID.FullyQualifiedName(true), "escaped + upper")
 	}
 }

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -98,8 +98,8 @@ WHERE
 }
 
 func (s *Store) Dedupe(tableID types.TableIdentifier) error {
-	fqTableName := tableID.FullyQualifiedName(true, s.ShouldUppercaseEscapedNames())
-	stagingTableName := shared.TempTableID(tableID, strings.ToLower(stringutil.Random(5))).FullyQualifiedName(true, s.ShouldUppercaseEscapedNames())
+	fqTableName := tableID.FullyQualifiedName(s.ShouldUppercaseEscapedNames())
+	stagingTableName := shared.TempTableID(tableID, strings.ToLower(stringutil.Random(5))).FullyQualifiedName(s.ShouldUppercaseEscapedNames())
 
 	query := fmt.Sprintf(`
 CREATE TABLE %s AS SELECT DISTINCT * FROM %s;

--- a/clients/redshift/redshift_test.go
+++ b/clients/redshift/redshift_test.go
@@ -25,6 +25,6 @@ func TestTempTableName(t *testing.T) {
 
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
 	tableID := (&Store{}).IdentifierFor(tableData.TopicConfig(), tableData.Name())
-	tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName(false, false)
+	tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName(false)
 	assert.Equal(t, "schema.table___artie_sUfFiX", trimTTL(tempTableName))
 }

--- a/clients/redshift/tableid.go
+++ b/clients/redshift/tableid.go
@@ -29,12 +29,12 @@ func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
 	return NewTableIdentifier(ti.schema, table)
 }
 
-func (ti TableIdentifier) FullyQualifiedName(escape, uppercaseEscNames bool) string {
+func (ti TableIdentifier) FullyQualifiedName(uppercaseEscNames bool) string {
 	// Redshift is Postgres compatible, so when establishing a connection, we'll specify a database.
 	// Thus, we only need to specify schema and table name here.
 	return fmt.Sprintf(
 		"%s.%s",
 		ti.schema,
-		sql.EscapeName(ti.table, uppercaseEscNames, &sql.NameArgs{Escape: escape, DestKind: constants.Redshift}),
+		sql.EscapeName(ti.table, uppercaseEscNames, &sql.NameArgs{Escape: true, DestKind: constants.Redshift}),
 	)
 }

--- a/clients/redshift/tableid_test.go
+++ b/clients/redshift/tableid_test.go
@@ -19,17 +19,13 @@ func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	{
 		// Table name that does not need escaping:
 		tableID := NewTableIdentifier("schema", "foo")
-		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(true, false), "escaped")
-		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(true, true), "escaped + upper")
-		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(false, false), "unescaped")
-		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(false, true), "unescaped + upper")
+		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(false), "escaped")
+		assert.Equal(t, "schema.foo", tableID.FullyQualifiedName(true), "escaped + upper")
 	}
 	{
 		// Table name that needs escaping:
 		tableID := NewTableIdentifier("schema", "table")
-		assert.Equal(t, `schema."table"`, tableID.FullyQualifiedName(true, false), "escaped")
-		assert.Equal(t, `schema."TABLE"`, tableID.FullyQualifiedName(true, true), "escaped + upper")
-		assert.Equal(t, "schema.table", tableID.FullyQualifiedName(false, false), "unescaped")
-		assert.Equal(t, "schema.table", tableID.FullyQualifiedName(false, true), "unescaped + upper")
+		assert.Equal(t, `schema."table"`, tableID.FullyQualifiedName(false), "escaped")
+		assert.Equal(t, `schema."TABLE"`, tableID.FullyQualifiedName(true), "escaped + upper")
 	}
 }

--- a/clients/redshift/writes.go
+++ b/clients/redshift/writes.go
@@ -13,12 +13,12 @@ func (s *Store) Append(tableData *optimization.TableData) error {
 
 	// Redshift is slightly different, we'll load and create the temporary table via shared.Append
 	// Then, we'll invoke `ALTER TABLE target APPEND FROM staging` to combine the diffs.
-	temporaryTableName := shared.TempTableID(tableID, tableData.TempTableSuffix()).FullyQualifiedName(false, s.ShouldUppercaseEscapedNames())
+	temporaryTableName := shared.TempTableID(tableID, tableData.TempTableSuffix()).FullyQualifiedName(s.ShouldUppercaseEscapedNames())
 	if err := shared.Append(s, tableData, s.config, types.AppendOpts{TempTableName: temporaryTableName}); err != nil {
 		return err
 	}
 
-	_, err := s.Exec(fmt.Sprintf(`ALTER TABLE %s APPEND FROM %s;`, tableID.FullyQualifiedName(true, s.ShouldUppercaseEscapedNames()), temporaryTableName))
+	_, err := s.Exec(fmt.Sprintf(`ALTER TABLE %s APPEND FROM %s;`, tableID.FullyQualifiedName(s.ShouldUppercaseEscapedNames()), temporaryTableName))
 	return err
 }
 

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -59,7 +59,7 @@ func (s *Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) ty
 // > optionalPrefix/fullyQualifiedTableName/YYYY-MM-DD
 func (s *Store) ObjectPrefix(tableData *optimization.TableData) string {
 	tableID := s.IdentifierFor(tableData.TopicConfig(), tableData.Name())
-	fqTableName := tableID.FullyQualifiedName(false, false)
+	fqTableName := tableID.FullyQualifiedName(false)
 	yyyyMMDDFormat := tableData.LatestCDCTs.Format(ext.PostgresDateFormat)
 
 	if len(s.config.S3.OptionalPrefix) > 0 {

--- a/clients/s3/tableid.go
+++ b/clients/s3/tableid.go
@@ -32,7 +32,7 @@ func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
 	return NewTableIdentifier(ti.database, ti.schema, table)
 }
 
-func (ti TableIdentifier) FullyQualifiedName(_, _ bool) string {
+func (ti TableIdentifier) FullyQualifiedName(_ bool) string {
 	// S3 should be db.schema.tableName, but we don't need to escape, since it's not a SQL db.
 	return fmt.Sprintf("%s.%s.%s", ti.database, ti.schema, ti.table)
 }

--- a/clients/s3/tableid_test.go
+++ b/clients/s3/tableid_test.go
@@ -19,8 +19,6 @@ func TestTableIdentifier_WithTable(t *testing.T) {
 func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	// S3 doesn't escape the table name.
 	tableID := NewTableIdentifier("database", "schema", "table")
-	assert.Equal(t, "database.schema.table", tableID.FullyQualifiedName(true, false), "escaped")
-	assert.Equal(t, "database.schema.table", tableID.FullyQualifiedName(true, true), "escaped + upper")
-	assert.Equal(t, "database.schema.table", tableID.FullyQualifiedName(false, false), "unescaped")
-	assert.Equal(t, "database.schema.table", tableID.FullyQualifiedName(false, true), "unescaped + upper")
+	assert.Equal(t, "database.schema.table", tableID.FullyQualifiedName(false), "escaped")
+	assert.Equal(t, "database.schema.table", tableID.FullyQualifiedName(true), "escaped + upper")
 }

--- a/clients/shared/append.go
+++ b/clients/shared/append.go
@@ -23,7 +23,7 @@ func Append(dwh destination.DataWarehouse, tableData *optimization.TableData, cf
 	}
 
 	tableID := dwh.IdentifierFor(tableData.TopicConfig(), tableData.Name())
-	fqName := tableID.FullyQualifiedName(true, dwh.ShouldUppercaseEscapedNames())
+	fqName := tableID.FullyQualifiedName(dwh.ShouldUppercaseEscapedNames())
 	tableConfig, err := dwh.GetTableConfig(tableData)
 	if err != nil {
 		return err

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -35,7 +35,7 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, cfg
 		tableData.TopicConfig().IncludeDatabaseUpdatedAt, tableData.Mode())
 
 	tableID := dwh.IdentifierFor(tableData.TopicConfig(), tableData.Name())
-	fqName := tableID.FullyQualifiedName(true, dwh.ShouldUppercaseEscapedNames())
+	fqName := tableID.FullyQualifiedName(dwh.ShouldUppercaseEscapedNames())
 	createAlterTableArgs := ddl.AlterTableArgs{
 		Dwh:               dwh,
 		Tc:                tableConfig,
@@ -73,7 +73,7 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, cfg
 	tableConfig.AuditColumnsToDelete(srcKeysMissing)
 	tableData.MergeColumnsFromDestination(tableConfig.Columns().GetColumns()...)
 	temporaryTableID := TempTableID(dwh.IdentifierFor(tableData.TopicConfig(), tableData.Name()), tableData.TempTableSuffix())
-	temporaryTableName := temporaryTableID.FullyQualifiedName(false, dwh.ShouldUppercaseEscapedNames())
+	temporaryTableName := temporaryTableID.FullyQualifiedName(dwh.ShouldUppercaseEscapedNames())
 	if err = dwh.PrepareTemporaryTable(tableData, tableConfig, temporaryTableName, types.AdditionalSettings{}, true); err != nil {
 		return fmt.Errorf("failed to prepare temporary table: %w", err)
 	}

--- a/clients/shared/table_config.go
+++ b/clients/shared/table_config.go
@@ -41,7 +41,7 @@ func (g GetTableCfgArgs) ShouldParseComment(comment string) bool {
 }
 
 func (g GetTableCfgArgs) GetTableConfig() (*types.DwhTableConfig, error) {
-	fqName := g.TableID.FullyQualifiedName(true, g.Dwh.ShouldUppercaseEscapedNames())
+	fqName := g.TableID.FullyQualifiedName(g.Dwh.ShouldUppercaseEscapedNames())
 
 	// Check if it already exists in cache
 	tableConfig := g.ConfigMap.TableConfig(fqName)

--- a/clients/shared/table_config_test.go
+++ b/clients/shared/table_config_test.go
@@ -80,7 +80,7 @@ type MockTableIdentifier struct{ fqName string }
 
 func (MockTableIdentifier) Table() string                                { panic("not implemented") }
 func (MockTableIdentifier) WithTable(table string) types.TableIdentifier { panic("not implemented") }
-func (m MockTableIdentifier) FullyQualifiedName(_, _ bool) string        { return m.fqName }
+func (m MockTableIdentifier) FullyQualifiedName(_ bool) string           { return m.fqName }
 
 func TestGetTableConfig(t *testing.T) {
 	// Return early because table is found in configMap.

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -37,7 +37,7 @@ func (s *Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) ty
 
 func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTableConfig, error) {
 	tableID := s.IdentifierFor(tableData.TopicConfig(), tableData.Name())
-	fqName := tableID.FullyQualifiedName(true, s.ShouldUppercaseEscapedNames())
+	fqName := tableID.FullyQualifiedName(s.ShouldUppercaseEscapedNames())
 	return shared.GetTableCfgArgs{
 		Dwh:                s,
 		TableID:            tableID,
@@ -121,7 +121,7 @@ func (s *Store) reestablishConnection() error {
 }
 
 func (s *Store) Dedupe(tableID types.TableIdentifier) error {
-	fqTableName := tableID.FullyQualifiedName(true, s.ShouldUppercaseEscapedNames())
+	fqTableName := tableID.FullyQualifiedName(s.ShouldUppercaseEscapedNames())
 	_, err := s.Exec(fmt.Sprintf("CREATE OR REPLACE TABLE %s AS SELECT DISTINCT * FROM %s", fqTableName, fqTableName))
 	return err
 }

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -24,7 +24,7 @@ import (
 
 func (s *SnowflakeTestSuite) fullyQualifiedName(tableData *optimization.TableData) string {
 	tableID := s.stageStore.IdentifierFor(tableData.TopicConfig(), tableData.Name())
-	return tableID.FullyQualifiedName(true, s.stageStore.config.SharedDestinationConfig.UppercaseEscapedNames)
+	return tableID.FullyQualifiedName(s.stageStore.config.SharedDestinationConfig.UppercaseEscapedNames)
 }
 
 func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
@@ -307,6 +307,6 @@ func TestTempTableName(t *testing.T) {
 
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
 	tableID := (&Store{}).IdentifierFor(tableData.TopicConfig(), tableData.Name())
-	tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName(false, false)
+	tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName(false)
 	assert.Equal(t, "db.schema.table___artie_sUfFiX", trimTTL(tempTableName))
 }

--- a/clients/snowflake/tableid.go
+++ b/clients/snowflake/tableid.go
@@ -34,11 +34,11 @@ func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
 	return NewTableIdentifier(ti.database, ti.schema, table)
 }
 
-func (ti TableIdentifier) FullyQualifiedName(escape, uppercaseEscNames bool) string {
+func (ti TableIdentifier) FullyQualifiedName(uppercaseEscNames bool) string {
 	return fmt.Sprintf(
 		"%s.%s.%s",
 		ti.database,
 		ti.schema,
-		sql.EscapeName(ti.table, uppercaseEscNames, &sql.NameArgs{Escape: escape, DestKind: constants.Snowflake}),
+		sql.EscapeName(ti.table, uppercaseEscNames, &sql.NameArgs{Escape: true, DestKind: constants.Snowflake}),
 	)
 }

--- a/clients/snowflake/tableid_test.go
+++ b/clients/snowflake/tableid_test.go
@@ -20,17 +20,13 @@ func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	{
 		// Table name that does not need escaping:
 		tableID := NewTableIdentifier("database", "schema", "foo")
-		assert.Equal(t, "database.schema.foo", tableID.FullyQualifiedName(true, false), "escaped")
-		assert.Equal(t, "database.schema.foo", tableID.FullyQualifiedName(true, true), "escaped + upper")
-		assert.Equal(t, "database.schema.foo", tableID.FullyQualifiedName(false, false), "unescaped")
-		assert.Equal(t, "database.schema.foo", tableID.FullyQualifiedName(false, true), "unescaped + upper")
+		assert.Equal(t, "database.schema.foo", tableID.FullyQualifiedName(false), "escaped")
+		assert.Equal(t, "database.schema.foo", tableID.FullyQualifiedName(true), "escaped + upper")
 	}
 	{
 		// Table name that needs escaping:
 		tableID := NewTableIdentifier("database", "schema", "table")
-		assert.Equal(t, `database.schema."table"`, tableID.FullyQualifiedName(true, false), "escaped")
-		assert.Equal(t, `database.schema."TABLE"`, tableID.FullyQualifiedName(true, true), "escaped + upper")
-		assert.Equal(t, "database.schema.table", tableID.FullyQualifiedName(false, false), "unescaped")
-		assert.Equal(t, "database.schema.table", tableID.FullyQualifiedName(false, true), "unescaped + upper")
+		assert.Equal(t, `database.schema."table"`, tableID.FullyQualifiedName(false), "escaped")
+		assert.Equal(t, `database.schema."TABLE"`, tableID.FullyQualifiedName(true), "escaped + upper")
 	}
 }

--- a/clients/snowflake/writes.go
+++ b/clients/snowflake/writes.go
@@ -27,7 +27,7 @@ func (s *Store) Append(tableData *optimization.TableData) error {
 		tableID := s.IdentifierFor(tableData.TopicConfig(), tableData.Name())
 		// TODO: For history mode - in the future, we could also have a separate stage name for history mode so we can enable parallel processing.
 		err = shared.Append(s, tableData, s.config, types.AppendOpts{
-			TempTableName:        tableID.FullyQualifiedName(true, s.ShouldUppercaseEscapedNames()),
+			TempTableName:        tableID.FullyQualifiedName(s.ShouldUppercaseEscapedNames()),
 			AdditionalCopyClause: `FILE_FORMAT = (TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE) PURGE = TRUE`,
 		})
 	}

--- a/lib/destination/ddl/ddl_alter_delete_test.go
+++ b/lib/destination/ddl/ddl_alter_delete_test.go
@@ -33,9 +33,9 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	}, "tableName")
 
 	originalColumnLength := len(cols.GetColumns())
-	bqName := d.bigQueryStore.IdentifierFor(td.TopicConfig(), td.Name()).FullyQualifiedName(true, false)
-	redshiftName := d.redshiftStore.IdentifierFor(td.TopicConfig(), td.Name()).FullyQualifiedName(true, false)
-	snowflakeName := d.snowflakeStagesStore.IdentifierFor(td.TopicConfig(), td.Name()).FullyQualifiedName(true, false)
+	bqName := d.bigQueryStore.IdentifierFor(td.TopicConfig(), td.Name()).FullyQualifiedName(false)
+	redshiftName := d.redshiftStore.IdentifierFor(td.TopicConfig(), td.Name()).FullyQualifiedName(false)
+	snowflakeName := d.snowflakeStagesStore.IdentifierFor(td.TopicConfig(), td.Name()).FullyQualifiedName(false)
 
 	// Testing 3 scenarios here
 	// 1. DropDeletedColumns = false, ContainOtherOperations = true, don't delete ever.

--- a/lib/destination/ddl/ddl_bq_test.go
+++ b/lib/destination/ddl/ddl_bq_test.go
@@ -45,7 +45,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	fqName := d.bigQueryStore.IdentifierFor(td.TopicConfig(), td.Name()).FullyQualifiedName(true, false)
+	fqName := d.bigQueryStore.IdentifierFor(td.TopicConfig(), td.Name()).FullyQualifiedName(false)
 	originalColumnLength := len(cols.GetColumns())
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, true))
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)
@@ -246,7 +246,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	fqName := d.bigQueryStore.IdentifierFor(td.TopicConfig(), td.Name()).FullyQualifiedName(true, false)
+	fqName := d.bigQueryStore.IdentifierFor(td.TopicConfig(), td.Name()).FullyQualifiedName(false)
 	originalColumnLength := len(columnNameToKindDetailsMap)
 	d.bigQueryStore.GetConfigMap().AddTableToConfig(fqName, types.NewDwhTableConfig(&cols, nil, false, false))
 	tc := d.bigQueryStore.GetConfigMap().TableConfig(fqName)

--- a/lib/destination/types/types.go
+++ b/lib/destination/types/types.go
@@ -62,5 +62,5 @@ func (a AppendOpts) Validate() error {
 type TableIdentifier interface {
 	Table() string
 	WithTable(table string) TableIdentifier
-	FullyQualifiedName(escape, uppercaseEscNames bool) string
+	FullyQualifiedName(uppercaseEscNames bool) string
 }


### PR DESCRIPTION
Instead we'll always attempt to escape table names.