### PR TITLE
[mssql] Always escape table names

### DIFF
--- a/clients/mssql/store_test.go
+++ b/clients/mssql/store_test.go
@@ -20,7 +20,7 @@ func TestTempTableName(t *testing.T) {
 		epoch, err := strconv.ParseInt(tableName[lastUnderscore+1:len(tableName)-1], 10, 64)
 		assert.NoError(t, err)
 		assert.Greater(t, time.Unix(epoch, 0), time.Now().Add(5*time.Hour)) // default TTL is 6 hours from now
-		return tableName[:lastUnderscore] + `"`
+		return tableName[:lastUnderscore] + string(tableName[len(tableName)-1])
 	}
 
 	store := Store{}

--- a/clients/mssql/store_test.go
+++ b/clients/mssql/store_test.go
@@ -17,10 +17,10 @@ func TestTempTableName(t *testing.T) {
 	trimTTL := func(tableName string) string {
 		lastUnderscore := strings.LastIndex(tableName, "_")
 		assert.GreaterOrEqual(t, lastUnderscore, 0)
-		epoch, err := strconv.ParseInt(tableName[lastUnderscore+1:], 10, 64)
+		epoch, err := strconv.ParseInt(tableName[lastUnderscore+1:len(tableName)-1], 10, 64)
 		assert.NoError(t, err)
 		assert.Greater(t, time.Unix(epoch, 0), time.Now().Add(5*time.Hour)) // default TTL is 6 hours from now
-		return tableName[:lastUnderscore]
+		return tableName[:lastUnderscore] + `"`
 	}
 
 	store := Store{}
@@ -29,13 +29,13 @@ func TestTempTableName(t *testing.T) {
 		tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
 		tableID := store.IdentifierFor(tableData.TopicConfig(), tableData.Name())
 		tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName()
-		assert.Equal(t, "schema.table___artie_sUfFiX", trimTTL(tempTableName))
+		assert.Equal(t, `schema."table___artie_sUfFiX"`, trimTTL(tempTableName))
 	}
 	{
 		// Schema is "public" -> "dbo":
 		tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "public"}, "table")
 		tableID := store.IdentifierFor(tableData.TopicConfig(), tableData.Name())
 		tempTableName := shared.TempTableID(tableID, "sUfFiX").FullyQualifiedName()
-		assert.Equal(t, "dbo.table___artie_sUfFiX", trimTTL(tempTableName))
+		assert.Equal(t, `dbo."table___artie_sUfFiX"`, trimTTL(tempTableName))
 	}
 }

--- a/clients/mssql/tableid.go
+++ b/clients/mssql/tableid.go
@@ -33,6 +33,6 @@ func (ti TableIdentifier) FullyQualifiedName() string {
 	return fmt.Sprintf(
 		"%s.%s",
 		ti.schema,
-		sql.EscapeNameIfNecessary(ti.table, false, constants.MSSQL),
+		sql.EscapeName(ti.table, false, constants.MSSQL),
 	)
 }

--- a/clients/mssql/tableid_test.go
+++ b/clients/mssql/tableid_test.go
@@ -16,9 +16,9 @@ func TestTableIdentifier_WithTable(t *testing.T) {
 }
 
 func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
-	// Table name that does not need escaping:
-	assert.Equal(t, "schema.foo", NewTableIdentifier("schema", "foo").FullyQualifiedName())
+	// Table name that is not a reserved word:
+	assert.Equal(t, `schema."foo"`, NewTableIdentifier("schema", "foo").FullyQualifiedName())
 
-	// Table name that needs escaping:
+	// Table name that is a reserved word:
 	assert.Equal(t, `schema."table"`, NewTableIdentifier("schema", "table").FullyQualifiedName())
 }

--- a/lib/sql/escape.go
+++ b/lib/sql/escape.go
@@ -14,7 +14,7 @@ var symbolsToEscape = []string{":"}
 
 func EscapeNameIfNecessary(name string, uppercaseEscNames bool, destKind constants.DestinationKind) string {
 	if needsEscaping(name, destKind) {
-		return escapeName(name, uppercaseEscNames, destKind)
+		return EscapeName(name, uppercaseEscNames, destKind)
 	}
 	return name
 }
@@ -48,7 +48,7 @@ func needsEscaping(name string, destKind constants.DestinationKind) bool {
 	return false
 }
 
-func escapeName(name string, uppercaseEscNames bool, destKind constants.DestinationKind) string {
+func EscapeName(name string, uppercaseEscNames bool, destKind constants.DestinationKind) string {
 	if uppercaseEscNames {
 		name = strings.ToUpper(name)
 	}


### PR DESCRIPTION
When you create a table or column in MS SQL, and do not quote the identifier, the database uses the exact casing that the identifier was supplied in.

```
CREATE SCHEMA teST
CREATE TABLE teST.UPPER (lower INT NOT NULL, UPPER INT NOT NULL, MiXeD INT NOT NULL)
CREATE TABLE teST.lower (lower INT NOT NULL, UPPER INT NOT NULL, MiXeD INT NOT NULL)
CREATE TABLE teST.mIxEd (lower INT NOT NULL, UPPER INT NOT NULL, MiXeD INT NOT NULL)
CREATE TABLE teST.MiXeD1 (lower INT NOT NULL, UPPER INT NOT NULL, MiXeD INT NOT NULL)
```

Result:
```
table    column
-----    ------
UPPER    lower
UPPER    MiXeD
UPPER    UPPER
lower    lower
lower    MiXeD                                                                                                                           
lower    UPPER                                                                                                                           
mIxEd    lower                                                                                                                           
mIxEd    MiXeD                                                                                                                           
mIxEd    UPPER                                                                                                                           
MiXeD1   lower                                                                                                                           
MiXeD1   MiXeD                                                                                                                           
MiXeD1   UPPER
```