### PR TITLE
Moving defer dropping temporary table up

### DIFF
--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -70,15 +70,16 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, opt
 	}
 
 	temporaryTableID := TempTableIDWithSuffix(dwh.IdentifierFor(tableData.TopicConfig(), tableData.Name()), tableData.TempTableSuffix())
-	if err = dwh.PrepareTemporaryTable(tableData, tableConfig, temporaryTableID, types.AdditionalSettings{}, true); err != nil {
-		return fmt.Errorf("failed to prepare temporary table: %w", err)
-	}
 
 	defer func() {
 		if dropErr := ddl.DropTemporaryTable(dwh, temporaryTableID, false); dropErr != nil {
 			slog.Warn("Failed to drop temporary table", slog.Any("err", dropErr), slog.String("tableName", temporaryTableID.FullyQualifiedName()))
 		}
 	}()
+
+	if err = dwh.PrepareTemporaryTable(tableData, tableConfig, temporaryTableID, types.AdditionalSettings{}, true); err != nil {
+		return fmt.Errorf("failed to prepare temporary table: %w", err)
+	}
 
 	// Now iterate over all the in-memory cols and see which ones require a backfill.
 	for _, col := range tableData.ReadOnlyInMemoryCols().GetColumns() {

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -127,9 +127,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 	err := s.stageStore.Merge(tableData)
 	assert.NoError(s.T(), err, "transient errors like auth errors will be retried")
 
-	// 5 regular ones and then 1 additional one to re-establish auth.
+	// 5 regular ones and then 1 additional one to re-establish auth and another one for dropping the temporary table
 	baseline := 5
-	assert.Equal(s.T(), s.fakeStageStore.ExecCallCount(), baseline+1, "called merge")
+	assert.Equal(s.T(), baseline+2, s.fakeStageStore.ExecCallCount(), "called merge")
 }
 
 func (s *SnowflakeTestSuite) TestExecuteMerge() {


### PR DESCRIPTION
The problem is that `PrepareTemporaryTable` may actually end up creating a temporary table and fail to load the data in.

If it fails to load data into it, it will then immediately return and the temporary table will not get dropped until much later