### PR TITLE
Refactoring `ParseFromInterface`

### DIFF
--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -7,22 +7,21 @@ import (
 )
 
 func ParseFromInterface(val any, additionalDateFormats []string) (*ExtendedTime, error) {
-	if val == nil {
+	switch convertedVal := val.(type) {
+	case nil:
 		return nil, fmt.Errorf("val is nil")
-	}
+	case *ExtendedTime:
+		return convertedVal, nil
+	case string:
+		extendedTime, err := ParseExtendedDateTime(convertedVal, additionalDateFormats)
+		if err != nil {
+			return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", val, err)
+		}
 
-	extendedTime, isOk := val.(*ExtendedTime)
-	if isOk {
 		return extendedTime, nil
+	default:
+		return nil, fmt.Errorf("failed to parse colVal, expected type string or *ExtendedTime and got: %T", convertedVal)
 	}
-
-	var err error
-	extendedTime, err = ParseExtendedDateTime(fmt.Sprint(val), additionalDateFormats)
-	if err != nil {
-		return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", val, err)
-	}
-
-	return extendedTime, nil
 }
 
 // ParseTimeExactMatch - This function is the same as `ParseTimeExactMatchLegacy` with the only exception that it'll return an error if it was not an exact match

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -43,12 +43,12 @@ func TestParseFromInterface(t *testing.T) {
 	{
 		// True
 		_, err := ParseFromInterface(true, nil)
-		assert.ErrorContains(t, err, "true is not supported")
+		assert.ErrorContains(t, err, "failed to parse colVal, expected type string or *ExtendedTime and got: bool")
 	}
 	{
 		// False
 		_, err := ParseFromInterface(false, nil)
-		assert.ErrorContains(t, err, "false is not supported")
+		assert.ErrorContains(t, err, "failed to parse colVal, expected type string or *ExtendedTime and got: bool")
 	}
 }
 


### PR DESCRIPTION
Refactoring `ParseFromInterface` by expecting the value to be either `*ExtendedTime` or `string` type.

The overall goal of this is to clean up how we call `ParseExtendedDateTime`