### PR TITLE
Snowflake: don't null out column values when soft-deleting

### DIFF
--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -249,9 +249,9 @@ MERGE INTO %s %s USING %s AS %s ON %s`,
 		tableID.FullyQualifiedName(), constants.TargetAlias, subQuery, constants.StagingAlias, strings.Join(equalitySQLParts, " AND "),
 	)
 
-	cols, removed := columns.RemoveOnlySetDeletedColumnMarker(cols)
+	cols, removed := columns.RemoveOnlySetDeleteColumnMarker(cols)
 	if !removed {
-		return []string{}, errors.New("artie only_set_deleted flag doesn't exist")
+		return []string{}, errors.New("artie only_set_delete flag doesn't exist")
 	}
 
 	if softDelete {

--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -249,6 +249,10 @@ MERGE INTO %s %s USING %s AS %s ON %s`,
 		tableID.FullyQualifiedName(), constants.TargetAlias, subQuery, constants.StagingAlias, strings.Join(equalitySQLParts, " AND "),
 	)
 
+	cols, removed := columns.RemoveOnlySetDeletedColumnMarker(cols)
+	if !removed {
+		return []string{}, errors.New("artie set deleted only flag doesn't exist")
+	}
 	if softDelete {
 		return []string{baseQuery + fmt.Sprintf(`
 WHEN MATCHED %sTHEN UPDATE SET %s
@@ -263,7 +267,7 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
 	}
 
 	// We also need to remove __artie flags since it does not exist in the destination table
-	cols, removed := columns.RemoveDeleteColumnMarker(cols)
+	cols, removed = columns.RemoveDeleteColumnMarker(cols)
 	if !removed {
 		return []string{}, errors.New("artie delete flag doesn't exist")
 	}

--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -251,8 +251,9 @@ MERGE INTO %s %s USING %s AS %s ON %s`,
 
 	cols, removed := columns.RemoveOnlySetDeletedColumnMarker(cols)
 	if !removed {
-		return []string{}, errors.New("artie set deleted only flag doesn't exist")
+		return []string{}, errors.New("artie only_set_deleted flag doesn't exist")
 	}
+
 	if softDelete {
 		return []string{baseQuery + fmt.Sprintf(`
 WHEN MATCHED %sTHEN UPDATE SET %s

--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -255,6 +255,7 @@ MERGE INTO %s %s USING %s AS %s ON %s`,
 	}
 
 	if softDelete {
+		// TODO alter this merge query to update only the __artie_delete column if OnlySetDeleteColumnMarker is true
 		return []string{baseQuery + fmt.Sprintf(`
 WHEN MATCHED %sTHEN UPDATE SET %s
 WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,

--- a/clients/bigquery/dialect/dialect_test.go
+++ b/clients/bigquery/dialect/dialect_test.go
@@ -216,7 +216,7 @@ func TestBigQueryDialect_BuildMergeQueries_TempTable(t *testing.T) {
 		columns.NewColumn("order_id", typing.Integer),
 		columns.NewColumn("name", typing.String),
 		columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean),
-		columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean),
+		columns.NewColumn(constants.OnlySetDeleteColumnMarker, typing.Boolean),
 	}
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -247,7 +247,7 @@ func TestBigQueryDialect_BuildMergeQueries_SoftDelete(t *testing.T) {
 		columns.NewColumn("order_id", typing.Integer),
 		columns.NewColumn("name", typing.String),
 		columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean),
-		columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean),
+		columns.NewColumn(constants.OnlySetDeleteColumnMarker, typing.Boolean),
 	}
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -277,7 +277,7 @@ func TestBigQueryDialect_BuildMergeQueries_IdempotentKey(t *testing.T) {
 		columns.NewColumn("order_id", typing.Integer),
 		columns.NewColumn("name", typing.String),
 		columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean),
-		columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean),
+		columns.NewColumn(constants.OnlySetDeleteColumnMarker, typing.Boolean),
 	}
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -308,7 +308,7 @@ func TestBigQueryDialect_BuildMergeQueries_JSONKey(t *testing.T) {
 	cols.AddColumn(orderOIDCol)
 	cols.AddColumn(columns.NewColumn("name", typing.String))
 	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
-	cols.AddColumn(columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean))
+	cols.AddColumn(columns.NewColumn(constants.OnlySetDeleteColumnMarker, typing.Boolean))
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
 	fakeTableID.FullyQualifiedNameReturns("customers.orders")

--- a/clients/bigquery/dialect/dialect_test.go
+++ b/clients/bigquery/dialect/dialect_test.go
@@ -216,6 +216,7 @@ func TestBigQueryDialect_BuildMergeQueries_TempTable(t *testing.T) {
 		columns.NewColumn("order_id", typing.Integer),
 		columns.NewColumn("name", typing.String),
 		columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean),
+		columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean),
 	}
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -246,6 +247,7 @@ func TestBigQueryDialect_BuildMergeQueries_SoftDelete(t *testing.T) {
 		columns.NewColumn("order_id", typing.Integer),
 		columns.NewColumn("name", typing.String),
 		columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean),
+		columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean),
 	}
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -275,6 +277,7 @@ func TestBigQueryDialect_BuildMergeQueries_IdempotentKey(t *testing.T) {
 		columns.NewColumn("order_id", typing.Integer),
 		columns.NewColumn("name", typing.String),
 		columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean),
+		columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean),
 	}
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -305,6 +308,7 @@ func TestBigQueryDialect_BuildMergeQueries_JSONKey(t *testing.T) {
 	cols.AddColumn(orderOIDCol)
 	cols.AddColumn(columns.NewColumn("name", typing.String))
 	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
+	cols.AddColumn(columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean))
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
 	fakeTableID.FullyQualifiedNameReturns("customers.orders")

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -205,6 +205,7 @@ USING %s AS %s ON %s`,
 	}
 
 	if softDelete {
+		// TODO alter this merge query to update only the __artie_delete column if OnlySetDeleteColumnMarker is true
 		return []string{baseQuery + fmt.Sprintf(`
 WHEN MATCHED %sTHEN UPDATE SET %s
 WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -199,6 +199,11 @@ USING %s AS %s ON %s`,
 		strings.Join(sql.BuildColumnComparisons(primaryKeys, constants.TargetAlias, constants.StagingAlias, sql.Equal, md), " AND "),
 	)
 
+	cols, removed := columns.RemoveOnlySetDeletedColumnMarker(cols)
+	if !removed {
+		return []string{}, errors.New("artie only_set_deleted flag doesn't exist")
+	}
+
 	if softDelete {
 		return []string{baseQuery + fmt.Sprintf(`
 WHEN MATCHED %sTHEN UPDATE SET %s
@@ -213,7 +218,7 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
 	}
 
 	// We also need to remove __artie flags since it does not exist in the destination table
-	cols, removed := columns.RemoveDeleteColumnMarker(cols)
+	cols, removed = columns.RemoveDeleteColumnMarker(cols)
 	if !removed {
 		return nil, errors.New("artie delete flag doesn't exist")
 	}

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -199,9 +199,9 @@ USING %s AS %s ON %s`,
 		strings.Join(sql.BuildColumnComparisons(primaryKeys, constants.TargetAlias, constants.StagingAlias, sql.Equal, md), " AND "),
 	)
 
-	cols, removed := columns.RemoveOnlySetDeletedColumnMarker(cols)
+	cols, removed := columns.RemoveOnlySetDeleteColumnMarker(cols)
 	if !removed {
-		return []string{}, errors.New("artie only_set_deleted flag doesn't exist")
+		return []string{}, errors.New("artie only_set_delete flag doesn't exist")
 	}
 
 	if softDelete {

--- a/clients/mssql/dialect/dialect_test.go
+++ b/clients/mssql/dialect/dialect_test.go
@@ -165,7 +165,7 @@ func TestMSSQLDialect_BuildMergeQueries(t *testing.T) {
 		columns.NewColumn("updated_at", typing.String),
 		columns.NewColumn("start", typing.String),
 		columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean),
-		columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean),
+		columns.NewColumn(constants.OnlySetDeleteColumnMarker, typing.Boolean),
 	}
 
 	fqTable := "database.schema.table"

--- a/clients/mssql/dialect/dialect_test.go
+++ b/clients/mssql/dialect/dialect_test.go
@@ -167,6 +167,7 @@ func TestMSSQLDialect_BuildMergeQueries(t *testing.T) {
 		columns.NewColumn("updated_at", typing.String),
 		columns.NewColumn("start", typing.String),
 		columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean),
+		columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean),
 	}
 	cols := make([]string, len(_cols))
 	for i, col := range _cols {

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -271,6 +271,7 @@ func (rd RedshiftDialect) BuildMergeQueries(
 		}
 	}
 
+	// TODO alter the merge query to update only the __artie_delete column if softDelete is true and OnlySetDeleteColumnMarker is true
 	parts := []string{
 		rd.buildMergeInsertQuery(tableID, subQuery, primaryKeys, cols),
 		rd.buildMergeUpdateQuery(tableID, subQuery, primaryKeys, cols, idempotentKey, softDelete),

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -257,9 +257,9 @@ func (rd RedshiftDialect) BuildMergeQueries(
 	// With AI, the sequence will increment (never decrement). And UUID is there to prevent universal hash collision
 	// However, there may be edge cases where folks end up restoring deleted rows (which will contain the same PK).
 
-	cols, removed := columns.RemoveOnlySetDeletedColumnMarker(cols)
+	cols, removed := columns.RemoveOnlySetDeleteColumnMarker(cols)
 	if !removed {
-		return []string{}, errors.New("artie only_set_deleted flag doesn't exist")
+		return []string{}, errors.New("artie only_set_delete flag doesn't exist")
 	}
 
 	if !softDelete {

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -257,6 +257,11 @@ func (rd RedshiftDialect) BuildMergeQueries(
 	// With AI, the sequence will increment (never decrement). And UUID is there to prevent universal hash collision
 	// However, there may be edge cases where folks end up restoring deleted rows (which will contain the same PK).
 
+	cols, removed := columns.RemoveOnlySetDeletedColumnMarker(cols)
+	if !removed {
+		return []string{}, errors.New("artie only_set_deleted flag doesn't exist")
+	}
+
 	if !softDelete {
 		// We also need to remove __artie flags since it does not exist in the destination table
 		var removed bool

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -306,6 +306,7 @@ func getBasicColumnsForTest(compositeKey bool) result {
 	cols.AddColumn(columns.NewColumn("created_at", typing.ETime))
 	cols.AddColumn(textToastCol)
 	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
+	cols.AddColumn(columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean))
 
 	var pks []columns.Column
 	pks = append(pks, idCol)

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -306,7 +306,7 @@ func getBasicColumnsForTest(compositeKey bool) result {
 	cols.AddColumn(columns.NewColumn("created_at", typing.ETime))
 	cols.AddColumn(textToastCol)
 	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
-	cols.AddColumn(columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Boolean))
+	cols.AddColumn(columns.NewColumn(constants.OnlySetDeleteColumnMarker, typing.Boolean))
 
 	var pks []columns.Column
 	pks = append(pks, idCol)

--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -227,7 +227,7 @@ MERGE INTO %s %s USING ( %s ) AS %s ON %s`,
 
 	cols, removed := columns.RemoveOnlySetDeletedColumnMarker(cols)
 	if !removed {
-		return []string{}, errors.New("only set deleted flag doesn't exist")
+		return []string{}, errors.New("artie only_set_deleted flag doesn't exist")
 	}
 
 	if softDelete {

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -276,11 +276,11 @@ func TestSnowflakeDialect_BuildMergeQueries_SoftDelete(t *testing.T) {
 	// No idempotent key
 	fqTable := "database.schema.table"
 	_cols := buildColumns(map[string]typing.KindDetails{
-		"id":                                 typing.String,
-		"bar":                                typing.String,
-		"updated_at":                         typing.ETime,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.String,
+		"bar":                               typing.String,
+		"updated_at":                        typing.ETime,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 	})
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -301,8 +301,8 @@ func TestSnowflakeDialect_BuildMergeQueries_SoftDelete(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, `
 MERGE INTO database.schema.table tgt USING ( database.schema.table ) AS stg ON tgt."ID" = stg."ID"
-WHEN MATCHED AND IFNULL(stg."__ARTIE_ONLY_SET_DELETED", false) = false THEN UPDATE SET "__ARTIE_DELETE"=stg."__ARTIE_DELETE","BAR"=stg."BAR","ID"=stg."ID","UPDATED_AT"=stg."UPDATED_AT"
-WHEN MATCHED AND IFNULL(stg."__ARTIE_ONLY_SET_DELETED", false) = true THEN UPDATE SET "__ARTIE_DELETE"=stg."__ARTIE_DELETE"
+WHEN MATCHED AND IFNULL(stg."__ARTIE_ONLY_SET_DELETE", false) = false THEN UPDATE SET "__ARTIE_DELETE"=stg."__ARTIE_DELETE","BAR"=stg."BAR","ID"=stg."ID","UPDATED_AT"=stg."UPDATED_AT"
+WHEN MATCHED AND IFNULL(stg."__ARTIE_ONLY_SET_DELETE", false) = true THEN UPDATE SET "__ARTIE_DELETE"=stg."__ARTIE_DELETE"
 WHEN NOT MATCHED THEN INSERT ("__ARTIE_DELETE","BAR","ID","UPDATED_AT") VALUES (stg."__ARTIE_DELETE",stg."BAR",stg."ID",stg."UPDATED_AT");`, statements[0])
 	}
 	{
@@ -320,8 +320,8 @@ WHEN NOT MATCHED THEN INSERT ("__ARTIE_DELETE","BAR","ID","UPDATED_AT") VALUES (
 		assert.Len(t, statements, 1)
 		assert.Equal(t, `
 MERGE INTO database.schema.table tgt USING ( database.schema.table ) AS stg ON tgt."ID" = stg."ID"
-WHEN MATCHED AND stg.updated_at >= tgt.updated_at AND IFNULL(stg."__ARTIE_ONLY_SET_DELETED", false) = false THEN UPDATE SET "__ARTIE_DELETE"=stg."__ARTIE_DELETE","BAR"=stg."BAR","ID"=stg."ID","UPDATED_AT"=stg."UPDATED_AT"
-WHEN MATCHED AND stg.updated_at >= tgt.updated_at AND IFNULL(stg."__ARTIE_ONLY_SET_DELETED", false) = true THEN UPDATE SET "__ARTIE_DELETE"=stg."__ARTIE_DELETE"
+WHEN MATCHED AND stg.updated_at >= tgt.updated_at AND IFNULL(stg."__ARTIE_ONLY_SET_DELETE", false) = false THEN UPDATE SET "__ARTIE_DELETE"=stg."__ARTIE_DELETE","BAR"=stg."BAR","ID"=stg."ID","UPDATED_AT"=stg."UPDATED_AT"
+WHEN MATCHED AND stg.updated_at >= tgt.updated_at AND IFNULL(stg."__ARTIE_ONLY_SET_DELETE", false) = true THEN UPDATE SET "__ARTIE_DELETE"=stg."__ARTIE_DELETE"
 WHEN NOT MATCHED THEN INSERT ("__ARTIE_DELETE","BAR","ID","UPDATED_AT") VALUES (stg."__ARTIE_DELETE",stg."BAR",stg."ID",stg."UPDATED_AT");`, statements[0])
 	}
 }
@@ -330,12 +330,12 @@ func TestSnowflakeDialect_BuildMergeQueries(t *testing.T) {
 	// No idempotent key
 	fqTable := "database.schema.table"
 	_cols := buildColumns(map[string]typing.KindDetails{
-		"id":                                 typing.String,
-		"bar":                                typing.String,
-		"updated_at":                         typing.String,
-		"start":                              typing.String,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.String,
+		"bar":                               typing.String,
+		"updated_at":                        typing.String,
+		"start":                             typing.String,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 	})
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -363,9 +363,9 @@ WHEN NOT MATCHED AND IFNULL(stg."__ARTIE_DELETE", false) = false THEN INSERT ("B
 func TestSnowflakeDialect_BuildMergeQueries_IdempotentKey(t *testing.T) {
 	fqTable := "database.schema.table"
 	_cols := buildColumns(map[string]typing.KindDetails{
-		"id":                                 typing.String,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.String,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 	})
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -393,10 +393,10 @@ WHEN NOT MATCHED AND IFNULL(stg."__ARTIE_DELETE", false) = false THEN INSERT ("I
 func TestSnowflakeDialect_BuildMergeQueries_CompositeKey(t *testing.T) {
 	fqTable := "database.schema.table"
 	_cols := buildColumns(map[string]typing.KindDetails{
-		"id":                                 typing.String,
-		"another_id":                         typing.String,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.String,
+		"another_id":                        typing.String,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 	})
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -428,12 +428,12 @@ func TestSnowflakeDialect_BuildMergeQueries_EscapePrimaryKeys(t *testing.T) {
 	// No idempotent key
 	fqTable := "database.schema.table"
 	_cols := buildColumns(map[string]typing.KindDetails{
-		"id":                                 typing.String,
-		"group":                              typing.String,
-		"updated_at":                         typing.String,
-		"start":                              typing.String,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.String,
+		"group":                             typing.String,
+		"updated_at":                        typing.String,
+		"start":                             typing.String,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 	})
 
 	fakeTableID := &mocks.FakeTableIdentifier{}

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -330,11 +330,12 @@ func TestSnowflakeDialect_BuildMergeQueries(t *testing.T) {
 	// No idempotent key
 	fqTable := "database.schema.table"
 	_cols := buildColumns(map[string]typing.KindDetails{
-		"id":                         typing.String,
-		"bar":                        typing.String,
-		"updated_at":                 typing.String,
-		"start":                      typing.String,
-		constants.DeleteColumnMarker: typing.Boolean,
+		"id":                                 typing.String,
+		"bar":                                typing.String,
+		"updated_at":                         typing.String,
+		"start":                              typing.String,
+		constants.DeleteColumnMarker:         typing.Boolean,
+		constants.OnlySetDeletedColumnMarker: typing.Boolean,
 	})
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -362,8 +363,9 @@ WHEN NOT MATCHED AND IFNULL(stg."__ARTIE_DELETE", false) = false THEN INSERT ("B
 func TestSnowflakeDialect_BuildMergeQueries_IdempotentKey(t *testing.T) {
 	fqTable := "database.schema.table"
 	_cols := buildColumns(map[string]typing.KindDetails{
-		"id":                         typing.String,
-		constants.DeleteColumnMarker: typing.Boolean,
+		"id":                                 typing.String,
+		constants.DeleteColumnMarker:         typing.Boolean,
+		constants.OnlySetDeletedColumnMarker: typing.Boolean,
 	})
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -391,9 +393,10 @@ WHEN NOT MATCHED AND IFNULL(stg."__ARTIE_DELETE", false) = false THEN INSERT ("I
 func TestSnowflakeDialect_BuildMergeQueries_CompositeKey(t *testing.T) {
 	fqTable := "database.schema.table"
 	_cols := buildColumns(map[string]typing.KindDetails{
-		"id":                         typing.String,
-		"another_id":                 typing.String,
-		constants.DeleteColumnMarker: typing.Boolean,
+		"id":                                 typing.String,
+		"another_id":                         typing.String,
+		constants.DeleteColumnMarker:         typing.Boolean,
+		constants.OnlySetDeletedColumnMarker: typing.Boolean,
 	})
 
 	fakeTableID := &mocks.FakeTableIdentifier{}
@@ -425,11 +428,12 @@ func TestSnowflakeDialect_BuildMergeQueries_EscapePrimaryKeys(t *testing.T) {
 	// No idempotent key
 	fqTable := "database.schema.table"
 	_cols := buildColumns(map[string]typing.KindDetails{
-		"id":                         typing.String,
-		"group":                      typing.String,
-		"updated_at":                 typing.String,
-		"start":                      typing.String,
-		constants.DeleteColumnMarker: typing.Boolean,
+		"id":                                 typing.String,
+		"group":                              typing.String,
+		"updated_at":                         typing.String,
+		"start":                              typing.String,
+		constants.DeleteColumnMarker:         typing.Boolean,
+		constants.OnlySetDeletedColumnMarker: typing.Boolean,
 	})
 
 	fakeTableID := &mocks.FakeTableIdentifier{}

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -35,11 +35,11 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	// TableData will think the column is invalid and tableConfig will think column = string
 	// Before we call merge, it should reconcile it.
 	colToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                                 typing.String,
-		"first_name":                         typing.String,
-		"invalid_column":                     typing.Invalid,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.String,
+		"first_name":                        typing.String,
+		"invalid_column":                    typing.Invalid,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 	}
 
 	var cols columns.Columns
@@ -67,10 +67,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	}
 
 	anotherColToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                                 typing.String,
-		"first_name":                         typing.String,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.String,
+		"first_name":                        typing.String,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 	}
 
 	var anotherCols columns.Columns
@@ -89,10 +89,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 
 func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 	colToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                                 typing.Integer,
-		"name":                               typing.String,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.Integer,
+		"name":                              typing.String,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
 		"created_at": typing.ParseValue(typing.Settings{}, "", nil, time.Now().Format(time.RFC3339Nano)),
 	}
@@ -137,10 +137,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 
 func (s *SnowflakeTestSuite) TestExecuteMerge() {
 	colToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                                 typing.Integer,
-		"name":                               typing.String,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.Integer,
+		"name":                              typing.String,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
 		"created_at": typing.ParseValue(typing.Settings{}, "", nil, time.Now().Format(time.RFC3339Nano)),
 	}
@@ -227,10 +227,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	}
 
 	colToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                                 typing.Integer,
-		"name":                               typing.String,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.Integer,
+		"name":                              typing.String,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
 		"created_at": typing.ParseValue(typing.Settings{}, "", nil, time.Now().Format(time.RFC3339Nano)),
 	}
@@ -247,11 +247,11 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	}
 
 	snowflakeColToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                                 typing.Integer,
-		"created_at":                         typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
-		"name":                               typing.String,
-		constants.DeleteColumnMarker:         typing.Boolean,
-		constants.OnlySetDeletedColumnMarker: typing.Boolean,
+		"id":                                typing.Integer,
+		"created_at":                        typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
+		"name":                              typing.String,
+		constants.DeleteColumnMarker:        typing.Boolean,
+		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 	}
 
 	var sflkCols columns.Columns

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -35,10 +35,11 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	// TableData will think the column is invalid and tableConfig will think column = string
 	// Before we call merge, it should reconcile it.
 	colToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                         typing.String,
-		"first_name":                 typing.String,
-		"invalid_column":             typing.Invalid,
-		constants.DeleteColumnMarker: typing.Boolean,
+		"id":                                 typing.String,
+		"first_name":                         typing.String,
+		"invalid_column":                     typing.Invalid,
+		constants.DeleteColumnMarker:         typing.Boolean,
+		constants.OnlySetDeletedColumnMarker: typing.Boolean,
 	}
 
 	var cols columns.Columns
@@ -66,9 +67,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	}
 
 	anotherColToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                         typing.String,
-		"first_name":                 typing.String,
-		constants.DeleteColumnMarker: typing.Boolean,
+		"id":                                 typing.String,
+		"first_name":                         typing.String,
+		constants.DeleteColumnMarker:         typing.Boolean,
+		constants.OnlySetDeletedColumnMarker: typing.Boolean,
 	}
 
 	var anotherCols columns.Columns
@@ -87,9 +89,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 
 func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 	colToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                         typing.Integer,
-		"name":                       typing.String,
-		constants.DeleteColumnMarker: typing.Boolean,
+		"id":                                 typing.Integer,
+		"name":                               typing.String,
+		constants.DeleteColumnMarker:         typing.Boolean,
+		constants.OnlySetDeletedColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
 		"created_at": typing.ParseValue(typing.Settings{}, "", nil, time.Now().Format(time.RFC3339Nano)),
 	}
@@ -134,9 +137,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 
 func (s *SnowflakeTestSuite) TestExecuteMerge() {
 	colToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                         typing.Integer,
-		"name":                       typing.String,
-		constants.DeleteColumnMarker: typing.Boolean,
+		"id":                                 typing.Integer,
+		"name":                               typing.String,
+		constants.DeleteColumnMarker:         typing.Boolean,
+		constants.OnlySetDeletedColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
 		"created_at": typing.ParseValue(typing.Settings{}, "", nil, time.Now().Format(time.RFC3339Nano)),
 	}
@@ -223,9 +227,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	}
 
 	colToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                         typing.Integer,
-		"name":                       typing.String,
-		constants.DeleteColumnMarker: typing.Boolean,
+		"id":                                 typing.Integer,
+		"name":                               typing.String,
+		constants.DeleteColumnMarker:         typing.Boolean,
+		constants.OnlySetDeletedColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
 		"created_at": typing.ParseValue(typing.Settings{}, "", nil, time.Now().Format(time.RFC3339Nano)),
 	}
@@ -242,10 +247,11 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	}
 
 	snowflakeColToKindDetailsMap := map[string]typing.KindDetails{
-		"id":                         typing.Integer,
-		"created_at":                 typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
-		"name":                       typing.String,
-		constants.DeleteColumnMarker: typing.Boolean,
+		"id":                                 typing.Integer,
+		"created_at":                         typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType),
+		"name":                               typing.String,
+		constants.DeleteColumnMarker:         typing.Boolean,
+		constants.OnlySetDeletedColumnMarker: typing.Boolean,
 	}
 
 	var sflkCols columns.Columns

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -157,8 +157,10 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 		// the PK. We can explore simplifying this interface in the future by leveraging before.
 		if len(s.Payload.beforeMap) > 0 {
 			retMap = s.Payload.beforeMap
+			retMap[constants.OnlySetDeletedColumnMarker] = false
 		} else {
 			retMap = make(map[string]any)
+			retMap[constants.OnlySetDeletedColumnMarker] = true
 		}
 
 		retMap[constants.DeleteColumnMarker] = true
@@ -179,6 +181,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 		}
 
 		retMap[constants.DeleteColumnMarker] = false
+		retMap[constants.OnlySetDeletedColumnMarker] = false
 	}
 
 	if tc.IncludeArtieUpdatedAt {

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -157,13 +157,15 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 		// the PK. We can explore simplifying this interface in the future by leveraging before.
 		if len(s.Payload.beforeMap) > 0 {
 			retMap = s.Payload.beforeMap
-			retMap[constants.OnlySetDeletedColumnMarker] = false
 		} else {
 			retMap = make(map[string]any)
-			retMap[constants.OnlySetDeletedColumnMarker] = true
 		}
 
 		retMap[constants.DeleteColumnMarker] = true
+		// For now, assume we only want to set the deleted column and leave other values alone.
+		// If previous values for the other columns are in memory (not flushed yet), [TableData.InsertRow] will handle
+		// filling them in and setting this to false.
+		retMap[constants.OnlySetDeletedColumnMarker] = true
 		for k, v := range pkMap {
 			retMap[k] = v
 		}

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -165,7 +165,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 		// For now, assume we only want to set the deleted column and leave other values alone.
 		// If previous values for the other columns are in memory (not flushed yet), [TableData.InsertRow] will handle
 		// filling them in and setting this to false.
-		retMap[constants.OnlySetDeletedColumnMarker] = true
+		retMap[constants.OnlySetDeleteColumnMarker] = true
 		for k, v := range pkMap {
 			retMap[k] = v
 		}
@@ -183,7 +183,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 		}
 
 		retMap[constants.DeleteColumnMarker] = false
-		retMap[constants.OnlySetDeletedColumnMarker] = false
+		retMap[constants.OnlySetDeleteColumnMarker] = false
 	}
 
 	if tc.IncludeArtieUpdatedAt {

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -199,6 +199,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomer() {
 
 	assert.Equal(m.T(), nestedData["object"], "foo")
 	assert.Equal(m.T(), evtData[constants.DeleteColumnMarker], false)
+	assert.Equal(m.T(), evtData[constants.OnlySetDeleteColumnMarker], false)
 	assert.Equal(m.T(), evt.GetExecutionTime(),
 		time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC))
 	assert.Equal(m.T(), "customers", evt.GetTableName())
@@ -246,8 +247,12 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore_NoData() {
 		_, isOk := evtData[constants.UpdateColumnMarker]
 		assert.False(m.T(), isOk)
 
-		_, isOk = evtData[constants.DeleteColumnMarker]
+		deletionFlag, isOk := evtData[constants.DeleteColumnMarker]
 		assert.True(m.T(), isOk)
+		assert.True(m.T(), deletionFlag.(bool))
+		deletionOnlyFlag, isOk := evtData[constants.OnlySetDeleteColumnMarker]
+		assert.True(m.T(), isOk)
+		assert.True(m.T(), deletionOnlyFlag.(bool))
 
 		assert.Equal(m.T(), evt.GetExecutionTime(), time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC))
 		assert.Equal(m.T(), true, evt.DeletePayload())
@@ -296,10 +301,11 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 		assert.False(m.T(), isOk)
 
 		expectedKeyToVal := map[string]any{
-			"_id":                        1003,
-			constants.DeleteColumnMarker: true,
-			"first_name":                 "Robin",
-			"email":                      "robin@example.com",
+			"_id":                               1003,
+			constants.DeleteColumnMarker:        true,
+			constants.OnlySetDeleteColumnMarker: true,
+			"first_name":                        "Robin",
+			"email":                             "robin@example.com",
 		}
 
 		for expectedKey, expectedVal := range expectedKeyToVal {

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -84,11 +84,10 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 			if err != nil {
 				return nil, err
 			}
-			retMap[constants.OnlySetDeletedColumnMarker] = false
 		} else {
 			retMap = make(map[string]any)
-			retMap[constants.OnlySetDeletedColumnMarker] = true
 		}
+		retMap[constants.OnlySetDeletedColumnMarker] = true
 		// This is a delete payload, so mark it as deleted.
 		// And we need to reconstruct the data bit since it will be empty.
 		// We _can_ rely on *before* since even without running replicate identity, it will still copy over
@@ -109,6 +108,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 			return nil, err
 		}
 		retMap[constants.DeleteColumnMarker] = false
+		retMap[constants.OnlySetDeletedColumnMarker] = false
 	}
 
 	if tc.IncludeArtieUpdatedAt {

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -87,12 +87,15 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 		} else {
 			retMap = make(map[string]any)
 		}
-		retMap[constants.OnlySetDeletedColumnMarker] = true
 		// This is a delete payload, so mark it as deleted.
 		// And we need to reconstruct the data bit since it will be empty.
 		// We _can_ rely on *before* since even without running replicate identity, it will still copy over
 		// the PK. We can explore simplifying this interface in the future by leveraging before.
 		retMap[constants.DeleteColumnMarker] = true
+		// For now, assume we only want to set the deleted column and leave other values alone.
+		// If previous values for the other columns are in memory (not flushed yet), [TableData.InsertRow] will handle
+		// filling them in and setting this to false.
+		retMap[constants.OnlySetDeletedColumnMarker] = true
 		for k, v := range pkMap {
 			retMap[k] = v
 		}

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -95,7 +95,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 		// For now, assume we only want to set the deleted column and leave other values alone.
 		// If previous values for the other columns are in memory (not flushed yet), [TableData.InsertRow] will handle
 		// filling them in and setting this to false.
-		retMap[constants.OnlySetDeletedColumnMarker] = true
+		retMap[constants.OnlySetDeleteColumnMarker] = true
 		for k, v := range pkMap {
 			retMap[k] = v
 		}
@@ -111,7 +111,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 			return nil, err
 		}
 		retMap[constants.DeleteColumnMarker] = false
-		retMap[constants.OnlySetDeletedColumnMarker] = false
+		retMap[constants.OnlySetDeleteColumnMarker] = false
 	}
 
 	if tc.IncludeArtieUpdatedAt {

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -84,8 +84,10 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 			if err != nil {
 				return nil, err
 			}
+			retMap[constants.OnlySetDeletedColumnMarker] = false
 		} else {
 			retMap = make(map[string]any)
+			retMap[constants.OnlySetDeletedColumnMarker] = true
 		}
 		// This is a delete payload, so mark it as deleted.
 		// And we need to reconstruct the data bit since it will be empty.

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -119,11 +119,15 @@ func TestGetDataTestInsert(t *testing.T) {
 	deletionFlag, isOk := evtData[constants.DeleteColumnMarker]
 	assert.True(t, isOk)
 	assert.False(t, deletionFlag.(bool))
+	deletionOnlyFlag, isOk := evtData[constants.OnlySetDeleteColumnMarker]
+	assert.True(t, isOk)
+	assert.False(t, deletionOnlyFlag.(bool))
 
 	_, isOk = evtData[constants.UpdateColumnMarker]
 	assert.False(t, isOk)
 
 	delete(evtData, constants.DeleteColumnMarker)
+	delete(evtData, constants.OnlySetDeleteColumnMarker)
 	assert.Equal(t, after, evtData)
 
 	evtData, err = schemaEventPayload.GetData(map[string]any{"pk": 1}, &kafkalib.TopicConfig{
@@ -141,11 +145,12 @@ func TestGetData_TestDelete(t *testing.T) {
 	}
 
 	expectedKeyValues := map[string]any{
-		"id":                         int64(1004),
-		"first_name":                 "Anne",
-		"last_name":                  "Kretchmar",
-		"email":                      "annek@noanswer.org",
-		constants.DeleteColumnMarker: true,
+		"id":                                int64(1004),
+		"first_name":                        "Anne",
+		"last_name":                         "Kretchmar",
+		"email":                             "annek@noanswer.org",
+		constants.DeleteColumnMarker:        true,
+		constants.OnlySetDeleteColumnMarker: true,
 	}
 
 	kvMap := map[string]any{"pk": 1004}
@@ -214,11 +219,15 @@ func TestGetDataTestUpdate(t *testing.T) {
 	deletionFlag, isOk := evtData[constants.DeleteColumnMarker]
 	assert.True(t, isOk)
 	assert.False(t, deletionFlag.(bool))
+	deletionOnlyFlag, isOk := evtData[constants.OnlySetDeleteColumnMarker]
+	assert.True(t, isOk)
+	assert.False(t, deletionOnlyFlag.(bool))
 
 	_, isOk = evtData[constants.UpdateColumnMarker]
 	assert.False(t, isOk)
 
 	delete(evtData, constants.DeleteColumnMarker)
+	delete(evtData, constants.OnlySetDeleteColumnMarker)
 	assert.Equal(t, after, evtData)
 
 	evtData, err = schemaEventPayload.GetData(kvMap, &kafkalib.TopicConfig{

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -12,10 +12,16 @@ const (
 	// We will strip this out from our partition key parsing.
 	DebeziumTopicRoutingKey = "__dbz__physicalTableIdentifier"
 
-	HistoryModeSuffix           = "__history"
-	ArtiePrefix                 = "__artie"
-	DeleteColumnMarker          = ArtiePrefix + "_delete"
-	OnlySetDeleteColumnMarker   = ArtiePrefix + "_only_set_delete"
+	HistoryModeSuffix = "__history"
+	ArtiePrefix       = "__artie"
+	// DeleteColumnMarker is used to indicate that a row has been deleted. It will be
+	// included in the target table if soft deletion is enabled.
+	DeleteColumnMarker = ArtiePrefix + "_delete"
+	// OnlySetDeleteColumnMarker is used internally to indicate that only the __artie_delete column
+	// should be updated, meaning existing values should be preserved for all other columns. This is
+	// not a real column and should never be included in the target table.
+	OnlySetDeleteColumnMarker = ArtiePrefix + "_only_set_delete"
+
 	DeletionConfidencePadding   = 4 * time.Hour
 	UpdateColumnMarker          = ArtiePrefix + "_updated_at"
 	DatabaseUpdatedColumnMarker = ArtiePrefix + "_db_updated_at"

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -15,7 +15,7 @@ const (
 	HistoryModeSuffix           = "__history"
 	ArtiePrefix                 = "__artie"
 	DeleteColumnMarker          = ArtiePrefix + "_delete"
-	OnlySetDeletedColumnMarker  = ArtiePrefix + "_only_set_deleted"
+	OnlySetDeleteColumnMarker   = ArtiePrefix + "_only_set_delete"
 	DeletionConfidencePadding   = 4 * time.Hour
 	UpdateColumnMarker          = ArtiePrefix + "_updated_at"
 	DatabaseUpdatedColumnMarker = ArtiePrefix + "_db_updated_at"

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -15,6 +15,7 @@ const (
 	HistoryModeSuffix           = "__history"
 	ArtiePrefix                 = "__artie"
 	DeleteColumnMarker          = ArtiePrefix + "_delete"
+	OnlySetDeletedColumnMarker  = ArtiePrefix + "_only_set_deleted"
 	DeletionConfidencePadding   = 4 * time.Hour
 	UpdateColumnMarker          = ArtiePrefix + "_updated_at"
 	DatabaseUpdatedColumnMarker = ArtiePrefix + "_db_updated_at"

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -131,8 +131,14 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 	if prevRow, isOk := t.rowsData[pk]; isOk {
 		prevRowSize = size.GetApproxSize(prevRow)
 		if delete {
-			// If the row was deleted, preserve the previous values that we have in memory
+			// If the row was deleted, preserve the previous values that we have in memory,
+			// unless the previous row was also a delete operation
+			// TODO add test cases for two deletes in a row, delete followed by create
 			rowData = prevRow
+			prevRowDeleted, isOk := prevRow[constants.DeleteColumnMarker]
+			if !isOk || !prevRowDeleted.(bool) {
+				rowData[constants.OnlySetDeletedColumnMarker] = false
+			}
 			rowData[constants.DeleteColumnMarker] = true
 		} else {
 			for key, val := range rowData {

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -133,7 +133,6 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 		if delete {
 			// If the row was deleted, preserve the previous values that we have in memory,
 			// unless the previous row was also a delete operation
-			// TODO add test cases for two deletes in a row, delete followed by create
 			rowData = prevRow
 			prevRowDeleted, isOk := prevRow[constants.DeleteColumnMarker]
 			if !isOk || !prevRowDeleted.(bool) {

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -136,7 +136,7 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 			rowData = prevRow
 			prevRowDeleted, isOk := prevRow[constants.DeleteColumnMarker]
 			if !isOk || !prevRowDeleted.(bool) {
-				rowData[constants.OnlySetDeletedColumnMarker] = false
+				rowData[constants.OnlySetDeleteColumnMarker] = false
 			}
 			rowData[constants.DeleteColumnMarker] = true
 		} else {

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -131,13 +131,8 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 	if prevRow, isOk := t.rowsData[pk]; isOk {
 		prevRowSize = size.GetApproxSize(prevRow)
 		if delete {
-			// If the row was deleted, preserve the previous values that we have in memory,
-			// unless the previous row was also a delete operation
+			// If the row was deleted, preserve the previous values that we have in memory
 			rowData = prevRow
-			prevRowDeleted, isOk := prevRow[constants.DeleteColumnMarker]
-			if !isOk || !prevRowDeleted.(bool) {
-				rowData[constants.OnlySetDeleteColumnMarker] = false
-			}
 			rowData[constants.DeleteColumnMarker] = true
 		} else {
 			for key, val := range rowData {

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -285,47 +285,47 @@ func TestTableData_InsertRowSoftDelete(t *testing.T) {
 	td := NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{SoftDelete: true}, "foo")
 	assert.Equal(t, 0, int(td.NumberOfRows()))
 
-	td.InsertRow("123", map[string]any{"id": "123", "name": "dana", constants.DeleteColumnMarker: false, constants.OnlySetDeletedColumnMarker: false}, false)
+	td.InsertRow("123", map[string]any{"id": "123", "name": "dana", constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false}, false)
 	assert.Equal(t, 1, int(td.NumberOfRows()))
 	assert.Equal(t, "dana", td.Rows()[0]["name"])
 
-	td.InsertRow("123", map[string]any{"id": "123", "name": "dana2", constants.DeleteColumnMarker: false, constants.OnlySetDeletedColumnMarker: false}, false)
+	td.InsertRow("123", map[string]any{"id": "123", "name": "dana2", constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false}, false)
 	assert.Equal(t, 1, int(td.NumberOfRows()))
 	assert.Equal(t, "dana2", td.Rows()[0]["name"])
 
-	td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeletedColumnMarker: true}, true)
+	td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeleteColumnMarker: true}, true)
 	assert.Equal(t, 1, int(td.NumberOfRows()))
 	// The previous value should be preserved, along with the delete marker
 	assert.Equal(t, "dana2", td.Rows()[0]["name"])
 	assert.Equal(t, true, td.Rows()[0][constants.DeleteColumnMarker])
-	// OnlySetDeletedColumnMarker should be false because we want to set the previously received values that haven't been flushed yet
-	assert.Equal(t, false, td.Rows()[0][constants.OnlySetDeletedColumnMarker])
+	// OnlySetDeleteColumnMarker should be false because we want to set the previously received values that haven't been flushed yet
+	assert.Equal(t, false, td.Rows()[0][constants.OnlySetDeleteColumnMarker])
 
 	// Ensure two deletes in a row are handled idempotently (in case the delete event is sent twice)
-	td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeletedColumnMarker: true}, true)
+	td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeleteColumnMarker: true}, true)
 	assert.Equal(t, 1, int(td.NumberOfRows()))
 	assert.Equal(t, "dana2", td.Rows()[0]["name"])
 	assert.Equal(t, true, td.Rows()[0][constants.DeleteColumnMarker])
-	assert.Equal(t, false, td.Rows()[0][constants.OnlySetDeletedColumnMarker])
+	assert.Equal(t, false, td.Rows()[0][constants.OnlySetDeleteColumnMarker])
 
 	{
-		// If deleting a row we don't have in memory, OnlySetDeletedColumnMarker should stay true
+		// If deleting a row we don't have in memory, OnlySetDeleteColumnMarker should stay true
 		td := NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{SoftDelete: true}, "foo")
 		assert.Equal(t, 0, int(td.NumberOfRows()))
-		td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeletedColumnMarker: true}, true)
-		assert.Equal(t, true, td.Rows()[0][constants.OnlySetDeletedColumnMarker])
-		// Two deletes in a row; OnlySetDeletedColumnMarker should still be true because we don't have the other values in memory
-		td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeletedColumnMarker: true}, true)
-		assert.Equal(t, true, td.Rows()[0][constants.OnlySetDeletedColumnMarker])
+		td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeleteColumnMarker: true}, true)
+		assert.Equal(t, true, td.Rows()[0][constants.OnlySetDeleteColumnMarker])
+		// Two deletes in a row; OnlySetDeleteColumnMarker should still be true because we don't have the other values in memory
+		td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeleteColumnMarker: true}, true)
+		assert.Equal(t, true, td.Rows()[0][constants.OnlySetDeleteColumnMarker])
 	}
 
 	{
 		// If a row is created and deleted, then another row with the same primary key is created, the previous values should not be used
 		td := NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{SoftDelete: true}, "foo")
 		assert.Equal(t, 0, int(td.NumberOfRows()))
-		td.InsertRow("123", map[string]any{"id": "123", "name": "dana", "foo": "abc", constants.DeleteColumnMarker: false, constants.OnlySetDeletedColumnMarker: false}, false)
-		td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeletedColumnMarker: true}, true)
-		td.InsertRow("123", map[string]any{"id": "123", "name": "dana-new", constants.DeleteColumnMarker: false, constants.OnlySetDeletedColumnMarker: false}, false)
+		td.InsertRow("123", map[string]any{"id": "123", "name": "dana", "foo": "abc", constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false}, false)
+		td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeleteColumnMarker: true}, true)
+		td.InsertRow("123", map[string]any{"id": "123", "name": "dana-new", constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false}, false)
 		assert.Equal(t, "dana-new", td.Rows()[0]["name"])
 		assert.Nil(t, td.Rows()[0]["foo"])
 		assert.Equal(t, false, td.Rows()[0][constants.DeleteColumnMarker])

--- a/lib/sql/columns.go
+++ b/lib/sql/columns.go
@@ -33,6 +33,10 @@ func QuotedDeleteColumnMarker(tableAlias constants.TableAlias, dialect Dialect) 
 	return QuoteTableAliasColumn(tableAlias, columns.NewColumn(constants.DeleteColumnMarker, typing.Invalid), dialect)
 }
 
+func QuotedOnlySetDeletedColumnMarker(tableAlias constants.TableAlias, dialect Dialect) string {
+	return QuoteTableAliasColumn(tableAlias, columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Invalid), dialect)
+}
+
 // BuildColumnsUpdateFragment will parse the columns and return a string like: first_name=tgt."first_name",last_name=stg."last_name",email=tgt."email"
 // NOTE: This should only be used with valid columns.
 func BuildColumnsUpdateFragment(columns []columns.Column, stagingAlias, targetAlias constants.TableAlias, dialect Dialect) string {

--- a/lib/sql/columns.go
+++ b/lib/sql/columns.go
@@ -33,8 +33,8 @@ func QuotedDeleteColumnMarker(tableAlias constants.TableAlias, dialect Dialect) 
 	return QuoteTableAliasColumn(tableAlias, columns.NewColumn(constants.DeleteColumnMarker, typing.Invalid), dialect)
 }
 
-func QuotedOnlySetDeletedColumnMarker(tableAlias constants.TableAlias, dialect Dialect) string {
-	return QuoteTableAliasColumn(tableAlias, columns.NewColumn(constants.OnlySetDeletedColumnMarker, typing.Invalid), dialect)
+func GetQuotedOnlySetDeleteColumnMarker(tableAlias constants.TableAlias, dialect Dialect) string {
+	return QuoteTableAliasColumn(tableAlias, columns.NewColumn(constants.OnlySetDeleteColumnMarker, typing.Invalid), dialect)
 }
 
 // BuildColumnsUpdateFragment will parse the columns and return a string like: first_name=tgt."first_name",last_name=stg."last_name",email=tgt."email"

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -240,8 +240,21 @@ func (c *Columns) DeleteColumn(name string) {
 func RemoveDeleteColumnMarker(cols []Column) ([]Column, bool) {
 	origLength := len(cols)
 	// Use [slices.Clone] because [slices.DeleteFunc] mutates its inputs.
-	cols = slices.DeleteFunc(slices.Clone(cols), func(col Column) bool { return col.Name() == constants.DeleteColumnMarker })
-	return cols, len(cols) != origLength
+	cols = slices.DeleteFunc(slices.Clone(cols), func(col Column) bool {
+		return col.Name() == constants.DeleteColumnMarker
+	})
+	// TODO return an error if the lengths aren't different, instead of a boolean
+	return cols, origLength != len(cols)
+}
+
+func RemoveOnlySetDeletedColumnMarker(cols []Column) ([]Column, bool) {
+	origLength := len(cols)
+	// Use [slices.Clone] because [slices.DeleteFunc] mutates its inputs.
+	cols = slices.DeleteFunc(slices.Clone(cols), func(col Column) bool {
+		return col.Name() == constants.OnlySetDeletedColumnMarker
+	})
+	// TODO return an error if the lengths aren't different, instead of a boolean
+	return cols, origLength != len(cols)
 }
 
 // ColumnNames takes a slice of [Column] and returns the names as a slice of strings.

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -240,11 +240,9 @@ func (c *Columns) DeleteColumn(name string) {
 func RemoveDeleteColumnMarker(cols []Column) ([]Column, bool) {
 	origLength := len(cols)
 	// Use [slices.Clone] because [slices.DeleteFunc] mutates its inputs.
-	cols = slices.DeleteFunc(slices.Clone(cols), func(col Column) bool {
-		return col.Name() == constants.DeleteColumnMarker
-	})
+	cols = slices.DeleteFunc(slices.Clone(cols), func(col Column) bool { return col.Name() == constants.DeleteColumnMarker })
 	// TODO return an error if the lengths aren't different, instead of a boolean
-	return cols, origLength != len(cols)
+	return cols, len(cols) != origLength
 }
 
 func RemoveOnlySetDeletedColumnMarker(cols []Column) ([]Column, bool) {
@@ -254,7 +252,7 @@ func RemoveOnlySetDeletedColumnMarker(cols []Column) ([]Column, bool) {
 		return col.Name() == constants.OnlySetDeletedColumnMarker
 	})
 	// TODO return an error if the lengths aren't different, instead of a boolean
-	return cols, origLength != len(cols)
+	return cols, len(cols) != origLength
 }
 
 // ColumnNames takes a slice of [Column] and returns the names as a slice of strings.

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -245,11 +245,11 @@ func RemoveDeleteColumnMarker(cols []Column) ([]Column, bool) {
 	return cols, len(cols) != origLength
 }
 
-func RemoveOnlySetDeletedColumnMarker(cols []Column) ([]Column, bool) {
+func RemoveOnlySetDeleteColumnMarker(cols []Column) ([]Column, bool) {
 	origLength := len(cols)
 	// Use [slices.Clone] because [slices.DeleteFunc] mutates its inputs.
 	cols = slices.DeleteFunc(slices.Clone(cols), func(col Column) bool {
-		return col.Name() == constants.OnlySetDeletedColumnMarker
+		return col.Name() == constants.OnlySetDeleteColumnMarker
 	})
 	// TODO return an error if the lengths aren't different, instead of a boolean
 	return cols, len(cols) != origLength

--- a/lib/typing/columns/diff.go
+++ b/lib/typing/columns/diff.go
@@ -16,7 +16,7 @@ func shouldSkipColumn(colName string, softDelete bool, includeArtieUpdatedAt boo
 		return false
 	}
 
-	if colName == constants.OnlySetDeletedColumnMarker {
+	if colName == constants.OnlySetDeleteColumnMarker {
 		// We never want to create this column in the destination table
 		return true
 	}

--- a/lib/typing/columns/diff.go
+++ b/lib/typing/columns/diff.go
@@ -16,6 +16,10 @@ func shouldSkipColumn(colName string, softDelete bool, includeArtieUpdatedAt boo
 		return false
 	}
 
+	if colName == constants.OnlySetDeletedColumnMarker {
+		return true
+	}
+
 	if colName == constants.UpdateColumnMarker && includeArtieUpdatedAt {
 		// We want to keep this column if includeArtieUpdatedAt is turned on
 		return false

--- a/lib/typing/columns/diff.go
+++ b/lib/typing/columns/diff.go
@@ -17,6 +17,7 @@ func shouldSkipColumn(colName string, softDelete bool, includeArtieUpdatedAt boo
 	}
 
 	if colName == constants.OnlySetDeletedColumnMarker {
+		// We never want to create this column in the destination table
 		return true
 	}
 

--- a/lib/typing/columns/diff.go
+++ b/lib/typing/columns/diff.go
@@ -11,7 +11,7 @@ import (
 // shouldSkipColumn takes the `colName` and `softDelete` and will return whether we should skip this column when calculating the diff.
 func shouldSkipColumn(colName string, softDelete bool, includeArtieUpdatedAt bool, includeDatabaseUpdatedAt bool, mode config.Mode) bool {
 	// TODO: Figure out a better way to not pass in so many variables when calculating shouldSkipColumn
-	if colName == constants.DeleteColumnMarker && softDelete {
+	if (colName == constants.DeleteColumnMarker || colName == constants.OnlySetDeletedColumnMarker) && softDelete {
 		// We need this column to be created if soft deletion is turned on.
 		return false
 	}

--- a/lib/typing/columns/diff.go
+++ b/lib/typing/columns/diff.go
@@ -11,7 +11,7 @@ import (
 // shouldSkipColumn takes the `colName` and `softDelete` and will return whether we should skip this column when calculating the diff.
 func shouldSkipColumn(colName string, softDelete bool, includeArtieUpdatedAt bool, includeDatabaseUpdatedAt bool, mode config.Mode) bool {
 	// TODO: Figure out a better way to not pass in so many variables when calculating shouldSkipColumn
-	if (colName == constants.DeleteColumnMarker || colName == constants.OnlySetDeletedColumnMarker) && softDelete {
+	if colName == constants.DeleteColumnMarker && softDelete {
 		// We need this column to be created if soft deletion is turned on.
 		return false
 	}

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -69,6 +69,7 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc *kafkalib.TopicConf
 
 		// We don't need this either.
 		delete(evtData, constants.DeleteColumnMarker)
+		delete(evtData, constants.OnlySetDeletedColumnMarker)
 	}
 
 	return Event{

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -69,7 +69,7 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc *kafkalib.TopicConf
 
 		// We don't need this either.
 		delete(evtData, constants.DeleteColumnMarker)
-		delete(evtData, constants.OnlySetDeletedColumnMarker)
+		delete(evtData, constants.OnlySetDeleteColumnMarker)
 	}
 
 	return Event{

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -67,7 +67,7 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc *kafkalib.TopicConf
 
 		evtData[constants.OperationColumnMarker] = event.Operation()
 
-		// We don't need this either.
+		// We don't need the deletion markers either.
 		delete(evtData, constants.DeleteColumnMarker)
 		delete(evtData, constants.OnlySetDeleteColumnMarker)
 	}

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -43,7 +43,7 @@ func (f fakeEvent) GetColumns() (*columns.Columns, error) {
 }
 
 func (f fakeEvent) GetData(pkMap map[string]any, config *kafkalib.TopicConfig) (map[string]any, error) {
-	return map[string]any{constants.DeleteColumnMarker: false}, nil
+	return map[string]any{constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false}, nil
 }
 
 func (e *EventsTestSuite) TestEvent_IsValid() {
@@ -139,6 +139,16 @@ func (e *EventsTestSuite) TestEvent_Columns() {
 
 		_, isOk = evt.Columns.GetColumn("capital")
 		assert.True(e.T(), isOk)
+	}
+	{
+		// In history mode, the deletion column markers should be removed from the event data
+		evt, err := ToMemoryEvent(f, map[string]any{"id": 123}, &kafkalib.TopicConfig{}, config.History)
+		assert.NoError(e.T(), err)
+
+		_, isOk := evt.Data[constants.DeleteColumnMarker]
+		assert.False(e.T(), isOk)
+		_, isOk = evt.Data[constants.OnlySetDeleteColumnMarker]
+		assert.False(e.T(), isOk)
 	}
 }
 

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -94,12 +94,12 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 						"id": fmt.Sprintf("pk-%d", i),
 					},
 					Data: map[string]any{
-						"id":                                 fmt.Sprintf("pk-%d", i),
-						constants.DeleteColumnMarker:         true,
-						constants.OnlySetDeletedColumnMarker: true,
-						"pk":                                 fmt.Sprintf("pk-%d", i),
-						"foo":                                "bar",
-						"cat":                                "dog",
+						"id":                                fmt.Sprintf("pk-%d", i),
+						constants.DeleteColumnMarker:        true,
+						constants.OnlySetDeleteColumnMarker: true,
+						"pk":                                fmt.Sprintf("pk-%d", i),
+						"foo":                               "bar",
+						"cat":                               "dog",
 					},
 				}
 

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -94,11 +94,12 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 						"id": fmt.Sprintf("pk-%d", i),
 					},
 					Data: map[string]any{
-						"id":                         fmt.Sprintf("pk-%d", i),
-						constants.DeleteColumnMarker: true,
-						"pk":                         fmt.Sprintf("pk-%d", i),
-						"foo":                        "bar",
-						"cat":                        "dog",
+						"id":                                 fmt.Sprintf("pk-%d", i),
+						constants.DeleteColumnMarker:         true,
+						constants.OnlySetDeletedColumnMarker: true,
+						"pk":                                 fmt.Sprintf("pk-%d", i),
+						"foo":                                "bar",
+						"cat":                                "dog",
 					},
 				}
 


### PR DESCRIPTION
When a row is soft-deleted, now we'll preserve the previous values of all the columns (other than the `__artie_delete` column) instead of overwriting them all to be empty.

- Added a temporary column marker to indicate if a row should have only its `__artie_delete` column updated
- Made snowflake's merge function check that value to decide how to merge
- Made all dialects filter out this temporary column before merging so it doesn't end up in the destination

As a followup, I'll make the other dialects use the new marker when merging.