### PR TITLE
[go] Include MS for ISO8601.

### DIFF
--- a/lib/cdc/postgres/debezium_test.go
+++ b/lib/cdc/postgres/debezium_test.go
@@ -90,7 +90,7 @@ func (p *PostgresTestSuite) TestPostgresEvent() {
 	})
 	assert.NoError(p.T(), err)
 	assert.Equal(p.T(), float64(59), evtData["id"])
-	assert.Equal(p.T(), "2022-11-16T04:01:53+00:00", evtData[constants.DatabaseUpdatedColumnMarker])
+	assert.Equal(p.T(), "2022-11-16T04:01:53.308+00:00", evtData[constants.DatabaseUpdatedColumnMarker])
 
 	assert.Equal(p.T(), "Barings Participation Investors", evtData["item"])
 	assert.Equal(p.T(), map[string]any{"object": "foo"}, evtData["nested"])

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -127,7 +127,7 @@ func TestColumn_DefaultValue(t *testing.T) {
 			args: &DefaultValueArgs{
 				Escape: true,
 			},
-			expectedValue: "'03:19:24'",
+			expectedValue: "'03:19:24.942'",
 		},
 		{
 			name: "datetime",
@@ -138,7 +138,7 @@ func TestColumn_DefaultValue(t *testing.T) {
 			args: &DefaultValueArgs{
 				Escape: true,
 			},
-			expectedValue: "'2022-09-06T03:19:24Z'",
+			expectedValue: "'2022-09-06T03:19:24.942Z'",
 		},
 	}
 

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -4,7 +4,7 @@ import "time"
 
 const (
 	BigQueryDateTimeFormat = "2006-01-02 15:04:05.999999"
-	ISO8601                = "2006-01-02T15:04:05-07:00"
+	ISO8601                = "2006-01-02T15:04:05.999-07:00"
 	PostgresDateFormat     = "2006-01-02"
 	PostgresTimeFormat     = "15:04:05.999999-07" // microsecond precision
 	AdditionalTimeFormat   = "15:04:05.999999Z07"


### PR DESCRIPTION
The ISO8601 format we were using did not include ms precision. This PR adds `ms` precision. This will be particularly helpful in history mode, where there may be more than one update within a second for the same row.