### PR TITLE
ToMemoryEvent - Edge case w/ primary keys

### DIFF
--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -68,6 +68,7 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 		s.credentialsClause,
 	)
 
+	slog.Info("copying data into temporary table", slog.String("copyStmt", copyStmt))
 	if _, err = s.Exec(copyStmt); err != nil {
 		return fmt.Errorf("failed to run COPY for temporary table: %w", err)
 	}

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -68,7 +68,6 @@ func (s *Store) PrepareTemporaryTable(tableData *optimization.TableData, tableCo
 		s.credentialsClause,
 	)
 
-	slog.Info("copying data into temporary table", slog.String("copyStmt", copyStmt))
 	if _, err = s.Exec(copyStmt); err != nil {
 		return fmt.Errorf("failed to run COPY for temporary table: %w", err)
 	}

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -21,9 +21,11 @@ import (
 func DropTemporaryTable(dwh destination.DataWarehouse, tableIdentifier sql.TableIdentifier, shouldReturnError bool) error {
 	if strings.Contains(tableIdentifier.Table(), constants.ArtiePrefix) {
 		sqlCommand := fmt.Sprintf("DROP TABLE IF EXISTS %s", tableIdentifier.FullyQualifiedName())
-		slog.Debug("Dropping temporary table", slog.String("sql", sqlCommand))
 		if _, err := dwh.Exec(sqlCommand); err != nil {
-			slog.Warn("Failed to drop temporary table, it will get garbage collected by the TTL...", slog.Any("err", err))
+			slog.Warn("Failed to drop temporary table, it will get garbage collected by the TTL...",
+				slog.Any("err", err),
+				slog.String("sqlCommand", sqlCommand),
+			)
 			if shouldReturnError {
 				return fmt.Errorf("failed to drop temp table: %w", err)
 			}

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -44,6 +44,7 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc *kafkalib.TopicConf
 	if cols != nil {
 		for primaryKey := range pkMap {
 			cols.UpsertColumn(
+				// We need to escape the column name similar to have parity with event.GetColumns()
 				columns.EscapeName(primaryKey),
 				columns.UpsertColumnArg{
 					PrimaryKey: ptr.ToBool(true),

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -43,9 +43,12 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc *kafkalib.TopicConf
 	// Now iterate over pkMap and tag each column that is a primary key
 	if cols != nil {
 		for primaryKey := range pkMap {
-			cols.UpsertColumn(primaryKey, columns.UpsertColumnArg{
-				PrimaryKey: ptr.ToBool(true),
-			})
+			cols.UpsertColumn(
+				columns.EscapeName(primaryKey),
+				columns.UpsertColumnArg{
+					PrimaryKey: ptr.ToBool(true),
+				},
+			)
 		}
 	}
 

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -118,6 +118,30 @@ func (e *EventsTestSuite) TestEvent_TableName() {
 	}
 }
 
+func (e *EventsTestSuite) TestEvent_Columns() {
+	var f fakeEvent
+	{
+		evt, err := ToMemoryEvent(f, map[string]any{"id": 123}, &kafkalib.TopicConfig{}, config.Replication)
+		assert.NoError(e.T(), err)
+
+		assert.Equal(e.T(), 1, len(evt.Columns.GetColumns()))
+		_, isOk := evt.Columns.GetColumn("id")
+		assert.True(e.T(), isOk)
+	}
+	{
+		// Now it should handle escaping column names
+		evt, err := ToMemoryEvent(f, map[string]any{"id": 123, "CAPITAL": "foo"}, &kafkalib.TopicConfig{}, config.Replication)
+		assert.NoError(e.T(), err)
+
+		assert.Equal(e.T(), 2, len(evt.Columns.GetColumns()))
+		_, isOk := evt.Columns.GetColumn("id")
+		assert.True(e.T(), isOk)
+
+		_, isOk = evt.Columns.GetColumn("capital")
+		assert.True(e.T(), isOk)
+	}
+}
+
 func (e *EventsTestSuite) TestEventPrimaryKeys() {
 	evt := &Event{
 		Table: "foo",


### PR DESCRIPTION
This PR addresses a bug where if we have a mixed case primary key column such as `fooBar`, we will end up with 2 columns: `foobar` and `fooBar`