### PR TITLE
[debezium] Change function signature of `EncodeDecimal`

### DIFF
--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -100,8 +100,8 @@ func EncodeDecimal(decimal *apd.Decimal) ([]byte, int32) {
 	return encodeBigInt(bigIntValue), -decimal.Exponent
 }
 
-// EncodeDecimalWithScale is used to encode a [apd.Decimal] to [org.apache.kafka.connect.data.Decimal] using a specific
-// scale.
+// EncodeDecimalWithScale is used to encode a [apd.Decimal] to [org.apache.kafka.connect.data.Decimal]
+// using a specific scale.
 func EncodeDecimalWithScale(decimal *apd.Decimal, scale int32) []byte {
 	targetExponent := -scale // Negate scale since [Decimal.Exponent] is negative.
 	if decimal.Exponent != targetExponent {

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -107,8 +107,8 @@ func EncodeDecimalWithScale(decimal *apd.Decimal, scale int32) []byte {
 	if decimal.Exponent != targetExponent {
 		decimal = decimalWithNewExponent(decimal, targetExponent)
 	}
-	out, _ := EncodeDecimal(decimal)
-	return out
+	bytes, _ := EncodeDecimal(decimal)
+	return bytes
 }
 
 // DecodeDecimal is used to decode `org.apache.kafka.connect.data.Decimal`.

--- a/lib/debezium/decimal.go
+++ b/lib/debezium/decimal.go
@@ -91,23 +91,24 @@ func decimalWithNewExponent(decimal *apd.Decimal, newExponent int32) *apd.Decima
 
 // EncodeDecimal is used to encode a [apd.Decimal] to [org.apache.kafka.connect.data.Decimal].
 // The scale of the value (which is the negated exponent of the decimal) is returned as the second argument.
-func EncodeDecimal(decimal *apd.Decimal) ([]byte, int32, error) {
+func EncodeDecimal(decimal *apd.Decimal) ([]byte, int32) {
 	bigIntValue := decimal.Coeff.MathBigInt()
 	if decimal.Negative {
 		bigIntValue.Neg(bigIntValue)
 	}
 
-	return encodeBigInt(bigIntValue), -decimal.Exponent, nil
+	return encodeBigInt(bigIntValue), -decimal.Exponent
 }
 
 // EncodeDecimalWithScale is used to encode a [apd.Decimal] to [org.apache.kafka.connect.data.Decimal] using a specific
 // scale.
-func EncodeDecimalWithScale(decimal *apd.Decimal, scale int32) ([]byte, int32, error) {
+func EncodeDecimalWithScale(decimal *apd.Decimal, scale int32) []byte {
 	targetExponent := -scale // Negate scale since [Decimal.Exponent] is negative.
 	if decimal.Exponent != targetExponent {
 		decimal = decimalWithNewExponent(decimal, targetExponent)
 	}
-	return EncodeDecimal(decimal)
+	out, _ := EncodeDecimal(decimal)
+	return out
 }
 
 // DecodeDecimal is used to decode `org.apache.kafka.connect.data.Decimal`.

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -90,7 +90,7 @@ func TestEncodeDecimal(t *testing.T) {
 }
 
 func TestEncodeDecimalWithScale(t *testing.T) {
-	mustEncodeAndDecodeDecimalWithScale := func(value string, scale int32) string {
+	mustEncodeAndDecodeDecimal := func(value string, scale int32) string {
 		bytes := EncodeDecimalWithScale(mustParseDecimal(value), scale)
 		return DecodeDecimal(bytes, nil, int(scale)).String()
 	}
@@ -98,40 +98,40 @@ func TestEncodeDecimalWithScale(t *testing.T) {
 	// Whole numbers:
 	for i := range 100_000 {
 		strValue := fmt.Sprint(i)
-		assert.Equal(t, strValue, mustEncodeAndDecodeDecimalWithScale(strValue, 0))
+		assert.Equal(t, strValue, mustEncodeAndDecodeDecimal(strValue, 0))
 		if i != 0 {
 			strValue := "-" + strValue
-			assert.Equal(t, strValue, mustEncodeAndDecodeDecimalWithScale(strValue, 0))
+			assert.Equal(t, strValue, mustEncodeAndDecodeDecimal(strValue, 0))
 		}
 	}
 
 	// Scale of 15 that is equal to the amount of decimal places in the value:
-	assert.Equal(t, "145.183000000000000", mustEncodeAndDecodeDecimalWithScale("145.183000000000000", 15))
-	assert.Equal(t, "-145.183000000000000", mustEncodeAndDecodeDecimalWithScale("-145.183000000000000", 15))
+	assert.Equal(t, "145.183000000000000", mustEncodeAndDecodeDecimal("145.183000000000000", 15))
+	assert.Equal(t, "-145.183000000000000", mustEncodeAndDecodeDecimal("-145.183000000000000", 15))
 	// If scale is smaller than the amount of decimal places then the extra places should be truncated without rounding:
-	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimalWithScale("145.183000000000000", 14))
-	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimalWithScale("145.183000000000005", 14))
-	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimalWithScale("-145.183000000000005", 14))
-	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimalWithScale("145.183000000000009", 14))
-	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimalWithScale("-145.183000000000009", 14))
-	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimalWithScale("-145.183000000000000", 14))
-	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimalWithScale("145.183000000000001", 14))
-	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimalWithScale("-145.183000000000001", 14))
-	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimalWithScale("145.183000000000004", 14))
-	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimalWithScale("-145.183000000000004", 14))
+	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimal("145.183000000000000", 14))
+	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimal("145.183000000000005", 14))
+	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimal("-145.183000000000005", 14))
+	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimal("145.183000000000009", 14))
+	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimal("-145.183000000000009", 14))
+	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimal("-145.183000000000000", 14))
+	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimal("145.183000000000001", 14))
+	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimal("-145.183000000000001", 14))
+	assert.Equal(t, "145.18300000000000", mustEncodeAndDecodeDecimal("145.183000000000004", 14))
+	assert.Equal(t, "-145.18300000000000", mustEncodeAndDecodeDecimal("-145.183000000000004", 14))
 	// If scale is larger than the amount of decimal places then the extra places should be padded with zeros:
