### PR TITLE
[Typing] Improve the way we parse MongoDB

### DIFF
--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -83,7 +83,7 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 func bsonValueToGoValue(value any) (any, error) {
 	switch v := value.(type) {
 	case primitive.DateTime:
-		return time.Unix(0, int64(v)*int64(time.Millisecond)).UTC().Format(ext.ISO8601), nil
+		return v.Time().UTC().Format(ext.ISO8601), nil
 	case primitive.ObjectID:
 		return v.Hex(), nil
 	case primitive.Binary:

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -34,11 +34,9 @@ func JSONEToMap(val []byte) (map[string]any, error) {
 		return nil, fmt.Errorf("failed to unmarshal ext json: %w", err)
 	}
 
-	// Directly decode bsonDoc to map[string]any
 	return bsonDocToMap(bsonDoc)
 }
 
-// Helper function to convert bson.D to map[string]any
 func bsonDocToMap(doc bson.D) (map[string]any, error) {
 	result := make(map[string]any)
 	for _, elem := range doc {
@@ -76,14 +74,14 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 		}
 
 		return parsedUUID.String(), nil
+	default:
+		return map[string]any{
+			"$binary": map[string]any{
+				"base64":  base64.StdEncoding.EncodeToString(value.Data),
+				"subType": fmt.Sprintf("%02x", value.Subtype),
+			},
+		}, nil
 	}
-
-	return map[string]any{
-		"$binary": map[string]any{
-			"base64":  base64.StdEncoding.EncodeToString(value.Data),
-			"subType": fmt.Sprintf("%02x", value.Subtype),
-		},
-	}, nil
 }
 
 // bsonValueToGoValue - https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -93,7 +93,18 @@ func bsonValueToGoValue(value any) (any, error) {
 	case primitive.Binary:
 		return bsonBinaryValueToMap(v)
 	case primitive.Decimal128:
-		return strconv.ParseFloat(v.String(), 64)
+		potentialFloat, err := strconv.ParseFloat(v.String(), 64)
+		if err != nil {
+			return nil, err
+		}
+
+		if v.String() == fmt.Sprint(potentialFloat) {
+			return potentialFloat, nil
+		}
+
+		// If the string representation of the Decimal128 is not equal to the float representation
+		// then we return the string representation
+		return v.String(), nil
 	case primitive.Timestamp:
 		return time.Unix(int64(v.T), 0).UTC().Format(ext.ISO8601), nil
 	case bson.D:

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -89,6 +89,7 @@ func bsonValueToGoValue(value any) (any, error) {
 	case primitive.Binary:
 		return bsonBinaryValueToMap(v)
 	case primitive.Decimal128:
+		// We purposefully chose a string representation here because not all systems can correctly handle Decimal128 without losing precision
 		return v.String(), nil
 	case primitive.Timestamp:
 		return time.Unix(int64(v.T), 0).UTC().Format(ext.ISO8601), nil

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -9,15 +9,13 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
-// JSONEToMap will take JSONE data in bytes, parse all the custom types
-// Then from all the custom types,
+// JSONEToMap - Takes a JSON Extended string and converts it to a map[string]any
 func JSONEToMap(val []byte) (map[string]any, error) {
 	// We are escaping `NaN`, `Infinity` and `-Infinity` (literal values)
 	re := regexp.MustCompile(`\bNaN\b|"\bNaN\b"|-\bInfinity\b|"-\bInfinity\b"|\bInfinity\b|"\bInfinity\b"`)
@@ -83,7 +81,6 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 	}
 }
 
-// bsonValueToGoValue - https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/
 func bsonValueToGoValue(value any) (any, error) {
 	switch v := value.(type) {
 	case primitive.DateTime:

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -29,8 +29,7 @@ func JSONEToMap(val []byte) (map[string]any, error) {
 	}))
 
 	var bsonDoc bson.D
-	err := bson.UnmarshalExtJSON(val, false, &bsonDoc)
-	if err != nil {
+	if err := bson.UnmarshalExtJSON(val, false, &bsonDoc); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal ext json: %w", err)
 	}
 

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -35,29 +35,37 @@ func JSONEToMap(val []byte) (map[string]any, error) {
 	}
 
 	// Directly decode bsonDoc to map[string]any
-	return bsonDocToMap(bsonDoc), nil
+	return bsonDocToMap(bsonDoc)
 }
 
 // Helper function to convert bson.D to map[string]any
