### PR TITLE
[go] Fix bug with encoding negative decimal numbers

### DIFF
--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -29,7 +29,8 @@ func EncodeDecimal(value string, scale uint16) ([]byte, error) {
 		// Convert to two's complement if the number is negative
 
 		if data[0] > 127 {
-			// Prepend an empty byte if the first bit is already set.
+			// If the first bit is already set then it is a significant bit and we need to prepend an additional byte
+			// that will be used to indicate whether the number is positive or negative.
 			data = slices.Concat([]byte{0}, data)
 		}
 

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -31,7 +31,7 @@ func EncodeDecimal(value string, scale uint16) ([]byte, error) {
 		if data[0] >= 0x80 {
 			// If the first bit is already set then it is a significant bit and we need to prepend an additional byte
 			// so that the first bit can safely be used to indicate whether the number is positive or negative.
-			data = slices.Concat([]byte{0}, data)
+			data = slices.Concat([]byte{0x00}, data)
 		}
 
 		// Inverting bits for two's complement.

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -30,7 +30,7 @@ func EncodeDecimal(value string, scale uint16) ([]byte, error) {
 
 		if data[0] > 127 {
 			// If the first bit is already set then it is a significant bit and we need to prepend an additional byte
-			// that will be used to indicate whether the number is positive or negative.
+			// so that the first bit can be used to indicate whether the number is positive or negative.
 			data = slices.Concat([]byte{0}, data)
 		}
 

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -30,7 +30,7 @@ func EncodeDecimal(value string, scale uint16) ([]byte, error) {
 
 		if data[0] > 127 {
 			// If the first bit is already set then it is a significant bit and we need to prepend an additional byte
-			// so that the first bit can be used to indicate whether the number is positive or negative.
+			// so that the first bit can safely be used to indicate whether the number is positive or negative.
 			data = slices.Concat([]byte{0}, data)
 		}
 

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -28,7 +28,7 @@ func EncodeDecimal(value string, scale uint16) ([]byte, error) {
 	if bigIntValue.Sign() < 0 {
 		// Convert to two's complement if the number is negative
 
-		if data[0] > 127 {
+		if data[0] >= 0x80 {
 			// If the first bit is already set then it is a significant bit and we need to prepend an additional byte
 			// so that the first bit can safely be used to indicate whether the number is positive or negative.
 			data = slices.Concat([]byte{0}, data)

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -3,6 +3,7 @@ package debezium
 import (
 	"fmt"
 	"math/big"
+	"slices"
 
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 )
@@ -23,11 +24,14 @@ func EncodeDecimal(value string, scale uint16) ([]byte, error) {
 		return nil, fmt.Errorf("unable to use %q as a floating-point number", value)
 	}
 
-	data := bigIntValue.Bytes()
+	data := bigIntValue.Bytes() // [Bytes] returns the absolute value of the number.
 	if bigIntValue.Sign() < 0 {
 		// Convert to two's complement if the number is negative
-		bigIntValue = bigIntValue.Neg(bigIntValue)
-		data = bigIntValue.Bytes()
+
+		if data[0] > 127 {
+			// Prepend an empty byte if the first bit is already set.
+			data = slices.Concat([]byte{0}, data)
+		}
 
 		// Inverting bits for two's complement.
 		for i := range data {

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -1,6 +1,7 @@
 package debezium
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,11 +20,19 @@ func mustEncodeDecode(value string, scale uint16) string {
 	if err != nil {
 		panic(err)
 	}
-
 	return out
 }
 
 func TestEncodeDecimal(t *testing.T) {
+	// Whole numbers:
+	for i := range 100_000 {
+		strValue := fmt.Sprint(i)
+		assert.Equal(t, strValue, mustEncodeDecode(strValue, 0))
+		if i != 0 {
+			assert.Equal(t, "-"+strValue, mustEncodeDecode("-"+strValue, 0))
+		}
+	}
+
 	testCases := []struct {
 		name  string
 		value string
@@ -111,10 +120,9 @@ func TestEncodeDecimal(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		encodedValue, err := EncodeDecimal(testCase.value, testCase.scale)
+		actual, err := encodeDecode(testCase.value, testCase.scale)
 		if testCase.expectedErr == "" {
-			decodedValue := DecodeDecimal(encodedValue, nil, int(testCase.scale))
-			assert.Equal(t, testCase.value, decodedValue.String(), testCase.name)
+			assert.Equal(t, testCase.value, actual, testCase.name)
 		} else {
 			assert.ErrorContains(t, err, testCase.expectedErr, testCase.name)
 		}

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func encodeDecode(value string, scale uint16) (string, error) {
+func encodeAndDecodeDecimal(value string, scale uint16) (string, error) {
 	bytes, err := EncodeDecimal(value, scale)
 	if err != nil {
 		return "", err
@@ -15,8 +15,8 @@ func encodeDecode(value string, scale uint16) (string, error) {
 	return DecodeDecimal(bytes, nil, int(scale)).String(), nil
 }
 
-func mustEncodeDecode(value string, scale uint16) string {
-	out, err := encodeDecode(value, scale)
+func mustEncodeAndDecodeDecimal(value string, scale uint16) string {
+	out, err := encodeAndDecodeDecimal(value, scale)
 	if err != nil {
 		panic(err)
 	}
@@ -27,10 +27,10 @@ func TestEncodeDecimal(t *testing.T) {
 	// Whole numbers:
 	for i := range 100_000 {
 		strValue := fmt.Sprint(i)
-		assert.Equal(t, strValue, mustEncodeDecode(strValue, 0))
+		assert.Equal(t, strValue, mustEncodeAndDecodeDecimal(strValue, 0))
 		if i != 0 {
 			strValue := "-" + strValue
-			assert.Equal(t, strValue, mustEncodeDecode(strValue, 0))
+			assert.Equal(t, strValue, mustEncodeAndDecodeDecimal(strValue, 0))
 		}
 	}
 
@@ -121,7 +121,7 @@ func TestEncodeDecimal(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actual, err := encodeDecode(testCase.value, testCase.scale)
+		actual, err := encodeAndDecodeDecimal(testCase.value, testCase.scale)
 		if testCase.expectedErr == "" {
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.value, actual, testCase.name)

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -6,6 +6,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func encodeDecode(value string, scale uint16) (string, error) {
+	bytes, err := EncodeDecimal(value, scale)
+	if err != nil {
+		return "", err
+	}
+	return DecodeDecimal(bytes, nil, int(scale)).String(), nil
+}
+
+func mustEncodeDecode(value string, scale uint16) string {
+	out, err := encodeDecode(value, scale)
+	if err != nil {
+		panic(err)
+	}
+
+	return out
+}
+
 func TestEncodeDecimal(t *testing.T) {
 	testCases := []struct {
 		name  string
@@ -70,6 +87,16 @@ func TestEncodeDecimal(t *testing.T) {
 			name:  "total",
 			value: "1.05",
 			scale: 2,
+		},
+		{
+			name:  "negative number: 2^16 - 255",
+			value: "-65281",
+			scale: 0,
+		},
+		{
+			name:  "negative number: 2^16 - 1",
+			value: "-65535",
+			scale: 0,
 		},
 		{
 			name:        "malformed - empty string",

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -122,6 +122,7 @@ func TestEncodeDecimal(t *testing.T) {
 	for _, testCase := range testCases {
 		actual, err := encodeDecode(testCase.value, testCase.scale)
 		if testCase.expectedErr == "" {
+			assert.NoError(t, err)
 			assert.Equal(t, testCase.value, actual, testCase.name)
 		} else {
 			assert.ErrorContains(t, err, testCase.expectedErr, testCase.name)

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -29,7 +29,8 @@ func TestEncodeDecimal(t *testing.T) {
 		strValue := fmt.Sprint(i)
 		assert.Equal(t, strValue, mustEncodeDecode(strValue, 0))
 		if i != 0 {
-			assert.Equal(t, "-"+strValue, mustEncodeDecode("-"+strValue, 0))
+			strValue := "-" + strValue
+			assert.Equal(t, strValue, mustEncodeDecode(strValue, 0))
 		}
 	}
 


### PR DESCRIPTION
When encoding a negative decimal number we have to convert the bytes into two's complement. In two's complement the first bit is reserved for the sign, however for certain numbers the sign is already a positive, so in that case we need to pad the output by one empty byte so that the first bit can safely be set to 0 without changing the value. Specifically we were encoding values `-65,281` through `-65,535` incorrectly.