-	assert.Equal(t, "145.1830000000000000", mustEncodeAndDecodeDecimalWithScale("145.183000000000000", 16))
-	assert.Equal(t, "-145.1830000000000000", mustEncodeAndDecodeDecimalWithScale("-145.183000000000000", 16))
-	assert.Equal(t, "145.1830000000000010", mustEncodeAndDecodeDecimalWithScale("145.183000000000001", 16))
-	assert.Equal(t, "-145.1830000000000010", mustEncodeAndDecodeDecimalWithScale("-145.183000000000001", 16))
-	assert.Equal(t, "145.1830000000000040", mustEncodeAndDecodeDecimalWithScale("145.183000000000004", 16))
-	assert.Equal(t, "-145.1830000000000040", mustEncodeAndDecodeDecimalWithScale("-145.183000000000004", 16))
-	assert.Equal(t, "145.1830000000000050", mustEncodeAndDecodeDecimalWithScale("145.183000000000005", 16))
-	assert.Equal(t, "-145.1830000000000050", mustEncodeAndDecodeDecimalWithScale("-145.183000000000005", 16))
-	assert.Equal(t, "145.1830000000000090", mustEncodeAndDecodeDecimalWithScale("145.183000000000009", 16))
-	assert.Equal(t, "-145.1830000000000090", mustEncodeAndDecodeDecimalWithScale("-145.183000000000009", 16))
+	assert.Equal(t, "145.1830000000000000", mustEncodeAndDecodeDecimal("145.183000000000000", 16))
+	assert.Equal(t, "-145.1830000000000000", mustEncodeAndDecodeDecimal("-145.183000000000000", 16))
+	assert.Equal(t, "145.1830000000000010", mustEncodeAndDecodeDecimal("145.183000000000001", 16))
+	assert.Equal(t, "-145.1830000000000010", mustEncodeAndDecodeDecimal("-145.183000000000001", 16))
+	assert.Equal(t, "145.1830000000000040", mustEncodeAndDecodeDecimal("145.183000000000004", 16))
+	assert.Equal(t, "-145.1830000000000040", mustEncodeAndDecodeDecimal("-145.183000000000004", 16))
+	assert.Equal(t, "145.1830000000000050", mustEncodeAndDecodeDecimal("145.183000000000005", 16))
+	assert.Equal(t, "-145.1830000000000050", mustEncodeAndDecodeDecimal("-145.183000000000005", 16))
+	assert.Equal(t, "145.1830000000000090", mustEncodeAndDecodeDecimal("145.183000000000009", 16))
+	assert.Equal(t, "-145.1830000000000090", mustEncodeAndDecodeDecimal("-145.183000000000009", 16))
 
