### PR TITLE
Passing along the MongoDB before object

### DIFF
--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -28,8 +28,7 @@ func (d *Debezium) GetEventFromBytes(typingSettings typing.Settings, bytes []byt
 		return nil, fmt.Errorf("empty message")
 	}
 
-	err := json.Unmarshal(bytes, &schemaEventPayload)
-	if err != nil {
+	if err := json.Unmarshal(bytes, &schemaEventPayload); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
@@ -156,10 +155,14 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 		// And we need to reconstruct the data bit since it will be empty.
 		// We _can_ rely on *before* since even without running replicate identity, it will still copy over
 		// the PK. We can explore simplifying this interface in the future by leveraging before.
-		retMap = map[string]any{
-			constants.DeleteColumnMarker: true,
+
+		if len(s.Payload.beforeMap) == 0 {
+			retMap = make(map[string]any)
+		} else {
+			retMap = s.Payload.beforeMap
 		}
 
+		retMap[constants.DeleteColumnMarker] = true
 		for k, v := range pkMap {
 			retMap[k] = v
 		}

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -155,11 +155,10 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 		// And we need to reconstruct the data bit since it will be empty.
 		// We _can_ rely on *before* since even without running replicate identity, it will still copy over
 		// the PK. We can explore simplifying this interface in the future by leveraging before.
-
-		if len(s.Payload.beforeMap) == 0 {
-			retMap = make(map[string]any)
-		} else {
+		if len(s.Payload.beforeMap) > 0 {
 			retMap = s.Payload.beforeMap
+		} else {
+			retMap = make(map[string]any)
 		}
 
 		retMap[constants.DeleteColumnMarker] = true

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -23,7 +23,6 @@ const (
 
 	TemporaryTableTTL = 6 * time.Hour
 
-	// DBZPostgresFormat is the only supported CDC format right now
 	DBZPostgresFormat    = "debezium.postgres"
 	DBZPostgresAltFormat = "debezium.postgres.wal2json"
 	DBZMongoFormat       = "debezium.mongodb"


### PR DESCRIPTION
Following the same pattern that we implemented for Postgres https://github.com/artie-labs/transfer/pull/431, but this time for MongoDB