### PR TITLE
Removing `kafkalib.TopicConfig` as a pointer

### DIFF
--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -12,7 +12,7 @@ import (
 
 type Format interface {
 	Labels() []string // Labels() to return a list of strings to maintain backward compatibility.
-	GetPrimaryKey(key []byte, tc *kafkalib.TopicConfig) (map[string]any, error)
+	GetPrimaryKey(key []byte, tc kafkalib.TopicConfig) (map[string]any, error)
 	GetEventFromBytes(bytes []byte) (Event, error)
 }
 
@@ -21,7 +21,7 @@ type Event interface {
 	Operation() string
 	DeletePayload() bool
 	GetTableName() string
-	GetData(pkMap map[string]any, config *kafkalib.TopicConfig) (map[string]any, error)
+	GetData(pkMap map[string]any, tc kafkalib.TopicConfig) (map[string]any, error)
 	GetOptionalSchema() map[string]typing.KindDetails
 	// GetColumns will inspect the envelope's payload right now and return.
 	GetColumns() (*columns.Columns, error)

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -73,7 +73,7 @@ func (d *Debezium) Labels() []string {
 	return []string{constants.DBZMongoFormat}
 }
 
-func (d *Debezium) GetPrimaryKey(key []byte, tc *kafkalib.TopicConfig) (map[string]any, error) {
+func (d *Debezium) GetPrimaryKey(key []byte, tc kafkalib.TopicConfig) (map[string]any, error) {
 	kvMap, err := debezium.ParsePartitionKey(key, tc.CDCKeyFormat)
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ func (s *SchemaEventPayload) GetColumns() (*columns.Columns, error) {
 	return &cols, nil
 }
 
-func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicConfig) (map[string]any, error) {
+func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc kafkalib.TopicConfig) (map[string]any, error) {
 	var retMap map[string]any
 	if len(s.Payload.afterMap) == 0 {
 		// This is a delete event, so mark it as deleted.

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -48,7 +48,7 @@ func (m *MongoTestSuite) TestGetPrimaryKey() {
 	}
 
 	for _, tc := range tcs {
-		pkMap, err := m.GetPrimaryKey(tc.key, &kafkalib.TopicConfig{
+		pkMap, err := m.GetPrimaryKey(tc.key, kafkalib.TopicConfig{
 			CDCKeyFormat: tc.keyFormat,
 		})
 
@@ -154,7 +154,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomer() {
 
 	evt, err := m.Debezium.GetEventFromBytes([]byte(payload))
 	assert.NoError(m.T(), err)
-	evtData, err := evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{})
+	evtData, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{})
 	assert.NoError(m.T(), err)
 	_, isOk := evtData[constants.UpdateColumnMarker]
 	assert.False(m.T(), isOk)
@@ -163,15 +163,12 @@ func (m *MongoTestSuite) TestMongoDBEventCustomer() {
 	assert.Equal(m.T(), evtData["last_name"], "Tang")
 	assert.Equal(m.T(), evtData["email"], "robin@example.com")
 
-	evtDataWithIncludedAt, err := evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{})
+	evtDataWithIncludedAt, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{})
 	assert.NoError(m.T(), err)
 	_, isOk = evtDataWithIncludedAt[constants.UpdateColumnMarker]
 	assert.False(m.T(), isOk)
 
-	evtDataWithIncludedAt, err = evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{
-		IncludeDatabaseUpdatedAt: true,
-		IncludeArtieUpdatedAt:    true,
-	})
+	evtDataWithIncludedAt, err = evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true, IncludeArtieUpdatedAt: true})
 	assert.NoError(m.T(), err)
 
 	assert.Equal(m.T(), ext.NewExtendedTime(time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), evtDataWithIncludedAt[constants.DatabaseUpdatedColumnMarker])
@@ -227,7 +224,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore_NoData() {
 	assert.NoError(m.T(), err)
 	{
 		// Making sure the `before` payload is set.
-		evtData, err := evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{})
+		evtData, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{})
 		assert.NoError(m.T(), err)
 		assert.Equal(m.T(), "customers123", evt.GetTableName())
 
@@ -280,7 +277,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 	assert.NoError(m.T(), err)
 	{
 		// Making sure the `before` payload is set.
-		evtData, err := evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{})
+		evtData, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{})
 		assert.NoError(m.T(), err)
 		assert.Equal(m.T(), "customers123", evt.GetTableName())
 
@@ -304,9 +301,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 	}
 	{
 		// Check `__artie_updated_at` is included
-		evtData, err := evt.GetData(map[string]any{"_id": 1003}, &kafkalib.TopicConfig{
-			IncludeArtieUpdatedAt: true,
-		})
+		evtData, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
 		assert.NoError(m.T(), err)
 		_, isOk := evtData[constants.UpdateColumnMarker]
 		assert.True(m.T(), isOk)

--- a/lib/cdc/mongo/mongo_bench_test.go
+++ b/lib/cdc/mongo/mongo_bench_test.go
@@ -16,11 +16,13 @@ func BenchmarkGetPrimaryKey(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		newObjectID := primitive.NewObjectID().Hex()
 
-		pkMap, err := dbz.GetPrimaryKey([]byte(fmt.Sprintf(`{"schema":{"type":"struct","fields":[{"type":"string","optional":false,"field":"id"}],"optional":false,"name":"1a75f632-29d2-419b-9ffe-d18fa12d74d5.38d5d2db-870a-4a38-a76c-9891b0e5122d.myFirstDatabase.stock.Key"},"payload":{"id":"{\"$oid\": \"%s\"}"}}`, newObjectID)), &kafkalib.TopicConfig{
-			CDCKeyFormat: kafkalib.JSONKeyFmt,
-		})
-
-		assert.Equal(b, err, nil)
+		pkMap, err := dbz.GetPrimaryKey(
+			[]byte(fmt.Sprintf(`{"schema":{"type":"struct","fields":[{"type":"string","optional":false,"field":"id"}],"optional":false,"name":"1a75f632-29d2-419b-9ffe-d18fa12d74d5.38d5d2db-870a-4a38-a76c-9891b0e5122d.myFirstDatabase.stock.Key"},"payload":{"id":"{\"$oid\": \"%s\"}"}}`, newObjectID)),
+			kafkalib.TopicConfig{
+				CDCKeyFormat: kafkalib.JSONKeyFmt,
+			},
+		)
+		assert.NoError(b, err)
 
 		pkVal, isOk := pkMap["_id"]
 		assert.True(b, isOk)

--- a/lib/cdc/relational/debezium.go
+++ b/lib/cdc/relational/debezium.go
@@ -35,6 +35,6 @@ func (d *Debezium) Labels() []string {
 	}
 }
 
-func (d *Debezium) GetPrimaryKey(key []byte, tc kafkalib.TopicConfig) (kvMap map[string]any, err error) {
+func (d *Debezium) GetPrimaryKey(key []byte, tc kafkalib.TopicConfig) (map[string]any, error) {
 	return debezium.ParsePartitionKey(key, tc.CDCKeyFormat)
 }

--- a/lib/cdc/relational/debezium.go
+++ b/lib/cdc/relational/debezium.go
@@ -35,6 +35,6 @@ func (d *Debezium) Labels() []string {
 	}
 }
 
-func (d *Debezium) GetPrimaryKey(key []byte, tc *kafkalib.TopicConfig) (kvMap map[string]any, err error) {
+func (d *Debezium) GetPrimaryKey(key []byte, tc kafkalib.TopicConfig) (kvMap map[string]any, err error) {
 	return debezium.ParsePartitionKey(key, tc.CDCKeyFormat)
 }

--- a/lib/cdc/relational/debezium_test.go
+++ b/lib/cdc/relational/debezium_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var validTc = &kafkalib.TopicConfig{
+var validTc = kafkalib.TopicConfig{
 	CDCKeyFormat: "org.apache.kafka.connect.json.JsonConverter",
 }
 
@@ -87,9 +87,7 @@ func (r *RelationTestSuite) TestPostgresEvent() {
 	assert.Nil(r.T(), err)
 	assert.False(r.T(), evt.DeletePayload())
 
-	evtData, err := evt.GetData(map[string]any{"id": 59}, &kafkalib.TopicConfig{
-		IncludeDatabaseUpdatedAt: true,
-	})
+	evtData, err := evt.GetData(map[string]any{"id": 59}, kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true})
 	assert.NoError(r.T(), err)
 	assert.Equal(r.T(), float64(59), evtData["id"])
 	assert.Equal(r.T(), ext.NewExtendedTime(time.Date(2022, time.November, 16, 4, 1, 53, 308000000, time.UTC), ext.DateTimeKindType, ext.ISO8601), evtData[constants.DatabaseUpdatedColumnMarker])
@@ -193,7 +191,7 @@ func (r *RelationTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 	assert.Nil(r.T(), err)
 	assert.False(r.T(), evt.DeletePayload())
 
-	evtData, err := evt.GetData(map[string]any{"id": 1001}, &kafkalib.TopicConfig{})
+	evtData, err := evt.GetData(map[string]any{"id": 1001}, kafkalib.TopicConfig{})
 	assert.NoError(r.T(), err)
 
 	// Testing typing.
@@ -525,7 +523,7 @@ func (r *RelationTestSuite) TestGetEventFromBytes_MySQL() {
 		"id": 1001,
 	}
 
-	evtData, err := evt.GetData(kvMap, &kafkalib.TopicConfig{})
+	evtData, err := evt.GetData(kvMap, kafkalib.TopicConfig{})
 	assert.NoError(r.T(), err)
 
 	// Should have no Artie updated or database updated fields
@@ -535,10 +533,7 @@ func (r *RelationTestSuite) TestGetEventFromBytes_MySQL() {
 	_, isOk = evtData[constants.DatabaseUpdatedColumnMarker]
 	assert.False(r.T(), isOk)
 
-	evtData, err = evt.GetData(kvMap, &kafkalib.TopicConfig{
-		IncludeDatabaseUpdatedAt: true,
-		IncludeArtieUpdatedAt:    true,
-	})
+	evtData, err = evt.GetData(kvMap, kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true, IncludeArtieUpdatedAt: true})
 	assert.NoError(r.T(), err)
 
 	assert.Equal(r.T(), ext.NewExtendedTime(time.Date(2023, time.March, 13, 19, 19, 24, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), evtData[constants.DatabaseUpdatedColumnMarker])

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -74,7 +74,7 @@ func (s *SchemaEventPayload) GetTableName() string {
 	return s.Payload.Source.Table
 }
 
-func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc *kafkalib.TopicConfig) (map[string]any, error) {
+func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc kafkalib.TopicConfig) (map[string]any, error) {
 	var retMap map[string]any
 	if len(s.Payload.After) == 0 {
 		if len(s.Payload.Before) > 0 {

--- a/lib/cdc/util/relational_event_decimal_test.go
+++ b/lib/cdc/util/relational_event_decimal_test.go
@@ -23,7 +23,7 @@ func TestSchemaEventPayload_MiscNumbers_GetData(t *testing.T) {
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
 
-	retMap, err := schemaEventPayload.GetData(nil, &kafkalib.TopicConfig{})
+	retMap, err := schemaEventPayload.GetData(nil, kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), retMap["smallint_test"])
 	assert.Equal(t, int64(2), retMap["smallserial_test"])
@@ -43,7 +43,7 @@ func TestSchemaEventPayload_Numeric_GetData(t *testing.T) {
 	var schemaEventPayload SchemaEventPayload
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
-	retMap, err := schemaEventPayload.GetData(nil, &kafkalib.TopicConfig{})
+	retMap, err := schemaEventPayload.GetData(nil, kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "123456.789", retMap["numeric_test"].(*decimal.Decimal).String())
@@ -72,7 +72,7 @@ func TestSchemaEventPayload_Decimal_GetData(t *testing.T) {
 	var schemaEventPayload SchemaEventPayload
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
-	retMap, err := schemaEventPayload.GetData(nil, &kafkalib.TopicConfig{})
+	retMap, err := schemaEventPayload.GetData(nil, kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, "123.45", retMap["decimal_test"].(*decimal.Decimal).String())
 	decimalWithScaleMap := map[string]string{
@@ -98,7 +98,7 @@ func TestSchemaEventPayload_Money_GetData(t *testing.T) {
 	var schemaEventPayload SchemaEventPayload
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
-	retMap, err := schemaEventPayload.GetData(nil, &kafkalib.TopicConfig{})
+	retMap, err := schemaEventPayload.GetData(nil, kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 
 	decimalWithScaleMap := map[string]string{

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -110,7 +110,7 @@ func TestGetDataTestInsert(t *testing.T) {
 
 	assert.False(t, schemaEventPayload.DeletePayload())
 
-	evtData, err := schemaEventPayload.GetData(map[string]any{"pk": 1}, &kafkalib.TopicConfig{})
+	evtData, err := schemaEventPayload.GetData(map[string]any{"pk": 1}, kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, len(after), len(evtData), "has deletion flag")
 
@@ -128,9 +128,7 @@ func TestGetDataTestInsert(t *testing.T) {
 	delete(evtData, constants.OnlySetDeleteColumnMarker)
 	assert.Equal(t, after, evtData)
 
-	evtData, err = schemaEventPayload.GetData(map[string]any{"pk": 1}, &kafkalib.TopicConfig{
-		IncludeArtieUpdatedAt: true,
-	})
+	evtData, err = schemaEventPayload.GetData(map[string]any{"pk": 1}, kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
 	assert.NoError(t, err)
 
 	_, isOk = evtData[constants.UpdateColumnMarker]
@@ -138,8 +136,7 @@ func TestGetDataTestInsert(t *testing.T) {
 }
 
 func TestGetData_TestDelete(t *testing.T) {
-	tc := &kafkalib.TopicConfig{}
-
+	tc := kafkalib.TopicConfig{}
 	expectedKeyValues := map[string]any{
 		"id":                                int64(1004),
 		"first_name":                        "Anne",
@@ -208,7 +205,7 @@ func TestGetDataTestUpdate(t *testing.T) {
 	assert.False(t, schemaEventPayload.DeletePayload())
 	kvMap := map[string]any{"pk": 1}
 
-	evtData, err := schemaEventPayload.GetData(kvMap, &kafkalib.TopicConfig{})
+	evtData, err := schemaEventPayload.GetData(kvMap, kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, len(after), len(evtData), "has deletion flag")
 
@@ -226,9 +223,7 @@ func TestGetDataTestUpdate(t *testing.T) {
 	delete(evtData, constants.OnlySetDeleteColumnMarker)
 	assert.Equal(t, after, evtData)
 
-	evtData, err = schemaEventPayload.GetData(kvMap, &kafkalib.TopicConfig{
-		IncludeArtieUpdatedAt: true,
-	})
+	evtData, err = schemaEventPayload.GetData(kvMap, kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
 	assert.NoError(t, err)
 
 	_, isOk = evtData[constants.UpdateColumnMarker]

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -35,7 +35,7 @@ type Event struct {
 	mode config.Mode
 }
 
-func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc *kafkalib.TopicConfig, cfgMode config.Mode) (Event, error) {
+func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc kafkalib.TopicConfig, cfgMode config.Mode) (Event, error) {
 	cols, err := event.GetColumns()
 	if err != nil {
 		return Event{}, err
@@ -132,11 +132,7 @@ func (e *Event) PrimaryKeyValue() string {
 
 // Save will save the event into our in memory event
 // It will return (flush bool, flushReason string, err error)
-func (e *Event) Save(cfg config.Config, inMemDB *models.DatabaseData, topicConfig *kafkalib.TopicConfig, message artie.Message) (bool, string, error) {
-	if topicConfig == nil {
-		return false, "", errors.New("topicConfig is missing")
-	}
-
+func (e *Event) Save(cfg config.Config, inMemDB *models.DatabaseData, tc kafkalib.TopicConfig, message artie.Message) (bool, string, error) {
 	if !e.IsValid() {
 		return false, "", errors.New("event not valid")
 	}
@@ -151,7 +147,7 @@ func (e *Event) Save(cfg config.Config, inMemDB *models.DatabaseData, topicConfi
 			cols = e.Columns
 		}
 
-		td.SetTableData(optimization.NewTableData(cols, cfg.Mode, e.PrimaryKeys(), *topicConfig, e.Table))
+		td.SetTableData(optimization.NewTableData(cols, cfg.Mode, e.PrimaryKeys(), tc, e.Table))
 	} else {
 		if e.Columns != nil {
 			// Iterate over this again just in case.

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var topicConfig = &kafkalib.TopicConfig{
+var topicConfig = kafkalib.TopicConfig{
 	Database:  "customer",
 	TableName: "users",
 	Schema:    "public",

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -60,24 +60,24 @@ func (e *EventsTestSuite) TestEvent_IsValid() {
 func (e *EventsTestSuite) TestEvent_TableName() {
 	{
 		// Don't pass in tableName.
-		evt, err := ToMemoryEvent(e.fakeEvent, idMap, &kafkalib.TopicConfig{}, config.Replication)
+		evt, err := ToMemoryEvent(e.fakeEvent, idMap, kafkalib.TopicConfig{}, config.Replication)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), e.fakeEvent.GetTableName(), evt.Table)
 	}
 	{
 		// Now pass it in, it should override.
-		evt, err := ToMemoryEvent(e.fakeEvent, idMap, &kafkalib.TopicConfig{TableName: "orders"}, config.Replication)
+		evt, err := ToMemoryEvent(e.fakeEvent, idMap, kafkalib.TopicConfig{TableName: "orders"}, config.Replication)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), "orders", evt.Table)
 	}
 	{
 		// Now, if it's history mode...
-		evt, err := ToMemoryEvent(e.fakeEvent, idMap, &kafkalib.TopicConfig{TableName: "orders"}, config.History)
+		evt, err := ToMemoryEvent(e.fakeEvent, idMap, kafkalib.TopicConfig{TableName: "orders"}, config.History)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), "orders__history", evt.Table)
 
 		// Table already has history suffix, so it won't add extra.
-		evt, err = ToMemoryEvent(e.fakeEvent, idMap, &kafkalib.TopicConfig{TableName: "dusty__history"}, config.History)
+		evt, err = ToMemoryEvent(e.fakeEvent, idMap, kafkalib.TopicConfig{TableName: "dusty__history"}, config.History)
 		assert.NoError(e.T(), err)
 		assert.Equal(e.T(), "dusty__history", evt.Table)
 	}
@@ -85,7 +85,7 @@ func (e *EventsTestSuite) TestEvent_TableName() {
 
 func (e *EventsTestSuite) TestEvent_Columns() {
 	{
-		evt, err := ToMemoryEvent(e.fakeEvent, map[string]any{"id": 123}, &kafkalib.TopicConfig{}, config.Replication)
+		evt, err := ToMemoryEvent(e.fakeEvent, map[string]any{"id": 123}, kafkalib.TopicConfig{}, config.Replication)
 		assert.NoError(e.T(), err)
 
 		assert.Equal(e.T(), 1, len(evt.Columns.GetColumns()))
@@ -94,7 +94,7 @@ func (e *EventsTestSuite) TestEvent_Columns() {
 	}
 	{
 		// Now it should handle escaping column names
-		evt, err := ToMemoryEvent(e.fakeEvent, map[string]any{"id": 123, "CAPITAL": "foo"}, &kafkalib.TopicConfig{}, config.Replication)
+		evt, err := ToMemoryEvent(e.fakeEvent, map[string]any{"id": 123, "CAPITAL": "foo"}, kafkalib.TopicConfig{}, config.Replication)
 		assert.NoError(e.T(), err)
 
 		assert.Equal(e.T(), 2, len(evt.Columns.GetColumns()))
@@ -106,7 +106,7 @@ func (e *EventsTestSuite) TestEvent_Columns() {
 	}
 	{
 		// In history mode, the deletion column markers should be removed from the event data
-		evt, err := ToMemoryEvent(e.fakeEvent, map[string]any{"id": 123}, &kafkalib.TopicConfig{}, config.History)
+		evt, err := ToMemoryEvent(e.fakeEvent, map[string]any{"id": 123}, kafkalib.TopicConfig{}, config.History)
 		assert.NoError(e.T(), err)
 
 		_, isOk := evt.Data[constants.DeleteColumnMarker]

--- a/processes/consumer/configs.go
+++ b/processes/consumer/configs.go
@@ -34,7 +34,7 @@ func (t *TcFmtMap) GetTopicFmt(topic string) (TopicConfigFormatter, bool) {
 }
 
 type TopicConfigFormatter struct {
-	tc *kafkalib.TopicConfig
+	tc kafkalib.TopicConfig
 	cdc.Format
 }
 

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/artie-labs/transfer/lib/kafkalib"
 )
 
-var topicConfig = &kafkalib.TopicConfig{
+var topicConfig = kafkalib.TopicConfig{
 	Database:  "customer",
 	TableName: "users",
 	Schema:    "public",

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -60,7 +60,7 @@ func StartConsumer(ctx context.Context, cfg config.Config, inMemDB *models.Datab
 	var topics []string
 	for _, topicConfig := range cfg.Kafka.TopicConfigs {
 		tcFmtMap.Add(topicConfig.Topic, TopicConfigFormatter{
-			tc:     topicConfig,
+			tc:     *topicConfig,
 			Format: format.GetFormatParser(topicConfig.CDCFormat, topicConfig.Topic),
 		})
 		topics = append(topics, topicConfig.Topic)

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -62,7 +62,7 @@ func TestProcessMessageFailures(t *testing.T) {
 
 	tcFmtMap := NewTcFmtMap()
 	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
-		tc: &kafkalib.TopicConfig{
+		tc: kafkalib.TopicConfig{
 			Database:     db,
 			TableName:    table,
 			Schema:       schema,
@@ -88,7 +88,7 @@ func TestProcessMessageFailures(t *testing.T) {
 	assert.Equal(t, 0, len(memDB.TableData()))
 	assert.Empty(t, tableName)
 
-	tc := &kafkalib.TopicConfig{
+	tc := kafkalib.TopicConfig{
 		Database:     db,
 		TableName:    table,
 		Schema:       schema,
@@ -240,7 +240,7 @@ func TestProcessMessageSkip(t *testing.T) {
 
 	tcFmtMap := NewTcFmtMap()
 	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
-		tc: &kafkalib.TopicConfig{
+		tc: kafkalib.TopicConfig{
 			Database:     db,
 			TableName:    table,
 			Schema:       schema,
@@ -251,7 +251,7 @@ func TestProcessMessageSkip(t *testing.T) {
 		Format: &mgo,
 	})
 
-	tc := &kafkalib.TopicConfig{
+	tc := kafkalib.TopicConfig{
 		Database:          db,
 		TableName:         table,
 		Schema:            schema,

--- a/processes/consumer/pubsub.go
+++ b/processes/consumer/pubsub.go
@@ -68,7 +68,7 @@ func StartSubscriber(ctx context.Context, cfg config.Config, inMemDB *models.Dat
 	tcFmtMap := NewTcFmtMap()
 	for _, topicConfig := range cfg.Pubsub.TopicConfigs {
 		tcFmtMap.Add(topicConfig.Topic, TopicConfigFormatter{
-			tc:     topicConfig,
+			tc:     *topicConfig,
 			Format: format.GetFormatParser(topicConfig.CDCFormat, topicConfig.Topic),
 		})
 	}


### PR DESCRIPTION
We don't need it to be a pointer, so let's remove it and simplify 