### PR TITLE
Update MS SQL merge logic to not null out values when soft-deleting

### DIFF
--- a/clients/mssql/dialect/dialect_test.go
+++ b/clients/mssql/dialect/dialect_test.go
@@ -230,7 +230,7 @@ WHEN NOT MATCHED AND COALESCE(stg."__artie_delete", 1) = 0 THEN INSERT ("id","ba
 		assert.Equal(t, `
 MERGE INTO database.schema.table tgt
 USING {SUB_QUERY} AS stg ON tgt."id" = stg."id"
-WHEN MATCHED THEN UPDATE SET "id"=stg."id","bar"=stg."bar","updated_at"=stg."updated_at","start"=stg."start","__artie_delete"=stg."__artie_delete"
+WHEN MATCHED THEN UPDATE SET "id"= CASE WHEN COALESCE(stg."__artie_only_set_delete", 0) = 0 THEN stg."id" ELSE tgt."id" END,"bar"= CASE WHEN COALESCE(stg."__artie_only_set_delete", 0) = 0 THEN stg."bar" ELSE tgt."bar" END,"updated_at"= CASE WHEN COALESCE(stg."__artie_only_set_delete", 0) = 0 THEN stg."updated_at" ELSE tgt."updated_at" END,"start"= CASE WHEN COALESCE(stg."__artie_only_set_delete", 0) = 0 THEN stg."start" ELSE tgt."start" END,"__artie_delete"=stg."__artie_delete"
 WHEN NOT MATCHED THEN INSERT ("id","bar","updated_at","start","__artie_delete") VALUES (stg."id",stg."bar",stg."updated_at",stg."start",stg."__artie_delete");`, queries[0])
 	}
 }

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -159,6 +159,7 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, opt
 	if err != nil {
 		return fmt.Errorf("failed to generate merge statements: %w", err)
 	}
+	fmt.Println(mergeStatements)
 
 	if err = destination.ExecStatements(dwh, mergeStatements); err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -159,7 +159,6 @@ func Merge(dwh destination.DataWarehouse, tableData *optimization.TableData, opt
 	if err != nil {
 		return fmt.Errorf("failed to generate merge statements: %w", err)
 	}
-	fmt.Println(mergeStatements)
 
 	if err = destination.ExecStatements(dwh, mergeStatements); err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)

--- a/lib/sql/columns.go
+++ b/lib/sql/columns.go
@@ -51,6 +51,7 @@ func BuildConditionalColumnsUpdateFragment(columns []columns.Column, stagingAlia
 			colVal = QuoteTableAliasColumn(stagingAlias, column, dialect)
 		}
 		if condition != "" {
+			// Only update the column if the condition is true; otherwise, preserve the existing value from the target table
 			colVal = fmt.Sprintf(" CASE WHEN %s THEN %s ELSE %s END", condition, colVal, QuoteTableAliasColumn(targetAlias, column, dialect))
 		}
 		cols = append(cols, fmt.Sprintf("%s=%s", dialect.QuoteIdentifier(column.Name()), colVal))


### PR DESCRIPTION
Had to use a different approach for this than for the other destinations, since MS SQL [doesn't allow](https://learn.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql?view=sql-server-ver16#when-matched-then-merge_matched) multiple `WHEN MATCHED THEN UPDATE` clauses. So instead, the `__artie_only_set_delete` flag is checked when determining the value to assign for each column (except the `__artie_delete` column). If `__artie_only_set_delete` is true, then it uses the target table's existing value; if false, it uses the new value from the staging table.

The update clause ends up looking like this:
```sql
WHEN MATCHED THEN UPDATE SET
  "id"=CASE WHEN COALESCE(stg."__artie_only_set_delete", 0) = 0 THEN stg."id" ELSE tgt."id" END,
  "first_name"=CASE WHEN COALESCE(stg."__artie_only_set_delete", 0) = 0 THEN stg."first_name" ELSE tgt."first_name" END,
  "last_name"=CASE WHEN COALESCE(stg."__artie_only_set_delete", 0) = 0 THEN stg."last_name" ELSE tgt."last_name" END,
  "email"=CASE WHEN COALESCE(stg."__artie_only_set_delete", 0) = 0 THEN stg."email" ELSE tgt."email" END,
  "__artie_updated_at"=CASE WHEN COALESCE(stg."__artie_only_set_delete", 0) = 0 THEN stg."__artie_updated_at" ELSE tgt."__artie_updated_at" END,
  "__artie_delete"=stg."__artie_delete"
```