### PR TITLE
[snowflake] Always escape column identifiers

### DIFF
--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -78,7 +78,7 @@ func (s *Store) Label() constants.DestinationKind {
 }
 
 func (s *Store) Dialect() sql.Dialect {
-	return sql.SnowflakeDialect{UppercaseEscNames: s.config.SharedDestinationConfig.UppercaseEscapedNames}
+	return sql.SnowflakeDialect{LegacyMode: !s.config.SharedDestinationConfig.UppercaseEscapedNames}
 }
 
 func (s *Store) GetConfigMap() *types.DwhToTablesConfigMap {
@@ -130,12 +130,12 @@ func (s *Store) reestablishConnection() error {
 func (s *Store) generateDedupeQueries(tableID, stagingTableID types.TableIdentifier, primaryKeys []string, topicConfig kafkalib.TopicConfig) []string {
 	var primaryKeysEscaped []string
 	for _, pk := range primaryKeys {
-		primaryKeysEscaped = append(primaryKeysEscaped, sql.EscapeNameIfNecessary(pk, s.Dialect()))
+		primaryKeysEscaped = append(primaryKeysEscaped, s.Dialect().QuoteIdentifier(pk))
 	}
 
 	orderColsToIterate := primaryKeysEscaped
 	if topicConfig.IncludeArtieUpdatedAt {
-		orderColsToIterate = append(orderColsToIterate, sql.EscapeNameIfNecessary(constants.UpdateColumnMarker, s.Dialect()))
+		orderColsToIterate = append(orderColsToIterate, s.Dialect().QuoteIdentifier(constants.UpdateColumnMarker))
 	}
 
 	var orderByCols []string

--- a/clients/snowflake/tableid.go
+++ b/clients/snowflake/tableid.go
@@ -7,7 +7,7 @@ import (
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
-var dialect = sql.SnowflakeDialect{UppercaseEscNames: true}
+var dialect = sql.SnowflakeDialect{}
 
 type TableIdentifier struct {
 	database string

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -129,7 +129,7 @@ func (m *MergeArgument) GetParts() ([]string, error) {
 	// We also need to remove __artie flags since it does not exist in the destination table
 	var removed bool
 	for idx, col := range cols {
-		if col == sql.EscapeNameIfNecessary(constants.DeleteColumnMarker, m.Dialect) {
+		if col == m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker) {
 			cols = append(cols[:idx], cols[idx+1:]...)
 			removed = true
 			break
@@ -252,7 +252,7 @@ WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`
 	// We also need to remove __artie flags since it does not exist in the destination table
 	var removed bool
 	for idx, col := range cols {
-		if col == sql.EscapeNameIfNecessary(constants.DeleteColumnMarker, m.Dialect) {
+		if col == m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker) {
 			cols = append(cols[:idx], cols[idx+1:]...)
 			removed = true
 			break
@@ -322,7 +322,7 @@ WHEN NOT MATCHED AND COALESCE(cc.%s, 0) = 0 THEN INSERT (%s) VALUES (%s);`,
 	// We also need to remove __artie flags since it does not exist in the destination table
 	var removed bool
 	for idx, col := range cols {
-		if col == sql.EscapeNameIfNecessary(constants.DeleteColumnMarker, m.Dialect) {
+		if col == m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker) {
 			cols = append(cols[:idx], cols[idx+1:]...)
 			removed = true
 			break

--- a/lib/destination/dml/merge_test.go
+++ b/lib/destination/dml/merge_test.go
@@ -56,7 +56,7 @@ func TestMergeStatementSoftDelete(t *testing.T) {
 	_cols.AddColumn(columns.NewColumn("id", typing.String))
 	_cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
-	dialect := sql.SnowflakeDialect{UppercaseEscNames: true}
+	dialect := sql.SnowflakeDialect{}
 	for _, idempotentKey := range []string{"", "updated_at"} {
 		mergeArg := MergeArgument{
 			TableID:       MockTableIdentifier{fqTable},
@@ -107,7 +107,7 @@ func TestMergeStatement(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
-	dialect := sql.SnowflakeDialect{UppercaseEscNames: true}
+	dialect := sql.SnowflakeDialect{}
 	mergeArg := MergeArgument{
 		TableID:       MockTableIdentifier{fqTable},
 		SubQuery:      subQuery,
@@ -156,7 +156,7 @@ func TestMergeStatementIdempotentKey(t *testing.T) {
 	_cols.AddColumn(columns.NewColumn("id", typing.String))
 	_cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
-	dialect := sql.SnowflakeDialect{UppercaseEscNames: true}
+	dialect := sql.SnowflakeDialect{}
 	mergeArg := MergeArgument{
 		TableID:       MockTableIdentifier{fqTable},
 		SubQuery:      subQuery,
@@ -199,7 +199,7 @@ func TestMergeStatementCompositeKey(t *testing.T) {
 	_cols.AddColumn(columns.NewColumn("another_id", typing.String))
 	_cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 
-	dialect := sql.SnowflakeDialect{UppercaseEscNames: true}
+	dialect := sql.SnowflakeDialect{}
 	mergeArg := MergeArgument{
 		TableID:       MockTableIdentifier{fqTable},
 		SubQuery:      subQuery,
@@ -249,7 +249,7 @@ func TestMergeStatementEscapePrimaryKeys(t *testing.T) {
 	subQuery := fmt.Sprintf("SELECT %s from (values %s) as %s(%s)",
 		strings.Join(cols, ","), strings.Join(tableValues, ","), "_tbl", strings.Join(cols, ","))
 
-	dialect := sql.SnowflakeDialect{UppercaseEscNames: true}
+	dialect := sql.SnowflakeDialect{}
 	mergeArg := MergeArgument{
 		TableID:       MockTableIdentifier{fqTable},
 		SubQuery:      subQuery,

--- a/lib/destination/dml/merge_valid_test.go
+++ b/lib/destination/dml/merge_valid_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestMergeArgument_Valid(t *testing.T) {
 	primaryKeys := []columns.Wrapper{
-		columns.NewWrapper(columns.NewColumn("id", typing.Integer), sql.SnowflakeDialect{UppercaseEscNames: true}),
+		columns.NewWrapper(columns.NewColumn("id", typing.Integer), sql.SnowflakeDialect{}),
 	}
 
 	var cols columns.Columns

--- a/lib/sql/dialect.go
+++ b/lib/sql/dialect.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -52,14 +51,7 @@ type SnowflakeDialect struct {
 }
 
 func (sd SnowflakeDialect) legacyNeedsEscaping(name string) bool {
-	if slices.Contains(constants.ReservedKeywords, name) || strings.Contains(name, ":") {
-		return true
-	}
-	// If it still doesn't need to be escaped, we should check if it's a number.
-	if _, err := strconv.Atoi(name); err == nil {
-		return true
-	}
-	return false
+	return slices.Contains(constants.ReservedKeywords, name) || strings.Contains(name, ":")
 }
 
 func (sd SnowflakeDialect) QuoteIdentifier(identifier string) string {

--- a/lib/sql/dialect_test.go
+++ b/lib/sql/dialect_test.go
@@ -24,39 +24,29 @@ func TestRedshiftDialect_QuoteIdentifier(t *testing.T) {
 	assert.Equal(t, `"foo"`, dialect.QuoteIdentifier("FOO"))
 }
 
-func TestSnowflakeDialect_NeedsEscaping(t *testing.T) {
-	{
-		// UppercaseEscNames enabled:
-		dialect := SnowflakeDialect{UppercaseEscNames: true}
-
-		assert.True(t, dialect.NeedsEscaping("select"))          // name that is reserved
-		assert.True(t, dialect.NeedsEscaping("foo"))             // name that is not reserved
-		assert.True(t, dialect.NeedsEscaping("__artie_foo"))     // Artie prefix
-		assert.True(t, dialect.NeedsEscaping("__artie_foo:bar")) // Artie prefix + symbol
-	}
-
-	{
-		// UppercaseEscNames disabled:
-		dialect := SnowflakeDialect{UppercaseEscNames: false}
-
-		assert.True(t, dialect.NeedsEscaping("select"))          // name that is reserved
-		assert.False(t, dialect.NeedsEscaping("foo"))            // name that is not reserved
-		assert.False(t, dialect.NeedsEscaping("__artie_foo"))    // Artie prefix
-		assert.True(t, dialect.NeedsEscaping("__artie_foo:bar")) // Artie prefix + symbol
-	}
+func TestSnowflakeDialect_legacyNeedsEscaping(t *testing.T) {
+	dialect := SnowflakeDialect{}
+	assert.True(t, dialect.legacyNeedsEscaping("select"))          // name that is reserved
+	assert.False(t, dialect.legacyNeedsEscaping("foo"))            // name that is not reserved
+	assert.False(t, dialect.legacyNeedsEscaping("__artie_foo"))    // Artie prefix
+	assert.True(t, dialect.legacyNeedsEscaping("__artie_foo:bar")) // Artie prefix + symbol
 }
 
 func TestSnowflakeDialect_QuoteIdentifier(t *testing.T) {
 	{
-		// UppercaseEscNames enabled:
-		dialect := SnowflakeDialect{UppercaseEscNames: true}
+		// New mode:
+		dialect := SnowflakeDialect{LegacyMode: false}
 		assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("foo"))
 		assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("FOO"))
 	}
 	{
-		// UppercaseEscNames disabled:
-		dialect := SnowflakeDialect{UppercaseEscNames: false}
-		assert.Equal(t, `"foo"`, dialect.QuoteIdentifier("foo"))
+		// Legacy mode:
+		dialect := SnowflakeDialect{LegacyMode: true}
+		assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("foo"))
 		assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("FOO"))
+		assert.Equal(t, `"select"`, dialect.QuoteIdentifier("select")) // Reserved name
+		assert.Equal(t, `"order"`, dialect.QuoteIdentifier("order"))   // Reserved name
+		assert.Equal(t, `"group"`, dialect.QuoteIdentifier("group"))   // Reserved name
+		assert.Equal(t, `"start"`, dialect.QuoteIdentifier("start"))   // Reserved name
 	}
 }

--- a/lib/sql/dialect_test.go
+++ b/lib/sql/dialect_test.go
@@ -44,9 +44,10 @@ func TestSnowflakeDialect_QuoteIdentifier(t *testing.T) {
 		dialect := SnowflakeDialect{LegacyMode: true}
 		assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("foo"))
 		assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("FOO"))
-		assert.Equal(t, `"select"`, dialect.QuoteIdentifier("select")) // Reserved name
-		assert.Equal(t, `"order"`, dialect.QuoteIdentifier("order"))   // Reserved name
-		assert.Equal(t, `"group"`, dialect.QuoteIdentifier("group"))   // Reserved name
-		assert.Equal(t, `"start"`, dialect.QuoteIdentifier("start"))   // Reserved name
+		assert.Equal(t, `"abc:def"`, dialect.QuoteIdentifier("abc:def")) // Symbol
+		assert.Equal(t, `"select"`, dialect.QuoteIdentifier("select"))   // Reserved name
+		assert.Equal(t, `"order"`, dialect.QuoteIdentifier("order"))     // Reserved name
+		assert.Equal(t, `"group"`, dialect.QuoteIdentifier("group"))     // Reserved name
+		assert.Equal(t, `"start"`, dialect.QuoteIdentifier("start"))     // Reserved name
 	}
 }

--- a/lib/sql/dialect_test.go
+++ b/lib/sql/dialect_test.go
@@ -46,10 +46,10 @@ func TestSnowflakeDialect_QuoteIdentifier(t *testing.T) {
 		dialect := SnowflakeDialect{LegacyMode: true}
 		assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("foo"))
 		assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("FOO"))
-		assert.Equal(t, `"abc:def"`, dialect.QuoteIdentifier("abc:def")) // Symbol
-		assert.Equal(t, `"select"`, dialect.QuoteIdentifier("select"))   // Reserved name
-		assert.Equal(t, `"order"`, dialect.QuoteIdentifier("order"))     // Reserved name
-		assert.Equal(t, `"group"`, dialect.QuoteIdentifier("group"))     // Reserved name
-		assert.Equal(t, `"start"`, dialect.QuoteIdentifier("start"))     // Reserved name
+		assert.Equal(t, `"abc:def"`, dialect.QuoteIdentifier("abc:def")) // symbol
+		assert.Equal(t, `"select"`, dialect.QuoteIdentifier("select"))   // reserved name
+		assert.Equal(t, `"order"`, dialect.QuoteIdentifier("order"))     // reserved name
+		assert.Equal(t, `"group"`, dialect.QuoteIdentifier("group"))     // reserved name
+		assert.Equal(t, `"start"`, dialect.QuoteIdentifier("start"))     // reserved name
 	}
 }

--- a/lib/sql/dialect_test.go
+++ b/lib/sql/dialect_test.go
@@ -24,7 +24,7 @@ func TestRedshiftDialect_QuoteIdentifier(t *testing.T) {
 	assert.Equal(t, `"foo"`, dialect.QuoteIdentifier("FOO"))
 }
 
-func TestSnowflakeDialect_legacyNeedsEscaping(t *testing.T) {
+func TestSnowflakeDialect_LegacyNeedsEscaping(t *testing.T) {
 	dialect := SnowflakeDialect{}
 	assert.True(t, dialect.legacyNeedsEscaping("select"))          // name that is reserved
 	assert.False(t, dialect.legacyNeedsEscaping("foo"))            // name that is not reserved

--- a/lib/sql/dialect_test.go
+++ b/lib/sql/dialect_test.go
@@ -38,6 +38,8 @@ func TestSnowflakeDialect_QuoteIdentifier(t *testing.T) {
 		dialect := SnowflakeDialect{LegacyMode: false}
 		assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("foo"))
 		assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("FOO"))
+		assert.Equal(t, `"SELECT"`, dialect.QuoteIdentifier("select"))
+		assert.Equal(t, `"GROUP"`, dialect.QuoteIdentifier("group"))
 	}
 	{
 		// Legacy mode:

--- a/lib/sql/escape.go
+++ b/lib/sql/escape.go
@@ -1,8 +1,0 @@
-package sql
-
-func EscapeNameIfNecessary(name string, dialect Dialect) string {
-	if dialect.NeedsEscaping(name) {
-		return dialect.QuoteIdentifier(name)
-	}
-	return name
-}

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -85,7 +85,7 @@ func (c *Column) RawName() string {
 
 // Name will give you c.name and escape it if necessary.
 func (c *Column) Name(dialect sql.Dialect) string {
-	return sql.EscapeNameIfNecessary(c.name, dialect)
+	return dialect.QuoteIdentifier(c.name)
 }
 
 type Columns struct {

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -170,7 +170,7 @@ func TestColumn_Name(t *testing.T) {
 
 		assert.Equal(t, testCase.expectedName, col.RawName(), testCase.colName)
 
-		assert.Equal(t, testCase.expectedNameEsc, col.Name(sql.SnowflakeDialect{UppercaseEscNames: true}), testCase.colName)
+		assert.Equal(t, testCase.expectedNameEsc, col.Name(sql.SnowflakeDialect{}), testCase.colName)
 		assert.Equal(t, testCase.expectedNameEscBq, col.Name(sql.BigQueryDialect{}), testCase.colName)
 	}
 }
@@ -282,7 +282,7 @@ func TestColumns_GetEscapedColumnsToUpdate(t *testing.T) {
 			columns: testCase.cols,
 		}
 
-		assert.Equal(t, testCase.expectedColsEsc, cols.GetEscapedColumnsToUpdate(sql.SnowflakeDialect{UppercaseEscNames: true}), testCase.name)
+		assert.Equal(t, testCase.expectedColsEsc, cols.GetEscapedColumnsToUpdate(sql.SnowflakeDialect{}), testCase.name)
 		assert.Equal(t, testCase.expectedColsEscBq, cols.GetEscapedColumnsToUpdate(sql.BigQueryDialect{}), testCase.name)
 	}
 }
@@ -486,7 +486,7 @@ func TestColumnsUpdateQuery(t *testing.T) {
 		{
 			name:           "string and toast",
 			columns:        stringAndToastCols,
-			dialect:        sql.SnowflakeDialect{UppercaseEscNames: true},
+			dialect:        sql.SnowflakeDialect{},
 			expectedString: `"FOO"= CASE WHEN COALESCE(cc."FOO" != '__debezium_unavailable_value', true) THEN cc."FOO" ELSE c."FOO" END,"BAR"=cc."BAR"`,
 		},
 		{

--- a/lib/typing/columns/default_test.go
+++ b/lib/typing/columns/default_test.go
@@ -17,7 +17,7 @@ import (
 var dialects = []sql.Dialect{
 	sql.BigQueryDialect{},
 	sql.RedshiftDialect{},
-	sql.SnowflakeDialect{UppercaseEscNames: true},
+	sql.SnowflakeDialect{},
 }
 
 func TestColumn_DefaultValue(t *testing.T) {

--- a/lib/typing/columns/wrapper_test.go
+++ b/lib/typing/columns/wrapper_test.go
@@ -41,7 +41,7 @@ func TestWrapper_Complete(t *testing.T) {
 
 	for _, testCase := range testCases {
 		// Snowflake escape
-		w := NewWrapper(NewColumn(testCase.name, typing.Invalid), sql.SnowflakeDialect{UppercaseEscNames: true})
+		w := NewWrapper(NewColumn(testCase.name, typing.Invalid), sql.SnowflakeDialect{})
 
 		assert.Equal(t, testCase.expectedEscapedName, w.EscapedName(), testCase.name)
 		assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
@@ -53,7 +53,7 @@ func TestWrapper_Complete(t *testing.T) {
 		assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
 
 		{
-			w = NewWrapper(NewColumn(testCase.name, typing.Invalid), sql.SnowflakeDialect{UppercaseEscNames: true})
+			w = NewWrapper(NewColumn(testCase.name, typing.Invalid), sql.SnowflakeDialect{})
 			assert.Equal(t, testCase.expectedRawName, w.RawName(), testCase.name)
 		}
 		{


### PR DESCRIPTION
Adds a new flag `LegacyMode` to `SnowflakeDialect`. In legacy mode reserved column identifiers are lowercased and non-reserved column identifiers are uppercased. In regular mode all column identifiers are uppercased.