### PR TITLE
[Table Config] Removing empty comment as a struct

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -25,7 +25,6 @@ import (
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/logger"
 	"github.com/artie-labs/transfer/lib/optimization"
-	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
@@ -118,7 +117,6 @@ func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTab
 		ColumnNameForName:     "column_name",
 		ColumnNameForDataType: "data_type",
 		ColumnNameForComment:  "description",
-		EmptyCommentValue:     ptr.ToString(""),
 		DropDeletedColumns:    tableData.TopicConfig().DropDeletedColumns,
 	}.GetTableConfig()
 }

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
-	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
@@ -87,7 +86,6 @@ func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTab
 		ColumnNameForName:     "column_name",
 		ColumnNameForDataType: "data_type",
 		ColumnNameForComment:  "description",
-		EmptyCommentValue:     ptr.ToString("<nil>"),
 		DropDeletedColumns:    tableData.TopicConfig().DropDeletedColumns,
 	}.GetTableConfig()
 }

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -14,7 +14,6 @@ import (
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
-	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
@@ -71,7 +70,6 @@ func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTab
 		ColumnNameForName:     "column_name",
 		ColumnNameForDataType: "data_type",
 		ColumnNameForComment:  "description",
-		EmptyCommentValue:     ptr.ToString("<nil>"),
 		DropDeletedColumns:    tableData.TopicConfig().DropDeletedColumns,
 	}.GetTableConfig()
 }

--- a/clients/shared/table_config.go
+++ b/clients/shared/table_config.go
@@ -86,11 +86,12 @@ func (g GetTableCfgArgs) GetTableConfig() (*types.DwhTableConfig, error) {
 				return nil, errors.New("invalid value")
 			}
 
+			var value string
 			if *interfaceVal != nil {
-				row[columnNameList[idx]] = strings.ToLower(fmt.Sprint(*interfaceVal))
-			} else {
-				row[columnNameList[idx]] = ""
+				value = strings.ToLower(fmt.Sprint(*interfaceVal))
 			}
+
+			row[columnNameList[idx]] = value
 		}
 
 		kindDetails, err := g.Dwh.Dialect().KindForDataType(row[g.ColumnNameForDataType], row[constants.StrPrecisionCol])

--- a/clients/shared/table_config.go
+++ b/clients/shared/table_config.go
@@ -111,7 +111,7 @@ func (g GetTableCfgArgs) GetTableConfig() (*types.DwhTableConfig, error) {
 		if comment, isOk := row[g.ColumnNameForComment]; isOk && *comment != "" {
 			var _colComment constants.ColComment
 			if err = json.Unmarshal([]byte(*comment), &_colComment); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal comment: %w", err)
+				return nil, fmt.Errorf("failed to unmarshal comment %q: %w", *comment, err)
 			}
 
 			col.SetBackfilled(_colComment.Backfilled)

--- a/clients/shared/table_config.go
+++ b/clients/shared/table_config.go
@@ -103,7 +103,7 @@ func (g GetTableCfgArgs) GetTableConfig() (*types.DwhTableConfig, error) {
 		}
 
 		if kindDetails.Kind == typing.Invalid.Kind {
-			return nil, fmt.Errorf("failed to get kind details: unable to map type: %q to dwh type", row[g.ColumnNameForDataType])
+			return nil, fmt.Errorf("failed to get kind details: unable to map type: %q to dwh type", *row[g.ColumnNameForDataType])
 		}
 
 		col := columns.NewColumn(*row[g.ColumnNameForName], kindDetails)

--- a/clients/shared/table_config.go
+++ b/clients/shared/table_config.go
@@ -7,11 +7,10 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/artie-labs/transfer/lib/ptr"
-
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
+	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
@@ -88,6 +87,7 @@ func (g GetTableCfgArgs) GetTableConfig() (*types.DwhTableConfig, error) {
 				return nil, errors.New("invalid value")
 			}
 
+			fmt.Println("*interfaceVal*", interfaceVal, "row[columnNameList[idx]]", row[columnNameList[idx]])
 			if *interfaceVal != nil {
 				row[columnNameList[idx]] = ptr.ToString(strings.ToLower(fmt.Sprint(*interfaceVal)))
 			}
@@ -108,8 +108,8 @@ func (g GetTableCfgArgs) GetTableConfig() (*types.DwhTableConfig, error) {
 		}
 
 		col := columns.NewColumn(*row[g.ColumnNameForName], kindDetails)
-		if comment, isOk := row[g.ColumnNameForComment]; isOk {
-			// Try to parse the comment.
+		// We need to check to make sure the comment is not an empty string
+		if comment, isOk := row[g.ColumnNameForComment]; isOk && *comment != "" {
 			var _colComment constants.ColComment
 			if err = json.Unmarshal([]byte(*comment), &_colComment); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal comment: %w", err)

--- a/clients/shared/table_config.go
+++ b/clients/shared/table_config.go
@@ -87,7 +87,6 @@ func (g GetTableCfgArgs) GetTableConfig() (*types.DwhTableConfig, error) {
 				return nil, errors.New("invalid value")
 			}
 
-			fmt.Println("*interfaceVal*", interfaceVal, "row[columnNameList[idx]]", row[columnNameList[idx]])
 			if *interfaceVal != nil {
 				row[columnNameList[idx]] = ptr.ToString(strings.ToLower(fmt.Sprint(*interfaceVal)))
 			}

--- a/clients/shared/table_config_test.go
+++ b/clients/shared/table_config_test.go
@@ -6,47 +6,10 @@ import (
 
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/mocks"
-	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestGetTableCfgArgs_ShouldParseComment(t *testing.T) {
-	type _testCase struct {
-		Name            string
-		EmptyCommentVal *string
-		Comment         string
-		ExpectedResult  bool
-	}
-
-	testCases := []_testCase{
-		{
-			Name:           "empty comment val = nil",
-			Comment:        "blah blah blah",
-			ExpectedResult: true,
-		},
-		{
-			Name:            "empty comment val = blah",
-			EmptyCommentVal: ptr.ToString("blah"),
-			Comment:         "blah",
-		},
-		{
-			Name:            "empty comment val = blah2",
-			EmptyCommentVal: ptr.ToString("blah2"),
-			Comment:         "blah",
-			ExpectedResult:  true,
-		},
-	}
-
-	for _, testCase := range testCases {
-		args := GetTableCfgArgs{
-			EmptyCommentValue: testCase.EmptyCommentVal,
-		}
-
-		assert.Equal(t, testCase.ExpectedResult, args.ShouldParseComment(testCase.Comment), testCase.Name)
-	}
-}
 
 func TestGetTableConfig(t *testing.T) {
 	// Return early because table is found in configMap.

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -41,7 +41,6 @@ func (s *Store) GetTableConfig(tableData *optimization.TableData) (*types.DwhTab
 		ColumnNameForName:     "name",
 		ColumnNameForDataType: "type",
 		ColumnNameForComment:  "comment",
-		EmptyCommentValue:     ptr.ToString("<nil>"),
 		DropDeletedColumns:    tableData.TopicConfig().DropDeletedColumns,
 	}.GetTableConfig()
 }


### PR DESCRIPTION
As part of simplifying the way we retrieve table config, this PR removes the need to specify what an "empty" comment looks like by having better parsing.