### PR TITLE
Refactoring BigQuery Dedupe

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -161,8 +161,8 @@ func (s *Store) generateDedupeQueries(tableID, stagingTableID types.TableIdentif
 	}
 
 	var orderByCols []string
-	for _, pk := range orderColsToIterate {
-		orderByCols = append(orderByCols, fmt.Sprintf("%s ASC", pk))
+	for _, orderByCol := range orderColsToIterate {
+		orderByCols = append(orderByCols, fmt.Sprintf("%s ASC", orderByCol))
 	}
 
 	var parts []string

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -21,9 +21,9 @@ import (
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/typing"
-	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
 const (
@@ -151,13 +151,12 @@ func (s *Store) putTable(ctx context.Context, tableID types.TableIdentifier, row
 func (s *Store) generateDedupeQueries(tableID, stagingTableID types.TableIdentifier, primaryKeys []string, topicConfig kafkalib.TopicConfig) []string {
 	var primaryKeysEscaped []string
 	for _, pk := range primaryKeys {
-		pkCol := columns.NewColumn(pk, typing.Invalid)
-		primaryKeysEscaped = append(primaryKeysEscaped, pkCol.Name(s.ShouldUppercaseEscapedNames(), s.Label()))
+		primaryKeysEscaped = append(primaryKeysEscaped, sql.EscapeNameIfNecessary(pk, s.ShouldUppercaseEscapedNames(), s.Label()))
 	}
 
 	orderColsToIterate := primaryKeysEscaped
 	if topicConfig.IncludeArtieUpdatedAt {
-		orderColsToIterate = append(orderColsToIterate, constants.UpdateColumnMarker)
+		orderColsToIterate = append(orderColsToIterate, sql.EscapeNameIfNecessary(constants.UpdateColumnMarker, s.ShouldUppercaseEscapedNames(), s.Label()))
 	}
 
 	var orderByCols []string

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/typing/columns"
-
 	"cloud.google.com/go/bigquery"
 	_ "github.com/viant/bigquery"
 
@@ -25,6 +23,7 @@ import (
 	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
 const (

--- a/clients/bigquery/bigquery_dedupe_test.go
+++ b/clients/bigquery/bigquery_dedupe_test.go
@@ -1,0 +1,90 @@
+package bigquery
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/typing"
+
+	"github.com/artie-labs/transfer/clients/shared"
+	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/stringutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func (b *BigQueryTestSuite) TestGenerateDedupeQueries() {
+	{
+		// Dedupe with one primary key + no `__artie_updated_at` flag.
+		tableID := NewTableIdentifier("project12", "public", "customers")
+		stagingTableID := shared.TempTableID(tableID, strings.ToLower(stringutil.Random(5)))
+
+		parts := b.store.generateDedupeQueries(tableID, stagingTableID, []string{"id"}, kafkalib.TopicConfig{})
+		assert.Len(b.T(), parts, 3)
+		assert.Equal(
+			b.T(),
+			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s) AS (SELECT * FROM `project12`.`public`.`customers` QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY id ASC) = 2)",
+				stagingTableID.FullyQualifiedName(),
+				fmt.Sprintf(`"%s"`, typing.ExpiresDate(time.Now().UTC().Add(constants.TemporaryTableTTL))),
+			),
+			parts[0],
+		)
+		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project12`.`public`.`customers` t1 USING %s t2 WHERE t1.id = t2.id", stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(b.T(), fmt.Sprintf("INSERT INTO `project12`.`public`.`customers` SELECT * FROM %s", stagingTableID.FullyQualifiedName()), parts[2])
+	}
+	{
+		// Dedupe with one primary key + `__artie_updated_at` flag.
+		tableID := NewTableIdentifier("project12", "public", "customers")
+		stagingTableID := shared.TempTableID(tableID, strings.ToLower(stringutil.Random(5)))
+
+		parts := b.store.generateDedupeQueries(tableID, stagingTableID, []string{"id"}, kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
+		assert.Len(b.T(), parts, 3)
+		assert.Equal(
+			b.T(),
+			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s) AS (SELECT * FROM `project12`.`public`.`customers` QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY id ASC, __artie_updated_at ASC) = 2)",
+				stagingTableID.FullyQualifiedName(),
+				fmt.Sprintf(`"%s"`, typing.ExpiresDate(time.Now().UTC().Add(constants.TemporaryTableTTL))),
+			),
+			parts[0],
+		)
+		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project12`.`public`.`customers` t1 USING %s t2 WHERE t1.id = t2.id", stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(b.T(), fmt.Sprintf("INSERT INTO `project12`.`public`.`customers` SELECT * FROM %s", stagingTableID.FullyQualifiedName()), parts[2])
+	}
+	{
+		// Dedupe with composite keys + no `__artie_updated_at` flag.
+		tableID := NewTableIdentifier("project123", "public", "user_settings")
+		stagingTableID := shared.TempTableID(tableID, strings.ToLower(stringutil.Random(5)))
+
+		parts := b.store.generateDedupeQueries(tableID, stagingTableID, []string{"user_id", "settings"}, kafkalib.TopicConfig{})
+		assert.Len(b.T(), parts, 3)
+		assert.Equal(
+			b.T(),
+			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s) AS (SELECT * FROM `project123`.`public`.`user_settings` QUALIFY ROW_NUMBER() OVER (PARTITION BY user_id, settings ORDER BY user_id ASC, settings ASC) = 2)",
+				stagingTableID.FullyQualifiedName(),
+				fmt.Sprintf(`"%s"`, typing.ExpiresDate(time.Now().UTC().Add(constants.TemporaryTableTTL))),
+			),
+			parts[0],
+		)
+		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project123`.`public`.`user_settings` t1 USING %s t2 WHERE t1.user_id = t2.user_id AND t1.settings = t2.settings", stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(b.T(), fmt.Sprintf("INSERT INTO `project123`.`public`.`user_settings` SELECT * FROM %s", stagingTableID.FullyQualifiedName()), parts[2])
+	}
+	{
+		// Dedupe with composite keys + `__artie_updated_at` flag.
+		tableID := NewTableIdentifier("project123", "public", "user_settings")
+		stagingTableID := shared.TempTableID(tableID, strings.ToLower(stringutil.Random(5)))
+
+		parts := b.store.generateDedupeQueries(tableID, stagingTableID, []string{"user_id", "settings"}, kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
+		assert.Len(b.T(), parts, 3)
+		assert.Equal(
+			b.T(),
+			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s) AS (SELECT * FROM `project123`.`public`.`user_settings` QUALIFY ROW_NUMBER() OVER (PARTITION BY user_id, settings ORDER BY user_id ASC, settings ASC, __artie_updated_at ASC) = 2)",
+				stagingTableID.FullyQualifiedName(),
+				fmt.Sprintf(`"%s"`, typing.ExpiresDate(time.Now().UTC().Add(constants.TemporaryTableTTL))),
+			),
+			parts[0],
+		)
+		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project123`.`public`.`user_settings` t1 USING %s t2 WHERE t1.user_id = t2.user_id AND t1.settings = t2.settings", stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(b.T(), fmt.Sprintf("INSERT INTO `project123`.`public`.`user_settings` SELECT * FROM %s", stagingTableID.FullyQualifiedName()), parts[2])
+	}
+}

--- a/clients/bigquery/bigquery_dedupe_test.go
+++ b/clients/bigquery/bigquery_dedupe_test.go
@@ -5,13 +5,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/clients/shared"
+	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/stringutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/artie-labs/transfer/lib/typing"
 )
 
 func (b *BigQueryTestSuite) TestGenerateDedupeQueries() {
@@ -24,13 +24,13 @@ func (b *BigQueryTestSuite) TestGenerateDedupeQueries() {
 		assert.Len(b.T(), parts, 3)
 		assert.Equal(
 			b.T(),
-			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s) AS (SELECT * FROM `project12`.`public`.`customers` QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY id ASC) = 2)",
+			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s)) AS (SELECT * FROM `project12`.`public`.`customers` QUALIFY ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `id` ASC) = 2)",
 				stagingTableID.FullyQualifiedName(),
 				fmt.Sprintf(`"%s"`, typing.ExpiresDate(time.Now().UTC().Add(constants.TemporaryTableTTL))),
 			),
 			parts[0],
 		)
