### PR TITLE
MongoDB clean up

### DIFF
--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -64,12 +64,17 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 	case
 		bson.TypeBinaryUUIDOld,
 		bson.TypeBinaryUUID:
-		parsedUUID, err := uuid.FromBytes(value.Data)
-		if err != nil {
-			return nil, err
+		if len(value.Data) == 16 {
+			// UUIDs must be 16 bytes
+			parsedUUID, err := uuid.FromBytes(value.Data)
+			if err != nil {
+				return nil, err
+			}
+
+			return parsedUUID.String(), nil
 		}
 
-		return parsedUUID.String(), nil
+		fallthrough
 	default:
 		return map[string]any{
 			"$binary": map[string]any{

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -119,7 +119,6 @@ func bsonValueToGoValue(value any) (any, error) {
 		float32:
 		return v, nil
 	case float64:
-		// Check Infinity, -Infinity, NaN
 		if math.IsNaN(v) || math.IsInf(v, 0) {
 			return nil, nil
 		}

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -120,15 +120,7 @@ func bsonValueToGoValue(value any) (any, error) {
 		return v, nil
 	case float64:
 		// Check Infinity, -Infinity, NaN
-		if math.IsNaN(v) {
-			return nil, nil
-		}
-
-		if math.IsInf(v, 1) {
-			return nil, nil
-		}
-
-		if math.IsInf(v, -1) {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
 			return nil, nil
 		}
 

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -3,6 +3,7 @@ package mongo
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 	"time"
@@ -115,7 +116,22 @@ func bsonValueToGoValue(value any) (any, error) {
 		bool,
 		string,
 		int32, int64,
-		float32, float64:
+		float32:
+		return v, nil
+	case float64:
+		// Check Infinity, -Infinity, NaN
+		if math.IsNaN(v) {
+			return nil, nil
+		}
+
+		if math.IsInf(v, 1) {
+			return nil, nil
+		}
+
+		if math.IsInf(v, -1) {
+			return nil, nil
+		}
+
 		return v, nil
 	default:
 		return nil, fmt.Errorf("unexpected type: %T, value: %v", v, v)

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -103,6 +103,8 @@ func bsonValueToGoValue(value any) (any, error) {
 		return map[string]any{"$minKey": 1}, nil
 	case primitive.JavaScript:
 		return map[string]any{"$code": string(v)}, nil
+	case primitive.CodeWithScope:
+		return map[string]any{"$code": string(v.Code), "$scope": v.Scope}, nil
 	case
 		nil,
 		bool,

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -258,6 +258,13 @@ func TestBsonValueToGoValue(t *testing.T) {
 		assert.Equal(t, map[string]any{"$code": "function() {return 0.10;}"}, result)
 	}
 	{
+		// primitive.CodeWithScope
+		code := primitive.CodeWithScope{Code: "function() {return 0.10;}", Scope: true}
+		result, err := bsonValueToGoValue(code)
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]any{"$code": "function() {return 0.10;}", "$scope": true}, result)
+	}
+	{
 		// something totally random
 		type randomDataType struct{}
 		_, err := bsonValueToGoValue(randomDataType{})

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -1,7 +1,6 @@
 package mongo
 
 import (
-	"math"
 	"testing"
 	"time"
 
@@ -107,17 +106,9 @@ func TestJSONEToMap(t *testing.T) {
 
 	{
 		// V2 of NaN and Infinity
-		float64Val, isOk := result["test_nan_v2"].(float64)
-		assert.True(t, isOk)
-		assert.True(t, math.IsNaN(float64Val))
-
-		float64Val, isOk = result["test_infinity_v2"].(float64)
-		assert.True(t, isOk)
-		assert.True(t, math.IsInf(float64Val, 1))
-
-		float64Val, isOk = result["test_negative_infinity_v2"].(float64)
-		assert.True(t, isOk)
-		assert.True(t, math.IsInf(float64Val, -1))
+		assert.Nil(t, result["test_nan_v2"])
+		assert.Nil(t, result["test_infinity_v2"])
+		assert.Nil(t, result["test_negative_infinity_v2"])
 	}
 
 	assert.Equal(t, int64(10004), result["_id"])

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -1,6 +1,8 @@
 package mongo
 
 import (
+	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -74,10 +76,13 @@ func TestJSONEToMap(t *testing.T) {
 	   "$timestamp": { "t": 1678929517, "i": 1 }
    	},
 	"test_nan": NaN,
+	"test_nan_v2": {"$numberDouble": "NaN"},
 	"test_nan_string": "NaN",
 	"test_nan_string33": "NaNaNaNa",
 	"test_infinity": Infinity,
 	"test_infinity_string": "Infinity",
+	"test_infinity_v2": {"$numberDouble": "Infinity"},
+	"test_negative_infinity_v2": {"$numberDouble": "-Infinity"},
 	"test_infinity_string1": "Infinity123",
 	"test_negative_infinity": -Infinity,
 	"test_negative_infinity_string": "-Infinity",
@@ -96,6 +101,24 @@ func TestJSONEToMap(t *testing.T) {
 	// NumberDecimal
 	assert.Equal(t, "13.37", result["test_decimal"])
 	assert.Equal(t, 13.37, result["test_decimal_2"])
+
+	{
+		// V2 of NaN and Infinity
+		float64Val, isOk := result["test_nan_v2"].(float64)
+		assert.True(t, isOk)
+		assert.True(t, math.IsNaN(float64Val))
+
+		float64Val, isOk = result["test_infinity_v2"].(float64)
+		assert.True(t, isOk)
+		assert.True(t, math.IsInf(float64Val, 1))
+
+		float64Val, isOk = result["test_negative_infinity_v2"].(float64)
+		assert.True(t, isOk)
+		assert.True(t, math.IsInf(float64Val, -1))
+
+		fmt.Println("###", fmt.Sprintf("%.0f", float64Val))
+		assert.False(t, true)
+	}
 
 	assert.Equal(t, int64(10004), result["_id"])
 	assert.Equal(t, int64(107), result["product_id"])

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -1,7 +1,6 @@
 package mongo
 
 import (
-	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -47,6 +46,8 @@ func TestJSONEToMap(t *testing.T) {
 		"$binary": "hW5W/8uwQR6FWpiwi4dRQA==",
 		"$type": "04"
 	},
+	"Binary": {"$binary": {"base64": "c8edabc3f7384ca3b68dab92a91478a3", "subType": "04"}},
+	"another_unique_id_v1": {"$binary": "ITG8xP+xRcquqqw3QT5IkA==", "$type": "04"},
 	"fileChecksum": {
 		"$binary": "1B2M2Y8AsgTpgAmY7PhCfg==",
 		"$type": "05"
@@ -95,6 +96,8 @@ func TestJSONEToMap(t *testing.T) {
 	result, err := JSONEToMap(bsonData)
 	assert.NoError(t, err)
 
+	assert.Equal(t, map[string]any{"$binary": map[string]any{"base64": "c8edabc3f7384ca3b68dab92a91478a3", "subType": "04"}}, result["Binary"])
+
 	// String
 	assert.Equal(t, "Robin Tang", result["full_name"])
 
@@ -115,9 +118,6 @@ func TestJSONEToMap(t *testing.T) {
 		float64Val, isOk = result["test_negative_infinity_v2"].(float64)
 		assert.True(t, isOk)
 		assert.True(t, math.IsInf(float64Val, -1))
-
-		fmt.Println("###", fmt.Sprintf("%.0f", float64Val))
-		assert.False(t, true)
 	}
 
 	assert.Equal(t, int64(10004), result["_id"])


### PR DESCRIPTION
As part of validating MongoDB streaming, I noticed we weren't handling `CodeWithScope` and also we were wrongfully assuming that BinData will be only 16 bytes. 

In MongoDB, you can create a BinData with any arbitrary value and assign whichever subtype you want. 