### PR TITLE
Update ms sql merge logic to not null out values when soft-deleting

### DIFF
--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -232,9 +232,9 @@ UPDATE %s SET %s
 FROM %s AS %s
 LEFT JOIN %s AS %s ON %s%s
 WHERE COALESCE(%s, 0) = 0;`,
-				// UPDATE table set col1 = stg. col1
+				// UPDATE table set [all columns]
 				constants.TargetAlias, sql.BuildColumnsUpdateFragment(cols, constants.StagingAlias, constants.TargetAlias, md),
-				// FROM staging WHERE join on PK(s)
+				// FROM staging AS stg LEFT JOIN target AS tgt ON tgt.pk = stg.pk
 				subQuery, constants.StagingAlias, tableID.FullyQualifiedName(), constants.TargetAlias, joinOn, idempotentClause,
 				// WHERE __artie_only_set_delete = 0
 				sql.GetQuotedOnlySetDeleteColumnMarker(constants.StagingAlias, md),
@@ -244,9 +244,9 @@ UPDATE %s SET %s
 FROM %s AS %s
 LEFT JOIN %s AS %s ON %s%s
 WHERE COALESCE(%s, 0) = 1;`,
-				// UPDATE table __artie_delete = stg.__artie_delete
+				// UPDATE table SET __artie_delete = stg.__artie_delete
 				constants.TargetAlias, sql.BuildColumnsUpdateFragment([]columns.Column{columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean)}, constants.StagingAlias, constants.TargetAlias, md),
-				// FROM staging WHERE join on PK(s)
+				// FROM staging AS stg LEFT JOIN target AS tgt ON tgt.pk = stg.pk
 				subQuery, constants.StagingAlias, tableID.FullyQualifiedName(), constants.TargetAlias, joinOn, idempotentClause,
 				// WHERE __artie_only_set_delete = 1
 				sql.GetQuotedOnlySetDeleteColumnMarker(constants.StagingAlias, md),

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -229,8 +229,7 @@ WHERE %s IS NULL;`,
 			),
 			fmt.Sprintf(`
 UPDATE %s SET %s
-FROM %s AS %s
-LEFT JOIN %s AS %s ON %s%s
+FROM %s AS %s LEFT JOIN %s AS %s ON %s%s
 WHERE COALESCE(%s, 0) = 0;`,
 				// UPDATE table set [all columns]
 				constants.TargetAlias, sql.BuildColumnsUpdateFragment(cols, constants.StagingAlias, constants.TargetAlias, md),
@@ -241,8 +240,7 @@ WHERE COALESCE(%s, 0) = 0;`,
 			),
 			fmt.Sprintf(`
 UPDATE %s SET %s
-FROM %s AS %s
-LEFT JOIN %s AS %s ON %s%s
+FROM %s AS %s LEFT JOIN %s AS %s ON %s%s
 WHERE COALESCE(%s, 0) = 1;`,
 				// UPDATE table SET __artie_delete = stg.__artie_delete
 				constants.TargetAlias, sql.BuildColumnsUpdateFragment([]columns.Column{columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean)}, constants.StagingAlias, constants.TargetAlias, md),

--- a/clients/mssql/dialect/dialect_test.go
+++ b/clients/mssql/dialect/dialect_test.go
@@ -234,13 +234,11 @@ LEFT JOIN database.schema.table AS tgt ON tgt."id" = stg."id"
 WHERE tgt."id" IS NULL;`, queries[0])
 		assert.Equal(t, `
 UPDATE tgt SET "id"=stg."id","bar"=stg."bar","updated_at"=stg."updated_at","start"=stg."start","__artie_delete"=stg."__artie_delete"
-FROM {SUB_QUERY} AS stg
-LEFT JOIN database.schema.table AS tgt ON tgt."id" = stg."id"
+FROM {SUB_QUERY} AS stg LEFT JOIN database.schema.table AS tgt ON tgt."id" = stg."id"
 WHERE COALESCE(stg."__artie_only_set_delete", 0) = 0;`, queries[1])
 		assert.Equal(t, `
 UPDATE tgt SET "__artie_delete"=stg."__artie_delete"
-FROM {SUB_QUERY} AS stg
-LEFT JOIN database.schema.table AS tgt ON tgt."id" = stg."id"
+FROM {SUB_QUERY} AS stg LEFT JOIN database.schema.table AS tgt ON tgt."id" = stg."id"
 WHERE COALESCE(stg."__artie_only_set_delete", 0) = 1;`, queries[2])
 	}
 }

--- a/clients/mssql/dialect/dialect_test.go
+++ b/clients/mssql/dialect/dialect_test.go
@@ -226,7 +226,7 @@ WHEN NOT MATCHED AND COALESCE(stg."__artie_delete", 1) = 0 THEN INSERT ("id","ba
 			false,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, queries, 2)
+		assert.Len(t, queries, 3)
 		assert.Equal(t, `
 INSERT INTO database.schema.table ("id","bar","updated_at","start","__artie_delete")
 SELECT stg."id",stg."bar",stg."updated_at",stg."start",stg."__artie_delete" FROM {SUB_QUERY} AS stg
@@ -235,6 +235,12 @@ WHERE tgt."id" IS NULL;`, queries[0])
 		assert.Equal(t, `
 UPDATE tgt SET "id"=stg."id","bar"=stg."bar","updated_at"=stg."updated_at","start"=stg."start","__artie_delete"=stg."__artie_delete"
 FROM {SUB_QUERY} AS stg
-LEFT JOIN database.schema.table AS tgt ON tgt."id" = stg."id" ;`, queries[1])
+LEFT JOIN database.schema.table AS tgt ON tgt."id" = stg."id"
+WHERE COALESCE(stg."__artie_only_set_delete", 0) = 0;`, queries[1])
+		assert.Equal(t, `
+UPDATE tgt SET "__artie_delete"=stg."__artie_delete"
+FROM {SUB_QUERY} AS stg
+LEFT JOIN database.schema.table AS tgt ON tgt."id" = stg."id"
+WHERE COALESCE(stg."__artie_only_set_delete", 0) = 1;`, queries[2])
 	}
 }


### PR DESCRIPTION
MS SQL [doesn't allow](https://learn.microsoft.com/en-us/sql/t-sql/statements/merge-transact-sql?view=sql-server-ver16#when-matched-then-merge_matched) multiple `WHEN MATCHED THEN UPDATE` clauses, so in https://github.com/artie-labs/transfer/pull/804 I converted it to use insert + update statements instead. This PRs adds an extra update statement to handle only updating the `__artie_delete` field if we're soft-deleting a row and don't have the previous values in memory.