### PR TITLE
[debezium] Fix bug with `EncodeDecimal`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.19
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.18
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.35.0
+	github.com/cockroachdb/apd/v3 v3.2.1
 	github.com/getsentry/sentry-go v0.27.0
 	github.com/google/uuid v1.6.0
 	github.com/jessevdk/go-flags v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cockroachdb/apd/v3 v3.2.1 h1:U+8j7t0axsIgvQUqthuNm82HIrYXodOV2iWLWtEaIwg=
+github.com/cockroachdb/apd/v3 v3.2.1/go.mod h1:klXJcjp+FffLTHlhIG69tezTDvdP065naDsHzKhYSqc=
 github.com/colinmarc/hdfs/v2 v2.1.1/go.mod h1:M3x+k8UKKmxtFu++uAZ0OtDU8jR3jnaZIAc6yK4Ue0c=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -82,6 +82,7 @@ func TestDecimalWithNewExponent(t *testing.T) {
 	assert.Equal(t, "12.34", decimalWithNewExponent(mustParseDecimalFromString("12.349"), -2).Text('f'))
 	assert.Equal(t, "12.3", decimalWithNewExponent(mustParseDecimalFromString("12.349"), -1).Text('f'))
 	assert.Equal(t, "12", decimalWithNewExponent(mustParseDecimalFromString("12.349"), 0).Text('f'))
+	assert.Equal(t, "10", decimalWithNewExponent(mustParseDecimalFromString("12.349"), 1).Text('f'))
 }
 
 func TestEncodeDecimal(t *testing.T) {

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -195,6 +195,16 @@ func TestEncodeDecimal(t *testing.T) {
 			scale: 0,
 		},
 		{
+			name:  "number with a scale of 15",
+			value: "0.000022998904125",
+			scale: 15,
+		},
+		{
+			name:  "number with a scale of 15",
+			value: "145.183000000000000",
+			scale: 15,
+		},
+		{
 			name:        "malformed - empty string",
 			value:       "",
 			expectedErr: `unable to use "" as a floating-point number`,

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -94,13 +94,15 @@ func TestEncodeDecimal(t *testing.T) {
 		}
 	}
 
-	// Scale of 15 that is equal to the amount of decimal places:
+	// Scale of 15 that is equal to the amount of decimal places in the value:
 	assert.Equal(t, "145.183000000000000", mustEncodeAndDecodeDecimal("145.183000000000000", 15))
-
 	assert.Equal(t, "-145.183000000000000", mustEncodeAndDecodeDecimal("-145.183000000000000", 15))
-	// If scale is smaller than the amount of decimal places then the extra places should be truncated after rounding:
+	// If scale is smaller than the amount of decimal places then the extra places should be truncated without rounding:
 	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimal("145.183000000000000", 14))
-
+	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimal("145.183000000000005", 14))
+	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimal("-145.183000000000005", 14))
+	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimal("145.183000000000009", 14))
+	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimal("-145.183000000000009", 14))
 	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimal("-145.183000000000000", 14))
 	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimal("145.183000000000001", 14))
 	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimal("-145.183000000000001", 14))

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -57,7 +57,7 @@ func mustEncodeAndDecodeDecimal(value string, scale uint16) string {
 	return out
 }
 
-func mustParseString(in string) *apd.Decimal {
+func mustParseDecimalFromString(in string) *apd.Decimal {
 	out, _, err := apd.NewFromString(in)
 	if err != nil {
 		panic(err)
@@ -72,15 +72,15 @@ func TestDecimalWithNewExponent(t *testing.T) {
 	assert.Equal(t, "0.0", decimalWithNewExponent(apd.New(0, 0), -1).Text('f'))
 
 	// Same exponent:
-	assert.Equal(t, "12.349", decimalWithNewExponent(mustParseString("12.349"), -3).Text('f'))
+	assert.Equal(t, "12.349", decimalWithNewExponent(mustParseDecimalFromString("12.349"), -3).Text('f'))
 	// More precise exponent:
-	assert.Equal(t, "12.3490", decimalWithNewExponent(mustParseString("12.349"), -4).Text('f'))
-	assert.Equal(t, "12.34900", decimalWithNewExponent(mustParseString("12.349"), -5).Text('f'))
+	assert.Equal(t, "12.3490", decimalWithNewExponent(mustParseDecimalFromString("12.349"), -4).Text('f'))
+	assert.Equal(t, "12.34900", decimalWithNewExponent(mustParseDecimalFromString("12.349"), -5).Text('f'))
 	// Lest precise exponent:
 	// Extra digits should be truncated rather than rounded.
-	assert.Equal(t, "12.34", decimalWithNewExponent(mustParseString("12.349"), -2).Text('f'))
-	assert.Equal(t, "12.3", decimalWithNewExponent(mustParseString("12.349"), -1).Text('f'))
-	assert.Equal(t, "12", decimalWithNewExponent(mustParseString("12.349"), 0).Text('f'))
+	assert.Equal(t, "12.34", decimalWithNewExponent(mustParseDecimalFromString("12.349"), -2).Text('f'))
+	assert.Equal(t, "12.3", decimalWithNewExponent(mustParseDecimalFromString("12.349"), -1).Text('f'))
+	assert.Equal(t, "12", decimalWithNewExponent(mustParseDecimalFromString("12.349"), 0).Text('f'))
 }
 
 func TestEncodeDecimal(t *testing.T) {

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -67,6 +67,7 @@ func mustParseDecimalFromString(in string) *apd.Decimal {
 
 func TestDecimalWithNewExponent(t *testing.T) {
 	assert.Equal(t, "0", decimalWithNewExponent(apd.New(0, 0), 0).Text('f'))
+	assert.Equal(t, "00", decimalWithNewExponent(apd.New(0, 1), 1).Text('f'))
 	assert.Equal(t, "0", decimalWithNewExponent(apd.New(0, 100), 0).Text('f'))
 	assert.Equal(t, "00", decimalWithNewExponent(apd.New(0, 0), 1).Text('f'))
 	assert.Equal(t, "0.0", decimalWithNewExponent(apd.New(0, 0), -1).Text('f'))


### PR DESCRIPTION
While doing some testing I discovered that if we encode and decode `-9063701308.217222135` with `EncodeDecimal`/`DecodeDecimal` the result comes back as `-9063701308.217222134`. In order to fix this and mitigate other potential issues with decimals this switches us to use https://github.com/cockroachdb/apd for decimals.