### PR TITLE
[typing] Split out `DecimalDetails`

### DIFF
--- a/lib/cdc/util/optional_schema_test.go
+++ b/lib/cdc/util/optional_schema_test.go
@@ -67,35 +67,35 @@ func TestGetOptionalSchema(t *testing.T) {
 				"bit_test":     typing.Boolean,
 				"numeric_test": {
 					Kind:                   typing.EDecimal.Kind,
-					ExtendedDecimalDetails: decimal.NewDecimal(ptr.ToInt(decimal.PrecisionNotSpecified), decimal.DefaultScale, nil),
+					ExtendedDecimalDetails: decimal.NewDecimalDetails(ptr.ToInt(decimal.PrecisionNotSpecified), decimal.DefaultScale),
 				},
 				"numeric_5": {
 					Kind:                   typing.EDecimal.Kind,
-					ExtendedDecimalDetails: decimal.NewDecimal(ptr.ToInt(5), 0, nil),
+					ExtendedDecimalDetails: decimal.NewDecimalDetails(ptr.ToInt(5), 0),
 				},
 				"numeric_5_2": {
 					Kind:                   typing.EDecimal.Kind,
-					ExtendedDecimalDetails: decimal.NewDecimal(ptr.ToInt(5), 2, nil),
+					ExtendedDecimalDetails: decimal.NewDecimalDetails(ptr.ToInt(5), 2),
 				},
 				"numeric_5_6": {
 					Kind:                   typing.EDecimal.Kind,
-					ExtendedDecimalDetails: decimal.NewDecimal(ptr.ToInt(5), 6, nil),
+					ExtendedDecimalDetails: decimal.NewDecimalDetails(ptr.ToInt(5), 6),
 				},
 				"numeric_5_0": {
 					Kind:                   typing.EDecimal.Kind,
-					ExtendedDecimalDetails: decimal.NewDecimal(ptr.ToInt(5), 0, nil),
+					ExtendedDecimalDetails: decimal.NewDecimalDetails(ptr.ToInt(5), 0),
 				},
 				"numeric_39_0": {
 					Kind:                   typing.EDecimal.Kind,
-					ExtendedDecimalDetails: decimal.NewDecimal(ptr.ToInt(39), 0, nil),
+					ExtendedDecimalDetails: decimal.NewDecimalDetails(ptr.ToInt(39), 0),
 				},
 				"numeric_39_2": {
 					Kind:                   typing.EDecimal.Kind,
-					ExtendedDecimalDetails: decimal.NewDecimal(ptr.ToInt(39), 2, nil),
+					ExtendedDecimalDetails: decimal.NewDecimalDetails(ptr.ToInt(39), 2),
 				},
 				"numeric_39_6": {
 					Kind:                   typing.EDecimal.Kind,
-					ExtendedDecimalDetails: decimal.NewDecimal(ptr.ToInt(39), 6, nil),
+					ExtendedDecimalDetails: decimal.NewDecimalDetails(ptr.ToInt(39), 6),
 				},
 			},
 		},

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -99,14 +99,14 @@ func (f Field) ToKindDetails() typing.KindDetails {
 		}
 
 		eDecimal := typing.EDecimal
-		eDecimal.ExtendedDecimalDetails = decimal.NewDecimal(precision, scale, nil)
+		eDecimal.ExtendedDecimalDetails = decimal.NewDecimalDetails(precision, scale)
 		return eDecimal
 	case KafkaVariableNumericType:
 		// For variable numeric types, we are defaulting to a scale of 5
 		// This is because scale is not specified at the column level, rather at the row level
 		// It shouldn't matter much anyway since the column type we are creating is `TEXT` to avoid boundary errors.
 		eDecimal := typing.EDecimal
-		eDecimal.ExtendedDecimalDetails = decimal.NewDecimal(ptr.ToInt(decimal.PrecisionNotSpecified), decimal.DefaultScale, nil)
+		eDecimal.ExtendedDecimalDetails = decimal.NewDecimalDetails(ptr.ToInt(decimal.PrecisionNotSpecified), decimal.DefaultScale)
 		return eDecimal
 	}
 

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -89,10 +89,10 @@ func TestField_ToKindDetails(t *testing.T) {
 	}
 
 	eDecimal := typing.EDecimal
-	eDecimal.ExtendedDecimalDetails = decimal.NewDecimal(ptr.ToInt(decimal.PrecisionNotSpecified), decimal.DefaultScale, nil)
+	eDecimal.ExtendedDecimalDetails = decimal.NewDecimalDetails(ptr.ToInt(decimal.PrecisionNotSpecified), decimal.DefaultScale)
 
 	kafkaDecimalType := typing.EDecimal
