### PR TITLE
Update redshift merge logic to not null out values when soft-deleting

### DIFF
--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -217,29 +217,39 @@ func TestRedshiftDialect_BuildMergeUpdateQuery(t *testing.T) {
 		name          string
 		softDelete    bool
 		idempotentKey string
-		expected      string
+		expected      []string
 	}{
 		{
 			name:       "soft delete enabled",
 			softDelete: true,
-			expected:   `UPDATE {TABLE_ID} AS tgt SET "col1"=stg."col1","col2"=stg."col2","col3"=stg."col3" FROM {SUB_QUERY} AS stg WHERE tgt."col1" = stg."col1" AND tgt."col3" = stg."col3";`,
+			expected: []string{
+				`UPDATE {TABLE_ID} AS tgt SET "col1"=stg."col1","col2"=stg."col2","col3"=stg."col3" FROM {SUB_QUERY} AS stg WHERE tgt."col1" = stg."col1" AND tgt."col3" = stg."col3" AND COALESCE(stg."__artie_only_set_delete", false) = false;`,
+				`UPDATE {TABLE_ID} AS tgt SET "__artie_delete"=stg."__artie_delete" FROM {SUB_QUERY} AS stg WHERE tgt."col1" = stg."col1" AND tgt."col3" = stg."col3" AND COALESCE(stg."__artie_only_set_delete", false) = true;`,
+			},
 		},
 		{
 			name:          "soft delete enabled + idempotent key",
 			softDelete:    true,
 			idempotentKey: "{ID_KEY}",
-			expected:      `UPDATE {TABLE_ID} AS tgt SET "col1"=stg."col1","col2"=stg."col2","col3"=stg."col3" FROM {SUB_QUERY} AS stg WHERE tgt."col1" = stg."col1" AND tgt."col3" = stg."col3" AND stg.{ID_KEY} >= tgt.{ID_KEY};`,
+			expected: []string{
+				`UPDATE {TABLE_ID} AS tgt SET "col1"=stg."col1","col2"=stg."col2","col3"=stg."col3" FROM {SUB_QUERY} AS stg WHERE tgt."col1" = stg."col1" AND tgt."col3" = stg."col3" AND stg.{ID_KEY} >= tgt.{ID_KEY} AND COALESCE(stg."__artie_only_set_delete", false) = false;`,
+				`UPDATE {TABLE_ID} AS tgt SET "__artie_delete"=stg."__artie_delete" FROM {SUB_QUERY} AS stg WHERE tgt."col1" = stg."col1" AND tgt."col3" = stg."col3" AND stg.{ID_KEY} >= tgt.{ID_KEY} AND COALESCE(stg."__artie_only_set_delete", false) = true;`,
+			},
 		},
 		{
 			name:       "soft delete disabled",
 			softDelete: false,
-			expected:   `UPDATE {TABLE_ID} AS tgt SET "col1"=stg."col1","col2"=stg."col2","col3"=stg."col3" FROM {SUB_QUERY} AS stg WHERE tgt."col1" = stg."col1" AND tgt."col3" = stg."col3" AND COALESCE(stg."__artie_delete", false) = false;`,
+			expected: []string{
+				`UPDATE {TABLE_ID} AS tgt SET "col1"=stg."col1","col2"=stg."col2","col3"=stg."col3" FROM {SUB_QUERY} AS stg WHERE tgt."col1" = stg."col1" AND tgt."col3" = stg."col3" AND COALESCE(stg."__artie_delete", false) = false;`,
+			},
 		},
 		{
 			name:          "soft delete disabled + idempotent key",
 			softDelete:    false,
 			idempotentKey: "{ID_KEY}",
-			expected:      `UPDATE {TABLE_ID} AS tgt SET "col1"=stg."col1","col2"=stg."col2","col3"=stg."col3" FROM {SUB_QUERY} AS stg WHERE tgt."col1" = stg."col1" AND tgt."col3" = stg."col3" AND stg.{ID_KEY} >= tgt.{ID_KEY} AND COALESCE(stg."__artie_delete", false) = false;`,
+			expected: []string{
+				`UPDATE {TABLE_ID} AS tgt SET "col1"=stg."col1","col2"=stg."col2","col3"=stg."col3" FROM {SUB_QUERY} AS stg WHERE tgt."col1" = stg."col1" AND tgt."col3" = stg."col3" AND stg.{ID_KEY} >= tgt.{ID_KEY} AND COALESCE(stg."__artie_delete", false) = false;`,
+			},
 		},
 	}
 
