### PR TITLE
[mssql] Rename `DefaultDialect` to `MSSQLDialect`

### DIFF
--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -36,7 +36,7 @@ func (s *Store) Label() constants.DestinationKind {
 }
 
 func (s *Store) Dialect() sql.Dialect {
-	return sql.DefaultDialect{}
+	return sql.MSSQLDialect{}
 }
 
 func (s *Store) Merge(tableData *optimization.TableData) error {

--- a/clients/mssql/tableid.go
+++ b/clients/mssql/tableid.go
@@ -7,7 +7,7 @@ import (
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
-var dialect = sql.DefaultDialect{}
+var dialect = sql.MSSQLDialect{}
 
 type TableIdentifier struct {
 	schema string

--- a/lib/destination/dml/merge_mssql_test.go
+++ b/lib/destination/dml/merge_mssql_test.go
@@ -44,10 +44,10 @@ func Test_GetMSSQLStatement(t *testing.T) {
 		TableID:       MockTableIdentifier{fqTable},
 		SubQuery:      subQuery,
 		IdempotentKey: "",
-		PrimaryKeys:   []columns.Wrapper{columns.NewWrapper(columns.NewColumn("id", typing.Invalid), sql.DefaultDialect{})},
+		PrimaryKeys:   []columns.Wrapper{columns.NewWrapper(columns.NewColumn("id", typing.Invalid), sql.MSSQLDialect{})},
 		Columns:       &_cols,
 		DestKind:      constants.MSSQL,
-		Dialect:       sql.DefaultDialect{},
+		Dialect:       sql.MSSQLDialect{},
 		SoftDelete:    false,
 	}
 

--- a/lib/destination/dml/merge_parts_test.go
+++ b/lib/destination/dml/merge_parts_test.go
@@ -48,10 +48,10 @@ func getBasicColumnsForTest(compositeKey bool) result {
 	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
 	var pks []columns.Wrapper
-	pks = append(pks, columns.NewWrapper(idCol, sql.DefaultDialect{}))
+	pks = append(pks, columns.NewWrapper(idCol, sql.MSSQLDialect{}))
 
 	if compositeKey {
-		pks = append(pks, columns.NewWrapper(emailCol, sql.DefaultDialect{}))
+		pks = append(pks, columns.NewWrapper(emailCol, sql.MSSQLDialect{}))
 	}
 
 	return result{

--- a/lib/sql/dialect.go
+++ b/lib/sql/dialect.go
@@ -15,11 +15,11 @@ type Dialect interface {
 	QuoteIdentifier(identifier string) string
 }
 
-type DefaultDialect struct{}
+type MSSQLDialect struct{}
 
-func (DefaultDialect) NeedsEscaping(_ string) bool { return true }
+func (MSSQLDialect) NeedsEscaping(_ string) bool { return true }
 
-func (DefaultDialect) QuoteIdentifier(identifier string) string {
+func (MSSQLDialect) QuoteIdentifier(identifier string) string {
 	return fmt.Sprintf(`"%s"`, identifier)
 }
 

--- a/lib/sql/dialect_test.go
+++ b/lib/sql/dialect_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestDefaultDialect_QuoteIdentifier(t *testing.T) {
-	dialect := DefaultDialect{}
+	dialect := MSSQLDialect{}
 	assert.Equal(t, `"foo"`, dialect.QuoteIdentifier("foo"))
 	assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("FOO"))
 }

--- a/lib/sql/dialect_test.go
+++ b/lib/sql/dialect_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDefaultDialect_QuoteIdentifier(t *testing.T) {
+func TestMSSQLDialect_QuoteIdentifier(t *testing.T) {
 	dialect := MSSQLDialect{}
 	assert.Equal(t, `"foo"`, dialect.QuoteIdentifier("foo"))
 	assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("FOO"))


### PR DESCRIPTION
`DefaultDialect` is only used by MS SQL so might as well make it specific.