### PR TITLE
[Typing] Remove passing in `typing.Settings` to `ParseValue`

### DIFF
--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -94,7 +94,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 		constants.DeleteColumnMarker:        typing.Boolean,
 		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
-		"created_at": typing.ParseValue(typing.Settings{}, "", nil, time.Now().Format(time.RFC3339Nano)),
+		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
 	var cols columns.Columns
@@ -142,7 +142,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 		constants.DeleteColumnMarker:        typing.Boolean,
 		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
-		"created_at": typing.ParseValue(typing.Settings{}, "", nil, time.Now().Format(time.RFC3339Nano)),
+		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
 	var cols columns.Columns
@@ -232,7 +232,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		constants.DeleteColumnMarker:        typing.Boolean,
 		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 		// Add kindDetails to created_at
-		"created_at": typing.ParseValue(typing.Settings{}, "", nil, time.Now().Format(time.RFC3339Nano)),
+		"created_at": typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano)),
 	}
 
 	var cols columns.Columns
@@ -282,7 +282,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 		inMemColumns := tableData.ReadOnlyInMemoryCols()
 		// Since sflkColumns overwrote the format, let's set it correctly again.
-		inMemColumns.UpdateColumn(columns.NewColumn("created_at", typing.ParseValue(typing.Settings{}, "", nil, time.Now().Format(time.RFC3339Nano))))
+		inMemColumns.UpdateColumn(columns.NewColumn("created_at", typing.ParseValue("", nil, time.Now().Format(time.RFC3339Nano))))
 		tableData.SetInMemoryColumns(inMemColumns)
 		break
 	}

--- a/lib/cdc/relational/debezium_test.go
+++ b/lib/cdc/relational/debezium_test.go
@@ -197,7 +197,7 @@ func (r *RelationTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 	// Testing typing.
 	assert.Equal(r.T(), evtData["id"], int64(1001))
 	assert.Equal(r.T(), evtData["another_id"], int64(333))
-	assert.Equal(r.T(), typing.ParseValue(typing.Settings{}, "another_id", evt.GetOptionalSchema(), evtData["another_id"]), typing.Integer)
+	assert.Equal(r.T(), typing.ParseValue("another_id", evt.GetOptionalSchema(), evtData["another_id"]), typing.Integer)
 	assert.Equal(r.T(), evtData["email"], "sally.thomas@acme.com")
 
 	// Datetime without TZ is emitted in microseconds which is 1000x larger than nanoseconds.

--- a/lib/typing/parse.go
+++ b/lib/typing/parse.go
@@ -9,7 +9,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
-func ParseValue(_ Settings, key string, optionalSchema map[string]KindDetails, val any) KindDetails {
+func ParseValue(key string, optionalSchema map[string]KindDetails, val any) KindDetails {
 	if kindDetail, isOk := optionalSchema[key]; isOk {
 		return kindDetail
 	}

--- a/lib/typing/parse_test.go
+++ b/lib/typing/parse_test.go
@@ -12,40 +12,38 @@ import (
 func Test_ParseValue(t *testing.T) {
 	{
 		// Optional schema exists, so we are using it
-		optionalSchema := map[string]KindDetails{
-			"created_at": String,
-		}
+		optionalSchema := map[string]KindDetails{"created_at": String}
 		for _, val := range []any{"2023-01-01", nil} {
-			assert.Equal(t, String, ParseValue(Settings{}, "created_at", optionalSchema, val))
+			assert.Equal(t, String, ParseValue("created_at", optionalSchema, val))
 		}
 	}
 	{
 		// Invalid
-		assert.Equal(t, ParseValue(Settings{}, "", nil, nil), Invalid)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, errors.New("hello")), Invalid)
+		assert.Equal(t, ParseValue("", nil, nil), Invalid)
+		assert.Equal(t, ParseValue("", nil, errors.New("hello")), Invalid)
 	}
 	{
 		// Nil
-		assert.Equal(t, ParseValue(Settings{}, "", nil, ""), String)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, "nil"), String)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, nil), Invalid)
+		assert.Equal(t, ParseValue("", nil, ""), String)
+		assert.Equal(t, ParseValue("", nil, "nil"), String)
+		assert.Equal(t, ParseValue("", nil, nil), Invalid)
 	}
 	{
 		// Floats
-		assert.Equal(t, ParseValue(Settings{}, "", nil, 7.5), Float)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, -7.4999999), Float)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, 7.0), Float)
+		assert.Equal(t, ParseValue("", nil, 7.5), Float)
+		assert.Equal(t, ParseValue("", nil, -7.4999999), Float)
+		assert.Equal(t, ParseValue("", nil, 7.0), Float)
 	}
 	{
 		// Integers
-		assert.Equal(t, ParseValue(Settings{}, "", nil, 9), Integer)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, math.MaxInt), Integer)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, -1*math.MaxInt), Integer)
+		assert.Equal(t, ParseValue("", nil, 9), Integer)
+		assert.Equal(t, ParseValue("", nil, math.MaxInt), Integer)
+		assert.Equal(t, ParseValue("", nil, -1*math.MaxInt), Integer)
 	}
 	{
 		// Boolean
-		assert.Equal(t, ParseValue(Settings{}, "", nil, true), Boolean)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, false), Boolean)
+		assert.Equal(t, ParseValue("", nil, true), Boolean)
+		assert.Equal(t, ParseValue("", nil, false), Boolean)
 	}
 	{
 		// Strings
@@ -56,20 +54,20 @@ func Test_ParseValue(t *testing.T) {
 		}
 
 		for _, possibleString := range possibleStrings {
-			assert.Equal(t, ParseValue(Settings{}, "", nil, possibleString), String)
+			assert.Equal(t, ParseValue("", nil, possibleString), String)
 		}
 	}
 	{
 		// Arrays
-		assert.Equal(t, ParseValue(Settings{}, "", nil, []string{"a", "b", "c"}), Array)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, []any{"a", 123, "c"}), Array)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, []int64{1}), Array)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, []bool{false}), Array)
-		assert.Equal(t, ParseValue(Settings{}, "", nil, []any{false, true}), Array)
+		assert.Equal(t, ParseValue("", nil, []string{"a", "b", "c"}), Array)
+		assert.Equal(t, ParseValue("", nil, []any{"a", 123, "c"}), Array)
+		assert.Equal(t, ParseValue("", nil, []int64{1}), Array)
+		assert.Equal(t, ParseValue("", nil, []bool{false}), Array)
+		assert.Equal(t, ParseValue("", nil, []any{false, true}), Array)
 	}
 	{
 		// Time in string w/ no schema
-		kindDetails := ParseValue(Settings{}, "", nil, "00:18:11.13116+00")
+		kindDetails := ParseValue("", nil, "00:18:11.13116+00")
 		assert.Equal(t, String, kindDetails)
 	}
 	{
@@ -99,7 +97,7 @@ func Test_ParseValue(t *testing.T) {
 		}
 
 		for _, randomMap := range randomMaps {
-			assert.Equal(t, ParseValue(Settings{}, "", nil, randomMap), Struct, fmt.Sprintf("Failed message is: %v", randomMap))
+			assert.Equal(t, ParseValue("", nil, randomMap), Struct, fmt.Sprintf("Failed message is: %v", randomMap))
 		}
 	}
 }

