### PR TITLE
When soft deleting, preserve previous values if we have them in memory

### DIFF
--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -132,11 +132,8 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 	if isOk {
 		prevRowSize = size.GetApproxSize(prevRow)
 		if delete {
-			// If the row was deleted, preserve the previous values if we have them in memory
+			// If the row was deleted, preserve the previous values that we have in memory
 			rowData = prevRow
-			if len(rowData) == 0 {
-				rowData = map[string]any{}
-			}
 			rowData[constants.DeleteColumnMarker] = true
 		} else {
 			for key, val := range rowData {

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -130,18 +130,25 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 	var prevRowSize int
 	prevRow, isOk := t.rowsData[pk]
 	if isOk {
-		prevRowSize = size.GetApproxSize(prevRow)
-		for key, val := range rowData {
-			if val == constants.ToastUnavailableValuePlaceholder {
-				// Copy it from prevRow.
-				prevVal, isOk := prevRow[key]
-				if !isOk {
-					continue
-				}
+		if delete {
+			// if the row was deleted, copy the previous values and just update the deleted flag
+			rowData = prevRow
+			rowData[constants.DeleteColumnMarker] = true
+		} else {
+			prevRowSize = size.GetApproxSize(prevRow)
+			for key, val := range rowData {
+				if val == constants.ToastUnavailableValuePlaceholder {
+					// Copy it from prevRow.
+					prevVal, isOk := prevRow[key]
+					if !isOk {
+						continue
+					}
 
-				// If we got back a TOASTED value, we need to use the previous row.
-				rowData[key] = prevVal
+					// If we got back a TOASTED value, we need to use the previous row.
+					rowData[key] = prevVal
+				}
 			}
+
 		}
 	}
 

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -134,6 +134,9 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 		if delete {
 			// if the row was deleted, copy the previous values and just update the deleted flag
 			rowData = prevRow
+			if _, isOk := rowData[constants.DeleteColumnMarker]; !isOk {
+				rowData = map[string]any{}
+			}
 			rowData[constants.DeleteColumnMarker] = true
 		} else {
 			for key, val := range rowData {

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -132,9 +132,9 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 	if isOk {
 		prevRowSize = size.GetApproxSize(prevRow)
 		if delete {
-			// if the row was deleted, copy the previous values and just update the deleted flag
+			// If the row was deleted, preserve the previous values if we have them in memory
 			rowData = prevRow
-			if _, isOk := rowData[constants.DeleteColumnMarker]; !isOk {
+			if len(rowData) == 0 {
 				rowData = map[string]any{}
 			}
 			rowData[constants.DeleteColumnMarker] = true

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -130,12 +130,12 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 	var prevRowSize int
 	prevRow, isOk := t.rowsData[pk]
 	if isOk {
+		prevRowSize = size.GetApproxSize(prevRow)
 		if delete {
 			// if the row was deleted, copy the previous values and just update the deleted flag
 			rowData = prevRow
 			rowData[constants.DeleteColumnMarker] = true
 		} else {
-			prevRowSize = size.GetApproxSize(prevRow)
 			for key, val := range rowData {
 				if val == constants.ToastUnavailableValuePlaceholder {
 					// Copy it from prevRow.

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -279,3 +279,21 @@ func TestTableData_InsertRowIntegrity(t *testing.T) {
 		assert.True(t, td.ContainOtherOperations())
 	}
 }
+
+func TestTableData_InsertRowSoftDelete(t *testing.T) {
+	td := NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{SoftDelete: true}, "foo")
+	assert.Equal(t, 0, int(td.NumberOfRows()))
+
+	td.InsertRow("123", map[string]any{"name": "dana"}, false)
+	assert.Equal(t, 1, int(td.NumberOfRows()))
+	assert.Equal(t, "dana", td.Rows()[0]["name"])
+
+	td.InsertRow("123", map[string]any{"name": "dana2"}, false)
+	assert.Equal(t, 1, int(td.NumberOfRows()))
+	assert.Equal(t, "dana2", td.Rows()[0]["name"])
+
+	td.InsertRow("123", map[string]any{}, true)
+	assert.Equal(t, 1, int(td.NumberOfRows()))
+	// The previous value should be preserved
+	assert.Equal(t, "dana2", td.Rows()[0]["name"])
+}

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -270,12 +270,12 @@ func TestTableData_InsertRowIntegrity(t *testing.T) {
 	assert.False(t, td.ContainOtherOperations())
 
 	for i := 0; i < 100; i++ {
-		td.InsertRow("123", nil, true)
+		td.InsertRow("123", map[string]any{}, true)
 		assert.False(t, td.ContainOtherOperations())
 	}
 
 	for i := 0; i < 100; i++ {
-		td.InsertRow("123", nil, false)
+		td.InsertRow("123", map[string]any{}, false)
 		assert.True(t, td.ContainOtherOperations())
 	}
 }

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -270,12 +270,12 @@ func TestTableData_InsertRowIntegrity(t *testing.T) {
 	assert.False(t, td.ContainOtherOperations())
 
 	for i := 0; i < 100; i++ {
-		td.InsertRow("123", map[string]any{}, true)
+		td.InsertRow("123", nil, true)
 		assert.False(t, td.ContainOtherOperations())
 	}
 
 	for i := 0; i < 100; i++ {
-		td.InsertRow("123", map[string]any{}, false)
+		td.InsertRow("123", nil, false)
 		assert.True(t, td.ContainOtherOperations())
 	}
 }


### PR DESCRIPTION
Step 1 of not clearing out the values of a row when it's soft deleted.

If a row is updated and then deleted before the next flush, we have its previous values in memory so we can use those and just add the deleted flag.