### PR TITLE
Improve Redshift casting

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -16,7 +16,13 @@ const maxRedshiftLength = 65535
 func replaceExceededValues(colVal string, colKind columns.Column) string {
 	structOrString := colKind.KindDetails.Kind == typing.Struct.Kind || colKind.KindDetails.Kind == typing.String.Kind
 	if structOrString {
-		if shouldReplace := len(colVal) > maxRedshiftLength; shouldReplace {
+		maxLength := maxRedshiftLength
+		// If the customer has specified the maximum string precision, let's use that as the max length.
+		if colKind.KindDetails.OptionalStringPrecision != nil {
+			maxLength = *colKind.KindDetails.OptionalStringPrecision
+		}
+
+		if shouldReplace := len(colVal) > maxLength; shouldReplace {
 			if colKind.KindDetails.Kind == typing.Struct.Kind {
 				return fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker)
 			}

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/ptr"
+
 	"github.com/artie-labs/transfer/lib/stringutil"
 
 	"github.com/artie-labs/transfer/lib/db"
@@ -32,6 +34,17 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 			colVal: stringutil.Random(maxRedshiftLength + 1),
 			colKind: columns.Column{
 				KindDetails: typing.String,
+			},
+			expectedResult: constants.ExceededValueMarker,
+		},
+		{
+			name:   "string (specified string precision)",
+			colVal: "hello dusty",
+			colKind: columns.Column{
+				KindDetails: typing.KindDetails{
+					Kind:                    typing.String.Kind,
+					OptionalStringPrecision: ptr.ToInt(3),
+				},
 			},
 			expectedResult: constants.ExceededValueMarker,
 		},


### PR DESCRIPTION
By default, Redshift strings and super data types have a precision limit of 2^16.

However, a customer can optionally specify this such as `status character varying(765)`. This PR adds the ability for us to respect the optional string precision