### PR TITLE
[dml] Remove `buildColumnsUpdateFragment` argument

### DIFF
--- a/lib/destination/dml/columns.go
+++ b/lib/destination/dml/columns.go
@@ -20,14 +20,9 @@ func quoteColumns(cols []columns.Column, dialect sql.Dialect) []string {
 
 // buildColumnsUpdateFragment will parse the columns and then returns a list of strings like: cc.first_name=c.first_name,cc.last_name=c.last_name,cc.email=c.email
 // NOTE: This should only be used with valid columns.
-func buildColumnsUpdateFragment(columns []columns.Column, dialect sql.Dialect, skipDeleteCol bool) string {
+func buildColumnsUpdateFragment(columns []columns.Column, dialect sql.Dialect) string {
 	var cols []string
 	for _, column := range columns {
-		// skipDeleteCol is useful because we don't want to copy the deleted column over to the source table if we're doing a hard row delete.
-		if skipDeleteCol && column.Name() == constants.DeleteColumnMarker {
-			continue
-		}
-
 		colName := dialect.QuoteIdentifier(column.Name())
 		if column.ToastColumn {
 			var colValue string

--- a/lib/destination/dml/columns_test.go
+++ b/lib/destination/dml/columns_test.go
@@ -26,7 +26,6 @@ func TestBuildColumnsUpdateFragment(t *testing.T) {
 		columns        []columns.Column
 		expectedString string
 		dialect        sql.Dialect
-		skipDeleteCol  bool
 	}
 
 	fooBarCols := []string{"foo", "bar"}

--- a/lib/destination/dml/columns_test.go
+++ b/lib/destination/dml/columns_test.go
@@ -123,21 +123,12 @@ func TestBuildColumnsUpdateFragment(t *testing.T) {
 			columns: lastCaseEscapeTypes,
 			dialect: sql.BigQueryDialect{},
 			expectedString: fmt.Sprintf("`a1`= CASE WHEN COALESCE(TO_JSON_STRING(cc.`a1`) != '%s', true) THEN cc.`a1` ELSE c.`a1` END,`b2`= CASE WHEN COALESCE(cc.`b2` != '__debezium_unavailable_value', true) THEN cc.`b2` ELSE c.`b2` END,`c3`=cc.`c3`,%s,%s",
-				key, fmt.Sprintf("`start`= CASE WHEN COALESCE(TO_JSON_STRING(cc.`start`) != '%s', true) THEN cc.`start` ELSE c.`start` END", key), "`select`=cc.`select`"),
-			skipDeleteCol: true,
-		},
-		{
-			name:    "struct, string and toast string (bigquery) w/ reserved keywords",
-			columns: lastCaseEscapeTypes,
-			dialect: sql.BigQueryDialect{},
-			expectedString: fmt.Sprintf("`a1`= CASE WHEN COALESCE(TO_JSON_STRING(cc.`a1`) != '%s', true) THEN cc.`a1` ELSE c.`a1` END,`b2`= CASE WHEN COALESCE(cc.`b2` != '__debezium_unavailable_value', true) THEN cc.`b2` ELSE c.`b2` END,`c3`=cc.`c3`,%s,%s",
 				key, fmt.Sprintf("`start`= CASE WHEN COALESCE(TO_JSON_STRING(cc.`start`) != '%s', true) THEN cc.`start` ELSE c.`start` END", key), "`select`=cc.`select`,`__artie_delete`=cc.`__artie_delete`"),
-			skipDeleteCol: false,
 		},
 	}
 
 	for _, _testCase := range testCases {
-		actualQuery := buildColumnsUpdateFragment(_testCase.columns, _testCase.dialect, _testCase.skipDeleteCol)
+		actualQuery := buildColumnsUpdateFragment(_testCase.columns, _testCase.dialect)
 		assert.Equal(t, _testCase.expectedString, actualQuery, _testCase.name)
 	}
 }

--- a/lib/destination/dml/merge.go
+++ b/lib/destination/dml/merge.go
@@ -43,7 +43,7 @@ func (m *MergeArgument) Valid() error {
 		return fmt.Errorf("merge argument does not contain primary keys")
 	}
 
-	if len(m.Columns.GetColumns()) == 0 {
+	if len(m.Columns.ValidColumns()) == 0 {
 		return fmt.Errorf("columns cannot be empty")
 	}
 
@@ -132,7 +132,7 @@ func (m *MergeArgument) GetParts() ([]string, error) {
 			// UPDATE
 			fmt.Sprintf(`UPDATE %s as c SET %s FROM %s as cc WHERE %s%s;`,
 				// UPDATE table set col1 = cc. col1
-				m.TableID.FullyQualifiedName(), buildColumnsUpdateFragment(columns, m.Dialect, false),
+				m.TableID.FullyQualifiedName(), buildColumnsUpdateFragment(columns, m.Dialect),
 				// FROM table (temp) WHERE join on PK(s)
 				m.SubQuery, strings.Join(equalitySQLParts, " and "), idempotentClause,
 			),
@@ -157,7 +157,7 @@ func (m *MergeArgument) GetParts() ([]string, error) {
 		// UPDATE
 		fmt.Sprintf(`UPDATE %s as c SET %s FROM %s as cc WHERE %s%s AND COALESCE(cc.%s, false) = false;`,
 			// UPDATE table set col1 = cc. col1
-			m.TableID.FullyQualifiedName(), buildColumnsUpdateFragment(columns, m.Dialect, true),
+			m.TableID.FullyQualifiedName(), buildColumnsUpdateFragment(columns, m.Dialect),
 			// FROM staging WHERE join on PK(s)
 			m.SubQuery, strings.Join(equalitySQLParts, " and "), idempotentClause, m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker),
 		),
@@ -235,7 +235,7 @@ WHEN MATCHED %sTHEN UPDATE SET %s
 WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`,
 			m.TableID.FullyQualifiedName(), subQuery, strings.Join(equalitySQLParts, " and "),
 			// Update + Soft Deletion
-			idempotentClause, buildColumnsUpdateFragment(m.Columns.GetColumns(), m.Dialect, false),
+			idempotentClause, buildColumnsUpdateFragment(columns, m.Dialect),
 			// Insert
 			m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker), strings.Join(quoteColumns(columns, m.Dialect), ","),
 			array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
@@ -261,7 +261,7 @@ WHEN NOT MATCHED AND IFNULL(cc.%s, false) = false THEN INSERT (%s) VALUES (%s);`
 		// Delete
 		m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker),
 		// Update
-		m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker), idempotentClause, buildColumnsUpdateFragment(m.Columns.GetColumns(), m.Dialect, true),
+		m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker), idempotentClause, buildColumnsUpdateFragment(columns, m.Dialect),
 		// Insert
 		m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker), strings.Join(quoteColumns(columns, m.Dialect), ","),
 		array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
@@ -299,7 +299,7 @@ WHEN MATCHED %sTHEN UPDATE SET %s
 WHEN NOT MATCHED AND COALESCE(cc.%s, 0) = 0 THEN INSERT (%s) VALUES (%s);`,
 			m.TableID.FullyQualifiedName(), m.SubQuery, strings.Join(equalitySQLParts, " and "),
 			// Update + Soft Deletion
-			idempotentClause, buildColumnsUpdateFragment(columns, m.Dialect, false),
+			idempotentClause, buildColumnsUpdateFragment(columns, m.Dialect),
 			// Insert
 			m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker), strings.Join(quoteColumns(columns, m.Dialect), ","),
 			array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{
@@ -326,7 +326,7 @@ WHEN NOT MATCHED AND COALESCE(cc.%s, 1) = 0 THEN INSERT (%s) VALUES (%s);`,
 		// Delete
 		m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker),
 		// Update
-		m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker), idempotentClause, buildColumnsUpdateFragment(columns, m.Dialect, true),
+		m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker), idempotentClause, buildColumnsUpdateFragment(columns, m.Dialect),
 		// Insert
 		m.Dialect.QuoteIdentifier(constants.DeleteColumnMarker), strings.Join(quoteColumns(columns, m.Dialect), ","),
 		array.StringsJoinAddPrefix(array.StringsJoinAddPrefixArgs{


### PR DESCRIPTION
Instead of passing `skipDeleteCol` to `buildColumnsUpdateFragment`, we'll just pass a slice of columns that already has the delete column marker removed.