### PR TITLE
Change deprecated goreleaser property

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,7 +60,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Fixes: 
> DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotnametemplate for more info