### PR TITLE
[Extended Time] Dealing w/ time edge case

### DIFF
--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -2,6 +2,7 @@ package ext
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -81,6 +82,16 @@ func ParseExtendedDateTime(dtString string, additionalDateFormats []string) (*Ex
 	// If nothing fits, return the next best thing.
 	if potentialFormat != "" {
 		return NewExtendedTime(potentialTime, DateTimeKindType, potentialFormat), nil
+	}
+
+	// Last chance save, if the datetime string looks like this: YYYY-MM-DD, but YYYY exceeds 9999
+	if parts := strings.Split(dtString, "-"); len(parts) == 3 {
+		for _, part := range parts {
+			if len(part) > 4 {
+				var ts time.Time
+				return ParseExtendedDateTime(ts.Format(ISO8601), additionalDateFormats)
+			}
+		}
 	}
 
 	return nil, fmt.Errorf("dtString: %s is not supported", dtString)

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -105,6 +105,13 @@ func TestParseExtendedDateTime(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEqual(t, ts.String(""), dtString)
 	}
+	{
+		// Edge case
+		dtString := "+275760-09-13T00:00:00.000000Z"
+		ts, err := ParseExtendedDateTime(dtString, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "0001-01-01T00:00:00+00:00", ts.String(""))
+	}
 }
 
 func TestTimeLayout(t *testing.T) {


### PR DESCRIPTION
## Problem

There's an edge case right now with DateTimeWithTimeZone

Consider this, when Debezium gives us the field, it'll look like this:
```json
{
    "type": "string",
    "optional": false,
    "name": "io.debezium.time.ZonedTimestamp",
    "version": 1,
    "field": "due_date"
}
```

As a result, the string can look something like this: 
```
+275760-09-13T00:00:00.000000Z
```

This will fail the Go `time.Time` parsing logic. However, this is technically a validate datetime in Postgres.

## Solution

Right before we are about to error, let's check if there is a year component that exceeds 