### PR TITLE
[redshift] Remove `uppercaseEscapedNames` support

### DIFF
--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -46,7 +46,7 @@ func (s *Store) Label() constants.DestinationKind {
 }
 
 func (s *Store) ShouldUppercaseEscapedNames() bool {
-	return s.config.SharedDestinationConfig.UppercaseEscapedNames
+	return false
 }
 
 func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTableConfig, error) {

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -224,20 +224,24 @@ func readFileToConfig(pathToConfig string) (*Config, error) {
 
 func (c Config) ValidateRedshift() error {
 	if c.Output != constants.Redshift {
-		return fmt.Errorf("output is not redshift, output: %v", c.Output)
+		return fmt.Errorf("output is not Redshift, output: %v", c.Output)
 	}
 
 	if c.Redshift == nil {
-		return fmt.Errorf("redshift cfg is nil")
+		return fmt.Errorf("cfg for Redshift is nil")
 	}
 
 	if empty := stringutil.Empty(c.Redshift.Host, c.Redshift.Database, c.Redshift.Username,
 		c.Redshift.Password, c.Redshift.Bucket, c.Redshift.CredentialsClause); empty {
-		return fmt.Errorf("one of redshift settings is empty")
+		return fmt.Errorf("one of Redshift settings is empty")
 	}
 
 	if c.Redshift.Port <= 0 {
-		return fmt.Errorf("redshift invalid port")
+		return fmt.Errorf("invalid Redshift port")
+	}
+
+	if c.SharedDestinationConfig.UppercaseEscapedNames {
+		return fmt.Errorf("uppercaseEscapedNames is not supported for Redshift")
 	}
 
 	return nil

--- a/lib/config/config_validate_test.go
+++ b/lib/config/config_validate_test.go
@@ -86,12 +86,12 @@ func TestCfg_ValidateRedshift(t *testing.T) {
 		{
 			name:        "nil",
 			redshift:    nil,
-			expectedErr: "redshift cfg is nil",
+			expectedErr: "cfg for Redshift is nil",
 		},
 		{
 			name:        "redshift settings exist, but all empty",
 			redshift:    &Redshift{},
-			expectedErr: "one of redshift settings is empty",
+			expectedErr: "one of Redshift settings is empty",
 		},
 		{
 			name: "redshift settings all set (missing port)",
@@ -103,7 +103,7 @@ func TestCfg_ValidateRedshift(t *testing.T) {
 				Bucket:            "bucket",
 				CredentialsClause: "creds",
 			},
-			expectedErr: "redshift invalid port",
+			expectedErr: "invalid Redshift port",
 		},
 		{
 			name: "redshift settings all set (neg port)",
@@ -116,7 +116,7 @@ func TestCfg_ValidateRedshift(t *testing.T) {
 				Bucket:            "bucket",
 				CredentialsClause: "creds",
 			},
-			expectedErr: "redshift invalid port",
+			expectedErr: "invalid Redshift port",
 		},
 		{
 			name: "redshift settings all set",


### PR DESCRIPTION
Redshift lowercase tables and column names so this setting was misleading.