### PR TITLE
[Typing] Bring assert into Transfer

### DIFF
--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -115,11 +115,12 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 
 		switch column.KindDetails.Kind {
 		case typing.Boolean.Kind:
-			if boolValue, ok := value.(bool); ok {
-				message.Set(field, protoreflect.ValueOfBool(boolValue))
-			} else {
-				return nil, fmt.Errorf("expected bool received %T with value %v", value, value)
+			boolValue, err := typing.AssertType[bool](value)
+			if err != nil {
+				return nil, err
 			}
+
+			message.Set(field, protoreflect.ValueOfBool(boolValue))
 		case typing.Integer.Kind:
 			switch value := value.(type) {
 			case int:
@@ -160,11 +161,11 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 			}
 		case typing.String.Kind:
 			var stringValue string
-			switch value := value.(type) {
+			switch castedValue := value.(type) {
 			case string:
-				stringValue = value
+				stringValue = castedValue
 			case *decimal.Decimal:
-				stringValue = value.String()
+				stringValue = castedValue.String()
 			default:
 				return nil, fmt.Errorf("expected string/decimal.Decimal received %T with value %v", value, value)
 			}

--- a/lib/typing/assert.go
+++ b/lib/typing/assert.go
@@ -1,0 +1,12 @@
+package typing
+
+import "fmt"
+
+func AssertType[T any](val any) (T, error) {
+	castedVal, isOk := val.(T)
+	if !isOk {
+		var zero T
+		return zero, fmt.Errorf("expected type %T, got %T", zero, val)
+	}
+	return castedVal, nil
+}

--- a/lib/typing/assert_test.go
+++ b/lib/typing/assert_test.go
@@ -1,0 +1,32 @@
+package typing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssertType(t *testing.T) {
+	{
+		// String to string
+		val, err := AssertType[string]("hello")
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", val)
+	}
+	{
+		// Int to string
+		_, err := AssertType[string](1)
+		assert.ErrorContains(t, err, "expected type string, got int")
+	}
+	{
+		// Boolean to boolean
+		val, err := AssertType[bool](true)
+		assert.NoError(t, err)
+		assert.Equal(t, true, val)
+	}
+	{
+		// String to boolean
+		_, err := AssertType[bool]("true")
+		assert.ErrorContains(t, err, "expected type bool, got string")
+	}
+}


### PR DESCRIPTION
It's currently a private function here: https://github.com/artie-labs/reader/blob/86be21ae801eef22cfa4af4dd3a8e19abcf0cf29/lib/s3lib/dynamodb_export.go#L10

Bringing it to Transfer so all of our codebases can use it