-	assert.Equal(t, "-9063701308.217222135", mustEncodeAndDecodeDecimalWithScale("-9063701308.217222135", 9))
+	assert.Equal(t, "-9063701308.217222135", mustEncodeAndDecodeDecimal("-9063701308.217222135", 9))
 
 	testCases := []struct {
 		name  string
@@ -218,7 +218,7 @@ func TestEncodeDecimalWithScale(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actual := mustEncodeAndDecodeDecimalWithScale(testCase.value, testCase.scale)
+		actual := mustEncodeAndDecodeDecimal(testCase.value, testCase.scale)
 		assert.Equal(t, testCase.value, actual, testCase.name)
 	}
 }

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -72,8 +72,8 @@ func TestDecimalWithNewExponent(t *testing.T) {
 func TestEncodeDecimal(t *testing.T) {
 	testEncodeDecimal := func(value string, expectedScale int32) {
 		bytes, scale := EncodeDecimal(mustParseDecimal(value))
-		result := DecodeDecimal(bytes, nil, int(scale)).String()
-		assert.Equal(t, result, value, value)
+		actual := DecodeDecimal(bytes, nil, int(scale)).String()
+		assert.Equal(t, value, actual, value)
 		assert.Equal(t, expectedScale, scale, value)
 	}
 

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -70,23 +70,23 @@ func TestDecimalWithNewExponent(t *testing.T) {
 }
 
 func TestEncodeDecimal(t *testing.T) {
-	testValue := func(value string, expectedScale int32) {
+	testEncodeDecimal := func(value string, expectedScale int32) {
 		bytes, scale := EncodeDecimal(mustParseDecimal(value))
 		result := DecodeDecimal(bytes, nil, int(scale)).String()
 		assert.Equal(t, result, value, value)
 		assert.Equal(t, expectedScale, scale, value)
 	}
 
-	testValue("0", 0)
-	testValue("0.0", 1)
-	testValue("0.00", 2)
-	testValue("0.00000", 5)
-	testValue("1", 0)
-	testValue("1.0", 1)
-	testValue("-1", 0)
-	testValue("-1.0", 1)
-	testValue("145.183000000000009", 15)
-	testValue("-145.183000000000009", 15)
+	testEncodeDecimal("0", 0)
+	testEncodeDecimal("0.0", 1)
+	testEncodeDecimal("0.00", 2)
+	testEncodeDecimal("0.00000", 5)
+	testEncodeDecimal("1", 0)
+	testEncodeDecimal("1.0", 1)
+	testEncodeDecimal("-1", 0)
+	testEncodeDecimal("-1.0", 1)
+	testEncodeDecimal("145.183000000000009", 15)
+	testEncodeDecimal("-145.183000000000009", 15)
 }
 
 func TestEncodeDecimalWithScale(t *testing.T) {

--- a/lib/debezium/decimal_test.go
+++ b/lib/debezium/decimal_test.go
@@ -44,7 +44,7 @@ func TestDecodeBigInt(t *testing.T) {
 func mustParseDecimal(value string) *apd.Decimal {
 	decimal, _, err := apd.NewFromString(value)
 	if err != nil {
-		panic(fmt.Errorf("unable to use %q as a floating-point number: %w", value, err))
+		panic(err)
 	}
 	return decimal
 }


### PR DESCRIPTION
`EncodeDecimal` is only called by Reader in two places, and in one of those places we already have code to determine the scale, which is something we can simplify if we have a `apd.Decimal`, so rather than depend on Transfer to parse strings into encoded `org.apache.kafka.connect.data.Decimal`s we'll let Reader handle the parsing to `apd.Decimal` and just let Transfer handle the encoding.