### PR TITLE
[Snowflake] Use Abort Detached Queries.

### DIFF
--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -97,6 +97,11 @@ func (s *Store) reestablishConnection() error {
 		return nil
 	}
 
+	params := make(map[string]*string)
+
+	// https://docs.snowflake.com/en/sql-reference/parameters#abort-detached-query
+	params["ABORT_DETACHED_QUERY"] = ptr.ToString(fmt.Sprint(true))
+
 	cfg := &gosnowflake.Config{
 		Account:     s.config.Snowflake.AccountID,
 		User:        s.config.Snowflake.Username,
@@ -104,6 +109,9 @@ func (s *Store) reestablishConnection() error {
 		Warehouse:   s.config.Snowflake.Warehouse,
 		Region:      s.config.Snowflake.Region,
 		Application: s.config.Snowflake.Application,
+
+		// Try this as our params.
+		Params: params,
 	}
 
 	if s.config.Snowflake.Host != "" {

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -97,11 +97,6 @@ func (s *Store) reestablishConnection() error {
 		return nil
 	}
 
-	params := make(map[string]*string)
-
-	// https://docs.snowflake.com/en/sql-reference/parameters#abort-detached-query
-	params["ABORT_DETACHED_QUERY"] = ptr.ToString(fmt.Sprint(true))
-
 	cfg := &gosnowflake.Config{
 		Account:     s.config.Snowflake.AccountID,
 		User:        s.config.Snowflake.Username,
@@ -109,7 +104,10 @@ func (s *Store) reestablishConnection() error {
 		Warehouse:   s.config.Snowflake.Warehouse,
 		Region:      s.config.Snowflake.Region,
 		Application: s.config.Snowflake.Application,
-		Params:      params,
+		Params: map[string]*string{
+			// https://docs.snowflake.com/en/sql-reference/parameters#abort-detached-query
+			"ABORT_DETACHED_QUERY": ptr.ToString("true"),
+		},
 	}
 
 	if s.config.Snowflake.Host != "" {

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -109,9 +109,7 @@ func (s *Store) reestablishConnection() error {
 		Warehouse:   s.config.Snowflake.Warehouse,
 		Region:      s.config.Snowflake.Region,
 		Application: s.config.Snowflake.Application,
-
-		// Try this as our params.
-		Params: params,
+		Params:      params,
 	}
 
 	if s.config.Snowflake.Host != "" {


### PR DESCRIPTION
## Context

Right now, for history mode / appends, it is susceptible to duplicates when there's a process restart.

The flow goes like this right now:

1. Create local stage and upload data to Snowflake
2. Load data into the target table via COPY INTO
3. Commit Kafka offset

However, if there's a process restart while we're in the midst of step 2, the connection will disconnect, but they query will still keep executing.

When the process then restarts, it will then fetch from the previous offset and keep going. This will result in duplicates.

## Solution

We're enabling [ABORT_DETACHED_QUERY](https://docs.snowflake.com/en/sql-reference/parameters#abort-detached-query) which should help reduce the amount of duplicates that arise from process restarts.

![image](https://github.com/artie-labs/transfer/assets/4412200/cdb60a6f-632f-455c-a42d-6780033541a5)

