### PR TITLE
Simplifying Flush

### DIFF
--- a/lib/retry/retry.go
+++ b/lib/retry/retry.go
@@ -66,6 +66,7 @@ func sleepIfNecessary(cfg RetryConfig, attempt int, err error) {
 
 // WithRetries runs function `f` and returns the error if one occurs.
 func WithRetries(cfg RetryConfig, f func(attempt int, err error) error) error {
+	var prevErr error
 	var err error
 	for attempt := 0; attempt < cfg.MaxAttempts(); attempt++ {
 		sleepIfNecessary(cfg, attempt, err)
@@ -73,13 +74,15 @@ func WithRetries(cfg RetryConfig, f func(attempt int, err error) error) error {
 		if err == nil {
 			if attempt > 0 {
 				// Only log if there was more than one attempt, so it's less noisy.
-				slog.Info("Retry was successful!", slog.Int("attempts", attempt))
+				slog.Info("Retry was successful!", slog.Int("attempts", attempt), slog.Any("prevErr", prevErr))
 			}
 
 			return nil
 		} else if !cfg.IsRetryableErr(err) {
 			break
 		}
+
+		prevErr = err
 	}
 
 	return err

--- a/lib/retry/retry.go
+++ b/lib/retry/retry.go
@@ -71,11 +71,17 @@ func WithRetries(cfg RetryConfig, f func(attempt int, err error) error) error {
 		sleepIfNecessary(cfg, attempt, err)
 		err = f(attempt, err)
 		if err == nil {
+			if attempt > 0 {
+				// Only log if there was more than one attempt, so it's less noisy.
+				slog.Info("Retry was successful!", slog.Int("attempts", attempt))
+			}
+
 			return nil
 		} else if !cfg.IsRetryableErr(err) {
 			break
 		}
 	}
+
 	return err
 }
 

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -67,7 +67,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 				action = "append"
 			}
 
-			retryCfg, err := retry.NewJitterRetryConfig(250, 15_000, 5, retry.AlwaysRetry)
+			retryCfg, err := retry.NewJitterRetryConfig(500, 30_000, 10, retry.AlwaysRetry)
 			if err != nil {
 				slog.Error("Failed to create retry config", slog.Any("err", err))
 				return

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -129,7 +129,8 @@ func flush(ctx context.Context, dest destination.Baseline, metricsClient base.Cl
 	}
 
 	if err = commitOffset(ctx, _tableData.TopicConfig().Topic, _tableData.PartitionsToLastMessage); err != nil {
-		return fmt.Errorf("failed to commit offset: %w", err)
+		// Failure to commit Kafka offset shouldn't force the whole flush process to retry.
+		slog.Warn("Failed to commit Kafka offset", slog.Any("err", err), slog.String("tableName", _tableName))
 	}
 
 	return nil

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -127,7 +127,6 @@ func flush(ctx context.Context, dest destination.Baseline, _tableName string, _t
 	if err = commitOffset(ctx, _tableData.TopicConfig().Topic, _tableData.PartitionsToLastMessage); err != nil {
 		// Failure to commit Kafka offset shouldn't force the whole flush process to retry.
 		slog.Warn("Failed to commit Kafka offset", slog.Any("err", err), slog.String("tableName", _tableName))
-
 		return "commit_fail", nil
 	}
 

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -89,7 +89,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 			}
 
 			what, err := retry.WithRetriesAndResult(retryCfg, func(_ int, _ error) (string, error) {
-				return flush(ctx, dest, _tableName, _tableData)
+				return flush(ctx, dest, _tableData)
 			})
 
 			if err != nil {
@@ -108,7 +108,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 	return nil
 }
 
-func flush(ctx context.Context, dest destination.Baseline, _tableName string, _tableData *models.TableData) (string, error) {
+func flush(ctx context.Context, dest destination.Baseline, _tableData *models.TableData) (string, error) {
 	// This is added so that we have a new temporary table suffix for each merge / append.
 	_tableData.ResetTempTableSuffix()
 

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -81,9 +81,6 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 			}
 
 			start := time.Now()
-			err = retry.WithRetries(retryCfg, func(_ int, _ error) error {
-				return flush(ctx, dest, _tableName, _tableData)
-			})
 
 			tags := map[string]string{
 				"what":     "success",
@@ -93,6 +90,10 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 				"schema":   _tableData.TopicConfig().Schema,
 				"reason":   args.Reason,
 			}
+
+			err = retry.WithRetries(retryCfg, func(_ int, _ error) error {
+				return flush(ctx, dest, _tableName, _tableData)
+			})
 
 			if err != nil {
 				tags["what"] = "merge_fail"

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -7,10 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/retry"
-
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/destination"
+	"github.com/artie-labs/transfer/lib/retry"
 	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/telemetry/metrics/base"
 	"github.com/artie-labs/transfer/models"
@@ -68,7 +67,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 				action = "append"
 			}
 
-			retryCfg, err := retry.NewJitterRetryConfig(100, 15_000, 5, retry.AlwaysRetry)
+			retryCfg, err := retry.NewJitterRetryConfig(250, 15_000, 5, retry.AlwaysRetry)
 			if err != nil {
 				slog.Error("Failed to create retry config", slog.Any("err", err))
 				return

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -95,8 +95,8 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 			if err != nil {
 				slog.Error(fmt.Sprintf("Failed to %s", action), slog.Any("err", err), slog.String("tableName", _tableName))
 			} else {
-				inMemDB.ClearTableConfig(_tableName)
 				slog.Info(fmt.Sprintf("%s success, clearing memory...", stringutil.CapitalizeFirstLetter(action)), slog.String("tableName", _tableName))
+				inMemDB.ClearTableConfig(_tableName)
 			}
 
 			tags["what"] = what

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -75,13 +75,11 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 
 			_tableData.Lock()
 			defer _tableData.Unlock()
-
 			if _tableData.Empty() {
 				return
 			}
 
 			start := time.Now()
-
 			tags := map[string]string{
 				"what":     "success",
 				"mode":     _tableData.Mode().String(),

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -62,11 +62,6 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 				return
 			}
 
-			action := "merge"
-			if _tableData.Mode() == config.History {
-				action = "append"
-			}
-
 			retryCfg, err := retry.NewJitterRetryConfig(500, 30_000, 10, retry.AlwaysRetry)
 			if err != nil {
 				slog.Error("Failed to create retry config", slog.Any("err", err))
@@ -77,6 +72,11 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 			defer _tableData.Unlock()
 			if _tableData.Empty() {
 				return
+			}
+
+			action := "merge"
+			if _tableData.Mode() == config.History {
+				action = "append"
 			}
 
 			start := time.Now()

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -125,9 +125,7 @@ func flush(ctx context.Context, dest destination.Baseline, _tableName string, _t
 	}
 
 	if err = commitOffset(ctx, _tableData.TopicConfig().Topic, _tableData.PartitionsToLastMessage); err != nil {
-		// Failure to commit Kafka offset shouldn't force the whole flush process to retry.
-		slog.Warn("Failed to commit Kafka offset", slog.Any("err", err), slog.String("tableName", _tableName))
-		return "commit_fail", nil
+		return "commit_fail", fmt.Errorf("failed to commit kafka offset: %w", err)
 	}
 
 	return "success", nil

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -74,7 +74,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 			}
 
 			err = retry.WithRetries(retryCfg, func(_ int, _ error) error {
-				return flush(ctx, dest, metricsClient, args.Reason, _tableName, _tableData, action)
+				return flush(ctx, dest, metricsClient, args.Reason, _tableName, _tableData)
 			})
 
 			if err != nil {
@@ -90,7 +90,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 	return nil
 }
 
-func flush(ctx context.Context, dest destination.Baseline, metricsClient base.Client, reason string, _tableName string, _tableData *models.TableData, action string) error {
+func flush(ctx context.Context, dest destination.Baseline, metricsClient base.Client, reason string, _tableName string, _tableData *models.TableData) error {
 	// Lock the tables when executing merge / append.
 	_tableData.Lock()
 	defer _tableData.Unlock()
@@ -125,7 +125,7 @@ func flush(ctx context.Context, dest destination.Baseline, metricsClient base.Cl
 
 	if err != nil {
 		tags["what"] = "merge_fail"
-		return fmt.Errorf("failed to %s: %w", action, err)
+		return fmt.Errorf("failed to flush: %w", err)
 	}
 
 	if err = commitOffset(ctx, _tableData.TopicConfig().Topic, _tableData.PartitionsToLastMessage); err != nil {

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -73,6 +73,8 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 				return
 			}
 
+			_tableData.Lock()
+			defer _tableData.Unlock()
 			err = retry.WithRetries(retryCfg, func(_ int, _ error) error {
 				return flush(ctx, dest, metricsClient, args.Reason, _tableName, _tableData)
 			})
@@ -91,9 +93,6 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 }
 
 func flush(ctx context.Context, dest destination.Baseline, metricsClient base.Client, reason string, _tableName string, _tableData *models.TableData) error {
-	// Lock the tables when executing merge / append.
-	_tableData.Lock()
-	defer _tableData.Unlock()
 	if _tableData.Empty() {
 		return nil
 	}

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -63,7 +63,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 				action = "append"
 			}
 
-			retryCfg, err := retry.NewJitterRetryConfig(100, 5_000, 5, retry.AlwaysRetry)
+			retryCfg, err := retry.NewJitterRetryConfig(100, 15_000, 5, retry.AlwaysRetry)
 			if err != nil {
 				slog.Error("Failed to create retry config", slog.Any("err", err))
 				return


### PR DESCRIPTION
## Scope

Simplifying our flush function to do the following:

1. Get rid of the concept of "retryable errors", this approach doesn't scale (There are far too many errors, and we'd be spending most of our time trying to chase down edge cases)

2. Split Flush into two separate function and implement the Retryable framework

The intended outcome of this PR is to have the ability to retry a few times (with some jitter) after we first fail to merge or append. The previous approach would wait until the next flush cycle to retry, rather than retry right away.

By doing this, this should help alleviate intermittent errors and make our monitor less flakey.