### PR TITLE
[Decimal] Fix Encoding Problem

### DIFF
--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -2,6 +2,7 @@ package debezium
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 
 	"github.com/artie-labs/transfer/lib/typing/decimal"
@@ -9,12 +10,13 @@ import (
 
 // EncodeDecimal is used to encode a string representation of a number to `org.apache.kafka.connect.data.Decimal`.
 func EncodeDecimal(value string, scale int) ([]byte, error) {
-	scaledValue := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
 	bigFloatValue := new(big.Float)
 	if _, success := bigFloatValue.SetString(value); !success {
 		return nil, fmt.Errorf("unable to use '%s' as a floating-point number", value)
 	}
-	bigFloatValue.Mul(bigFloatValue, new(big.Float).SetInt(scaledValue))
+
+	scaledValue := big.NewFloat(math.Pow(10, float64(scale)))
+	bigFloatValue.Mul(bigFloatValue, scaledValue)
 
 	// Extract the scaled integer value.
 	bigIntValue, _ := bigFloatValue.Int(nil)

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -2,7 +2,6 @@ package debezium
 
 import (
 	"fmt"
-	"math"
 	"math/big"
 
 	"github.com/artie-labs/transfer/lib/typing/decimal"
@@ -15,8 +14,8 @@ func EncodeDecimal(value string, scale int) ([]byte, error) {
 		return nil, fmt.Errorf("unable to use %q as a floating-point number", value)
 	}
 
-	scaledValue := big.NewFloat(math.Pow(10, float64(scale)))
-	bigFloatValue.Mul(bigFloatValue, scaledValue)
+	scaledValue := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
+	bigFloatValue.Mul(bigFloatValue, new(big.Float).SetInt(scaledValue))
 
 	// Extract the scaled integer value.
 	bigIntValue := new(big.Int)

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -9,6 +9,8 @@ import (
 
 // EncodeDecimal is used to encode a string representation of a number to `org.apache.kafka.connect.data.Decimal`.
 func EncodeDecimal(value string, scale int) ([]byte, error) {
+	// TODO: Refactor scale to be uint16
+
 	bigFloatValue := new(big.Float)
 	if _, success := bigFloatValue.SetString(value); !success {
 		return nil, fmt.Errorf("unable to use %q as a floating-point number", value)

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -19,7 +19,11 @@ func EncodeDecimal(value string, scale int) ([]byte, error) {
 	bigFloatValue.Mul(bigFloatValue, scaledValue)
 
 	// Extract the scaled integer value.
-	bigIntValue, _ := bigFloatValue.Int(nil)
+	bigIntValue := new(big.Int)
+	if _, success := bigIntValue.SetString(bigFloatValue.String(), 10); !success {
+		return nil, fmt.Errorf("unable to use '%s' as a floating-point number", value)
+	}
+
 	data := bigIntValue.Bytes()
 	if bigIntValue.Sign() < 0 {
 		// Convert to two's complement if the number is negative

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -12,7 +12,7 @@ import (
 func EncodeDecimal(value string, scale int) ([]byte, error) {
 	bigFloatValue := new(big.Float)
 	if _, success := bigFloatValue.SetString(value); !success {
-		return nil, fmt.Errorf("unable to use '%s' as a floating-point number", value)
+		return nil, fmt.Errorf("unable to use %q as a floating-point number", value)
 	}
 
 	scaledValue := big.NewFloat(math.Pow(10, float64(scale)))
@@ -21,7 +21,7 @@ func EncodeDecimal(value string, scale int) ([]byte, error) {
 	// Extract the scaled integer value.
 	bigIntValue := new(big.Int)
 	if _, success := bigIntValue.SetString(bigFloatValue.String(), 10); !success {
-		return nil, fmt.Errorf("unable to use '%s' as a floating-point number", value)
+		return nil, fmt.Errorf("unable to use %q as a floating-point number", value)
 	}
 
 	data := bigIntValue.Bytes()

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -67,14 +67,19 @@ func TestEncodeDecimal(t *testing.T) {
 			scale: 3,
 		},
 		{
+			name:  "total",
+			value: "1.05",
+			scale: 2,
+		},
+		{
 			name:        "malformed - empty string",
 			value:       "",
-			expectedErr: "unable to use '' as a floating-point number",
+			expectedErr: `unable to use "" as a floating-point number`,
 		},
 		{
 			name:        "malformed - not a floating-point",
 			value:       "abcdefg",
-			expectedErr: "unable to use 'abcdefg' as a floating-point number",
+			expectedErr: `unable to use "abcdefg" as a floating-point number`,
 		},
 	}
 


### PR DESCRIPTION
Our previous library was susceptible to precision loss when converting from a `big.Float` into a `big.Int`. Repro: https://go.dev/play/p/qg8NODRlxi5