### PR TITLE
[BigQuery] Specify column names for Append

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -68,14 +68,14 @@ func (s *Store) Append(tableData *optimization.TableData, useTempTable bool) err
 		return fmt.Errorf("failed to append: %w", err)
 	}
 
-	if _, err = s.Exec(
-		fmt.Sprintf(`INSERT INTO %s SELECT %s FROM %s`,
-			tableID.FullyQualifiedName(),
-			strings.Join(sql.QuoteIdentifiers(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(), s.Dialect()), ","),
-			temporaryTableID.FullyQualifiedName(),
-		),
-	); err != nil {
-		return fmt.Errorf("failed to insert data into target table: %w", err)
+	query := fmt.Sprintf(`INSERT INTO %s SELECT %s FROM %s`,
+		tableID.FullyQualifiedName(),
+		strings.Join(sql.QuoteIdentifiers(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(), s.Dialect()), ","),
+		temporaryTableID.FullyQualifiedName(),
+	)
+
+	if _, err = s.Exec(query); err != nil {
+		return fmt.Errorf("failed to insert data into target table: %w, query: %q", err, query)
 	}
 
 	return nil

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -76,7 +76,7 @@ func (s *Store) Append(tableData *optimization.TableData, useTempTable bool) err
 	)
 
 	if _, err = s.Exec(query); err != nil {
-		return fmt.Errorf("failed to insert data into target table: %w, query: %q", err, query)
+		return fmt.Errorf("failed to insert data into target table: %w", err)
 	}
 
 	return nil

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -68,8 +68,9 @@ func (s *Store) Append(tableData *optimization.TableData, useTempTable bool) err
 		return fmt.Errorf("failed to append: %w", err)
 	}
 
-	query := fmt.Sprintf(`INSERT INTO %s SELECT %s FROM %s`,
+	query := fmt.Sprintf(`INSERT INTO %s (%s) SELECT %s FROM %s`,
 		tableID.FullyQualifiedName(),
+		strings.Join(sql.QuoteIdentifiers(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(), s.Dialect()), ","),
 		strings.Join(sql.QuoteIdentifiers(tableData.ReadOnlyInMemoryCols().GetColumnsToUpdate(), s.Dialect()), ","),
 		temporaryTableID.FullyQualifiedName(),
 	)


### PR DESCRIPTION
If we don't specify column names, it'll use the natural order which may not be consistent between staging and target.