### PR TITLE
Replace `stringutil.Override` with `cmp.Or`

### DIFF
--- a/lib/stringutil/strings.go
+++ b/lib/stringutil/strings.go
@@ -13,18 +13,6 @@ func CapitalizeFirstLetter(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
-// Override - pass in a list of vals, the right most value that is not empty will override.
-func Override(vals ...string) string {
-	var retVal string
-	for _, val := range vals {
-		if val != "" {
-			retVal = val
-		}
-	}
-
-	return retVal
-}
-
 func EscapeBackslashes(value string) string {
 	return strings.ReplaceAll(value, `\`, `\\`)
 }

--- a/lib/stringutil/strings_test.go
+++ b/lib/stringutil/strings_test.go
@@ -18,56 +18,6 @@ func TestCapitalizeFirstLetter(t *testing.T) {
 	}
 }
 
-func TestOverride(t *testing.T) {
-	type _testCase struct {
-		name        string
-		vals        []string
-		expectedVal string
-	}
-
-	testCases := []_testCase{
-		{
-			name:        "empty",
-			expectedVal: "",
-		},
-		{
-			name:        "empty (empty list)",
-			vals:        []string{},
-			expectedVal: "",
-		},
-		{
-			name:        "empty (list w/ empty val)",
-			vals:        []string{""},
-			expectedVal: "",
-		},
-		{
-			name:        "one value",
-			vals:        []string{"hi"},
-			expectedVal: "hi",
-		},
-		{
-			name:        "override (2 vals)",
-			vals:        []string{"hi", "latest"},
-			expectedVal: "latest",
-		},
-		{
-			name:        "override (3 vals)",
-			vals:        []string{"hi", "", "latest"},
-			expectedVal: "latest",
-		},
-		{
-			name:        "override (all empty)",
-			vals:        []string{"hii", "", ""},
-			expectedVal: "hii",
-		},
-	}
-
-	for _, testCase := range testCases {
-		actualVal := Override(testCase.vals...)
-		assert.Equal(t, testCase.expectedVal, actualVal, testCase.name)
-	}
-}
-
 func TestEscapeBackslashes(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -53,7 +54,7 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc *kafkalib.TopicConf
 	if err != nil {
 		return Event{}, err
 	}
-	tblName := stringutil.Override(event.GetTableName(), tc.TableName)
+	tblName := cmp.Or(tc.TableName, event.GetTableName())
 	if cfgMode == config.History {
 		if !strings.HasSuffix(tblName, constants.HistoryModeSuffix) {
 			// History mode will include a table suffix and operation column


### PR DESCRIPTION
`stringutil.Override` is [equivalent](https://go.dev/play/p/TmpKBQAQjKS) to calling `cmp.Or` with the order of values reversed.