-		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project12`.`public`.`customers` t1 USING %s t2 WHERE t1.id = t2.id", stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project12`.`public`.`customers` t1 WHERE EXISTS (SELECT * FROM %s t2 WHERE t1.`id` = t2.`id`)", stagingTableID.FullyQualifiedName()), parts[1])
 		assert.Equal(b.T(), fmt.Sprintf("INSERT INTO `project12`.`public`.`customers` SELECT * FROM %s", stagingTableID.FullyQualifiedName()), parts[2])
 	}
 	{
@@ -42,13 +42,13 @@ func (b *BigQueryTestSuite) TestGenerateDedupeQueries() {
 		assert.Len(b.T(), parts, 3)
 		assert.Equal(
 			b.T(),
-			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s) AS (SELECT * FROM `project12`.`public`.`customers` QUALIFY ROW_NUMBER() OVER (PARTITION BY id ORDER BY id ASC, __artie_updated_at ASC) = 2)",
+			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s)) AS (SELECT * FROM `project12`.`public`.`customers` QUALIFY ROW_NUMBER() OVER (PARTITION BY `id` ORDER BY `id` ASC, __artie_updated_at ASC) = 2)",
 				stagingTableID.FullyQualifiedName(),
 				fmt.Sprintf(`"%s"`, typing.ExpiresDate(time.Now().UTC().Add(constants.TemporaryTableTTL))),
 			),
 			parts[0],
 		)
