### PR TITLE
[redshift] Don't uppercase escaped table names

### DIFF
--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -30,7 +30,7 @@ type Store struct {
 }
 
 func (s *Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) types.TableIdentifier {
-	return NewTableIdentifier(topicConfig.Schema, table, s.ShouldUppercaseEscapedNames())
+	return NewTableIdentifier(topicConfig.Schema, table)
 }
 
 func (s *Store) GetConfigMap() *types.DwhToTablesConfigMap {

--- a/clients/redshift/tableid.go
+++ b/clients/redshift/tableid.go
@@ -9,13 +9,12 @@ import (
 )
 
 type TableIdentifier struct {
-	schema                string
-	table                 string
-	uppercaseEscapedNames bool
+	schema string
+	table  string
 }
 
-func NewTableIdentifier(schema, table string, uppercaseEscapedNames bool) TableIdentifier {
-	return TableIdentifier{schema: schema, table: table, uppercaseEscapedNames: uppercaseEscapedNames}
+func NewTableIdentifier(schema, table string) TableIdentifier {
+	return TableIdentifier{schema: schema, table: table}
 }
 
 func (ti TableIdentifier) Schema() string {
@@ -27,7 +26,7 @@ func (ti TableIdentifier) Table() string {
 }
 
 func (ti TableIdentifier) WithTable(table string) types.TableIdentifier {
-	return NewTableIdentifier(ti.schema, table, ti.uppercaseEscapedNames)
+	return NewTableIdentifier(ti.schema, table)
 }
 
 func (ti TableIdentifier) FullyQualifiedName() string {
@@ -36,6 +35,6 @@ func (ti TableIdentifier) FullyQualifiedName() string {
 	return fmt.Sprintf(
 		"%s.%s",
 		ti.schema,
-		sql.EscapeNameIfNecessary(ti.table, ti.uppercaseEscapedNames, constants.Redshift),
+		sql.EscapeNameIfNecessary(ti.table, false, constants.Redshift),
 	)
 }

--- a/clients/redshift/tableid_test.go
+++ b/clients/redshift/tableid_test.go
@@ -7,21 +7,18 @@ import (
 )
 
 func TestTableIdentifier_WithTable(t *testing.T) {
-	tableID := NewTableIdentifier("schema", "foo", true)
+	tableID := NewTableIdentifier("schema", "foo")
 	tableID2 := tableID.WithTable("bar")
 	typedTableID2, ok := tableID2.(TableIdentifier)
 	assert.True(t, ok)
 	assert.Equal(t, "schema", typedTableID2.Schema())
 	assert.Equal(t, "bar", tableID2.Table())
-	assert.True(t, typedTableID2.uppercaseEscapedNames)
 }
 
 func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
-	// Table name that does not need escaping:
-	assert.Equal(t, "schema.foo", NewTableIdentifier("schema", "foo", false).FullyQualifiedName())
-	assert.Equal(t, "schema.foo", NewTableIdentifier("schema", "foo", true).FullyQualifiedName())
+	// Table name that is not a reserved word:
+	assert.Equal(t, `schema.foo`, NewTableIdentifier("schema", "foo").FullyQualifiedName())
 
-	// Table name that needs escaping:
-	assert.Equal(t, `schema."table"`, NewTableIdentifier("schema", "table", false).FullyQualifiedName())
-	assert.Equal(t, `schema."TABLE"`, NewTableIdentifier("schema", "table", true).FullyQualifiedName())
+	// Table name that is a reserved word:
+	assert.Equal(t, `schema."table"`, NewTableIdentifier("schema", "table").FullyQualifiedName())
 }


### PR DESCRIPTION
Note that column names will still be uppercased if and only if `SharedDestinationConfig.UppercaseEscapedNames` is set to true.