### PR TITLE
[debezium] Fix bug in `EncodeDecimal`

### DIFF
--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -69,12 +69,14 @@ func EncodeDecimal(value string, scale uint16) ([]byte, error) {
 		return nil, fmt.Errorf("unable to use %q as a floating-point number", value)
 	}
 
-	scaledValue := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
-	bigFloatValue.Mul(bigFloatValue, new(big.Float).SetInt(scaledValue))
+	if scale > 0 {
+		scaledValue := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(scale)), nil)
+		bigFloatValue.Mul(bigFloatValue, new(big.Float).SetInt(scaledValue))
+	}
 
 	// Extract the scaled integer value.
 	bigIntValue := new(big.Int)
-	if _, success := bigIntValue.SetString(bigFloatValue.String(), 10); !success {
+	if _, success := bigIntValue.SetString(bigFloatValue.Text('f', 0), 10); !success {
 		return nil, fmt.Errorf("unable to use %q as a floating-point number", value)
 	}
 

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -140,6 +140,16 @@ func TestEncodeDecimal(t *testing.T) {
 			scale: 0,
 		},
 		{
+			name:  "number with a scale of 15",
+			value: "0.000022998904125",
+			scale: 15,
+		},
+		{
+			name:  "number with a scale of 15",
+			value: "145.183000000000000",
+			scale: 15,
+		},
+		{
 			name:        "malformed - empty string",
 			value:       "",
 			expectedErr: `unable to use "" as a floating-point number`,


### PR DESCRIPTION
Fixes `unable to use "0.000022998904125" as a floating-point number`.