### PR TITLE
`DropTemporaryTable` to take a `TableIdentifier`

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -156,7 +156,7 @@ func (s *Store) Dedupe(tableID sql.TableIdentifier, primaryKeys []string, topicC
 
 	dedupeQueries := s.Dialect().BuildDedupeQueries(tableID, stagingTableID, primaryKeys, topicConfig)
 
-	defer func() { _ = ddl.DropTemporaryTable(s, stagingTableID.FullyQualifiedName(), false) }()
+	defer func() { _ = ddl.DropTemporaryTable(s, stagingTableID, false) }()
 
 	return destination.ExecStatements(s, dedupeQueries)
 }

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -63,8 +63,8 @@ func (s *Store) Sweep() error {
 		return err
 	}
 
-	queryFunc := func(dbAndSchemaPair kafkalib.DatabaseSchemaPair) (string, []any) {
-		return sweepQuery(getSchema(dbAndSchemaPair.Schema))
+	queryFunc := func(topicConfig kafkalib.TopicConfig) (string, []any) {
+		return sweepQuery(getSchema(topicConfig.Schema))
 	}
 
 	return shared.Sweep(s, tcs, queryFunc)

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -96,7 +96,7 @@ func (s *Store) Sweep() error {
 	}
 
 	// `relkind` will filter for only ordinary tables and exclude sequences, views, etc.
-	queryFunc := func(dbAndSchemaPair kafkalib.DatabaseSchemaPair) (string, []any) {
+	queryFunc := func(topicConfig kafkalib.TopicConfig) (string, []any) {
 		return `
 SELECT
     n.nspname, c.relname
@@ -105,7 +105,7 @@ FROM
 JOIN
     PG_CATALOG.PG_NAMESPACE n ON n.oid = c.relnamespace
 WHERE
-    n.nspname = $1 AND c.relname ILIKE $2 AND c.relkind = 'r';`, []any{dbAndSchemaPair.Schema, "%" + constants.ArtiePrefix + "%"}
+    n.nspname = $1 AND c.relname ILIKE $2 AND c.relkind = 'r';`, []any{topicConfig.Schema, "%" + constants.ArtiePrefix + "%"}
 	}
 
 	return shared.Sweep(s, tcs, queryFunc)

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -61,14 +61,14 @@ func (s *Store) Sweep() error {
 		return err
 	}
 
-	queryFunc := func(dbAndSchemaPair kafkalib.DatabaseSchemaPair) (string, []any) {
+	queryFunc := func(topicConfig kafkalib.TopicConfig) (string, []any) {
 		return fmt.Sprintf(`
 SELECT
     table_schema, table_name
 FROM
     %s.information_schema.tables
 WHERE
-    UPPER(table_schema) = UPPER(?) AND table_name ILIKE ?`, dbAndSchemaPair.Database), []any{dbAndSchemaPair.Schema, "%" + constants.ArtiePrefix + "%"}
+    UPPER(table_schema) = UPPER(?) AND table_name ILIKE ?`, topicConfig.Database), []any{topicConfig.Schema, "%" + constants.ArtiePrefix + "%"}
 	}
 
 	return shared.Sweep(s, tcs, queryFunc)

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -18,9 +18,9 @@ import (
 // DropTemporaryTable - this will drop the temporary table from Snowflake w/ stages and BigQuery
 // It has a safety check to make sure the tableName contains the `constants.ArtiePrefix` key.
 // Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(5)_expiryUnixTs
-func DropTemporaryTable(dwh destination.DataWarehouse, fqTableName string, shouldReturnError bool) error {
-	if strings.Contains(strings.ToLower(fqTableName), constants.ArtiePrefix) {
-		sqlCommand := fmt.Sprintf("DROP TABLE IF EXISTS %s", fqTableName)
+func DropTemporaryTable(dwh destination.DataWarehouse, tableIdentifier sql.TableIdentifier, shouldReturnError bool) error {
+	if strings.Contains(tableIdentifier.Table(), constants.ArtiePrefix) {
+		sqlCommand := fmt.Sprintf("DROP TABLE IF EXISTS %s", tableIdentifier.FullyQualifiedName())
 		slog.Debug("Dropping temporary table", slog.String("sql", sqlCommand))
 		if _, err := dwh.Exec(sqlCommand); err != nil {
 			slog.Warn("Failed to drop temporary table, it will get garbage collected by the TTL...", slog.Any("err", err))
@@ -29,7 +29,7 @@ func DropTemporaryTable(dwh destination.DataWarehouse, fqTableName string, shoul
 			}
 		}
 	} else {
-		slog.Warn(fmt.Sprintf("Skipped dropping table: %s because it does not contain the artie prefix", fqTableName))
+		slog.Warn(fmt.Sprintf("Skipped dropping table: %s because it does not contain the artie prefix", tableIdentifier.FullyQualifiedName()))
 	}
 
 	return nil

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -10,27 +10,24 @@ import (
 )
 
 type DatabaseSchemaPair struct {
-	Database string
-	Schema   string
+	Database    string
+	Schema      string
+	TopicConfig TopicConfig
 }
 
-// GetUniqueDatabaseAndSchema - does not guarantee ordering.
-func GetUniqueDatabaseAndSchema(tcs []*TopicConfig) []DatabaseSchemaPair {
-	dbMap := make(map[string]DatabaseSchemaPair)
+func GetUniqueTopicConfigs(tcs []*TopicConfig) []TopicConfig {
+	tcMap := make(map[string]TopicConfig)
 	for _, tc := range tcs {
 		key := fmt.Sprintf("%s###%s", tc.Database, tc.Schema)
-		dbMap[key] = DatabaseSchemaPair{
-			Database: tc.Database,
-			Schema:   tc.Schema,
-		}
+		tcMap[key] = *tc
 	}
 
-	var pairs []DatabaseSchemaPair
-	for _, pair := range dbMap {
-		pairs = append(pairs, pair)
+	var uniqueTopicConfigs []TopicConfig
+	for _, topicConfig := range tcMap {
+		uniqueTopicConfigs = append(uniqueTopicConfigs, topicConfig)
 	}
 
-	return pairs
+	return uniqueTopicConfigs
 }
 
 type TopicConfig struct {

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -16,9 +16,8 @@ func GetUniqueTopicConfigs(tcs []*TopicConfig) []TopicConfig {
 	for _, tc := range tcs {
 		key := fmt.Sprintf("%s###%s", tc.Database, tc.Schema)
 		if _, isOk := seenMap[key]; !isOk {
-			// Mark as seen
-			seenMap[key] = true
-			uniqueTopicConfigs = append(uniqueTopicConfigs, *tc)
+			seenMap[key] = true                                  // Mark this as seen
+			uniqueTopicConfigs = append(uniqueTopicConfigs, *tc) // Now add this to the list
 		}
 	}
 

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -9,12 +9,6 @@ import (
 	"github.com/artie-labs/transfer/lib/stringutil"
 )
 
-type DatabaseSchemaPair struct {
-	Database    string
-	Schema      string
-	TopicConfig TopicConfig
-}
-
 // GetUniqueTopicConfigs - will return a list of unique TopicConfigs based on the database and schema in O(n) time.
 func GetUniqueTopicConfigs(tcs []*TopicConfig) []TopicConfig {
 	var uniqueTopicConfigs []TopicConfig
@@ -22,6 +16,9 @@ func GetUniqueTopicConfigs(tcs []*TopicConfig) []TopicConfig {
 	for _, tc := range tcs {
 		key := fmt.Sprintf("%s###%s", tc.Database, tc.Schema)
 		if _, isOk := seenMap[key]; !isOk {
+			// Mark as seen
+			seenMap[key] = true
+			// Now add
 			uniqueTopicConfigs = append(uniqueTopicConfigs, *tc)
 		}
 	}

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -16,15 +16,13 @@ type DatabaseSchemaPair struct {
 }
 
 func GetUniqueTopicConfigs(tcs []*TopicConfig) []TopicConfig {
-	tcMap := make(map[string]TopicConfig)
+	var uniqueTopicConfigs []TopicConfig
+	seenMap := make(map[string]bool)
 	for _, tc := range tcs {
 		key := fmt.Sprintf("%s###%s", tc.Database, tc.Schema)
-		tcMap[key] = *tc
-	}
-
-	var uniqueTopicConfigs []TopicConfig
-	for _, topicConfig := range tcMap {
-		uniqueTopicConfigs = append(uniqueTopicConfigs, topicConfig)
+		if _, isOk := seenMap[key]; !isOk {
+			uniqueTopicConfigs = append(uniqueTopicConfigs, *tc)
+		}
 	}
 
 	return uniqueTopicConfigs

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -15,6 +15,7 @@ type DatabaseSchemaPair struct {
 	TopicConfig TopicConfig
 }
 
+// GetUniqueTopicConfigs - will return a list of unique TopicConfigs based on the database and schema in O(n) time.
 func GetUniqueTopicConfigs(tcs []*TopicConfig) []TopicConfig {
 	var uniqueTopicConfigs []TopicConfig
 	seenMap := make(map[string]bool)

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -18,7 +18,6 @@ func GetUniqueTopicConfigs(tcs []*TopicConfig) []TopicConfig {
 		if _, isOk := seenMap[key]; !isOk {
 			// Mark as seen
 			seenMap[key] = true
-			// Now add
 			uniqueTopicConfigs = append(uniqueTopicConfigs, *tc)
 		}
 	}

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -42,6 +42,28 @@ func TestGetUniqueTopicConfigs(t *testing.T) {
 		assert.Len(t, actual, 1)
 		assert.Equal(t, *tcs[0], actual[0])
 	}
+	{
+		// 3 topic configs (2 the same)
+		tcs := []*TopicConfig{
+			{
+				Database: "db",
+				Schema:   "schema",
+			},
+			{
+				Database: "db",
+				Schema:   "schema",
+			},
+			{
+				Database: "db",
+				Schema:   "schema2",
+			},
+		}
+
+		actual := GetUniqueTopicConfigs(tcs)
+		assert.Len(t, actual, 2)
+		assert.Equal(t, *tcs[0], actual[0])
+		assert.Equal(t, *tcs[2], actual[1])
+	}
 }
 
 func TestTopicConfig_String(t *testing.T) {

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -7,94 +7,102 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetUniqueDatabaseAndSchema(t *testing.T) {
-	type _testCase struct {
-		name          string
-		tcs           []*TopicConfig
-		expectedPairs []DatabaseSchemaPair
-	}
-
-	testCases := []_testCase{
-		{
-			name: "happy path",
-			tcs: []*TopicConfig{
-				{
-					Database: "db",
-					Schema:   "schema",
-				},
-			},
-			expectedPairs: []DatabaseSchemaPair{
-				{
-					Database: "db",
-					Schema:   "schema",
-				},
-			},
-		},
-		{
-			name: "1 database and 2 schemas",
-			tcs: []*TopicConfig{
-				{
-					Database: "db",
-					Schema:   "schema_uno",
-				},
-				{
-					Database: "db",
-					Schema:   "schema_deux",
-				},
-			},
-			expectedPairs: []DatabaseSchemaPair{
-				{
-					Database: "db",
-					Schema:   "schema_uno",
-				},
-				{
-					Database: "db",
-					Schema:   "schema_deux",
-				},
-			},
-		},
-		{
-			name: "multiple topic configs with same db",
-			tcs: []*TopicConfig{
-				{
-					Database:  "db",
-					Schema:    "schema",
-					TableName: "foo",
-				},
-				{
-					Database:  "db",
-					Schema:    "schema",
-					TableName: "bar",
-				},
-				{
-					Database:  "db",
-					Schema:    "schema",
-					TableName: "dusty",
-				},
-			},
-			expectedPairs: []DatabaseSchemaPair{
-				{
-					Database: "db",
-					Schema:   "schema",
-				},
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		actualPairs := GetUniqueDatabaseAndSchema(testCase.tcs)
-		assert.Equal(t, len(testCase.expectedPairs), len(actualPairs), testCase.name)
-		for _, actualPair := range actualPairs {
-			var found bool
-			for _, expectedPair := range testCase.expectedPairs {
-				if found = actualPair == expectedPair; found {
-					break
-				}
-			}
-			assert.True(t, found, fmt.Sprintf("missingPair=%s, testName=%s", actualPair, testCase.name))
-		}
-	}
-}
+//func TestGetUniqueDatabaseAndSchema(t *testing.T) {
+//	type _testCase struct {
+//		name          string
+//		tcs           []*TopicConfig
+//		expectedPairs []DatabaseSchemaPair
+//	}
+//
+//	testCases := []_testCase{
+//		{
+//			name: "happy path",
+//			tcs: []*TopicConfig{
+//				{
+//					Database: "db",
+//					Schema:   "schema",
+//				},
+//			},
+//			expectedPairs: []DatabaseSchemaPair{
+//				{
+//					Database: "db",
+//					Schema:   "schema",
+//					TopicConfig: TopicConfig{
+//						Database: "db",
+//						Schema:   "schema",
+//					},
+//				},
+//			},
+//		},
+//		{
+//			name: "1 database and 2 schemas",
+//			tcs: []*TopicConfig{
+//				{
+//					Database: "db",
+//					Schema:   "schema_uno",
+//				},
+//				{
+//					Database: "db",
+//					Schema:   "schema_deux",
+//				},
+//			},
+//			expectedPairs: []DatabaseSchemaPair{
+//				{
+//					Database: "db",
+//					Schema:   "schema_uno",
+//					TopicConfig: TopicConfig{
+//						Database: "db",
+//						Schema:   "schema_uno",
+//					},
+//				},
+//				{
+//					Database: "db",
+//					Schema:   "schema_deux",
+//				},
+//			},
+//		},
+//		{
+//			name: "multiple topic configs with same db",
+//			tcs: []*TopicConfig{
+//				{
+//					Database:  "db",
+//					Schema:    "schema",
+//					TableName: "foo",
+//				},
+//				{
+//					Database:  "db",
+//					Schema:    "schema",
+//					TableName: "bar",
+//				},
+//				{
+//					Database:  "db",
+//					Schema:    "schema",
+//					TableName: "dusty",
+//				},
+//			},
+//			expectedPairs: []DatabaseSchemaPair{
+//				{
+//					Database: "db",
+//					Schema:   "schema",
+//				},
+//			},
+//		},
+//	}
+//
+//	for _, testCase := range testCases {
+//		actualPairs := GetUniqueDatabaseAndSchema(testCase.tcs)
+//		assert.Equal(t, len(testCase.expectedPairs), len(actualPairs), testCase.name)
+//		for _, actualPair := range actualPairs {
+//			var found bool
+//			for _, expectedPair := range testCase.expectedPairs {
+//				if found = reflect.DeepEqual(actualPair, expectedPair); found {
+//					break
+//				}
+//			}
+//			assert.True(t, found, fmt.Sprintf("missingPair=%s, testName=%s", actualPair, testCase.name))
+//		}
+//	}
+//}
 
 func TestTopicConfig_String(t *testing.T) {
 	tc := TopicConfig{

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -7,102 +7,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//func TestGetUniqueDatabaseAndSchema(t *testing.T) {
-//	type _testCase struct {
-//		name          string
-//		tcs           []*TopicConfig
-//		expectedPairs []DatabaseSchemaPair
-//	}
-//
-//	testCases := []_testCase{
-//		{
-//			name: "happy path",
-//			tcs: []*TopicConfig{
-//				{
-//					Database: "db",
-//					Schema:   "schema",
-//				},
-//			},
-//			expectedPairs: []DatabaseSchemaPair{
-//				{
-//					Database: "db",
-//					Schema:   "schema",
-//					TopicConfig: TopicConfig{
-//						Database: "db",
-//						Schema:   "schema",
-//					},
-//				},
-//			},
-//		},
-//		{
-//			name: "1 database and 2 schemas",
-//			tcs: []*TopicConfig{
-//				{
-//					Database: "db",
-//					Schema:   "schema_uno",
-//				},
-//				{
-//					Database: "db",
-//					Schema:   "schema_deux",
-//				},
-//			},
-//			expectedPairs: []DatabaseSchemaPair{
-//				{
-//					Database: "db",
-//					Schema:   "schema_uno",
-//					TopicConfig: TopicConfig{
-//						Database: "db",
-//						Schema:   "schema_uno",
-//					},
-//				},
-//				{
-//					Database: "db",
-//					Schema:   "schema_deux",
-//				},
-//			},
-//		},
-//		{
-//			name: "multiple topic configs with same db",
-//			tcs: []*TopicConfig{
-//				{
-//					Database:  "db",
-//					Schema:    "schema",
-//					TableName: "foo",
-//				},
-//				{
-//					Database:  "db",
-//					Schema:    "schema",
-//					TableName: "bar",
-//				},
-//				{
-//					Database:  "db",
-//					Schema:    "schema",
-//					TableName: "dusty",
-//				},
-//			},
-//			expectedPairs: []DatabaseSchemaPair{
-//				{
-//					Database: "db",
-//					Schema:   "schema",
-//				},
-//			},
-//		},
-//	}
-//
-//	for _, testCase := range testCases {
-//		actualPairs := GetUniqueDatabaseAndSchema(testCase.tcs)
-//		assert.Equal(t, len(testCase.expectedPairs), len(actualPairs), testCase.name)
-//		for _, actualPair := range actualPairs {
-//			var found bool
-//			for _, expectedPair := range testCase.expectedPairs {
-//				if found = reflect.DeepEqual(actualPair, expectedPair); found {
-//					break
-//				}
-//			}
-//			assert.True(t, found, fmt.Sprintf("missingPair=%s, testName=%s", actualPair, testCase.name))
-//		}
-//	}
-//}
+func TestGetUniqueTopicConfigs(t *testing.T) {
+	{
+		// No topic configs
+		assert.Empty(t, GetUniqueTopicConfigs(nil))
+	}
+	{
+		// 1 topic config
+		tcs := []*TopicConfig{
+			{
+				Database: "db",
+				Schema:   "schema",
+			},
+		}
+
+		actual := GetUniqueTopicConfigs(tcs)
+		assert.Len(t, actual, 1)
+		assert.Equal(t, *tcs[0], actual[0])
+	}
+	{
+		// 2 topic configs (both the same)
+		tcs := []*TopicConfig{
+			{
+				Database: "db",
+				Schema:   "schema",
+			},
+			{
+				Database: "db",
+				Schema:   "schema",
+			},
+		}
+
+		actual := GetUniqueTopicConfigs(tcs)
+		assert.Len(t, actual, 1)
+		assert.Equal(t, *tcs[0], actual[0])
+	}
+}
 
 func TestTopicConfig_String(t *testing.T) {
 	tc := TopicConfig{


### PR DESCRIPTION
## Changes

1. Removing DatabaseSchemaPair and standardize on TopicConfig
2. Changed the function to be O(n) and guarantee ordering
3. `DropTemporaryTable` now takes a `TableIdentifier` vs `tableName`