### PR TITLE
Emit `database.lag`

### DIFF
--- a/models/event/event.go
+++ b/models/event/event.go
@@ -84,7 +84,7 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc *kafkalib.TopicConf
 	}, nil
 }
 
-func (e *Event) EmitDatabaseLag(metricsClient base.Client, mode config.Mode, groupID string) {
+func (e *Event) EmitDatabaseLag(metricsClient base.Client, mode config.Mode, groupID string, topic string) {
 	if e.ExecutionTime.IsZero() {
 		// We don't want to emit a metric if the execution time is zero.
 		return
@@ -94,6 +94,7 @@ func (e *Event) EmitDatabaseLag(metricsClient base.Client, mode config.Mode, gro
 		"mode":    mode.String(),
 		"groupID": groupID,
 		"table":   e.Table,
+		"topic":   topic,
 	})
 }
 

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -75,6 +75,8 @@ func (p processArgs) process(ctx context.Context, cfg config.Config, inMemDB *mo
 		return evt.Table, nil
 	}
 
+	evt.EmitDatabaseLag(metricsClient, cfg.Mode, p.GroupID)
+
 	shouldFlush, flushReason, err := evt.Save(cfg, inMemDB, topicConfig.tc, p.Msg)
 	if err != nil {
 		tags["what"] = "save_fail"

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -75,7 +75,7 @@ func (p processArgs) process(ctx context.Context, cfg config.Config, inMemDB *mo
 		return evt.Table, nil
 	}
 
-	evt.EmitDatabaseLag(metricsClient, cfg.Mode, p.GroupID)
+	evt.EmitDatabaseLag(metricsClient, cfg.Mode, p.GroupID, p.Msg.Topic())
 
 	shouldFlush, flushReason, err := evt.Save(cfg, inMemDB, topicConfig.tc, p.Msg)
 	if err != nil {

--- a/processes/consumer/pubsub.go
+++ b/processes/consumer/pubsub.go
@@ -48,10 +48,10 @@ func findOrCreateSubscription(ctx context.Context, cfg config.Config, client *gc
 		}
 	}
 
-	// This should be the same as our buffer rows so we don't limit our processing throughput
+	// This should be the same as our buffer rows, so we don't limit our processing throughput
 	sub.ReceiveSettings.MaxOutstandingMessages = int(cfg.BufferRows) + 1
 
-	// By default, the pub/sub library will try to spawns 10 additional Go-routines per subscription,
+	// By default, the pub/sub library will try to spawn 10 additional Go-routines per subscription,
 	// it actually does not make the process faster. Rather, it creates more coordination overhead.
 	// Our process message is already extremely fast (~100-200 ns), so we're reducing this down to 1.
 	sub.ReceiveSettings.NumGoroutines = 1
@@ -111,7 +111,6 @@ func StartSubscriber(ctx context.Context, cfg config.Config, inMemDB *models.Dat
 					logger.Panic("Sub receive error", slog.Any("err", err))
 				}
 			}
-
 		}(ctx, client, topicConfig.Topic)
 
 	}


### PR DESCRIPTION
## Changes

Adding an additional metric that Transfer will now emit, which is `database.lag` which is recording the delta between the current timestamp and the database transaction timestamp