--- a/lib/typing/typing_bench_test.go
+++ b/lib/typing/typing_bench_test.go
@@ -36,7 +36,7 @@ func BenchmarkLargeMapLengthQuery_WithMassiveValues(b *testing.B) {
 
 func BenchmarkParseValueIntegerArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ParseValue(Settings{}, "", nil, 45456312)
+		ParseValue("", nil, 45456312)
 	}
 }
 
@@ -48,7 +48,7 @@ func BenchmarkParseValueIntegerGo(b *testing.B) {
 
 func BenchmarkParseValueBooleanArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ParseValue(Settings{}, "", nil, true)
+		ParseValue("", nil, true)
 	}
 }
 
@@ -60,7 +60,7 @@ func BenchmarkParseValueBooleanGo(b *testing.B) {
 
 func BenchmarkParseValueFloatArtie(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		ParseValue(Settings{}, "", nil, 7.44)
+		ParseValue("", nil, 7.44)
 	}
 }
 

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -157,8 +157,6 @@ func (e *Event) Save(cfg config.Config, inMemDB *models.DatabaseData, tc kafkali
 		}
 	}
 
-	typingSettings := cfg.SharedTransferConfig.TypingSettings
-
 	// Table columns
 	inMemoryColumns := td.ReadOnlyInMemoryCols()
 	// Update col if necessary
@@ -199,14 +197,14 @@ func (e *Event) Save(cfg config.Config, inMemDB *models.DatabaseData, tc kafkali
 			retrievedColumn, isOk := inMemoryColumns.GetColumn(newColName)
 			if !isOk {
 				// This would only happen if the columns did not get passed in initially.
-				inMemoryColumns.AddColumn(columns.NewColumn(newColName, typing.ParseValue(typingSettings, _col, e.OptionalSchema, val)))
+				inMemoryColumns.AddColumn(columns.NewColumn(newColName, typing.ParseValue(_col, e.OptionalSchema, val)))
 			} else {
 				if retrievedColumn.KindDetails == typing.Invalid {
 					// If colType is Invalid, let's see if we can update it to a better type
 					// If everything is nil, we don't need to add a column
 					// However, it's important to create a column even if it's nil.
 					// This is because we don't want to think that it's okay to drop a column in DWH
-					if kindDetails := typing.ParseValue(typingSettings, _col, e.OptionalSchema, val); kindDetails.Kind != typing.Invalid.Kind {
+					if kindDetails := typing.ParseValue(_col, e.OptionalSchema, val); kindDetails.Kind != typing.Invalid.Kind {
 						retrievedColumn.KindDetails = kindDetails
 						inMemoryColumns.UpdateColumn(retrievedColumn)
 					}


### PR DESCRIPTION
We don't need it anymore