### PR TITLE
[ddl] Pass `Dialect` in `AlterTableArgs`

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -49,7 +49,7 @@ func (s *Store) Append(tableData *optimization.TableData) error {
 func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableID types.TableIdentifier, _ types.AdditionalSettings, createTempTable bool) error {
 	if createTempTable {
 		tempAlterTableArgs := ddl.AlterTableArgs{
-			Dwh:            s,
+			Dialect:        s.Dialect(),
 			Tc:             tableConfig,
 			TableID:        tempTableID,
 			CreateTable:    true,
@@ -58,7 +58,7 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 			Mode:           tableData.Mode(),
 		}
 
-		if err := tempAlterTableArgs.AlterTable(tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {
+		if err := tempAlterTableArgs.AlterTable(s, tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {
 			return fmt.Errorf("failed to create temp table: %w", err)
 		}
 	}

--- a/clients/mssql/staging.go
+++ b/clients/mssql/staging.go
@@ -14,7 +14,7 @@ import (
 func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableID types.TableIdentifier, _ types.AdditionalSettings, createTempTable bool) error {
 	if createTempTable {
 		tempAlterTableArgs := ddl.AlterTableArgs{
-			Dwh:            s,
+			Dialect:        s.Dialect(),
 			Tc:             tableConfig,
 			TableID:        tempTableID,
 			CreateTable:    true,
@@ -23,7 +23,7 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 			Mode:           tableData.Mode(),
 		}
 
-		if err := tempAlterTableArgs.AlterTable(tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {
+		if err := tempAlterTableArgs.AlterTable(s, tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {
 			return fmt.Errorf("failed to create temp table: %w", err)
 		}
 	}

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -18,7 +18,7 @@ import (
 func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableID types.TableIdentifier, _ types.AdditionalSettings, createTempTable bool) error {
 	if createTempTable {
 		tempAlterTableArgs := ddl.AlterTableArgs{
-			Dwh:            s,
+			Dialect:        s.Dialect(),
 			Tc:             tableConfig,
 			TableID:        tempTableID,
 			CreateTable:    true,
@@ -27,7 +27,7 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 			Mode:           tableData.Mode(),
 		}
 
-		if err := tempAlterTableArgs.AlterTable(tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {
+		if err := tempAlterTableArgs.AlterTable(s, tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {
 			return fmt.Errorf("failed to create temp table: %w", err)
 		}
 	}

--- a/clients/shared/append.go
+++ b/clients/shared/append.go
@@ -33,7 +33,7 @@ func Append(dwh destination.DataWarehouse, tableData *optimization.TableData, op
 
 	tableID := dwh.IdentifierFor(tableData.TopicConfig(), tableData.Name())
 	createAlterTableArgs := ddl.AlterTableArgs{
-		Dwh:         dwh,
+		Dialect:     dwh.Dialect(),
 		Tc:          tableConfig,
 		TableID:     tableID,
 		CreateTable: tableConfig.CreateTable(),
@@ -43,7 +43,7 @@ func Append(dwh destination.DataWarehouse, tableData *optimization.TableData, op
 	}
 
 	// Keys that exist in CDC stream, but not in DWH
-	if err = createAlterTableArgs.AlterTable(targetKeysMissing...); err != nil {
+	if err = createAlterTableArgs.AlterTable(dwh, targetKeysMissing...); err != nil {
 		return fmt.Errorf("failed to alter table: %w", err)
 	}
 

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -49,7 +49,7 @@ func castColValStaging(colVal any, colKind columns.Column, additionalDateFmts []
 func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableConfig *types.DwhTableConfig, tempTableID types.TableIdentifier, additionalSettings types.AdditionalSettings, createTempTable bool) error {
 	if createTempTable {
 		tempAlterTableArgs := ddl.AlterTableArgs{
-			Dwh:            s,
+			Dialect:        s.Dialect(),
 			Tc:             tableConfig,
 			TableID:        tempTableID,
 			CreateTable:    true,
@@ -58,7 +58,7 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 			Mode:           tableData.Mode(),
 		}
 
-		if err := tempAlterTableArgs.AlterTable(tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {
+		if err := tempAlterTableArgs.AlterTable(s, tableData.ReadOnlyInMemoryCols().GetColumns()...); err != nil {
 			return fmt.Errorf("failed to create temp table: %w", err)
 		}
 	}

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -52,6 +52,10 @@ type AlterTableArgs struct {
 }
 
 func (a AlterTableArgs) Validate() error {
+	if a.Dialect == nil {
+		return fmt.Errorf("dialect cannot be nil")
+	}
+
 	// You can't DROP a column and try to create a table at the same time.
 	if a.ColumnOp == constants.Delete && a.CreateTable {
 		return fmt.Errorf("incompatible operation - cannot drop columns and create table at the same time")

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -37,8 +37,8 @@ func DropTemporaryTable(dwh destination.DataWarehouse, fqTableName string, shoul
 }
 
 type AlterTableArgs struct {
-	Dwh destination.DataWarehouse
-	Tc  *types.DwhTableConfig
+	Dialect sql.Dialect
+	Tc      *types.DwhTableConfig
 	// ContainsOtherOperations - this is sourced from tableData `containOtherOperations`
 	ContainOtherOperations bool
 	TableID                types.TableIdentifier
@@ -91,22 +91,22 @@ func (a AlterTableArgs) buildStatements(cols ...columns.Column) ([]string, []col
 		mutateCol = append(mutateCol, col)
 		switch a.ColumnOp {
 		case constants.Add:
-			colName := a.Dwh.Dialect().QuoteIdentifier(col.Name())
+			colName := a.Dialect.QuoteIdentifier(col.Name())
 
 			if col.PrimaryKey() && a.Mode != config.History {
 				// Don't create a PK for history mode because it's append-only, so the primary key should not be enforced.
 				pkCols = append(pkCols, colName)
 			}
 
-			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, colName, a.Dwh.Dialect().DataTypeForKind(col.KindDetails, col.PrimaryKey())))
+			colSQLParts = append(colSQLParts, fmt.Sprintf(`%s %s`, colName, a.Dialect.DataTypeForKind(col.KindDetails, col.PrimaryKey())))
 		case constants.Delete:
-			colSQLParts = append(colSQLParts, a.Dwh.Dialect().QuoteIdentifier(col.Name()))
+			colSQLParts = append(colSQLParts, a.Dialect.QuoteIdentifier(col.Name()))
 		}
 	}
 
 	if len(pkCols) > 0 {
 		pkStatement := fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(pkCols, ", "))
-		if _, ok := a.Dwh.Dialect().(sql.BigQueryDialect); ok {
+		if _, ok := a.Dialect.(sql.BigQueryDialect); ok {
 			pkStatement += " NOT ENFORCED"
 		}
 
@@ -119,9 +119,9 @@ func (a AlterTableArgs) buildStatements(cols ...columns.Column) ([]string, []col
 	if a.CreateTable {
 		var sqlQuery string
 		if a.TemporaryTable {
-			sqlQuery = a.Dwh.Dialect().BuildCreateTempTableQuery(fqTableName, colSQLParts)
+			sqlQuery = a.Dialect.BuildCreateTempTableQuery(fqTableName, colSQLParts)
 		} else {
-			if _, ok := a.Dwh.Dialect().(sql.MSSQLDialect); ok {
+			if _, ok := a.Dialect.(sql.MSSQLDialect); ok {
 				// MSSQL doesn't support IF NOT EXISTS
 				sqlQuery = fmt.Sprintf("CREATE TABLE %s (%s)", fqTableName, strings.Join(colSQLParts, ","))
 			} else {
@@ -133,7 +133,7 @@ func (a AlterTableArgs) buildStatements(cols ...columns.Column) ([]string, []col
 	} else {
 		for _, colSQLPart := range colSQLParts {
 			var sqlQuery string
-			if _, ok := a.Dwh.Dialect().(sql.MSSQLDialect); ok {
+			if _, ok := a.Dialect.(sql.MSSQLDialect); ok {
 				// MSSQL doesn't support the COLUMN keyword
 				sqlQuery = fmt.Sprintf("ALTER TABLE %s %s %s", fqTableName, a.ColumnOp, colSQLPart)
 			} else {
@@ -146,7 +146,7 @@ func (a AlterTableArgs) buildStatements(cols ...columns.Column) ([]string, []col
 	return alterStatements, mutateCol
 }
 
-func (a AlterTableArgs) AlterTable(cols ...columns.Column) error {
+func (a AlterTableArgs) AlterTable(dwh destination.DataWarehouse, cols ...columns.Column) error {
 	if err := a.Validate(); err != nil {
 		return err
 	}
@@ -159,8 +159,8 @@ func (a AlterTableArgs) AlterTable(cols ...columns.Column) error {
 
 	for _, sqlQuery := range alterStatements {
 		slog.Info("DDL - executing sql", slog.String("query", sqlQuery))
-		if _, err := a.Dwh.Exec(sqlQuery); err != nil {
-			if !a.Dwh.Dialect().IsColumnAlreadyExistsErr(err) {
+		if _, err := dwh.Exec(sqlQuery); err != nil {
+			if !a.Dialect.IsColumnAlreadyExistsErr(err) {
 				return fmt.Errorf("failed to apply ddl, sql: %q, err: %w", sqlQuery, err)
 			}
 		}

--- a/lib/destination/ddl/ddl_alter_delete_test.go
+++ b/lib/destination/ddl/ddl_alter_delete_test.go
@@ -60,7 +60,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	// Snowflake
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:                    d.snowflakeStagesStore,
+			Dialect:                d.snowflakeStagesStore.Dialect(),
 			Tc:                     snowflakeTc,
 			TableID:                snowflakeTableID,
 			CreateTable:            snowflakeTc.CreateTable(),
@@ -70,7 +70,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.snowflakeStagesStore, column))
 	}
 
 	// Never actually deleted.
@@ -80,7 +80,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	// BigQuery
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:                    d.bigQueryStore,
+			Dialect:                d.bigQueryStore.Dialect(),
 			Tc:                     bqTc,
 			TableID:                bqTableID,
 			CreateTable:            bqTc.CreateTable(),
@@ -90,7 +90,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		err := alterTableArgs.AlterTable(column)
+		err := alterTableArgs.AlterTable(d.bigQueryStore, column)
 		assert.NoError(d.T(), err)
 	}
 
@@ -101,7 +101,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	// Redshift
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:                    d.redshiftStore,
+			Dialect:                d.redshiftStore.Dialect(),
 			Tc:                     redshiftTc,
 			TableID:                redshiftTableID,
 			CreateTable:            redshiftTc.CreateTable(),
@@ -111,7 +111,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.redshiftStore, column))
 	}
 
 	// Never actually deleted.
@@ -135,7 +135,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:                    d.snowflakeStagesStore,
+			Dialect:                d.snowflakeStagesStore.Dialect(),
 			Tc:                     snowflakeTc,
 			TableID:                snowflakeTableID,
 			CreateTable:            snowflakeTc.CreateTable(),
@@ -145,7 +145,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.snowflakeStagesStore, column))
 	}
 
 	// Never actually deleted.
@@ -155,7 +155,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	// BigQuery
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:                    d.bigQueryStore,
+			Dialect:                d.bigQueryStore.Dialect(),
 			Tc:                     bqTc,
 			TableID:                bqTableID,
 			CreateTable:            bqTc.CreateTable(),
@@ -165,7 +165,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.bigQueryStore, column))
 	}
 
 	// Never actually deleted.
@@ -175,7 +175,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	// Redshift
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:                    d.redshiftStore,
+			Dialect:                d.redshiftStore.Dialect(),
 			Tc:                     redshiftTc,
 			TableID:                redshiftTableID,
 			CreateTable:            redshiftTc.CreateTable(),
@@ -185,7 +185,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.redshiftStore, column))
 	}
 
 	// Never actually deleted.
@@ -211,7 +211,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	// Snowflake
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:                    d.snowflakeStagesStore,
+			Dialect:                d.snowflakeStagesStore.Dialect(),
 			Tc:                     snowflakeTc,
 			TableID:                snowflakeTableID,
 			CreateTable:            snowflakeTc.CreateTable(),
@@ -221,13 +221,13 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.snowflakeStagesStore, column))
 	}
 
 	// BigQuery
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:                    d.bigQueryStore,
+			Dialect:                d.bigQueryStore.Dialect(),
 			Tc:                     bqTc,
 			TableID:                bqTableID,
 			CreateTable:            bqTc.CreateTable(),
@@ -237,13 +237,13 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.bigQueryStore, column))
 	}
 
 	// Redshift
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:                    d.redshiftStore,
+			Dialect:                d.redshiftStore.Dialect(),
 			Tc:                     redshiftTc,
 			TableID:                redshiftTableID,
 			CreateTable:            redshiftTc.CreateTable(),
@@ -253,7 +253,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.redshiftStore, column))
 	}
 
 	// Nothing has been deleted, but it is all added to the permissions table.
@@ -267,7 +267,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 
 	for _, column := range cols.GetColumns() {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:                    d.snowflakeStagesStore,
+			Dialect:                d.snowflakeStagesStore.Dialect(),
 			Tc:                     snowflakeTc,
 			TableID:                snowflakeTableID,
 			CreateTable:            snowflakeTc.CreateTable(),
@@ -277,11 +277,11 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.snowflakeStagesStore, column))
 
 		// BigQuery
 		alterTableArgs = ddl.AlterTableArgs{
-			Dwh:                    d.bigQueryStore,
+			Dialect:                d.bigQueryStore.Dialect(),
 			Tc:                     bqTc,
 			TableID:                bqTableID,
 			CreateTable:            bqTc.CreateTable(),
@@ -291,11 +291,11 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.bigQueryStore, column))
 
 		// Redshift
 		alterTableArgs = ddl.AlterTableArgs{
-			Dwh:                    d.redshiftStore,
+			Dialect:                d.redshiftStore.Dialect(),
 			Tc:                     redshiftTc,
 			TableID:                redshiftTableID,
 			CreateTable:            redshiftTc.CreateTable(),
@@ -305,7 +305,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 			Mode:                   config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(column))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.redshiftStore, column))
 	}
 
 	// Everything has been deleted.

--- a/lib/destination/ddl/ddl_create_table_test.go
+++ b/lib/destination/ddl/ddl_create_table_test.go
@@ -53,7 +53,7 @@ func (d *DDLTestSuite) Test_CreateTable() {
 		},
 	} {
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:         dwhTc._dwh,
+			Dialect:     dwhTc._dwh.Dialect(),
 			Tc:          dwhTc._tableConfig,
 			TableID:     dwhTc._tableID,
 			CreateTable: dwhTc._tableConfig.CreateTable(),
@@ -61,7 +61,7 @@ func (d *DDLTestSuite) Test_CreateTable() {
 			Mode:        config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(columns.NewColumn("name", typing.String)))
+		assert.NoError(d.T(), alterTableArgs.AlterTable(dwhTc._dwh, columns.NewColumn("name", typing.String)))
 		assert.Equal(d.T(), 1, dwhTc._fakeStore.ExecCallCount())
 
 		query, _ := dwhTc._fakeStore.ExecArgsForCall(0)
@@ -118,7 +118,7 @@ func (d *DDLTestSuite) TestCreateTable() {
 		tc := d.snowflakeStagesStore.GetConfigMap().TableConfig(tableID)
 
 		alterTableArgs := ddl.AlterTableArgs{
-			Dwh:         d.snowflakeStagesStore,
+			Dialect:     d.snowflakeStagesStore.Dialect(),
 			Tc:          tc,
 			TableID:     tableID,
 			CreateTable: tc.CreateTable(),
@@ -127,7 +127,7 @@ func (d *DDLTestSuite) TestCreateTable() {
 			Mode:        config.Replication,
 		}
 
-		assert.NoError(d.T(), alterTableArgs.AlterTable(testCase.cols...), testCase.name)
+		assert.NoError(d.T(), alterTableArgs.AlterTable(d.snowflakeStagesStore, testCase.cols...), testCase.name)
 
 		execQuery, _ := d.fakeSnowflakeStagesStore.ExecArgsForCall(index)
 		assert.Equal(d.T(), testCase.expectedQuery, execQuery, testCase.name)

--- a/lib/destination/ddl/ddl_temp_test.go
+++ b/lib/destination/ddl/ddl_temp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
 	"github.com/artie-labs/transfer/lib/destination/types"
+	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
 )
@@ -21,13 +22,15 @@ func (d *DDLTestSuite) TestValidate_AlterTableArgs() {
 		CreateTable: true,
 		Mode:        config.Replication,
 	}
+	assert.ErrorContains(d.T(), a.Validate(), "dialect cannot be nil")
 
-	assert.Contains(d.T(), a.Validate().Error(), "incompatible operation - cannot drop columns and create table at the same time")
+	a.Dialect = sql.BigQueryDialect{}
+	assert.ErrorContains(d.T(), a.Validate(), "incompatible operation - cannot drop columns and create table at the same time")
 
 	a.ColumnOp = constants.Add
 	a.CreateTable = false
 	a.TemporaryTable = true
-	assert.Contains(d.T(), a.Validate().Error(), "incompatible operation - we should not be altering temporary tables, only create")
+	assert.ErrorContains(d.T(), a.Validate(), "incompatible operation - we should not be altering temporary tables, only create")
 }
 
 func (d *DDLTestSuite) TestCreateTemporaryTable_Errors() {


### PR DESCRIPTION
Since the  Store/DataWarehouse is now only needed to execute the queries we'll pass it in the `AlterTable` method call.