### PR TITLE
[ddl] Drop Temp Table fix.

### DIFF
--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -19,7 +19,7 @@ import (
 // It has a safety check to make sure the tableName contains the `constants.ArtiePrefix` key.
 // Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(5)_expiryUnixTs
 func DropTemporaryTable(dwh destination.DataWarehouse, tableIdentifier sql.TableIdentifier, shouldReturnError bool) error {
-	if strings.Contains(tableIdentifier.Table(), constants.ArtiePrefix) {
+	if strings.Contains(strings.ToLower(tableIdentifier.Table()), constants.ArtiePrefix) {
 		sqlCommand := fmt.Sprintf("DROP TABLE IF EXISTS %s", tableIdentifier.FullyQualifiedName())
 		if _, err := dwh.Exec(sqlCommand); err != nil {
 			slog.Warn("Failed to drop temporary table, it will get garbage collected by the TTL...",


### PR DESCRIPTION
Snowflake tables come back as upper case, the previous PR that refactored this codepath didn't take into account lowercasing the table names.

https://github.com/artie-labs/transfer/commit/d6146a6f3fe4a360b39f0f9265a2aaaec07fd437#diff-a50f63a1ea9f7fdae96c789d0ed7e697b165abbc8acf7912f0a89cd2d67bf2f4