### PR TITLE
[Redshift] Copy Into to specify column ordering

### DIFF
--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -93,6 +93,7 @@ func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableID
 		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate() {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			castedValue, castErr := s.CastColValStaging(value[col], colKind, additionalDateFmts)
+			fmt.Println("castedValue", castedValue, "colKind", colKind.KindDetails, "colName", colKind.Name())
 			if castErr != nil {
 				return "", castErr
 			}

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
@@ -60,11 +61,14 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 	// Note, we need to specify `\\N` here and in `CastColVal(..)` we are only doing `\N`, this is because Redshift treats backslashes as an escape character.
 	// So, it'll convert `\N` => `\\N` during COPY.
 	copyStmt := fmt.Sprintf(
-		`COPY %s FROM '%s' DELIMITER '\t' NULL AS '\\N' GZIP FORMAT CSV %s dateformat 'auto' timeformat 'auto';`,
+		`COPY %s (%s) FROM '%s' DELIMITER '\t' NULL AS '\\N' GZIP FORMAT CSV %s dateformat 'auto' timeformat 'auto';`,
 		tempTableID.FullyQualifiedName(),
+		strings.Join(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(), ","),
 		s3Uri,
 		s.credentialsClause,
 	)
+
+	fmt.Println("copyStmt", copyStmt)
 	if _, err = s.Exec(copyStmt); err != nil {
 		return fmt.Errorf("failed to run COPY for temporary table: %w", err)
 	}

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -63,7 +63,7 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 	copyStmt := fmt.Sprintf(
 		`COPY %s (%s) FROM '%s' DELIMITER '\t' NULL AS '\\N' GZIP FORMAT CSV %s dateformat 'auto' timeformat 'auto';`,
 		tempTableID.FullyQualifiedName(),
-		strings.Join(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(), ","),
+		strings.Join(sql.QuoteIdentifiers(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(), s.Dialect()), ","),
 		s3Uri,
 		s.credentialsClause,
 	)

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -68,7 +68,6 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 		s.credentialsClause,
 	)
 
-	fmt.Println("copyStmt", copyStmt)
 	if _, err = s.Exec(copyStmt); err != nil {
 		return fmt.Errorf("failed to run COPY for temporary table: %w", err)
 	}
@@ -97,7 +96,6 @@ func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableID
 		for _, col := range tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate() {
 			colKind, _ := tableData.ReadOnlyInMemoryCols().GetColumn(col)
 			castedValue, castErr := s.CastColValStaging(value[col], colKind, additionalDateFmts)
-			fmt.Println("castedValue", castedValue, "colKind", colKind.KindDetails, "colName", colKind.Name())
 			if castErr != nil {
 				return "", castErr
 			}


### PR DESCRIPTION
By not specifying the columns to load, Redshift is using the order of which columns appear in Redshift.

This PR adds the ability to specify and brings it to parity with Snowflake: https://github.com/artie-labs/transfer/blob/05b6fedcb7677a134fa293361253440c80f618f8/clients/snowflake/staging.go#L98C1-L99C1
