### PR TITLE
[debezium] Optimize `EncodeDecimal`

### DIFF
--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -74,6 +74,7 @@ func EncodeDecimal(value string, scale uint16) ([]byte, error) {
 		bigFloatValue.Mul(bigFloatValue, new(big.Float).SetInt(scaledValue))
 	}
 
+	// Extract the scaled integer value.
 	bigIntValue := new(big.Int)
 	if bigFloatValue.IsInt() {
 		bigFloatValue.Int(bigIntValue)

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -74,10 +74,13 @@ func EncodeDecimal(value string, scale uint16) ([]byte, error) {
 		bigFloatValue.Mul(bigFloatValue, new(big.Float).SetInt(scaledValue))
 	}
 
-	// Extract the scaled integer value.
 	bigIntValue := new(big.Int)
-	if _, success := bigIntValue.SetString(bigFloatValue.Text('f', 0), 10); !success {
-		return nil, fmt.Errorf("unable to use %q as a floating-point number", value)
+	if bigFloatValue.IsInt() {
+		bigFloatValue.Int(bigIntValue)
+	} else {
+		if _, success := bigIntValue.SetString(bigFloatValue.Text('f', 0), 10); !success {
+			return nil, fmt.Errorf("unable to use %q as a big.Int", bigFloatValue.String())
+		}
 	}
 
 	return encodeBigInt(bigIntValue), nil

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -78,8 +78,9 @@ func EncodeDecimal(value string, scale uint16) ([]byte, error) {
 	if bigFloatValue.IsInt() {
 		bigFloatValue.Int(bigIntValue)
 	} else {
-		if _, success := bigIntValue.SetString(bigFloatValue.Text('f', 0), 10); !success {
-			return nil, fmt.Errorf("unable to use %q as a big.Int", bigFloatValue.String())
+		strValue := bigFloatValue.Text('f', 0)
+		if _, success := bigIntValue.SetString(strValue, 10); !success {
+			return nil, fmt.Errorf("unable to use %q as a big.Int", strValue)
 		}
 	}
 

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -2,6 +2,7 @@ package debezium
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 	"testing"
 
@@ -28,7 +29,8 @@ func TestDecodeBigInt(t *testing.T) {
 	assert.Equal(t, big.NewInt(128), decodeBigInt([]byte{0x00, 0x80}))
 	assert.Equal(t, big.NewInt(-128), decodeBigInt([]byte{0xff, 0x80}))
 
-	for i := range 100_000 {
+	// Test all values that fit in two bytes + one more.
+	for i := range math.MaxUint16 + 2 {
 		bigInt := big.NewInt(int64(i))
 
 		assert.Equal(t, bigInt, decodeBigInt(encodeBigInt(bigInt)))


### PR DESCRIPTION
- Use `big.Float.Int()` when `big.Float.IsInt()` is true
- Improve error message in the case that `big.Int.SetString()` fails