### PR TITLE
Removing fake event

### DIFF
--- a/lib/mocks/generate.go
+++ b/lib/mocks/generate.go
@@ -7,3 +7,5 @@ package mocks
 //counterfeiter:generate -o=dwh.mock.go ../destination DataWarehouse
 //counterfeiter:generate -o=baseline.mock.go ../destination Baseline
 //counterfeiter:generate -o=tableid.mock.go ../sql TableIdentifier
+
+//counterfeiter:generate -o=event.mock.go ../cdc Event

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -1,49 +1,15 @@
 package event
 
 import (
-	"time"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
-	"github.com/artie-labs/transfer/lib/typing"
-	"github.com/artie-labs/transfer/lib/typing/columns"
 )
-
-type fakeEvent struct{}
 
 var idMap = map[string]any{
 	"id": 123,
-}
-
-func (f fakeEvent) Operation() string {
-	return "r"
-}
-
-func (f fakeEvent) DeletePayload() bool {
-	return false
-}
-
-func (f fakeEvent) GetExecutionTime() time.Time {
-	return time.Now()
-}
-
-func (f fakeEvent) GetTableName() string {
-	return "foo"
-}
-
-func (f fakeEvent) GetOptionalSchema() map[string]typing.KindDetails {
-	return nil
-}
-
-func (f fakeEvent) GetColumns() (*columns.Columns, error) {
-	return &columns.Columns{}, nil
-}
-
-func (f fakeEvent) GetData(pkMap map[string]any, config *kafkalib.TopicConfig) (map[string]any, error) {
-	return map[string]any{constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false}, nil
 }
 
 func (e *EventsTestSuite) TestEvent_IsValid() {
@@ -92,36 +58,28 @@ func (e *EventsTestSuite) TestEvent_IsValid() {
 }
 
 func (e *EventsTestSuite) TestEvent_TableName() {
-	var f fakeEvent
-	{
-		// Don't pass in tableName.
-		evt, err := ToMemoryEvent(f, idMap, &kafkalib.TopicConfig{}, config.Replication)
-		assert.NoError(e.T(), err)
-		assert.Equal(e.T(), f.GetTableName(), evt.Table)
-	}
 	{
 		// Now pass it in, it should override.
-		evt, err := ToMemoryEvent(f, idMap, &kafkalib.TopicConfig{TableName: "orders"}, config.Replication)
+		evt, err := ToMemoryEvent(e.fakeEvent, idMap, &kafkalib.TopicConfig{TableName: "orders"}, config.Replication)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), "orders", evt.Table)
 	}
 	{
 		// Now, if it's history mode...
-		evt, err := ToMemoryEvent(f, idMap, &kafkalib.TopicConfig{TableName: "orders"}, config.History)
+		evt, err := ToMemoryEvent(e.fakeEvent, idMap, &kafkalib.TopicConfig{TableName: "orders"}, config.History)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), "orders__history", evt.Table)
 
 		// Table already has history suffix, so it won't add extra.