-func bsonDocToMap(doc bson.D) map[string]any {
+func bsonDocToMap(doc bson.D) (map[string]any, error) {
 	result := make(map[string]any)
 	for _, elem := range doc {
-		result[elem.Key] = bsonValueToGoValue(elem.Value)
+		value, err := bsonValueToGoValue(elem.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		result[elem.Key] = value
 	}
-	return result
+	return result, nil
 }
 
-func bsonArrayToSlice(arr bson.A) []any {
+func bsonArrayToSlice(arr bson.A) ([]any, error) {
 	result := make([]any, len(arr))
 	for i, elem := range arr {
-		result[i] = bsonValueToGoValue(elem)
+		value, err := bsonValueToGoValue(elem)
+		if err != nil {
+			return nil, err
+		}
+
+		result[i] = value
 	}
-	return result
+	return result, nil
 }
 
 func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
-	action := "$binary"
-
 	switch value.Subtype {
 	case
 		bson.TypeBinaryUUIDOld,
@@ -70,14 +78,8 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 		return parsedUUID.String(), nil
 	}
 
-	//switch value.Subtype {
-	//case bson.TypeBinaryGeneric, bson.TypeBinaryFunction, bson.TypeBinaryMD5, bson.TypeBinaryEncrypted:
-	//
-	//case bson.TypeBinaryUUIDOld, bson.TypeBinaryUUID:
-	//}
-
 	return map[string]any{
-		action: map[string]any{
+		"$binary": map[string]any{
 			"base64":  base64.StdEncoding.EncodeToString(value.Data),
 			"subType": fmt.Sprintf("%02x", value.Subtype),
 		},
@@ -85,33 +87,36 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 }
 
 // bsonValueToGoValue - https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/
-func bsonValueToGoValue(value any) any {
+func bsonValueToGoValue(value any) (any, error) {
 	switch v := value.(type) {
 	case primitive.DateTime:
-		return time.Unix(0, int64(v)*int64(time.Millisecond)).UTC().Format(ext.ISO8601)
+		return time.Unix(0, int64(v)*int64(time.Millisecond)).UTC().Format(ext.ISO8601), nil
 	case primitive.ObjectID:
-		return v.Hex()
+		return v.Hex(), nil
 	case primitive.Binary:
 		return bsonBinaryValueToMap(v)
 	case primitive.Decimal128:
-		if parsedFloat, err := strconv.ParseFloat(v.String(), 64); err == nil {
-			return parsedFloat
-		}
-		return v.String()
+		return strconv.ParseFloat(v.String(), 64)
 	case primitive.Timestamp:
-		return time.Unix(int64(v.T), 0).UTC().Format(ext.ISO8601)
+		return time.Unix(int64(v.T), 0).UTC().Format(ext.ISO8601), nil
 	case bson.D:
 		return bsonDocToMap(v)
 	case bson.A:
 		return bsonArrayToSlice(v)
 	case primitive.MaxKey:
-		return map[string]any{"$maxKey": 1}
+		return map[string]any{"$maxKey": 1}, nil
 	case primitive.MinKey:
-		return map[string]any{"$minKey": 1}
+		return map[string]any{"$minKey": 1}, nil
 	case primitive.JavaScript:
-		return map[string]any{"$code": v}
+		return map[string]any{"$code": fmt.Sprint(v)}, nil
+	case
+		nil,
+		bool,
+		string,
+		int32, int64,
+		float32, float64:
+		return v, nil
 	default:
-		fmt.Println("v", v, fmt.Sprintf("type: %T", v))
-		return v
+		return nil, fmt.Errorf("unexpected type: %T, value: %v", v, v)
 	}
 }

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -90,18 +90,19 @@ func bsonValueToGoValue(value any) (any, error) {
 	case primitive.Binary:
 		return bsonBinaryValueToMap(v)
 	case primitive.Decimal128:
-		potentialFloat, err := strconv.ParseFloat(v.String(), 64)
+		valString := v.String()
+		potentialFloat, err := strconv.ParseFloat(valString, 64)
 		if err != nil {
 			return nil, err
 		}
 
-		if v.String() == fmt.Sprint(potentialFloat) {
+		if valString == fmt.Sprint(potentialFloat) {
 			return potentialFloat, nil
 		}
 
 		// If the string representation of the Decimal128 is not equal to the float representation
 		// then we return the string representation
-		return v.String(), nil
+		return valString, nil
 	case primitive.Timestamp:
 		return time.Unix(int64(v.T), 0).UTC().Format(ext.ISO8601), nil
 	case bson.D:
@@ -113,7 +114,7 @@ func bsonValueToGoValue(value any) (any, error) {
 	case primitive.MinKey:
 		return map[string]any{"$minKey": 1}, nil
 	case primitive.JavaScript:
-		return map[string]any{"$code": fmt.Sprint(v)}, nil
+		return map[string]any{"$code": string(v)}, nil
 	case
 		nil,
 		bool,

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -90,19 +89,7 @@ func bsonValueToGoValue(value any) (any, error) {
 	case primitive.Binary:
 		return bsonBinaryValueToMap(v)
 	case primitive.Decimal128:
-		valString := v.String()
-		potentialFloat, err := strconv.ParseFloat(valString, 64)
-		if err != nil {
-			return nil, err
-		}
-
-		if valString == fmt.Sprint(potentialFloat) {
-			return potentialFloat, nil
-		}
-
-		// If the string representation of the Decimal128 is not equal to the float representation
-		// then we return the string representation
-		return valString, nil
+		return v.String(), nil
 	case primitive.Timestamp:
 		return time.Unix(int64(v.T), 0).UTC().Format(ext.ISO8601), nil
 	case bson.D:

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -90,14 +90,13 @@ func TestMarshal(t *testing.T) {
 	assert.Equal(t, 13.37, result["test_decimal"])
 	assert.Equal(t, 13.37, result["test_decimal_2"])
 
-	// 64-bit integer / long
-	assert.Equal(t, float64(10004), result["_id"])
-	assert.Equal(t, float64(107), result["product_id"])
-	assert.Equal(t, float64(1), result["quantity"])
+	assert.Equal(t, int64(10004), result["_id"])
+	assert.Equal(t, int64(107), result["product_id"])
+	assert.Equal(t, int32(1), result["quantity"])
 
 	// 32-bit ints
-	assert.Equal(t, float64(30), result["number_int"])
-	assert.Equal(t, float64(1337), result["test_int"])
+	assert.Equal(t, int32(30), result["number_int"])
+	assert.Equal(t, int32(1337), result["test_int"])
 
 	// Date
 	assert.Equal(t, "2016-02-21T00:00:00+00:00", result["order_date"])
@@ -137,8 +136,8 @@ func TestMarshal(t *testing.T) {
 	assert.Equal(t, "-Infinity123", result["test_negative_infinity_string1"]) // This should not be escaped.
 
 	// Min and Max Keys
-	assert.Equal(t, map[string]any{"$maxKey": float64(1)}, result["maxValue"])
-	assert.Equal(t, map[string]any{"$minKey": float64(1)}, result["minValue"])
+	assert.Equal(t, map[string]any{"$maxKey": 1}, result["maxValue"])
+	assert.Equal(t, map[string]any{"$minKey": 1}, result["minValue"])
 
 	// All the binary data types.
 	// 0. Generic Binary
@@ -172,4 +171,6 @@ func TestMarshal(t *testing.T) {
 
 	// Regular Expressions
 	assert.Equal(t, map[string]any{"$options": "", "$regex": `@example\.com$`}, result["emailPattern"])
+
+	assert.False(t, true)
 }

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -1,8 +1,6 @@
 package mongo
 
 import (
-	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -216,11 +214,11 @@ func TestBsonValueToGoVale(t *testing.T) {
 		assert.Equal(t, float64(1337), result)
 
 		// Now a number larger than float64
-		decimal, err = primitive.ParseDecimal128(fmt.Sprint(math.MaxFloat64 + 1))
+		decimal = primitive.NewDecimal128(primitive.MaxDecimal128Exp, primitive.MaxDecimal128Exp)
 		assert.NoError(t, err)
 		result, err = bsonValueToGoValue(decimal)
 		assert.NoError(t, err)
-		assert.Equal(t, "1.7976931348623157E+308", result)
+		assert.Equal(t, "1.12728053034439069931487E-6153", result)
 	}
 	{
 		// bson.D

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -171,6 +171,4 @@ func TestMarshal(t *testing.T) {
 
 	// Regular Expressions
 	assert.Equal(t, map[string]any{"$options": "", "$regex": `@example\.com$`}, result["emailPattern"])
-
-	assert.False(t, true)
 }

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -94,7 +94,7 @@ func TestJSONEToMap(t *testing.T) {
 	assert.Equal(t, "Robin Tang", result["full_name"])
 
 	// NumberDecimal
-	assert.Equal(t, 13.37, result["test_decimal"])
+	assert.Equal(t, "13.37", result["test_decimal"])
 	assert.Equal(t, 13.37, result["test_decimal_2"])
 
 	assert.Equal(t, int64(10004), result["_id"])
@@ -211,7 +211,7 @@ func TestBsonValueToGoVale(t *testing.T) {
 		assert.NoError(t, err)
 		result, err := bsonValueToGoValue(decimal)
 		assert.NoError(t, err)
-		assert.Equal(t, float64(1337), result)
+		assert.Equal(t, "1337", result)
 
 		// Now a number larger than float64
 		decimal = primitive.NewDecimal128(primitive.MaxDecimal128Exp, primitive.MaxDecimal128Exp)

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -189,7 +189,7 @@ func TestBsonDocToMap(t *testing.T) {
 	assert.Equal(t, map[string]any{"foo": "bar"}, result)
 }
 
-func TestBsonValueToGoVale(t *testing.T) {
+func TestBsonValueToGoValue(t *testing.T) {
 	{
 		// primitive.DateTime
 		_time := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Context

The way we currently handle parsing MongoDB results has slight inefficiencies and causes us to not be able to delineate between floats and ints.

The current way is:
1. Take JSON extended string
2. Parse that into BSON
3. Run our types registry to convert BSON objects into regular values
4. JSON marshal into `map[string]any`

By running JSON marshal, we are losing the ability to delineate between floats and ints.

## Change

This PR directly takes the BSON object and converts it into `map[string]any` natively, without JSON marshal.

This change reduces the time it takes for us to parse by 27% (see below)


## Performance

### Before
```bash
BenchmarkJSONEToMap-12    	  122318	    199390 ns/op
```

### After
```bash
BenchmarkJSONEToMap-12    	  166398	    145455 ns/op
```