### PR TITLE
Log this as debug.

### DIFF
--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -61,7 +61,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 			}
 
 			if args.CoolDown != nil && _tableData.ShouldSkipFlush(*args.CoolDown) {
-				slog.With(logFields...).Info("Skipping flush because we are currently in a flush cooldown")
+				slog.With(logFields...).Debug("Skipping flush because we are currently in a flush cooldown")
 				return
 			}
 


### PR DESCRIPTION
This accounts for ~ 12% of our log usage for Transfer in Datadog.

This is also not particularly useful, let's change this to be `Debug` instead