-	kafkaDecimalType.ExtendedDecimalDetails = decimal.NewDecimal(ptr.ToInt(10), 5, nil)
+	kafkaDecimalType.ExtendedDecimalDetails = decimal.NewDecimalDetails(ptr.ToInt(10), 5)
 
 	tcs := []_tc{
 		{

--- a/lib/optimization/event_update_test.go
+++ b/lib/optimization/event_update_test.go
@@ -42,7 +42,7 @@ func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 		tableDataCols.AddColumn(columns.NewColumn("ext_dec", typing.String))
 
 		extDecimalType := typing.EDecimal
-		extDecimalType.ExtendedDecimalDetails = decimal.NewDecimal(ptr.ToInt(22), 2, nil)
+		extDecimalType.ExtendedDecimalDetails = decimal.NewDecimalDetails(ptr.ToInt(22), 2)
 		tableDataCols.AddColumn(columns.NewColumn("ext_dec_filled", extDecimalType))
 
 		tableDataCols.AddColumn(columns.NewColumn(strCol, typing.String))
@@ -121,7 +121,7 @@ func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 		assert.Equal(t, typing.String, extDecCol.KindDetails)
 
 		extDecimal := typing.EDecimal
-		extDecimal.ExtendedDecimalDetails = decimal.NewDecimal(ptr.ToInt(30), 2, nil)
+		extDecimal.ExtendedDecimalDetails = decimal.NewDecimalDetails(ptr.ToInt(30), 2)
 		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_dec", extDecimal)))
 		// Now it should be ext decimal type
 		extDecCol, isOk = tableData.inMemoryColumns.GetColumn("ext_dec")

--- a/lib/parquetutil/parse_values_test.go
+++ b/lib/parquetutil/parse_values_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestParseValue(t *testing.T) {
 	eDecimal := typing.EDecimal
-	eDecimal.ExtendedDecimalDetails = decimal.NewDecimal(ptr.ToInt(30), 5, nil)
+	eDecimal.ExtendedDecimalDetails = decimal.NewDecimalDetails(ptr.ToInt(30), 5)
 
 	eTime := typing.ETime
 	eTime.ExtendedTimeDetails = &ext.Time

--- a/lib/typing/decimal/base.go
+++ b/lib/typing/decimal/base.go
@@ -6,7 +6,7 @@ import (
 	"github.com/artie-labs/transfer/lib/numbers"
 )
 
-func (d *Decimal) isNumeric() bool {
+func (d *DecimalDetails) isNumeric() bool {
 	if d.precision == nil || *d.precision == PrecisionNotSpecified {
 		return false
 	}
@@ -20,7 +20,7 @@ func (d *Decimal) isNumeric() bool {
 	return numbers.BetweenEq(max(1, d.scale), d.scale+29, *d.precision)
 }
 
-func (d *Decimal) isBigNumeric() bool {
+func (d *DecimalDetails) isBigNumeric() bool {
 	if d.precision == nil || *d.precision == -1 {
 		return false
 	}
@@ -34,7 +34,7 @@ func (d *Decimal) isBigNumeric() bool {
 	return numbers.BetweenEq(max(1, d.scale), d.scale+38, *d.precision)
 }
 
-func (d *Decimal) toKind(maxPrecision int, exceededKind string) string {
+func (d *DecimalDetails) toKind(maxPrecision int, exceededKind string) string {
 	precision := maxPrecision
 	if d.precision != nil {
 		precision = *d.precision

--- a/lib/typing/decimal/decimal.go
+++ b/lib/typing/decimal/decimal.go
@@ -1,7 +1,6 @@
 package decimal
 
 import (
-	"fmt"
 	"math/big"
 
 	"github.com/artie-labs/transfer/lib/ptr"
@@ -66,29 +65,6 @@ func (d *Decimal) Value() any {
 	return d.value
 }
 
-// SnowflakeKind - is used to determine whether a NUMERIC data type should be a STRING or NUMERIC(p, s).
-func (d *Decimal) SnowflakeKind() string {
-	return d.toKind(MaxPrecisionBeforeString, "STRING")
-}
-
-// MsSQLKind - Has the same limitation as Redshift
-// Spec: https://learn.microsoft.com/en-us/sql/t-sql/data-types/decimal-and-numeric-transact-sql?view=sql-server-ver16#arguments
-func (d *Decimal) MsSQLKind() string {
-	return d.toKind(MaxPrecisionBeforeString, "TEXT")
-}
-
-// RedshiftKind - is used to determine whether a NUMERIC data type should be a TEXT or NUMERIC(p, s).
-func (d *Decimal) RedshiftKind() string {
-	return d.toKind(MaxPrecisionBeforeString, "TEXT")
-}
-
-// BigQueryKind - is inferring logic from: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
-func (d *Decimal) BigQueryKind() string {
-	if d.isNumeric() {
-		return fmt.Sprintf("NUMERIC(%v, %v)", *d.precision, d.scale)
-	} else if d.isBigNumeric() {
-		return fmt.Sprintf("BIGNUMERIC(%v, %v)", *d.precision, d.scale)
-	}
-
-	return "STRING"
+func (d *Decimal) Details() DecimalDetails {
+	return DecimalDetails{scale: d.scale, precision: d.precision}
 }

--- a/lib/typing/decimal/details.go
+++ b/lib/typing/decimal/details.go
@@ -1,0 +1,64 @@
+package decimal
+
+import (
+	"fmt"
+
+	"github.com/artie-labs/transfer/lib/ptr"
+)
+
+type DecimalDetails struct {
+	scale     int
+	precision *int
+}
+
+func NewDecimalDetails(precision *int, scale int) *DecimalDetails {
+	if precision != nil {
+		if scale > *precision && *precision != -1 {
+			// Note: -1 precision means it's not specified.
+
+			// This is typically not possible, but Postgres has a design flaw that allows you to do things like: NUMERIC(5, 6) which actually equates to NUMERIC(7, 6)
+			// We are setting precision to be scale + 1 to account for the leading zero for decimal numbers.
+			precision = ptr.ToInt(scale + 1)
+		}
+	}
+
+	return &DecimalDetails{
+		scale:     scale,
+		precision: precision,
+	}
+}
+
+func (d DecimalDetails) Scale() int {
+	return d.scale
+}
+
+func (d DecimalDetails) Precision() *int {
+	return d.precision
+}
+
+// SnowflakeKind - is used to determine whether a NUMERIC data type should be a STRING or NUMERIC(p, s).
+func (d *DecimalDetails) SnowflakeKind() string {
+	return d.toKind(MaxPrecisionBeforeString, "STRING")
+}
+
+// MsSQLKind - Has the same limitation as Redshift
+// Spec: https://learn.microsoft.com/en-us/sql/t-sql/data-types/decimal-and-numeric-transact-sql?view=sql-server-ver16#arguments
+func (d *DecimalDetails) MsSQLKind() string {
+	return d.toKind(MaxPrecisionBeforeString, "TEXT")
+}
+
+// RedshiftKind - is used to determine whether a NUMERIC data type should be a TEXT or NUMERIC(p, s).
+func (d *DecimalDetails) RedshiftKind() string {
+	return d.toKind(MaxPrecisionBeforeString, "TEXT")
+}
+
+// BigQueryKind - is inferring logic from: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
+func (d *DecimalDetails) BigQueryKind() string {
+	if d.isNumeric() {
+		return fmt.Sprintf("NUMERIC(%v, %v)", *d.precision, d.scale)
+	} else if d.isBigNumeric() {
+		return fmt.Sprintf("BIGNUMERIC(%v, %v)", *d.precision, d.scale)
+	}
+
+	return "STRING"
+}

--- a/lib/typing/decimal/details_test.go
+++ b/lib/typing/decimal/details_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/artie-labs/transfer/lib/ptr"
 )
 
-func TestDecimalDetails(t *testing.T) {
+func TestDecimalDetailsKind(t *testing.T) {
 	type _testCase struct {
 		Name      string
 		Precision int

--- a/lib/typing/decimal/details_test.go
+++ b/lib/typing/decimal/details_test.go
@@ -70,7 +70,7 @@ func TestDecimalKind(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		d := NewDecimal(ptr.ToInt(testCase.Precision), testCase.Scale, nil)
+		d := NewDecimalDetails(ptr.ToInt(testCase.Precision), testCase.Scale)
 		assert.Equal(t, testCase.ExpectedSnowflakeKind, d.SnowflakeKind(), testCase.Name)
 		assert.Equal(t, testCase.ExpectedRedshiftKind, d.RedshiftKind(), testCase.Name)
 		assert.Equal(t, testCase.ExpectedBigQueryKind, d.BigQueryKind(), testCase.Name)

--- a/lib/typing/decimal/details_test.go
+++ b/lib/typing/decimal/details_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/artie-labs/transfer/lib/ptr"
 )
 
-func TestDecimalKind(t *testing.T) {
+func TestDecimalDetails(t *testing.T) {
 	type _testCase struct {
 		Name      string
 		Precision int

--- a/lib/typing/numeric.go
+++ b/lib/typing/numeric.go
@@ -28,6 +28,6 @@ func ParseNumeric(parts []string) KindDetails {
 	}
 
 	eDec := EDecimal
-	eDec.ExtendedDecimalDetails = decimal.NewDecimal(&parsedNumbers[0], parsedNumbers[1], nil)
+	eDec.ExtendedDecimalDetails = decimal.NewDecimalDetails(&parsedNumbers[0], parsedNumbers[1])
 	return eDec
 }

--- a/lib/typing/parse.go
+++ b/lib/typing/parse.go
@@ -69,9 +69,10 @@ func parseValue(settings Settings, val any) KindDetails {
 		return String
 
 	case *decimal.Decimal:
+		extendedDetails := convertedVal.Details()
 		return KindDetails{
 			Kind:                   EDecimal.Kind,
-			ExtendedDecimalDetails: convertedVal,
+			ExtendedDecimalDetails: &extendedDetails,
 		}
 	case *ext.ExtendedTime:
 		return KindDetails{

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -20,7 +20,7 @@ type Settings struct {
 type KindDetails struct {
 	Kind                   string
 	ExtendedTimeDetails    *ext.NestedKind
-	ExtendedDecimalDetails *decimal.Decimal
+	ExtendedDecimalDetails *decimal.DecimalDetails
 
 	// Optional kind details metadata
 	OptionalStringPrecision *int


### PR DESCRIPTION
This way `decimal.Decimal` is just used for storing decimal values and not details about numeric columns.