### PR TITLE
[Typing] Stop implicit references of datetime in ParseValue

### DIFF
--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -303,7 +303,10 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 		// Check `__artie_updated_at` is included
 		evtData, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
 		assert.NoError(m.T(), err)
-		_, isOk := evtData[constants.UpdateColumnMarker]
+
+		updatedAt, isOk := evtData[constants.UpdateColumnMarker]
+		assert.True(m.T(), isOk)
+		_, isOk = updatedAt.(*ext.ExtendedTime)
 		assert.True(m.T(), isOk)
 	}
 }

--- a/lib/typing/parse.go
+++ b/lib/typing/parse.go
@@ -14,10 +14,6 @@ func ParseValue(_ Settings, key string, optionalSchema map[string]KindDetails, v
 		return kindDetail
 	}
 
-	return parseValue(val)
-}
-
-func parseValue(val any) KindDetails {
 	switch convertedVal := val.(type) {
 	case nil:
 		return Invalid

--- a/lib/typing/parse.go
+++ b/lib/typing/parse.go
@@ -4,21 +4,20 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
-	"strings"
 
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
-func ParseValue(settings Settings, key string, optionalSchema map[string]KindDetails, val any) KindDetails {
+func ParseValue(_ Settings, key string, optionalSchema map[string]KindDetails, val any) KindDetails {
 	if kindDetail, isOk := optionalSchema[key]; isOk {
 		return kindDetail
 	}
 
-	return parseValue(settings, val)
+	return parseValue(val)
 }
 
-func parseValue(settings Settings, val any) KindDetails {
+func parseValue(val any) KindDetails {
 	switch convertedVal := val.(type) {
 	case nil:
 		return Invalid
@@ -33,20 +32,6 @@ func parseValue(settings Settings, val any) KindDetails {
 	case bool:
 		return Boolean
 	case string:
-		// If it contains space or -, then we must check against date time.
-		// This way, we don't penalize every string into going through this loop
-		// In the future, we can have specific layout RFCs run depending on the char
-		if strings.Contains(convertedVal, ":") || strings.Contains(convertedVal, "-") {
-			// TODO: Remove this once we natively support every single Debezium datetime type
-			extendedKind, err := ext.ParseExtendedDateTime(convertedVal, settings.AdditionalDateFormats)
-			if err == nil {
-				return KindDetails{
-					Kind:                ETime.Kind,
-					ExtendedTimeDetails: &extendedKind.NestedKind,
-				}
-			}
-		}
-
 		if IsJSON(convertedVal) {
 			return Struct
 		}

--- a/lib/typing/parse_test.go
+++ b/lib/typing/parse_test.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -69,38 +68,9 @@ func Test_ParseValue(t *testing.T) {
 		assert.Equal(t, ParseValue(Settings{}, "", nil, []any{false, true}), Array)
 	}
 	{
-		// Time
+		// Time in string w/ no schema
 		kindDetails := ParseValue(Settings{}, "", nil, "00:18:11.13116+00")
-		assert.Equal(t, ETime.Kind, kindDetails.Kind)
-		assert.Equal(t, ext.TimeKindType, kindDetails.ExtendedTimeDetails.Type)
-	}
-	{
-		// Date layouts from Go's time.Time library
-		possibleDates := []any{
-			"01/02 03:04:05PM '06 -0700", // The reference time, in numerical order.
-			"Mon Jan 2 15:04:05 2006",
-			"Mon Jan 2 15:04:05 MST 2006",
-			"Mon Jan 02 15:04:05 -0700 2006",
-			"02 Jan 06 15:04 MST",
-			"02 Jan 06 15:04 -0700", // RFC822 with numeric zone
-			"Monday, 02-Jan-06 15:04:05 MST",
-			"Mon, 02 Jan 2006 15:04:05 MST",
-			"Mon, 02 Jan 2006 15:04:05 -0700", // RFC1123 with numeric zone
-			"2019-10-12T14:20:50.52+07:00",
-		}
-
-		for _, possibleDate := range possibleDates {
-			assert.Equal(t, ParseValue(Settings{}, "", nil, possibleDate).ExtendedTimeDetails.Type, ext.DateTime.Type, fmt.Sprintf("Failed format, value is: %v", possibleDate))
-
-			// Test the parseDT function as well.
-			ts, err := ext.ParseExtendedDateTime(fmt.Sprint(possibleDate), []string{})
-			assert.NoError(t, err, err)
-			assert.False(t, ts.IsZero(), ts)
-		}
-
-		ts, err := ext.ParseExtendedDateTime("random", []string{})
-		assert.ErrorContains(t, err, "dtString: random is not supported")
-		assert.Nil(t, ts)
+		assert.Equal(t, String, kindDetails)
 	}
 	{
 		// Maps

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
-	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -146,21 +145,29 @@ func (e *EventsTestSuite) TestEventSaveOptionalSchema() {
 	assert.Nil(e.T(), err)
 
 	td := e.db.GetOrCreateTableData("foo")
-	column, isOk := td.ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
-	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), typing.String, column.KindDetails)
+	{
+		// Optional schema w/ string
+		column, isOk := td.ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
+		assert.True(e.T(), isOk)
+		assert.Equal(e.T(), typing.String, column.KindDetails)
 
-	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("created_at_date_no_schema")
-	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), ext.Date.Type, column.KindDetails.ExtendedTimeDetails.Type)
-
-	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("json_object_string")
-	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), typing.String, column.KindDetails)
-
-	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("json_object_no_schema")
-	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), typing.Struct, column.KindDetails)
+		// String (with created_at datetime type)
+		column, isOk = td.ReadOnlyInMemoryCols().GetColumn("created_at_date_no_schema")
+		assert.True(e.T(), isOk)
+		assert.Equal(e.T(), typing.String, column.KindDetails)
+	}
+	{
+		// JSON string
+		column, isOk := td.ReadOnlyInMemoryCols().GetColumn("json_object_string")
+		assert.True(e.T(), isOk)
+		assert.Equal(e.T(), typing.String, column.KindDetails)
+	}
+	{
+		// JSON
+		column, isOk := td.ReadOnlyInMemoryCols().GetColumn("json_object_no_schema")
+		assert.True(e.T(), isOk)
+		assert.Equal(e.T(), typing.Struct, column.KindDetails)
+	}
 }
 
 func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