-		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project12`.`public`.`customers` t1 USING %s t2 WHERE t1.id = t2.id", stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project12`.`public`.`customers` t1 WHERE EXISTS (SELECT * FROM %s t2 WHERE t1.`id` = t2.`id`)", stagingTableID.FullyQualifiedName()), parts[1])
 		assert.Equal(b.T(), fmt.Sprintf("INSERT INTO `project12`.`public`.`customers` SELECT * FROM %s", stagingTableID.FullyQualifiedName()), parts[2])
 	}
 	{
@@ -60,13 +60,13 @@ func (b *BigQueryTestSuite) TestGenerateDedupeQueries() {
 		assert.Len(b.T(), parts, 3)
 		assert.Equal(
 			b.T(),
-			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s) AS (SELECT * FROM `project123`.`public`.`user_settings` QUALIFY ROW_NUMBER() OVER (PARTITION BY user_id, settings ORDER BY user_id ASC, settings ASC) = 2)",
+			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s)) AS (SELECT * FROM `project123`.`public`.`user_settings` QUALIFY ROW_NUMBER() OVER (PARTITION BY `user_id`, `settings` ORDER BY `user_id` ASC, `settings` ASC) = 2)",
 				stagingTableID.FullyQualifiedName(),
 				fmt.Sprintf(`"%s"`, typing.ExpiresDate(time.Now().UTC().Add(constants.TemporaryTableTTL))),
 			),
 			parts[0],
 		)
-		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project123`.`public`.`user_settings` t1 USING %s t2 WHERE t1.user_id = t2.user_id AND t1.settings = t2.settings", stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project123`.`public`.`user_settings` t1 WHERE EXISTS (SELECT * FROM %s t2 WHERE t1.`user_id` = t2.`user_id` AND t1.`settings` = t2.`settings`)", stagingTableID.FullyQualifiedName()), parts[1])
 		assert.Equal(b.T(), fmt.Sprintf("INSERT INTO `project123`.`public`.`user_settings` SELECT * FROM %s", stagingTableID.FullyQualifiedName()), parts[2])
 	}
 	{
@@ -78,13 +78,13 @@ func (b *BigQueryTestSuite) TestGenerateDedupeQueries() {
 		assert.Len(b.T(), parts, 3)
 		assert.Equal(
 			b.T(),
-			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s) AS (SELECT * FROM `project123`.`public`.`user_settings` QUALIFY ROW_NUMBER() OVER (PARTITION BY user_id, settings ORDER BY user_id ASC, settings ASC, __artie_updated_at ASC) = 2)",
+			fmt.Sprintf("CREATE OR REPLACE TABLE %s OPTIONS (expiration_timestamp = TIMESTAMP(%s)) AS (SELECT * FROM `project123`.`public`.`user_settings` QUALIFY ROW_NUMBER() OVER (PARTITION BY `user_id`, `settings` ORDER BY `user_id` ASC, `settings` ASC, __artie_updated_at ASC) = 2)",
 				stagingTableID.FullyQualifiedName(),
 				fmt.Sprintf(`"%s"`, typing.ExpiresDate(time.Now().UTC().Add(constants.TemporaryTableTTL))),
 			),
 			parts[0],
 		)
-		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project123`.`public`.`user_settings` t1 USING %s t2 WHERE t1.user_id = t2.user_id AND t1.settings = t2.settings", stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(b.T(), fmt.Sprintf("DELETE FROM `project123`.`public`.`user_settings` t1 WHERE EXISTS (SELECT * FROM %s t2 WHERE t1.`user_id` = t2.`user_id` AND t1.`settings` = t2.`settings`)", stagingTableID.FullyQualifiedName()), parts[1])
 		assert.Equal(b.T(), fmt.Sprintf("INSERT INTO `project123`.`public`.`user_settings` SELECT * FROM %s", stagingTableID.FullyQualifiedName()), parts[2])
 	}
 }

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -15,9 +15,8 @@ import (
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/stringutil"
-	"github.com/artie-labs/transfer/lib/typing"
-	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
 const maxRetries = 10
@@ -131,13 +130,12 @@ func (s *Store) reestablishConnection() error {
 func (s *Store) generateDedupeQueries(tableID, stagingTableID types.TableIdentifier, primaryKeys []string, topicConfig kafkalib.TopicConfig) []string {
 	var primaryKeysEscaped []string
 	for _, pk := range primaryKeys {
-		pkCol := columns.NewColumn(pk, typing.Invalid)
-		primaryKeysEscaped = append(primaryKeysEscaped, pkCol.Name(s.ShouldUppercaseEscapedNames(), s.Label()))
+		primaryKeysEscaped = append(primaryKeysEscaped, sql.EscapeNameIfNecessary(pk, s.ShouldUppercaseEscapedNames(), s.Label()))
 	}
 
 	orderColsToIterate := primaryKeysEscaped
 	if topicConfig.IncludeArtieUpdatedAt {
-		orderColsToIterate = append(orderColsToIterate, constants.UpdateColumnMarker)
+		orderColsToIterate = append(orderColsToIterate, sql.EscapeNameIfNecessary(constants.UpdateColumnMarker, s.ShouldUppercaseEscapedNames(), s.Label()))
 	}
 
 	var orderByCols []string


### PR DESCRIPTION
## Changes

Improving the way we handle deduping in BigQuery.

This way, we'll create a staging table that has all the duplicate rows.
* It stores the `latest` row in the staging table 
* We then delete all the duplicate rows from the target table
* We then copy the data from staging -> target
* Drop staging table