### PR TITLE
[DateTime] Solve Edge Case

### DIFF
--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -130,6 +131,26 @@ func (f Field) ParseValue(value any) (any, error) {
 		return f.DecodeDecimal(bytes)
 	case KafkaVariableNumericType:
 		return f.DecodeDebeziumVariableDecimal(value)
+	case DateTimeWithTimezone:
+		dtString, isOk := value.(string)
+		if !isOk {
+			return nil, fmt.Errorf("expected string got '%v' with type %T", value, value)
+		}
+
+		extTime, err := ext.ParseExtendedDateTime(dtString, nil)
+		if err == nil {
+			return extTime, nil
+		}
+
+		// Check if the year exceeds 9999, or is negative
+		if parts := strings.Split(dtString, "-"); len(parts) == 3 {
+			// The purpose of this is that `dtString` can be `+275760-09-13T00:00:00.000000Z` sometimes
+			if len(parts[0]) > 4 {
+				return nil, nil
+			}
+		}
+
+		return nil, fmt.Errorf("failed to parse %q, err: %w", dtString, err)
 	case
 		Timestamp,
 		MicroTimestamp,

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -148,9 +148,8 @@ func (f Field) ParseValue(value any) (any, error) {
 			return nil, nil
 		}
 
-		// Check if the year exceeds 9999
 		if parts := strings.Split(dtString, "-"); len(parts) == 3 {
-			// The purpose of this is that `dtString` can be `+275760-09-13T00:00:00.000000Z` sometimes
+			// Check if year exceeds 9999
 			if len(parts[0]) > 4 {
 				return nil, nil
 			}

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -143,6 +143,11 @@ func (f Field) ParseValue(value any) (any, error) {
 			return extTime, nil
 		}
 
+		// Check for negative years
+		if strings.HasPrefix(dtString, "-") {
+			return nil, nil
+		}
+
 		// Check if the year exceeds 9999, or is negative
 		if parts := strings.Split(dtString, "-"); len(parts) == 3 {
 			// The purpose of this is that `dtString` can be `+275760-09-13T00:00:00.000000Z` sometimes

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -148,7 +148,7 @@ func (f Field) ParseValue(value any) (any, error) {
 			return nil, nil
 		}
 
-		// Check if the year exceeds 9999, or is negative
+		// Check if the year exceeds 9999
 		if parts := strings.Split(dtString, "-"); len(parts) == 3 {
 			// The purpose of this is that `dtString` can be `+275760-09-13T00:00:00.000000Z` sometimes
 			if len(parts[0]) > 4 {

--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -137,6 +137,7 @@ func (f Field) ParseValue(value any) (any, error) {
 			return nil, fmt.Errorf("expected string got '%v' with type %T", value, value)
 		}
 
+		// We don't need to pass `additionalDateFormats` because this data type layout is standardized by Debezium
 		extTime, err := ext.ParseExtendedDateTime(dtString, nil)
 		if err == nil {
 			return extTime, nil

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -332,6 +332,30 @@ func TestField_ParseValue(t *testing.T) {
 			expectedErr: "failed to cast value '1712609795827000' with type 'string' to int64",
 		},
 		{
+			name: "string - datetime with timezone",
+			field: Field{
+				Type:         String,
+				DebeziumType: DateTimeWithTimezone,
+			},
+			value: "2025-09-13T00:00:00.000000Z",
+			expectedValue: &ext.ExtendedTime{
+				Time: time.Date(2025, time.September, 13, 0, 0, 0, 0, time.UTC),
+				NestedKind: ext.NestedKind{
+					Type:   ext.DateTimeKindType,
+					Format: "2006-01-02T15:04:05Z07:00",
+				},
+			},
+		},
+		{
+			name: "string - datetime with timezone (edge case)",
+			field: Field{
+				Type:         String,
+				DebeziumType: DateTimeWithTimezone,
+			},
+			value:         "+275760-09-13T00:00:00.000000Z",
+			expectedValue: nil,
+		},
+		{
 			name: "[]byte",
 			field: Field{
 				Type: Bytes,

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -347,12 +347,21 @@ func TestField_ParseValue(t *testing.T) {
 			},
 		},
 		{
-			name: "string - datetime with timezone (edge case)",
+			name: "string - datetime with timezone (edge case, year exceeds 9999)",
 			field: Field{
 				Type:         String,
 				DebeziumType: DateTimeWithTimezone,
 			},
 			value:         "+275760-09-13T00:00:00.000000Z",
+			expectedValue: nil,
+		},
+		{
+			name: "string - datetime with timezone (edge case, negative years)",
+			field: Field{
+				Type:         String,
+				DebeziumType: DateTimeWithTimezone,
+			},
+			value:         "-0999-10-10T10:10:10.000000Z",
 			expectedValue: nil,
 		},
 		{

--- a/lib/typing/parse.go
+++ b/lib/typing/parse.go
@@ -52,6 +52,7 @@ func parseValue(settings Settings, val any) KindDetails {
 		// This way, we don't penalize every string into going through this loop
 		// In the future, we can have specific layout RFCs run depending on the char
 		if strings.Contains(convertedVal, ":") || strings.Contains(convertedVal, "-") {
+			// TODO: Remove this once we natively support every single Debezium datetime type
 			extendedKind, err := ext.ParseExtendedDateTime(convertedVal, settings.AdditionalDateFormats)
 			if err == nil {
 				return KindDetails{


### PR DESCRIPTION
## Problem

There's an edge case right now with DateTimeWithTimeZone

Consider this, when Debezium gives us the field, it'll look like this:
```json
{
    "type": "string",
    "optional": false,
    "name": "io.debezium.time.ZonedTimestamp",
    "version": 1,
    "field": "due_date"
}
```

As a result, the string can look something like this: 
```
+275760-09-13T00:00:00.000000Z
```

This will fail the Go `time.Time` parsing logic. However, this is technically a validate datetime in Postgres.