### PR TITLE
Add warning for unhandled field / debezium type.

### DIFF
--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -1,6 +1,8 @@
 package debezium
 
 import (
+	"log/slog"
+
 	"github.com/artie-labs/transfer/lib/debezium/converters"
 	"github.com/artie-labs/transfer/lib/maputil"
 	"github.com/artie-labs/transfer/lib/ptr"
@@ -155,6 +157,10 @@ func (f Field) ToKindDetails() typing.KindDetails {
 	case Array:
 		return typing.Array
 	default:
+		if f.Type != "" && f.DebeziumType != "" {
+			slog.Warn("Unhandled field type", slog.String("type", string(f.Type)), slog.String("debeziumType", string(f.DebeziumType)))
+		}
+
 		return typing.Invalid
 	}
 }

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -157,7 +157,7 @@ func (f Field) ToKindDetails() typing.KindDetails {
 	case Array:
 		return typing.Array
 	default:
-		if f.Type != "" && f.DebeziumType != "" {
+		if f.Type != "" || f.DebeziumType != "" {
 			slog.Warn("Unhandled field type", slog.String("type", string(f.Type)), slog.String("debeziumType", string(f.DebeziumType)))
 		}
 

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -157,10 +157,7 @@ func (f Field) ToKindDetails() typing.KindDetails {
 	case Array:
 		return typing.Array
 	default:
-		if f.Type != "" || f.DebeziumType != "" {
-			slog.Warn("Unhandled field type", slog.String("type", string(f.Type)), slog.String("debeziumType", string(f.DebeziumType)))
-		}
-
+		slog.Warn("Unhandled field type", slog.String("type", string(f.Type)), slog.String("debeziumType", string(f.DebeziumType)))
 		return typing.Invalid
 	}
 }

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -141,6 +141,10 @@ func (f Field) ToKindDetails() typing.KindDetails {
 		return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(decimal.PrecisionNotSpecified, decimal.DefaultScale))
 	}
 
+	if f.DebeziumType != "" {
+		slog.Warn("Unhandled Debezium type", slog.String("type", string(f.Type)), slog.String("debeziumType", string(f.DebeziumType)))
+	}
+
 	switch f.Type {
 	case Map:
 		return typing.Struct


### PR DESCRIPTION
We should be able to natively handle every single Debezium or native type. This log will help us identify any unhandled types (if any).