### PR TITLE
[Typing] Removing the need to call `ext.ParseExtendedDateTime` from `parseValue`

### DIFF
--- a/lib/typing/parse.go
+++ b/lib/typing/parse.go
@@ -2,13 +2,13 @@ package typing
 
 import (
 	"reflect"
-	"strings"
 
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
-func ParseValue(settings Settings, key string, optionalSchema map[string]KindDetails, val any) KindDetails {
+// TODO: Separate PR to remove `settings` completely. Not doing it first pass because it'll generate a big diff.
+func ParseValue(_ Settings, key string, optionalSchema map[string]KindDetails, val any) KindDetails {
 	if len(optionalSchema) > 0 {
 		// If the column exists in the schema, let's early exit.
 		if kindDetail, isOk := optionalSchema[key]; isOk {
@@ -18,17 +18,17 @@ func ParseValue(settings Settings, key string, optionalSchema map[string]KindDet
 				// We are not skipping so that we are able to get the exact layout specified at the row level to preserve:
 				// 1. Layout for time / date / timestamps
 				// 2. Precision and scale for numeric values
-				return parseValue(settings, val)
+				return parseValue(val)
 			}
 
 			return kindDetail
 		}
 	}
 
-	return parseValue(settings, val)
+	return parseValue(val)
 }
 
-func parseValue(settings Settings, val any) KindDetails {
+func parseValue(val any) KindDetails {
 	switch convertedVal := val.(type) {
 	case nil:
 		return Invalid
@@ -43,26 +43,11 @@ func parseValue(settings Settings, val any) KindDetails {
 	case bool:
 		return Boolean
 	case string:
-		// If it contains space or -, then we must check against date time.
-		// This way, we don't penalize every string into going through this loop
-		// In the future, we can have specific layout RFCs run depending on the char
-		if strings.Contains(convertedVal, ":") || strings.Contains(convertedVal, "-") {
-			// TODO: Remove this once we natively support every single Debezium datetime type
-			extendedKind, err := ext.ParseExtendedDateTime(convertedVal, settings.AdditionalDateFormats)
-			if err == nil {
-				return KindDetails{
-					Kind:                ETime.Kind,
-					ExtendedTimeDetails: &extendedKind.NestedKind,
-				}
-			}
-		}
-
 		if IsJSON(convertedVal) {
 			return Struct
 		}
 
 		return String
-
 	case *decimal.Decimal:
 		extendedDetails := convertedVal.Details()
 		return KindDetails{

--- a/lib/typing/parse_test.go
+++ b/lib/typing/parse_test.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,36 +61,7 @@ func Test_ParseValue(t *testing.T) {
 	{
 		// Time
 		kindDetails := ParseValue(Settings{}, "", nil, "00:18:11.13116+00")
-		assert.Equal(t, ETime.Kind, kindDetails.Kind)
-		assert.Equal(t, ext.TimeKindType, kindDetails.ExtendedTimeDetails.Type)
-	}
-	{
-		// Date layouts from Go's time.Time library
-		possibleDates := []any{
-			"01/02 03:04:05PM '06 -0700", // The reference time, in numerical order.
-			"Mon Jan 2 15:04:05 2006",
-			"Mon Jan 2 15:04:05 MST 2006",
-			"Mon Jan 02 15:04:05 -0700 2006",
-			"02 Jan 06 15:04 MST",
-			"02 Jan 06 15:04 -0700", // RFC822 with numeric zone
-			"Monday, 02-Jan-06 15:04:05 MST",
-			"Mon, 02 Jan 2006 15:04:05 MST",
-			"Mon, 02 Jan 2006 15:04:05 -0700", // RFC1123 with numeric zone
-			"2019-10-12T14:20:50.52+07:00",
-		}
-
-		for _, possibleDate := range possibleDates {
-			assert.Equal(t, ParseValue(Settings{}, "", nil, possibleDate).ExtendedTimeDetails.Type, ext.DateTime.Type, fmt.Sprintf("Failed format, value is: %v", possibleDate))
-
-			// Test the parseDT function as well.
-			ts, err := ext.ParseExtendedDateTime(fmt.Sprint(possibleDate), []string{})
-			assert.NoError(t, err, err)
-			assert.False(t, ts.IsZero(), ts)
-		}
-
-		ts, err := ext.ParseExtendedDateTime("random", []string{})
-		assert.ErrorContains(t, err, "dtString: random is not supported")
-		assert.Nil(t, ts)
+		assert.Equal(t, String, kindDetails)
 	}
 	{
 		// Maps

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
-	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -152,7 +151,7 @@ func (e *EventsTestSuite) TestEventSaveOptionalSchema() {
 
 	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("created_at_date_no_schema")
 	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), ext.Date.Type, column.KindDetails.ExtendedTimeDetails.Type)
+	assert.Equal(e.T(), typing.String, column.KindDetails)
 
 	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("json_object_string")
 	assert.True(e.T(), isOk)
@@ -255,7 +254,7 @@ func (e *EventsTestSuite) TestEventSaveColumns() {
 
 	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
 	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), ext.DateKindType, column.KindDetails.ExtendedTimeDetails.Type)
+	assert.Equal(e.T(), typing.String, column.KindDetails)
 
 	column, isOk = td.ReadOnlyInMemoryCols().GetColumn(constants.DeleteColumnMarker)
 	assert.True(e.T(), isOk)


### PR DESCRIPTION
We should not need to parse parse any arbitrary string to see if it's time / date / date time. This is because all of this is already being handled natively within BSON or Debezium converters.

This is a pretty big change though, so we'll be taking the necessary precautions.

## Checks

### Postgres

- [ ] Ensure every date type is correctly being handled and parsed
- [ ] Ensure every time type is correctly being handled and parsed
- [ ] Ensure every datetime (w/o timezone) type is correctly being handled and parsed
- [ ] Ensure every datetime (w/ timezone) type is correctly being handled and parsed

### MySQL

- [ ] Ensure every date type is correctly being handled and parsed
- [ ] Ensure every time type is correctly being handled and parsed
- [ ] Ensure every datetime (w/o timezone) type is correctly being handled and parsed
- [ ] Ensure every datetime (w/ timezone) type is correctly being handled and parsed

### SQL Server

- [ ] Ensure every date type is correctly being handled and parsed
- [ ] Ensure every time type is correctly being handled and parsed
- [ ] Ensure every datetime (w/o timezone) type is correctly being handled and parsed
- [ ] Ensure every datetime (w/ timezone) type is correctly being handled and parsed

### MongoDB

- [ ] Ensure every date type is correctly being handled and parsed
- [ ] Ensure every time type is correctly being handled and parsed
- [ ] Ensure every datetime (w/o timezone) type is correctly being handled and parsed
- [ ] Ensure every datetime (w/ timezone) type is correctly being handled and parsed