### PR TITLE
Make RemoveDeleteColumnMarker and RemoveOnlySetDeletedColumnMarker return error instead of bool

### DIFF
--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -269,9 +269,9 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
 	}
 
 	// We also need to remove __artie flags since it does not exist in the destination table
-	cols, removed = columns.RemoveDeleteColumnMarker(cols)
-	if !removed {
-		return []string{}, errors.New("artie delete flag doesn't exist")
+	cols, err := columns.RemoveDeleteColumnMarker(cols)
+	if err != nil {
+		return []string{}, err
 	}
 
 	return []string{baseQuery + fmt.Sprintf(`

--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -1,7 +1,6 @@
 package dialect
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -249,9 +248,9 @@ MERGE INTO %s %s USING %s AS %s ON %s`,
 		tableID.FullyQualifiedName(), constants.TargetAlias, subQuery, constants.StagingAlias, strings.Join(equalitySQLParts, " AND "),
 	)
 
-	cols, removed := columns.RemoveOnlySetDeleteColumnMarker(cols)
-	if !removed {
-		return []string{}, errors.New("artie only_set_delete flag doesn't exist")
+	cols, err := columns.RemoveOnlySetDeleteColumnMarker(cols)
+	if err != nil {
+		return []string{}, err
 	}
 
 	if softDelete {
@@ -269,7 +268,7 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
 	}
 
 	// We also need to remove __artie flags since it does not exist in the destination table
-	cols, err := columns.RemoveDeleteColumnMarker(cols)
+	cols, err = columns.RemoveDeleteColumnMarker(cols)
 	if err != nil {
 		return []string{}, err
 	}

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -219,9 +219,9 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
 	}
 
 	// We also need to remove __artie flags since it does not exist in the destination table
-	cols, removed = columns.RemoveDeleteColumnMarker(cols)
-	if !removed {
-		return nil, errors.New("artie delete flag doesn't exist")
+	cols, err := columns.RemoveDeleteColumnMarker(cols)
+	if err != nil {
+		return nil, err
 	}
 
 	return []string{baseQuery + fmt.Sprintf(`

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -1,7 +1,6 @@
 package dialect
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -199,9 +198,9 @@ USING %s AS %s ON %s`,
 		strings.Join(sql.BuildColumnComparisons(primaryKeys, constants.TargetAlias, constants.StagingAlias, sql.Equal, md), " AND "),
 	)
 
-	cols, removed := columns.RemoveOnlySetDeleteColumnMarker(cols)
-	if !removed {
-		return []string{}, errors.New("artie only_set_delete flag doesn't exist")
+	cols, err := columns.RemoveOnlySetDeleteColumnMarker(cols)
+	if err != nil {
+		return []string{}, err
 	}
 
 	if softDelete {
@@ -219,7 +218,7 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
 	}
 
 	// We also need to remove __artie flags since it does not exist in the destination table
-	cols, err := columns.RemoveDeleteColumnMarker(cols)
+	cols, err = columns.RemoveDeleteColumnMarker(cols)
 	if err != nil {
 		return nil, err
 	}

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -263,11 +263,11 @@ func (rd RedshiftDialect) BuildMergeQueries(
 	}
 
 	if !softDelete {
+		var err error
 		// We also need to remove __artie flags since it does not exist in the destination table
-		var removed bool
-		cols, removed = columns.RemoveDeleteColumnMarker(cols)
-		if !removed {
-			return nil, errors.New("artie delete flag doesn't exist")
+		cols, err = columns.RemoveDeleteColumnMarker(cols)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -1,7 +1,6 @@
 package dialect
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -257,9 +256,9 @@ func (rd RedshiftDialect) BuildMergeQueries(
 	// With AI, the sequence will increment (never decrement). And UUID is there to prevent universal hash collision
 	// However, there may be edge cases where folks end up restoring deleted rows (which will contain the same PK).
 
-	cols, removed := columns.RemoveOnlySetDeleteColumnMarker(cols)
-	if !removed {
-		return []string{}, errors.New("artie only_set_delete flag doesn't exist")
+	cols, err := columns.RemoveOnlySetDeleteColumnMarker(cols)
+	if err != nil {
+		return []string{}, err
 	}
 
 	if !softDelete {

--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -246,9 +246,9 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
 	}
 
 	// We also need to remove __artie flags since it does not exist in the destination table
-	cols, removed = columns.RemoveDeleteColumnMarker(cols)
-	if !removed {
-		return []string{}, errors.New("artie delete flag doesn't exist")
+	cols, err := columns.RemoveDeleteColumnMarker(cols)
+	if err != nil {
+		return []string{}, err
 	}
 
 	return []string{baseQuery + fmt.Sprintf(`

--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -1,7 +1,6 @@
 package dialect
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -225,9 +224,9 @@ MERGE INTO %s %s USING ( %s ) AS %s ON %s`,
 		tableID.FullyQualifiedName(), constants.TargetAlias, subQuery, constants.StagingAlias, strings.Join(equalitySQLParts, " AND "),
 	)
 
-	cols, removed := columns.RemoveOnlySetDeleteColumnMarker(cols)
-	if !removed {
-		return []string{}, errors.New("artie only_set_delete flag doesn't exist")
+	cols, err := columns.RemoveOnlySetDeleteColumnMarker(cols)
+	if err != nil {
+		return []string{}, err
 	}
 
 	if softDelete {
@@ -246,7 +245,7 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s);`,
 	}
 
 	// We also need to remove __artie flags since it does not exist in the destination table
-	cols, err := columns.RemoveDeleteColumnMarker(cols)
+	cols, err = columns.RemoveDeleteColumnMarker(cols)
 	if err != nil {
 		return []string{}, err
 	}

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -246,17 +246,19 @@ func RemoveDeleteColumnMarker(cols []Column) ([]Column, error) {
 	if len(cols) == origLength {
 		return []Column{}, errors.New("artie delete flag doesn't exist")
 	}
+
 	return cols, nil
 }
 
-func RemoveOnlySetDeleteColumnMarker(cols []Column) ([]Column, bool) {
+func RemoveOnlySetDeleteColumnMarker(cols []Column) ([]Column, error) {
 	origLength := len(cols)
 	// Use [slices.Clone] because [slices.DeleteFunc] mutates its inputs.
-	cols = slices.DeleteFunc(slices.Clone(cols), func(col Column) bool {
-		return col.Name() == constants.OnlySetDeleteColumnMarker
-	})
-	// TODO return an error if the lengths aren't different, instead of a boolean
-	return cols, len(cols) != origLength
+	cols = slices.DeleteFunc(slices.Clone(cols), func(col Column) bool { return col.Name() == constants.OnlySetDeleteColumnMarker })
+	if len(cols) == origLength {
+		return []Column{}, errors.New("artie only_set_delete flag doesn't exist")
+	}
+
+	return cols, nil
 }
 
 // ColumnNames takes a slice of [Column] and returns the names as a slice of strings.

--- a/lib/typing/columns/columns.go
+++ b/lib/typing/columns/columns.go
@@ -1,6 +1,7 @@
 package columns
 
 import (
+	"errors"
 	"slices"
 	"strings"
 	"sync"
@@ -236,13 +237,16 @@ func (c *Columns) DeleteColumn(name string) {
 	}
 }
 
-// RemoveDeleteColumnMarker removes the deleted column marker from a slice (if present) returning a new slice and whether or not it was removed.
-func RemoveDeleteColumnMarker(cols []Column) ([]Column, bool) {
+// RemoveDeleteColumnMarker removes the deleted column marker from a slice and returns a new slice.
+// If the marker wasn't present, it returns an error.
+func RemoveDeleteColumnMarker(cols []Column) ([]Column, error) {
 	origLength := len(cols)
 	// Use [slices.Clone] because [slices.DeleteFunc] mutates its inputs.
 	cols = slices.DeleteFunc(slices.Clone(cols), func(col Column) bool { return col.Name() == constants.DeleteColumnMarker })
-	// TODO return an error if the lengths aren't different, instead of a boolean
-	return cols, len(cols) != origLength
+	if len(cols) == origLength {
+		return []Column{}, errors.New("artie delete flag doesn't exist")
+	}
+	return cols, nil
 }
 
 func RemoveOnlySetDeleteColumnMarker(cols []Column) ([]Column, bool) {

--- a/lib/typing/columns/columns_test.go
+++ b/lib/typing/columns/columns_test.go
@@ -290,33 +290,30 @@ func TestRemoveDeleteColumnMarker(t *testing.T) {
 	deleteColumnMarkerCol := NewColumn(constants.DeleteColumnMarker, typing.Invalid)
 
 	{
-		result, removed := RemoveDeleteColumnMarker([]Column{})
-		assert.Empty(t, result)
-		assert.False(t, removed)
+		_, err := RemoveDeleteColumnMarker([]Column{})
+		assert.ErrorContains(t, err, "doesn't exist")
 	}
 	{
-		result, removed := RemoveDeleteColumnMarker([]Column{col1})
-		assert.Equal(t, []Column{col1}, result)
-		assert.False(t, removed)
+		_, err := RemoveDeleteColumnMarker([]Column{col1})
+		assert.ErrorContains(t, err, "doesn't exist")
 	}
 	{
-		result, removed := RemoveDeleteColumnMarker([]Column{col1, col2})
-		assert.Equal(t, []Column{col1, col2}, result)
-		assert.False(t, removed)
+		_, err := RemoveDeleteColumnMarker([]Column{col1, col2})
+		assert.ErrorContains(t, err, "doesn't exist")
 	}
 	{
-		result, removed := RemoveDeleteColumnMarker([]Column{deleteColumnMarkerCol})
-		assert.True(t, removed)
+		result, err := RemoveDeleteColumnMarker([]Column{deleteColumnMarkerCol})
+		assert.NoError(t, err)
 		assert.Empty(t, result)
 	}
 	{
-		result, removed := RemoveDeleteColumnMarker([]Column{col1, deleteColumnMarkerCol, col2})
-		assert.True(t, removed)
+		result, err := RemoveDeleteColumnMarker([]Column{col1, deleteColumnMarkerCol, col2})
+		assert.NoError(t, err)
 		assert.Equal(t, []Column{col1, col2}, result)
 	}
 	{
-		result, removed := RemoveDeleteColumnMarker([]Column{col1, deleteColumnMarkerCol, col2, deleteColumnMarkerCol, col3})
-		assert.True(t, removed)
+		result, err := RemoveDeleteColumnMarker([]Column{col1, deleteColumnMarkerCol, col2, deleteColumnMarkerCol, col3})
+		assert.NoError(t, err)
 		assert.Equal(t, []Column{col1, col2, col3}, result)
 	}
 }


### PR DESCRIPTION
In all the places these are called, if the column wasn't present then the caller returns an error. Instead, these two util functions can just build the error themselves.