### PR TITLE
[BigQuery] Edge case with our decimal types

### DIFF
--- a/clients/bigquery/cast.go
+++ b/clients/bigquery/cast.go
@@ -21,7 +21,13 @@ func castColVal(colVal any, colKind columns.Column, additionalDateFmts []string)
 	}
 
 	switch colKind.KindDetails.Kind {
-	case typing.Float.Kind, typing.Integer.Kind, typing.Boolean.Kind, typing.String.Kind:
+	case typing.String.Kind:
+		if val, isOk := colVal.(*decimal.Decimal); isOk {
+			return val.String(), nil
+		}
+
+		return colVal, nil
+	case typing.Float.Kind, typing.Integer.Kind, typing.Boolean.Kind:
 		return colVal, nil
 	case typing.EDecimal.Kind:
 		val, isOk := colVal.(*decimal.Decimal)

--- a/clients/bigquery/cast_test.go
+++ b/clients/bigquery/cast_test.go
@@ -22,6 +22,12 @@ func (b *BigQueryTestSuite) TestCastColVal() {
 		colVal, err := castColVal("hello", columns.Column{KindDetails: typing.String}, nil)
 		assert.NoError(b.T(), err)
 		assert.Equal(b.T(), "hello", colVal)
+
+		// Decimal
+		dec := decimal.NewDecimal(ptr.ToInt(5), 2, big.NewFloat(123.45))
+		colVal, err = castColVal(dec, columns.Column{KindDetails: typing.String}, nil)
+		assert.NoError(b.T(), err)
+		assert.Equal(b.T(), "123.45", colVal)
 	}
 	{
 		// Integers


### PR DESCRIPTION
If a decimal's precision or scale [exceeds BigQuery's limits](https://github.com/artie-labs/transfer/blob/7caa28799a6ce49316d1ea4e96adc96421e67490/lib/typing/decimal/decimal.go#L86-L94), we will cast the column as a string.

However, the BigQuery API does not like it when we pass in a custom type `*decimal.Decimal` into a column that is a string.

Instead, we should return the string value.

