### PR TITLE
[Debezium] Converters clean up

### DIFF
--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -22,7 +22,7 @@ type Event interface {
 	DeletePayload() bool
 	GetTableName() string
 	GetData(pkMap map[string]any, tc kafkalib.TopicConfig) (map[string]any, error)
-	GetOptionalSchema() map[string]typing.KindDetails
+	GetOptionalSchema() (map[string]typing.KindDetails, error)
 	// GetColumns will inspect the envelope's payload right now and return.
 	GetColumns() (*columns.Columns, error)
 }

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -128,9 +128,9 @@ func (s *SchemaEventPayload) GetTableName() string {
 	return s.Payload.Source.Collection
 }
 
-func (s *SchemaEventPayload) GetOptionalSchema() map[string]typing.KindDetails {
+func (s *SchemaEventPayload) GetOptionalSchema() (map[string]typing.KindDetails, error) {
 	// MongoDB does not have a schema at the database level.
-	return nil
+	return nil, nil
 }
 
 func (s *SchemaEventPayload) GetColumns() (*columns.Columns, error) {

--- a/lib/cdc/relational/debezium_test.go
+++ b/lib/cdc/relational/debezium_test.go
@@ -200,8 +200,8 @@ func (r *RelationTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 
 	optionalSchema, err := evt.GetOptionalSchema()
 	assert.NoError(r.T(), err)
-	assert.Equal(r.T(), typing.ParseValue("another_id", optionalSchema, evtData["another_id"]), typing.Integer)
-	assert.Equal(r.T(), evtData["email"], "sally.thomas@acme.com")
+	assert.Equal(r.T(), typing.Integer, typing.ParseValue("another_id", optionalSchema, evtData["another_id"]))
+	assert.Equal(r.T(), "sally.thomas@acme.com", evtData["email"])
 
 	// Datetime without TZ is emitted in microseconds which is 1000x larger than nanoseconds.
 	assert.Equal(

--- a/lib/cdc/relational/debezium_test.go
+++ b/lib/cdc/relational/debezium_test.go
@@ -197,7 +197,10 @@ func (r *RelationTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 	// Testing typing.
 	assert.Equal(r.T(), evtData["id"], int64(1001))
 	assert.Equal(r.T(), evtData["another_id"], int64(333))
-	assert.Equal(r.T(), typing.ParseValue("another_id", evt.GetOptionalSchema(), evtData["another_id"]), typing.Integer)
+
+	optionalSchema, err := evt.GetOptionalSchema()
+	assert.NoError(r.T(), err)
+	assert.Equal(r.T(), typing.ParseValue("another_id", optionalSchema, evtData["another_id"]), typing.Integer)
 	assert.Equal(r.T(), evtData["email"], "sally.thomas@acme.com")
 
 	// Datetime without TZ is emitted in microseconds which is 1000x larger than nanoseconds.
@@ -513,13 +516,11 @@ func (r *RelationTestSuite) TestGetEventFromBytes_MySQL() {
 	assert.Equal(r.T(), time.Date(2023, time.March, 13, 19, 19, 24, 0, time.UTC), evt.GetExecutionTime())
 	assert.Equal(r.T(), "customers", evt.GetTableName())
 
-	schema := evt.GetOptionalSchema()
+	schema, err := evt.GetOptionalSchema()
+	assert.NoError(r.T(), err)
 	assert.Equal(r.T(), typing.Struct, schema["custom_fields"])
 
-	kvMap := map[string]any{
-		"id": 1001,
-	}
-
+	kvMap := map[string]any{"id": 1001}
 	evtData, err := evt.GetData(kvMap, kafkalib.TopicConfig{})
 	assert.NoError(r.T(), err)
 

--- a/lib/cdc/relational/debezium_test.go
+++ b/lib/cdc/relational/debezium_test.go
@@ -540,9 +540,9 @@ func (r *RelationTestSuite) TestGetEventFromBytes_MySQL() {
 	assert.True(r.T(), isOk)
 	assert.False(r.T(), updatedAtExtTime.GetTime().IsZero())
 
-	assert.Equal(r.T(), evtData["id"], int64(1001))
-	assert.Equal(r.T(), evtData["first_name"], "Sally")
-	assert.Equal(r.T(), evtData["bool_test"], false)
+	assert.Equal(r.T(), int64(1001), evtData["id"])
+	assert.Equal(r.T(), "Sally", evtData["first_name"])
+	assert.Equal(r.T(), false, evtData["bool_test"])
 	cols, err := evt.GetColumns()
 	assert.NoError(r.T(), err)
 	assert.NotNil(r.T(), cols)

--- a/lib/cdc/util/optional_schema.go
+++ b/lib/cdc/util/optional_schema.go
@@ -5,18 +5,21 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func (s *SchemaEventPayload) GetOptionalSchema() map[string]typing.KindDetails {
+func (s *SchemaEventPayload) GetOptionalSchema() (map[string]typing.KindDetails, error) {
 	fieldsObject := s.Schema.GetSchemaFromLabel(debezium.After)
 	if fieldsObject == nil {
-		return nil
+		return nil, nil
 	}
 
 	schema := make(map[string]typing.KindDetails)
 	for _, field := range fieldsObject.Fields {
-		if kd := field.ToKindDetails(); kd != typing.Invalid {
-			schema[field.FieldName] = kd
+		kd, err := field.ToKindDetails()
+		if err != nil {
+			return nil, err
 		}
+
+		schema[field.FieldName] = kd
 	}
 
-	return schema
+	return schema, nil
 }

--- a/lib/cdc/util/optional_schema_test.go
+++ b/lib/cdc/util/optional_schema_test.go
@@ -81,7 +81,9 @@ func TestGetOptionalSchema(t *testing.T) {
 		err := json.Unmarshal([]byte(tc.body), &schemaEventPayload)
 		assert.NoError(t, err, idx)
 
-		actualData := schemaEventPayload.GetOptionalSchema()
+		actualData, err := schemaEventPayload.GetOptionalSchema()
+		assert.NoError(t, err)
+
 		for actualKey, actualVal := range actualData {
 			testMsg := fmt.Sprintf("key: %s, actualKind: %s, index: %d", actualKey, actualVal.Kind, idx)
 

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -57,7 +57,10 @@ func TestSource_GetOptionalSchema(t *testing.T) {
 }`), &schemaEventPayload)
 
 	assert.NoError(t, err)
-	optionalSchema := schemaEventPayload.GetOptionalSchema()
+
+	optionalSchema, err := schemaEventPayload.GetOptionalSchema()
+	assert.NoError(t, err)
+
 	value, isOk := optionalSchema["last_modified"]
 	assert.True(t, isOk)
 	assert.Equal(t, value, typing.String)

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -168,7 +168,6 @@ func (f Field) ToKindDetails() (typing.KindDetails, error) {
 	case Array:
 		return typing.Array, nil
 	default:
-		slog.Warn("Unhandled field type", slog.String("type", string(f.Type)), slog.String("debeziumType", string(f.DebeziumType)))
 		return typing.Invalid, fmt.Errorf("unhandled field type %q", f.Type)
 	}
 }

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -1,6 +1,7 @@
 package debezium
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/artie-labs/transfer/lib/debezium/converters"
@@ -140,35 +141,34 @@ func (f Field) ToValueConverter() (converters.ValueConverter, error) {
 	}
 }
 
-func (f Field) ToKindDetails() typing.KindDetails {
+func (f Field) ToKindDetails() (typing.KindDetails, error) {
 	// Prioritize converters
 	converter, err := f.ToValueConverter()
 	if err != nil {
-		// TODO: Return an actual error instead.
-		return typing.Invalid
+		return typing.Invalid, err
 	}
 
 	if converter != nil {
-		return converter.ToKindDetails()
+		return converter.ToKindDetails(), nil
 	}
 
 	switch f.Type {
 	case Map:
-		return typing.Struct
+		return typing.Struct, nil
 	case Int16, Int32, Int64:
-		return typing.Integer
+		return typing.Integer, nil
 	case Float, Double:
-		return typing.Float
+		return typing.Float, nil
 	case String, Bytes:
-		return typing.String
+		return typing.String, nil
 	case Struct:
-		return typing.Struct
+		return typing.Struct, nil
 	case Boolean:
-		return typing.Boolean
+		return typing.Boolean, nil
 	case Array:
-		return typing.Array
+		return typing.Array, nil
 	default:
 		slog.Warn("Unhandled field type", slog.String("type", string(f.Type)), slog.String("debeziumType", string(f.DebeziumType)))
-		return typing.Invalid
+		return typing.Invalid, fmt.Errorf("unhandled field type %q", f.Type)
 	}
 }

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -81,113 +81,189 @@ func TestField_GetScaleAndPrecision(t *testing.T) {
 func TestField_ToKindDetails(t *testing.T) {
 	{
 		// Bytes
-		assert.Equal(t, typing.String, Field{Type: Bytes}.ToKindDetails())
+		kd, err := Field{Type: Bytes}.ToKindDetails()
+		assert.NoError(t, err)
+		assert.Equal(t, typing.String, kd)
 	}
 	{
 		// Integers
-		assert.Equal(t, typing.Integer, Field{Type: Int16}.ToKindDetails())
-		assert.Equal(t, typing.Integer, Field{Type: Int32}.ToKindDetails())
-		assert.Equal(t, typing.Integer, Field{Type: Int64}.ToKindDetails())
+		{
+			// Int16
+			kd, err := Field{Type: Int16}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.Integer, kd)
+		}
+		{
+			// Int32
+			kd, err := Field{Type: Int32}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.Integer, kd)
+		}
+		{
+			// Int64
+			kd, err := Field{Type: Int64}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.Integer, kd)
+		}
 	}
 	{
 		// Floats
-		assert.Equal(t, typing.Float, Field{Type: Float}.ToKindDetails())
-		assert.Equal(t, typing.Float, Field{Type: Double}.ToKindDetails())
+		{
+			// Float
+			kd, err := Field{Type: Float}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.Float, kd)
+		}
+		{
+			// Double
+			kd, err := Field{Type: Double}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.Float, kd)
+		}
 	}
 	{
 		// Decimals
 		{
-			assert.Equal(
-				t, typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(10, 5)),
-				Field{DebeziumType: KafkaDecimalType, Parameters: map[string]any{"scale": 5, KafkaDecimalPrecisionKey: 10}}.ToKindDetails(),
-			)
+			kd, err := Field{DebeziumType: KafkaDecimalType, Parameters: map[string]any{"scale": 5, KafkaDecimalPrecisionKey: 10}}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(10, 5)), kd)
 		}
 		{
 			// Variable numeric decimal
-			assert.Equal(
-				t, typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(decimal.PrecisionNotSpecified, decimal.DefaultScale)),
-				Field{DebeziumType: KafkaVariableNumericType, Parameters: map[string]any{"scale": 5}}.ToKindDetails(),
-			)
+			kd, err := Field{DebeziumType: KafkaVariableNumericType, Parameters: map[string]any{"scale": 5}}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(decimal.PrecisionNotSpecified, decimal.DefaultScale)), kd)
 		}
 	}
 	{
 		// String
-		assert.Equal(t, typing.String, Field{Type: String}.ToKindDetails())
+		kd, err := Field{Type: String}.ToKindDetails()
+		assert.NoError(t, err)
+		assert.Equal(t, typing.String, kd)
 	}
 	{
 		// Bytes
-		assert.Equal(t, typing.String, Field{Type: Bytes}.ToKindDetails())
+		kd, err := Field{Type: Bytes}.ToKindDetails()
+		assert.NoError(t, err)
+		assert.Equal(t, typing.String, kd)
 	}
 	{
 		// String passthrough
 		{
 			// UUID
-			assert.Equal(t, typing.String, Field{DebeziumType: UUID, Type: String}.ToKindDetails())
+			kd, err := Field{DebeziumType: UUID, Type: String}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.String, kd)
 		}
 		{
 			// Enum
-			assert.Equal(t, typing.String, Field{DebeziumType: Enum, Type: String}.ToKindDetails())
+			kd, err := Field{DebeziumType: Enum, Type: String}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.String, kd)
 		}
 		{
 			// LTree
-			assert.Equal(t, typing.String, Field{DebeziumType: LTree, Type: String}.ToKindDetails())
+			kd, err := Field{DebeziumType: LTree, Type: String}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.String, kd)
 		}
 		{
 			// Interval
-			assert.Equal(t, typing.String, Field{DebeziumType: Interval, Type: String}.ToKindDetails())
+			kd, err := Field{DebeziumType: Interval, Type: String}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.String, kd)
 		}
 		{
 			// XML
-			assert.Equal(t, typing.String, Field{DebeziumType: XML, Type: String}.ToKindDetails())
+			kd, err := Field{DebeziumType: XML, Type: String}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.String, kd)
 		}
 	}
 	{
 		// Structs
-		assert.Equal(t, typing.Struct, Field{Type: Struct}.ToKindDetails())
-		assert.Equal(t, typing.Struct, Field{Type: Map}.ToKindDetails())
-
-		assert.Equal(t, typing.Struct, Field{DebeziumType: JSON}.ToKindDetails())
+		{
+			// Struct
+			kd, err := Field{Type: Struct}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.Struct, kd)
+		}
+		{
+			// Map
+			kd, err := Field{Type: Map}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.Struct, kd)
+		}
+		{
+			// JSON
+			kd, err := Field{DebeziumType: JSON}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.Struct, kd)
+		}
 	}
 	{
 		// Booleans
-		assert.Equal(t, typing.Boolean, Field{Type: Boolean}.ToKindDetails())
+		kd, err := Field{Type: Boolean}.ToKindDetails()
+		assert.NoError(t, err)
+		assert.Equal(t, typing.Boolean, kd)
 	}
 	{
 		// Array
-		assert.Equal(t, typing.Array, Field{Type: Array}.ToKindDetails())
+		kd, err := Field{Type: Array}.ToKindDetails()
+		assert.NoError(t, err)
+		assert.Equal(t, typing.Array, kd)
 	}
 	{
 		// Invalid
-		assert.Equal(t, typing.Invalid, Field{Type: "unknown"}.ToKindDetails())
-		assert.Equal(t, typing.Invalid, Field{Type: ""}.ToKindDetails())
+		kd, err := Field{Type: "unknown"}.ToKindDetails()
+		assert.ErrorContains(t, err, `unhandled field type "unknown"`)
+		assert.Equal(t, typing.Invalid, kd)
+
+		kd, err = Field{Type: ""}.ToKindDetails()
+		assert.ErrorContains(t, err, `unhandled field type ""`)
+		assert.Equal(t, typing.Invalid, kd)
 	}
 	{
 		// Timestamp
 		// Datetime (for now)
 		for _, dbzType := range []SupportedDebeziumType{Timestamp, TimestampKafkaConnect, MicroTimestamp, NanoTimestamp, DateTimeWithTimezone} {
-			assert.Equal(t, typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType), Field{DebeziumType: dbzType}.ToKindDetails())
+			kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateTimeKindType), kd)
 		}
 	}
 	{
 		// Dates
 		for _, dbzType := range []SupportedDebeziumType{Date, DateKafkaConnect} {
-			assert.Equal(t, typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType), Field{DebeziumType: dbzType}.ToKindDetails())
+			kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.NewKindDetailsFromTemplate(typing.ETime, ext.DateKindType), kd)
 		}
 	}
 	{
 		// Time
 		for _, dbzType := range []SupportedDebeziumType{Time, TimeKafkaConnect, MicroTime, NanoTime, TimeWithTimezone} {
-			assert.Equal(t, typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType), Field{DebeziumType: dbzType}.ToKindDetails())
+			kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
+			assert.NoError(t, err)
+			assert.Equal(t, typing.NewKindDetailsFromTemplate(typing.ETime, ext.TimeKindType), kd)
 		}
 	}
 	{
 		// Basic
 		{
 			// Int64 Passthrough
-			assert.Equal(t, typing.Integer, Field{DebeziumType: Year}.ToKindDetails())
-			assert.Equal(t, typing.Integer, Field{DebeziumType: MicroDuration}.ToKindDetails())
+			{
+				// Year
+				kd, err := Field{DebeziumType: Year}.ToKindDetails()
+				assert.NoError(t, err)
+				assert.Equal(t, typing.Integer, kd)
+			}
+			{
+				// MicroDuration
+				kd, err := Field{DebeziumType: MicroDuration}.ToKindDetails()
+				assert.NoError(t, err)
+				assert.Equal(t, typing.Integer, kd)
+			}
 		}
-
-		assert.Equal(t, typing.Struct, Field{DebeziumType: JSON}.ToKindDetails())
 	}
 }

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -72,12 +72,17 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc kafkalib.TopicConfi
 		delete(evtData, constants.OnlySetDeleteColumnMarker)
 	}
 
+	optionalSchema, err := event.GetOptionalSchema()
+	if err != nil {
+		return Event{}, err
+	}
+
 	return Event{
 		mode:           cfgMode,
 		Table:          tblName,
 		PrimaryKeyMap:  pkMap,
 		ExecutionTime:  event.GetExecutionTime(),
-		OptionalSchema: event.GetOptionalSchema(),
+		OptionalSchema: optionalSchema,
 		Columns:        cols,
 		Data:           evtData,
 		Deleted:        event.DeletePayload(),


### PR DESCRIPTION
Addressing the TODO by returning an error along with `typing.Invalid` when parsing fails.