### PR TITLE
[MongoDB] BSON parse to return `*ext.ExtendedTime` rather than string

### DIFF
--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -89,7 +89,9 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 func bsonValueToGoValue(value any) (any, error) {
 	switch v := value.(type) {
 	case primitive.DateTime:
-		return v.Time().UTC().Format(ext.ISO8601), nil
+		return ext.NewExtendedTime(v.Time(), ext.DateTimeKindType, ext.ISO8601), nil
+	case primitive.Timestamp:
+		return ext.NewExtendedTime(time.Unix(int64(v.T), 0).UTC(), ext.DateTimeKindType, ext.ISO8601), nil
 	case primitive.ObjectID:
 		return v.Hex(), nil
 	case primitive.Binary:
@@ -97,8 +99,6 @@ func bsonValueToGoValue(value any) (any, error) {
 	case primitive.Decimal128:
 		// We purposefully chose a string representation here because not all systems can correctly handle Decimal128 without losing precision
 		return v.String(), nil
-	case primitive.Timestamp:
-		return time.Unix(int64(v.T), 0).UTC().Format(ext.ISO8601), nil
 	case bson.D:
 		return bsonDocToMap(v)
 	case bson.A:

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -89,7 +89,7 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 func bsonValueToGoValue(value any) (any, error) {
 	switch v := value.(type) {
 	case primitive.DateTime:
-		return ext.NewExtendedTime(v.Time(), ext.DateTimeKindType, ext.ISO8601), nil
+		return ext.NewExtendedTime(v.Time().UTC(), ext.DateTimeKindType, ext.ISO8601), nil
 	case primitive.Timestamp:
 		return ext.NewExtendedTime(time.Unix(int64(v.T), 0).UTC(), ext.DateTimeKindType, ext.ISO8601), nil
 	case primitive.ObjectID:

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -123,7 +123,7 @@ func TestJSONEToMap(t *testing.T) {
 		// Date
 		extendedTime, isOk := result["order_date"].(*ext.ExtendedTime)
 		assert.True(t, isOk)
-		assert.Equal(t, ext.NewExtendedTime(time.Date(2016, time.February, 20, 16, 0, 0, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), extendedTime)
+		assert.Equal(t, ext.NewExtendedTime(time.Date(2016, time.February, 21, 0, 0, 0, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), extendedTime)
 	}
 	{
 		// Timestamp
@@ -217,7 +217,7 @@ func TestBsonValueToGoValue(t *testing.T) {
 
 		extendedTime, isOk := result.(*ext.ExtendedTime)
 		assert.True(t, isOk)
-		assert.Equal(t, ext.NewExtendedTime(time.Date(2020, time.December, 31, 16, 0, 0, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), extendedTime)
+		assert.Equal(t, ext.NewExtendedTime(time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), extendedTime)
 	}
 	{
 		// primitive.ObjectID

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -119,11 +119,18 @@ func TestJSONEToMap(t *testing.T) {
 	assert.Equal(t, int32(30), result["number_int"])
 	assert.Equal(t, int32(1337), result["test_int"])
 
-	// Date
-	assert.Equal(t, "2016-02-21T00:00:00+00:00", result["order_date"])
-
-	// Timestamp
-	assert.Equal(t, "2023-03-16T01:18:37+00:00", result["test_timestamp"])
+	{
+		// Date
+		extendedTime, isOk := result["order_date"].(*ext.ExtendedTime)
+		assert.True(t, isOk)
+		assert.Equal(t, ext.NewExtendedTime(time.Date(2016, time.February, 20, 16, 0, 0, 0, time.Local), ext.DateTimeKindType, ext.ISO8601), extendedTime)
+	}
+	{
+		// Timestamp
+		extendedTime, isOk := result["test_timestamp"]
+		assert.True(t, isOk)
+		assert.Equal(t, ext.NewExtendedTime(time.Date(2023, time.March, 16, 1, 18, 37, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), extendedTime)
+	}
 
 	// Boolean
 	assert.Equal(t, false, result["test_bool_false"])
@@ -207,7 +214,10 @@ func TestBsonValueToGoValue(t *testing.T) {
 		dateTime := primitive.NewDateTimeFromTime(_time)
 		result, err := bsonValueToGoValue(dateTime)
 		assert.NoError(t, err)
-		assert.Equal(t, _time.Format(ext.ISO8601), result)
+
+		extendedTime, isOk := result.(*ext.ExtendedTime)
+		assert.True(t, isOk)
+		assert.Equal(t, ext.NewExtendedTime(time.Date(2020, time.December, 31, 16, 0, 0, 0, time.Local), ext.DateTimeKindType, ext.ISO8601), extendedTime)
 	}
 	{
 		// primitive.ObjectID

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -123,7 +123,7 @@ func TestJSONEToMap(t *testing.T) {
 		// Date
 		extendedTime, isOk := result["order_date"].(*ext.ExtendedTime)
 		assert.True(t, isOk)
-		assert.Equal(t, ext.NewExtendedTime(time.Date(2016, time.February, 20, 16, 0, 0, 0, time.Local), ext.DateTimeKindType, ext.ISO8601), extendedTime)
+		assert.Equal(t, ext.NewExtendedTime(time.Date(2016, time.February, 20, 16, 0, 0, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), extendedTime)
 	}
 	{
 		// Timestamp
@@ -217,7 +217,7 @@ func TestBsonValueToGoValue(t *testing.T) {
 
 		extendedTime, isOk := result.(*ext.ExtendedTime)
 		assert.True(t, isOk)
-		assert.Equal(t, ext.NewExtendedTime(time.Date(2020, time.December, 31, 16, 0, 0, 0, time.Local), ext.DateTimeKindType, ext.ISO8601), extendedTime)
+		assert.Equal(t, ext.NewExtendedTime(time.Date(2020, time.December, 31, 16, 0, 0, 0, time.UTC), ext.DateTimeKindType, ext.ISO8601), extendedTime)
 	}
 	{
 		// primitive.ObjectID


### PR DESCRIPTION
Instead of returning the string value in which we then try to parse to get `ext.ExtendedTime` type in `parseValue`, we can just natively return this.

This way, `parseValue` can take this directly and skip the inference.