### PR TITLE
[BigQuery] Improve castColVal function

### DIFF
--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -3,6 +3,7 @@ package bigquery
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/artie-labs/transfer/clients/bigquery/dialect"
@@ -93,5 +94,7 @@ func castColVal(colVal any, colKind columns.Column, additionalDateFmts []string)
 		return arrayString, nil
 	}
 
-	return nil, fmt.Errorf("unsupported kind: %s", colKind.KindDetails.Kind)
+	// TODO: Change this to return an error once we don't see Sentry
+	slog.Error("Unexpected BigQuery Data Type", slog.Any("colKind", colKind.KindDetails.Kind), slog.Any("colVal", colVal))
+	return fmt.Sprint(colVal), nil
 }

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -18,8 +18,12 @@ func castColVal(colVal any, colKind columns.Column, additionalDateFmts []string)
 	if colVal == nil {
 		return nil, nil
 	}
-
 	switch colKind.KindDetails.Kind {
+	case
+		typing.Float.Kind,
+		typing.Integer.Kind,
+		typing.Boolean.Kind:
+		return colVal, nil
 	case typing.EDecimal.Kind:
 		val, isOk := colVal.(*decimal.Decimal)
 		if !isOk {

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -18,8 +18,9 @@ func castColVal(colVal any, colKind columns.Column, additionalDateFmts []string)
 	if colVal == nil {
 		return nil, nil
 	}
+
 	switch colKind.KindDetails.Kind {
-	case typing.Float.Kind, typing.Integer.Kind, typing.Boolean.Kind:
+	case typing.Float.Kind, typing.Integer.Kind, typing.Boolean.Kind, typing.String.Kind:
 		return colVal, nil
 	case typing.EDecimal.Kind:
 		val, isOk := colVal.(*decimal.Decimal)
@@ -92,5 +93,5 @@ func castColVal(colVal any, colKind columns.Column, additionalDateFmts []string)
 		return arrayString, nil
 	}
 
-	return fmt.Sprint(colVal), nil
+	return nil, fmt.Errorf("unsupported kind: %s", colKind.KindDetails.Kind)
 }

--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -19,10 +19,7 @@ func castColVal(colVal any, colKind columns.Column, additionalDateFmts []string)
 		return nil, nil
 	}
 	switch colKind.KindDetails.Kind {
-	case
-		typing.Float.Kind,
-		typing.Integer.Kind,
-		typing.Boolean.Kind:
+	case typing.Float.Kind, typing.Integer.Kind, typing.Boolean.Kind:
 		return colVal, nil
 	case typing.EDecimal.Kind:
 		val, isOk := colVal.(*decimal.Decimal)

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -18,6 +18,12 @@ import (
 
 func (b *BigQueryTestSuite) TestCastColVal() {
 	{
+		// Strings
+		colVal, err := castColVal("hello", columns.Column{KindDetails: typing.String}, nil)
+		assert.NoError(b.T(), err)
+		assert.Equal(b.T(), "hello", colVal)
+	}
+	{
 		// Integers
 		colVal, err := castColVal(5, columns.Column{KindDetails: typing.Integer}, nil)
 		assert.NoError(b.T(), err)

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -2,147 +2,149 @@ package bigquery
 
 import (
 	"fmt"
+	"math/big"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/artie-labs/transfer/lib/typing/decimal"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
-
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/artie-labs/transfer/lib/typing"
 )
 
 func (b *BigQueryTestSuite) TestCastColVal() {
-	type _testCase struct {
-		name    string
-		colVal  any
-		colKind columns.Column
-
-		expectedErr   error
-		expectedValue any
+	{
+		// Integers
+		colVal, err := castColVal(5, columns.Column{KindDetails: typing.Integer}, nil)
+		assert.NoError(b.T(), err)
+		assert.Equal(b.T(), 5, colVal)
 	}
-
-	tsKind := typing.ETime
-	tsKind.ExtendedTimeDetails = &ext.DateTime
-
-	dateKind := typing.ETime
-	dateKind.ExtendedTimeDetails = &ext.Date
-
-	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
-	birthdayTSExt := ext.NewExtendedTime(birthday, tsKind.ExtendedTimeDetails.Type, "")
-
-	birthdayDateExt := ext.NewExtendedTime(birthday, dateKind.ExtendedTimeDetails.Type, "")
-
-	timeKind := typing.ETime
-	timeKind.ExtendedTimeDetails = &ext.Time
-	birthdayTimeExt := ext.NewExtendedTime(birthday, timeKind.ExtendedTimeDetails.Type, "")
-
-	invalidDate := time.Date(0, time.September, 6, 3, 19, 24, 942000000, time.UTC)
-	invalidDateTsExt := ext.NewExtendedTime(invalidDate, tsKind.ExtendedTimeDetails.Type, "")
-
-	testCases := []_testCase{
-		{
-			name:          "escaping string",
-			colVal:        "foo",
-			colKind:       columns.Column{KindDetails: typing.String},
-			expectedValue: "foo",
-		},
-		{
-			name:          "123 as int",
-			colVal:        123,
-			colKind:       columns.Column{KindDetails: typing.Integer},
-			expectedValue: "123",
-		},
-		{
-			name:          "struct w/ struct values",
-			colVal:        map[string]any{"hello": "world"},
-			colKind:       columns.Column{KindDetails: typing.Struct},
-			expectedValue: `{"hello":"world"}`,
-		},
-		{
-			name:          "struct w/ string values",
-			colVal:        `{"hello":"world"}`,
-			colKind:       columns.Column{KindDetails: typing.Struct},
-			expectedValue: `{"hello":"world"}`,
-		},
-		{
-			name:          "struct w/ empty string",
-			colVal:        ``,
-			colKind:       columns.Column{KindDetails: typing.Struct},
-			expectedValue: nil,
-		},
-		{
-			name:          "struct w/ array",
-			colVal:        []any{map[string]any{}, map[string]any{"hello": "world"}},
-			colKind:       columns.Column{KindDetails: typing.Struct},
-			expectedValue: `[{},{"hello":"world"}]`,
-		},
-		{
-			name:          "struct w/ toast",
-			colVal:        constants.ToastUnavailableValuePlaceholder,
-			colKind:       columns.Column{KindDetails: typing.Struct},
-			expectedValue: fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder),
-		},
-		{
-			name:          "array",
-			colVal:        []int{1, 2, 3, 4, 5},
-			colKind:       columns.Column{KindDetails: typing.Array},
-			expectedValue: []string{"1", "2", "3", "4", "5"},
-		},
-		{
-			name:          "empty array",
-			colVal:        []int{},
-			colKind:       columns.Column{KindDetails: typing.Array},
-			expectedValue: nil,
-		},
-		{
-			name:          "null array",
-			colVal:        nil,
-			colKind:       columns.Column{KindDetails: typing.Array},
-			expectedValue: nil,
-		},
-		{
-			name:          "timestamp",
-			colVal:        birthdayTSExt,
-			colKind:       columns.Column{KindDetails: tsKind},
-			expectedValue: "2022-09-06 03:19:24.942",
-		},
-		{
-			name:          "date",
-			colVal:        birthdayDateExt,
-			colKind:       columns.Column{KindDetails: dateKind},
-			expectedValue: "2022-09-06",
-		},
-		{
-			name:          "date (column is a date, but value is not)",
-			colVal:        birthdayTSExt,
-			colKind:       columns.Column{KindDetails: dateKind},
-			expectedValue: "2022-09-06",
-		},
-		{
-			name:          "time",
-			colVal:        birthdayTimeExt,
-			colKind:       columns.Column{KindDetails: timeKind},
-			expectedValue: "03:19:24",
-		},
-		{
-			name:    "date (column is a date, but value is invalid)",
-			colVal:  invalidDateTsExt,
-			colKind: columns.Column{KindDetails: dateKind},
-		},
-		{
-			name:    "datetime (column is a datetime, but value is invalid)",
-			colVal:  invalidDateTsExt,
-			colKind: columns.Column{KindDetails: tsKind},
-		},
+	{
+		// Floats
+		colVal, err := castColVal(5.55, columns.Column{KindDetails: typing.Float}, nil)
+		assert.NoError(b.T(), err)
+		assert.Equal(b.T(), 5.55, colVal)
 	}
+	{
+		// Booleans
+		colVal, err := castColVal(true, columns.Column{KindDetails: typing.Boolean}, nil)
+		assert.NoError(b.T(), err)
+		assert.True(b.T(), colVal.(bool))
+	}
+	{
+		// EDecimals
+		dec := decimal.NewDecimal(ptr.ToInt(5), 2, big.NewFloat(123.45))
+		colVal, err := castColVal(dec, columns.Column{KindDetails: typing.EDecimal}, nil)
+		assert.NoError(b.T(), err)
 
-	for _, testCase := range testCases {
-		actualString, actualErr := castColVal(testCase.colVal, testCase.colKind, nil)
-		assert.Equal(b.T(), testCase.expectedErr, actualErr, testCase.name)
-		assert.Equal(b.T(), testCase.expectedValue, actualString, testCase.name)
+		// Native type is big.Float if precision doesn't exceed the DWH limit
+		assert.Equal(b.T(), big.NewFloat(123.45), colVal)
+
+		// Precision has clearly exceeded the limit, so we should be returning a string
+		dec = decimal.NewDecimal(ptr.ToInt(50), 2, big.NewFloat(123.45))
+		colVal, err = castColVal(dec, columns.Column{KindDetails: typing.EDecimal}, nil)
+		assert.NoError(b.T(), err)
+		assert.Equal(b.T(), "123.45", colVal)
+	}
+	{
+		// ETime
+		birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
+
+		tsKind := typing.ETime
+		tsKind.ExtendedTimeDetails = &ext.DateTime
+
+		dateKind := typing.ETime
+		dateKind.ExtendedTimeDetails = &ext.Date
+		birthdayTSExt := ext.NewExtendedTime(birthday, tsKind.ExtendedTimeDetails.Type, "")
+		{
+			// Timestamp
+			colVal, err := castColVal(birthdayTSExt, columns.Column{KindDetails: tsKind}, nil)
+			assert.NoError(b.T(), err)
+			assert.Equal(b.T(), "2022-09-06 03:19:24.942", colVal)
+		}
+		{
+			// Date
+			birthdayDateExt := ext.NewExtendedTime(birthday, dateKind.ExtendedTimeDetails.Type, "")
+			colVal, err := castColVal(birthdayDateExt, columns.Column{KindDetails: dateKind}, nil)
+			assert.NoError(b.T(), err)
+			assert.Equal(b.T(), "2022-09-06", colVal)
+		}
+
+		{
+			// Date (column is a date, but value is not)
+			colVal, err := castColVal(birthdayTSExt, columns.Column{KindDetails: dateKind}, nil)
+			assert.NoError(b.T(), err)
+			assert.Equal(b.T(), "2022-09-06", colVal)
+		}
+		{
+			// Time
+			timeKind := typing.ETime
+			timeKind.ExtendedTimeDetails = &ext.Time
+			birthdayTimeExt := ext.NewExtendedTime(birthday, timeKind.ExtendedTimeDetails.Type, "")
+			colVal, err := castColVal(birthdayTimeExt, columns.Column{KindDetails: timeKind}, nil)
+			assert.NoError(b.T(), err)
+			assert.Equal(b.T(), "03:19:24", colVal)
+		}
+
+		invalidDate := time.Date(0, time.September, 6, 3, 19, 24, 942000000, time.UTC)
+		invalidDateTsExt := ext.NewExtendedTime(invalidDate, tsKind.ExtendedTimeDetails.Type, "")
+		{
+			// Date (column is a date, but value is invalid)
+			colVal, err := castColVal(invalidDateTsExt, columns.Column{KindDetails: dateKind}, nil)
+			assert.NoError(b.T(), err)
+			assert.Nil(b.T(), colVal)
+		}
+		{
+			// Datetime (column is datetime but value is invalid)
+			colVal, err := castColVal(invalidDateTsExt, columns.Column{KindDetails: tsKind}, nil)
+			assert.NoError(b.T(), err)
+			assert.Nil(b.T(), colVal)
+		}
+	}
+	{
+		// Structs
+		colVal, err := castColVal(map[string]any{"hello": "world"}, columns.Column{KindDetails: typing.Struct}, nil)
+		assert.NoError(b.T(), err)
+		assert.Equal(b.T(), `{"hello":"world"}`, colVal)
+
+		// With string values
+		colVal, err = castColVal(`{"hello":"world"}`, columns.Column{KindDetails: typing.Struct}, nil)
+		assert.NoError(b.T(), err)
+		assert.Equal(b.T(), `{"hello":"world"}`, colVal)
+
+		// With empty string
+		colVal, err = castColVal("", columns.Column{KindDetails: typing.Struct}, nil)
+		assert.NoError(b.T(), err)
+		assert.Nil(b.T(), colVal)
+
+		// With array
+		colVal, err = castColVal([]any{map[string]any{}, map[string]any{"hello": "world"}}, columns.Column{KindDetails: typing.Struct}, nil)
+		assert.NoError(b.T(), err)
+		assert.Equal(b.T(), `[{},{"hello":"world"}]`, colVal)
+
+		// With TOAST values
+		colVal, err = castColVal(constants.ToastUnavailableValuePlaceholder, columns.Column{KindDetails: typing.Struct}, nil)
+		assert.NoError(b.T(), err)
+		assert.Equal(b.T(), fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder), colVal)
+	}
+	{
+		// Arrays
+		colVal, err := castColVal([]any{1, 2, 3, 4, 5}, columns.Column{KindDetails: typing.Array}, nil)
+		assert.NoError(b.T(), err)
+		assert.Equal(b.T(), []string{"1", "2", "3", "4", "5"}, colVal)
+
+		// Empty array
+		colVal, err = castColVal([]any{}, columns.Column{KindDetails: typing.Array}, nil)
+		assert.NoError(b.T(), err)
+		assert.Nil(b.T(), colVal)
+
+		// Null array
+		colVal, err = castColVal(nil, columns.Column{KindDetails: typing.Array}, nil)
+		assert.NoError(b.T(), err)
+		assert.Nil(b.T(), colVal)
 	}
 }


### PR DESCRIPTION
We were converting most values to a string and letting the BigQuery API deal with all the type conversions.

This PR makes it so that we stop doing that for ints, floats and booleans. In addition, I also rewrote the tests to be more succinct 