@@ -253,7 +263,7 @@ func TestRedshiftDialect_BuildMergeUpdateQuery(t *testing.T) {
 	fakeTableID.FullyQualifiedNameReturns("{TABLE_ID}")
 
 	for _, testCase := range testCases {
-		actual := RedshiftDialect{}.buildMergeUpdateQuery(
+		actual := RedshiftDialect{}.buildMergeUpdateQueries(
 			fakeTableID,
 			"{SUB_QUERY}",
 			[]columns.Column{cols[0], cols[2]},
@@ -371,14 +381,17 @@ func TestRedshiftDialect_BuildMergeQueries_SoftDelete(t *testing.T) {
 			false,
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(parts))
+		assert.Equal(t, 3, len(parts))
 
 		assert.Equal(t,
 			`INSERT INTO public.tableName ("id","email","first_name","last_name","created_at","toast_text","__artie_delete") SELECT stg."id",stg."email",stg."first_name",stg."last_name",stg."created_at",stg."toast_text",stg."__artie_delete" FROM public.tableName__temp AS stg LEFT JOIN public.tableName AS tgt ON tgt."id" = stg."id" WHERE tgt."id" IS NULL;`,
 			parts[0])
 		assert.Equal(t,
-			`UPDATE public.tableName AS tgt SET "id"=stg."id","email"=stg."email","first_name"=stg."first_name","last_name"=stg."last_name","created_at"=stg."created_at","toast_text"= CASE WHEN COALESCE(stg."toast_text" != '__debezium_unavailable_value', true) THEN stg."toast_text" ELSE tgt."toast_text" END,"__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id";`,
+			`UPDATE public.tableName AS tgt SET "id"=stg."id","email"=stg."email","first_name"=stg."first_name","last_name"=stg."last_name","created_at"=stg."created_at","toast_text"= CASE WHEN COALESCE(stg."toast_text" != '__debezium_unavailable_value', true) THEN stg."toast_text" ELSE tgt."toast_text" END,"__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND COALESCE(stg."__artie_only_set_delete", false) = false;`,
 			parts[1])
+		assert.Equal(t,
+			`UPDATE public.tableName AS tgt SET "__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND COALESCE(stg."__artie_only_set_delete", false) = true;`,
+			parts[2])
 	}
 	{
 		parts, err := RedshiftDialect{}.BuildMergeQueries(
@@ -392,15 +405,19 @@ func TestRedshiftDialect_BuildMergeQueries_SoftDelete(t *testing.T) {
 			false,
 		)
 		assert.NoError(t, err)
+		assert.Equal(t, 3, len(parts))
 
 		// Parts[0] for insertion should be identical
 		assert.Equal(t,
 			`INSERT INTO public.tableName ("id","email","first_name","last_name","created_at","toast_text","__artie_delete") SELECT stg."id",stg."email",stg."first_name",stg."last_name",stg."created_at",stg."toast_text",stg."__artie_delete" FROM public.tableName__temp AS stg LEFT JOIN public.tableName AS tgt ON tgt."id" = stg."id" WHERE tgt."id" IS NULL;`,
 			parts[0])
-		// Parts[1] where we're doing UPDATES will have idempotency key.
+		// Parts[1:] where we're doing UPDATES will have idempotency key.
 		assert.Equal(t,
-			`UPDATE public.tableName AS tgt SET "id"=stg."id","email"=stg."email","first_name"=stg."first_name","last_name"=stg."last_name","created_at"=stg."created_at","toast_text"= CASE WHEN COALESCE(stg."toast_text" != '__debezium_unavailable_value', true) THEN stg."toast_text" ELSE tgt."toast_text" END,"__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND stg.created_at >= tgt.created_at;`,
+			`UPDATE public.tableName AS tgt SET "id"=stg."id","email"=stg."email","first_name"=stg."first_name","last_name"=stg."last_name","created_at"=stg."created_at","toast_text"= CASE WHEN COALESCE(stg."toast_text" != '__debezium_unavailable_value', true) THEN stg."toast_text" ELSE tgt."toast_text" END,"__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND stg.created_at >= tgt.created_at AND COALESCE(stg."__artie_only_set_delete", false) = false;`,
 			parts[1])
+		assert.Equal(t,
+			`UPDATE public.tableName AS tgt SET "__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND stg.created_at >= tgt.created_at AND COALESCE(stg."__artie_only_set_delete", false) = true;`,
+			parts[2])
 	}
 }
 
@@ -421,14 +438,17 @@ func TestRedshiftDialect_BuildMergeQueries_SoftDeleteComposite(t *testing.T) {
 			false,
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(parts))
+		assert.Equal(t, 3, len(parts))
 
 		assert.Equal(t,
 			`INSERT INTO public.tableName ("id","email","first_name","last_name","created_at","toast_text","__artie_delete") SELECT stg."id",stg."email",stg."first_name",stg."last_name",stg."created_at",stg."toast_text",stg."__artie_delete" FROM public.tableName__temp AS stg LEFT JOIN public.tableName AS tgt ON tgt."id" = stg."id" AND tgt."email" = stg."email" WHERE tgt."id" IS NULL;`,
 			parts[0])
 		assert.Equal(t,
-			`UPDATE public.tableName AS tgt SET "id"=stg."id","email"=stg."email","first_name"=stg."first_name","last_name"=stg."last_name","created_at"=stg."created_at","toast_text"= CASE WHEN COALESCE(stg."toast_text" != '__debezium_unavailable_value', true) THEN stg."toast_text" ELSE tgt."toast_text" END,"__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND tgt."email" = stg."email";`,
+			`UPDATE public.tableName AS tgt SET "id"=stg."id","email"=stg."email","first_name"=stg."first_name","last_name"=stg."last_name","created_at"=stg."created_at","toast_text"= CASE WHEN COALESCE(stg."toast_text" != '__debezium_unavailable_value', true) THEN stg."toast_text" ELSE tgt."toast_text" END,"__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND tgt."email" = stg."email" AND COALESCE(stg."__artie_only_set_delete", false) = false;`,
 			parts[1])
+		assert.Equal(t,
+			`UPDATE public.tableName AS tgt SET "__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND tgt."email" = stg."email" AND COALESCE(stg."__artie_only_set_delete", false) = true;`,
+			parts[2])
 	}
 	{
 		parts, err := RedshiftDialect{}.BuildMergeQueries(
@@ -442,15 +462,19 @@ func TestRedshiftDialect_BuildMergeQueries_SoftDeleteComposite(t *testing.T) {
 			false,
 		)
 		assert.NoError(t, err)
+		assert.Equal(t, 3, len(parts))
 
 		// Parts[0] for insertion should be identical
 		assert.Equal(t,
 			`INSERT INTO public.tableName ("id","email","first_name","last_name","created_at","toast_text","__artie_delete") SELECT stg."id",stg."email",stg."first_name",stg."last_name",stg."created_at",stg."toast_text",stg."__artie_delete" FROM public.tableName__temp AS stg LEFT JOIN public.tableName AS tgt ON tgt."id" = stg."id" AND tgt."email" = stg."email" WHERE tgt."id" IS NULL;`,
 			parts[0])
-		// Parts[1] where we're doing UPDATES will have idempotency key.
+		// Parts[1:] where we're doing UPDATES will have idempotency key.
 		assert.Equal(t,
-			`UPDATE public.tableName AS tgt SET "id"=stg."id","email"=stg."email","first_name"=stg."first_name","last_name"=stg."last_name","created_at"=stg."created_at","toast_text"= CASE WHEN COALESCE(stg."toast_text" != '__debezium_unavailable_value', true) THEN stg."toast_text" ELSE tgt."toast_text" END,"__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND tgt."email" = stg."email" AND stg.created_at >= tgt.created_at;`,
+			`UPDATE public.tableName AS tgt SET "id"=stg."id","email"=stg."email","first_name"=stg."first_name","last_name"=stg."last_name","created_at"=stg."created_at","toast_text"= CASE WHEN COALESCE(stg."toast_text" != '__debezium_unavailable_value', true) THEN stg."toast_text" ELSE tgt."toast_text" END,"__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND tgt."email" = stg."email" AND stg.created_at >= tgt.created_at AND COALESCE(stg."__artie_only_set_delete", false) = false;`,
 			parts[1])
+		assert.Equal(t,
+			`UPDATE public.tableName AS tgt SET "__artie_delete"=stg."__artie_delete" FROM public.tableName__temp AS stg WHERE tgt."id" = stg."id" AND tgt."email" = stg."email" AND stg.created_at >= tgt.created_at AND COALESCE(stg."__artie_only_set_delete", false) = true;`,
+			parts[2])
 	}
 }
 


### PR DESCRIPTION
In the same vein as #796 and #800.

![Screenshot 2024-07-18 at 3 29 26 PM](https://github.com/user-attachments/assets/f1af7976-fc20-4249-94b2-58d74abbab03)
^ row 1028 was deleted before these changes, so the other values were nulled out. Rows 1029-1031 were deleted with these changes, so the previous values were preserved. For rows 1030 & 1031, I included multiple operations in a single flush (c + u + d, u + d) to verify that the latest in-memory values were preserved.