### PR TITLE
[DateTime] Return `ext.ExtendedTime` as opposed to `string`

### DIFF
--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -184,7 +184,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 	}
 
 	if tc.IncludeArtieUpdatedAt {
-		retMap[constants.UpdateColumnMarker] = ext.NewUTCTime(ext.ISO8601)
+		retMap[constants.UpdateColumnMarker] = ext.NewExtendedTime(time.Now().UTC(), ext.DateTimeKindType, ext.ISO8601)
 	}
 
 	if tc.IncludeDatabaseUpdatedAt {

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -188,7 +188,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 	}
 
 	if tc.IncludeDatabaseUpdatedAt {
-		retMap[constants.DatabaseUpdatedColumnMarker] = s.GetExecutionTime().Format(ext.ISO8601)
+		retMap[constants.DatabaseUpdatedColumnMarker] = ext.NewExtendedTime(s.GetExecutionTime(), ext.DateTimeKindType, ext.ISO8601)
 	}
 
 	return retMap, nil

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -174,9 +174,11 @@ func (m *MongoTestSuite) TestMongoDBEventCustomer() {
 	})
 	assert.NoError(m.T(), err)
 
-	assert.Equal(m.T(), "2022-11-18T06:35:21+00:00", evtDataWithIncludedAt[constants.DatabaseUpdatedColumnMarker])
-	_, err = time.Parse(ext.ISO8601, evtDataWithIncludedAt[constants.UpdateColumnMarker].(string))
-	assert.NoError(m.T(), err, evtDataWithIncludedAt[constants.UpdateColumnMarker])
+	assert.Equal(m.T(), ext.NewExtendedTime(time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), evtDataWithIncludedAt[constants.DatabaseUpdatedColumnMarker])
+
+	updatedExtTime, isOk := evtDataWithIncludedAt[constants.UpdateColumnMarker].(*ext.ExtendedTime)
+	assert.True(m.T(), isOk)
+	assert.False(m.T(), updatedExtTime.IsZero())
 
 	var nestedData map[string]any
 	err = json.Unmarshal([]byte(evtData["nested"].(string)), &nestedData)

--- a/lib/cdc/relational/debezium_test.go
+++ b/lib/cdc/relational/debezium_test.go
@@ -92,7 +92,7 @@ func (r *RelationTestSuite) TestPostgresEvent() {
 	})
 	assert.NoError(r.T(), err)
 	assert.Equal(r.T(), float64(59), evtData["id"])
-	assert.Equal(r.T(), "2022-11-16T04:01:53.308+00:00", evtData[constants.DatabaseUpdatedColumnMarker])
+	assert.Equal(r.T(), ext.NewExtendedTime(time.Date(2022, time.November, 16, 4, 1, 53, 308000000, time.UTC), ext.DateTimeKindType, ext.ISO8601), evtData[constants.DatabaseUpdatedColumnMarker])
 
 	assert.Equal(r.T(), "Barings Participation Investors", evtData["item"])
 	assert.Equal(r.T(), map[string]any{"object": "foo"}, evtData["nested"])
@@ -541,10 +541,11 @@ func (r *RelationTestSuite) TestGetEventFromBytes_MySQL() {
 	})
 	assert.NoError(r.T(), err)
 
-	assert.Equal(r.T(), "2023-03-13T19:19:24+00:00", evtData[constants.DatabaseUpdatedColumnMarker])
+	assert.Equal(r.T(), ext.NewExtendedTime(time.Date(2023, time.March, 13, 19, 19, 24, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), evtData[constants.DatabaseUpdatedColumnMarker])
 
-	_, err = time.Parse(time.RFC3339, evtData[constants.UpdateColumnMarker].(string))
-	assert.NoError(r.T(), err, evtData[constants.UpdateColumnMarker])
+	updatedAtExtTime, isOk := evtData[constants.UpdateColumnMarker].(*ext.ExtendedTime)
+	assert.True(r.T(), isOk)
+	assert.False(r.T(), updatedAtExtTime.IsZero())
 
 	assert.Equal(r.T(), evtData["id"], int64(1001))
 	assert.Equal(r.T(), evtData["first_name"], "Sally")

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -109,11 +109,11 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicCon
 	}
 
 	if tc.IncludeArtieUpdatedAt {
-		retMap[constants.UpdateColumnMarker] = ext.NewUTCTime(ext.ISO8601)
+		retMap[constants.UpdateColumnMarker] = ext.NewExtendedTime(time.Now().UTC(), ext.DateTimeKindType, ext.ISO8601)
 	}
 
 	if tc.IncludeDatabaseUpdatedAt {
-		retMap[constants.DatabaseUpdatedColumnMarker] = s.GetExecutionTime().Format(ext.ISO8601)
+		retMap[constants.DatabaseUpdatedColumnMarker] = ext.NewExtendedTime(s.GetExecutionTime(), ext.DateTimeKindType, ext.ISO8601)
 	}
 
 	return retMap, nil

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -35,7 +35,3 @@ var SupportedTimeFormatsLegacy = []string{
 	PostgresTimeFormatNoTZ,
 	AdditionalTimeFormat,
 }
-
-func NewUTCTime(layout string) string {
-	return time.Now().UTC().Format(layout)
-}


### PR DESCRIPTION
Right now, we're returning `updated_at` back as a string. This then leads us to do additional parsing downstream