-		evt, err = ToMemoryEvent(f, idMap, &kafkalib.TopicConfig{TableName: "dusty__history"}, config.History)
+		evt, err = ToMemoryEvent(e.fakeEvent, idMap, &kafkalib.TopicConfig{TableName: "dusty__history"}, config.History)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), "dusty__history", evt.Table)
 	}
 }
 
 func (e *EventsTestSuite) TestEvent_Columns() {
-	var f fakeEvent
 	{
-		evt, err := ToMemoryEvent(f, map[string]any{"id": 123}, &kafkalib.TopicConfig{}, config.Replication)
+		evt, err := ToMemoryEvent(e.fakeEvent, map[string]any{"id": 123}, &kafkalib.TopicConfig{}, config.Replication)
 		assert.NoError(e.T(), err)
 
 		assert.Equal(e.T(), 1, len(evt.Columns.GetColumns()))
@@ -130,7 +88,7 @@ func (e *EventsTestSuite) TestEvent_Columns() {
 	}
 	{
 		// Now it should handle escaping column names
-		evt, err := ToMemoryEvent(f, map[string]any{"id": 123, "CAPITAL": "foo"}, &kafkalib.TopicConfig{}, config.Replication)
+		evt, err := ToMemoryEvent(e.fakeEvent, map[string]any{"id": 123, "CAPITAL": "foo"}, &kafkalib.TopicConfig{}, config.Replication)
 		assert.NoError(e.T(), err)
 
 		assert.Equal(e.T(), 2, len(evt.Columns.GetColumns()))
@@ -142,7 +100,7 @@ func (e *EventsTestSuite) TestEvent_Columns() {
 	}
 	{
 		// In history mode, the deletion column markers should be removed from the event data
-		evt, err := ToMemoryEvent(f, map[string]any{"id": 123}, &kafkalib.TopicConfig{}, config.History)
+		evt, err := ToMemoryEvent(e.fakeEvent, map[string]any{"id": 123}, &kafkalib.TopicConfig{}, config.History)
 		assert.NoError(e.T(), err)
 
 		_, isOk := evt.Data[constants.DeleteColumnMarker]

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -59,6 +59,12 @@ func (e *EventsTestSuite) TestEvent_IsValid() {
 
 func (e *EventsTestSuite) TestEvent_TableName() {
 	{
+		// Don't pass in tableName.
+		evt, err := ToMemoryEvent(e.fakeEvent, idMap, &kafkalib.TopicConfig{}, config.Replication)
+		assert.NoError(e.T(), err)
+		assert.Equal(e.T(), e.fakeEvent.GetTableName(), evt.Table)
+	}
+	{
 		// Now pass it in, it should override.
 		evt, err := ToMemoryEvent(e.fakeEvent, idMap, &kafkalib.TopicConfig{TableName: "orders"}, config.Replication)
 		assert.NoError(e.T(), err)

--- a/models/event/events_suite_test.go
+++ b/models/event/events_suite_test.go
@@ -3,6 +3,8 @@ package event
 import (
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/typing/columns"
+
 	"github.com/artie-labs/transfer/lib/config/constants"
 
 	"github.com/artie-labs/transfer/lib/mocks"
@@ -31,6 +33,8 @@ func (e *EventsTestSuite) SetupTest() {
 
 	fakeEvent := &mocks.FakeEvent{}
 	fakeEvent.GetDataReturns(map[string]any{constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false}, nil)
+	fakeEvent.GetColumnsReturns(&columns.Columns{}, nil)
+
 	e.fakeEvent = fakeEvent
 }
 

--- a/models/event/events_suite_test.go
+++ b/models/event/events_suite_test.go
@@ -34,7 +34,7 @@ func (e *EventsTestSuite) SetupTest() {
 	fakeEvent := &mocks.FakeEvent{}
 	fakeEvent.GetDataReturns(map[string]any{constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false}, nil)
 	fakeEvent.GetColumnsReturns(&columns.Columns{}, nil)
-
+	fakeEvent.GetTableNameReturns("foo")
 	e.fakeEvent = fakeEvent
 }
 

--- a/models/event/events_suite_test.go
+++ b/models/event/events_suite_test.go
@@ -3,6 +3,10 @@ package event
 import (
 	"testing"
 
+	"github.com/artie-labs/transfer/lib/config/constants"
+
+	"github.com/artie-labs/transfer/lib/mocks"
+
 	"github.com/artie-labs/transfer/models"
 
 	"github.com/artie-labs/transfer/lib/config"
@@ -12,8 +16,9 @@ import (
 
 type EventsTestSuite struct {
 	suite.Suite
-	cfg config.Config
-	db  *models.DatabaseData
+	cfg       config.Config
+	db        *models.DatabaseData
+	fakeEvent *mocks.FakeEvent
 }
 
 func (e *EventsTestSuite) SetupTest() {
@@ -23,6 +28,10 @@ func (e *EventsTestSuite) SetupTest() {
 		BufferRows:           1000,
 	}
 	e.db = models.NewMemoryDB()
+
+	fakeEvent := &mocks.FakeEvent{}
+	fakeEvent.GetDataReturns(map[string]any{constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false}, nil)
+	e.fakeEvent = fakeEvent
 }
 
 func TestEventsTestSuite(t *testing.T) {


### PR DESCRIPTION
Removing the need to hardcode a fake event that matches the `cdc.Event` interface. Standardizing this on counterfeiter mocks instead