### PR TITLE
Clean up more snowflake dialect tests

### DIFF
--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -257,18 +257,19 @@ func TestSnowflakeDialect_BuildIsNotToastValueExpression(t *testing.T) {
 }
 
 func buildColumns(colTypesMap map[string]typing.KindDetails) *columns.Columns {
-	// first sort the column names alphabetically to ensure deterministic order
 	colNames := []string{}
 	for colName := range colTypesMap {
 		colNames = append(colNames, colName)
 	}
+	// Sort the column names alphabetically to ensure deterministic order
 	sort.Strings(colNames)
 
-	var _cols columns.Columns
+	var cols columns.Columns
 	for _, colName := range colNames {
-		_cols.AddColumn(columns.NewColumn(colName, colTypesMap[colName]))
+		cols.AddColumn(columns.NewColumn(colName, colTypesMap[colName]))
 	}
-	return &_cols
+
+	return &cols
 }
 
 func TestSnowflakeDialect_BuildMergeQueries_SoftDelete(t *testing.T) {


### PR DESCRIPTION
Following https://github.com/artie-labs/transfer/pull/792, this removes the subquery from the other snowflake test cases that used one.

I also added a helper function to build the columns in a deterministic order so each test case doesn't have to implement that separately.