### PR TITLE
New Queue Kind.

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -115,7 +115,7 @@ func (k *Kafka) String() string {
 
 func (c Config) TopicConfigs() ([]*kafkalib.TopicConfig, error) {
 	switch c.Queue {
-	case constants.Kafka:
+	case constants.Kafka, constants.Reader:
 		return c.Kafka.TopicConfigs, nil
 	case constants.PubSub:
 		return c.Pubsub.TopicConfigs, nil
@@ -272,7 +272,8 @@ func (c Config) Validate() error {
 		}
 	}
 
-	if c.Queue == constants.Kafka {
+	switch c.Queue {
+	case constants.Kafka:
 		if c.Kafka == nil {
 			return fmt.Errorf("kafka config is nil")
 		}
@@ -281,9 +282,7 @@ func (c Config) Validate() error {
 		if array.Empty([]string{c.Kafka.GroupID, c.Kafka.BootstrapServer}) {
 			return fmt.Errorf("kafka group or bootstrap server is empty")
 		}
-	}
-
-	if c.Queue == constants.PubSub {
+	case constants.PubSub:
 		if c.Pubsub == nil {
 			return fmt.Errorf("pubsub config is nil")
 		}

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -143,6 +143,15 @@ bufferRows: 10
 	}
 
 	assert.Nil(t, config.Validate())
+
+	// Now let's unset Kafka.
+	config.Kafka.GroupID = ""
+	config.Kafka.BootstrapServer = ""
+	assert.ErrorContains(t, config.Validate(), "kafka group or bootstrap server is empty")
+
+	// Now if it's Reader, then it's fine.
+	config.Queue = constants.Reader
+	assert.Nil(t, config.Validate())
 }
 
 func TestOutputSourceInvalid(t *testing.T) {

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -50,6 +50,8 @@ type QueueKind string
 const (
 	Kafka  QueueKind = "kafka"
 	PubSub QueueKind = "pubsub"
+	// Reader - This is when Reader is directly importing code from Transfer and skipping Kafka.
+	Reader QueueKind = "reader"
 )
 
 type DestinationKind string


### PR DESCRIPTION
This PR adds a new queue kind - `reader` which symbolizes our snapshot mechanism of Reader directly importing and running Transfer without Kafka.

This queue kind is necessary as Reader's validation is reliant on Transfer's validate. Transfer's validation currently checks for the presence of Kafka bootstrap server and group id.