@@ -244,26 +251,36 @@ func (e *EventsTestSuite) TestEventSaveColumns() {
 	assert.Nil(e.T(), err)
 
 	td := e.db.GetOrCreateTableData("foo")
-
-	column, isOk := td.ReadOnlyInMemoryCols().GetColumn("randomcol")
-	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), typing.String, column.KindDetails)
-
-	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("anothercol")
-	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), typing.Float, column.KindDetails)
-
-	column, isOk = td.ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
-	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), ext.DateKindType, column.KindDetails.ExtendedTimeDetails.Type)
-
-	column, isOk = td.ReadOnlyInMemoryCols().GetColumn(constants.DeleteColumnMarker)
-	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), typing.Boolean, column.KindDetails)
-
-	column, isOk = td.ReadOnlyInMemoryCols().GetColumn(constants.OnlySetDeleteColumnMarker)
-	assert.True(e.T(), isOk)
-	assert.Equal(e.T(), typing.Boolean, column.KindDetails)
+	{
+		// String
+		column, isOk := td.ReadOnlyInMemoryCols().GetColumn("randomcol")
+		assert.True(e.T(), isOk)
+		assert.Equal(e.T(), typing.String, column.KindDetails)
+	}
+	{
+		// Number
+		column, isOk := td.ReadOnlyInMemoryCols().GetColumn("anothercol")
+		assert.True(e.T(), isOk)
+		assert.Equal(e.T(), typing.Float, column.KindDetails)
+	}
+	{
+		// String
+		column, isOk := td.ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
+		assert.True(e.T(), isOk)
+		assert.Equal(e.T(), typing.String, column.KindDetails)
+	}
+	{
+		// Boolean
+		column, isOk := td.ReadOnlyInMemoryCols().GetColumn(constants.DeleteColumnMarker)
+		assert.True(e.T(), isOk)
+		assert.Equal(e.T(), typing.Boolean, column.KindDetails)
+	}
+	{
+		// Boolean
+		column, isOk := td.ReadOnlyInMemoryCols().GetColumn(constants.OnlySetDeleteColumnMarker)
+		assert.True(e.T(), isOk)
+		assert.Equal(e.T(), typing.Boolean, column.KindDetails)
+	}
 }
 
 func (e *EventsTestSuite) TestEventSaveTestDeleteFlag() {


### PR DESCRIPTION
All date, time, datetime and timestamp values are natively handled in the BSON and Debezium converters.

There is no need to do this anymore.