### PR TITLE
Adding JSON marshal to custom types

### DIFF
--- a/lib/typing/decimal/decimal.go
+++ b/lib/typing/decimal/decimal.go
@@ -1,6 +1,8 @@
 package decimal
 
 import (
+	"encoding/json"
+
 	"github.com/cockroachdb/apd/v3"
 )
 
@@ -10,6 +12,10 @@ const PrecisionNotSpecified int32 = -1
 type Decimal struct {
 	precision int32
 	value     *apd.Decimal
+}
+
+func (d Decimal) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
 }
 
 func NewDecimalWithPrecision(value *apd.Decimal, precision int32) *Decimal {

--- a/lib/typing/decimal/decimal_test.go
+++ b/lib/typing/decimal/decimal_test.go
@@ -1,6 +1,7 @@
 package decimal
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/artie-labs/transfer/lib/numbers"
@@ -38,4 +39,28 @@ func TestDecimal_Details(t *testing.T) {
 	assert.Equal(t, Details{scale: 0, precision: 10}, NewDecimalWithPrecision(numbers.MustParseDecimal("-12"), 10).Details())
 	assert.Equal(t, Details{scale: 2, precision: 10}, NewDecimalWithPrecision(numbers.MustParseDecimal("12345.12"), 10).Details())
 	assert.Equal(t, Details{scale: 3, precision: 10}, NewDecimalWithPrecision(numbers.MustParseDecimal("-12345.123"), 10).Details())
+}
+
+func TestMarshalJSON(t *testing.T) {
+	{
+		// Zero
+		bytes, err := NewDecimal(numbers.MustParseDecimal("0")).MarshalJSON()
+		assert.NoError(t, err)
+		assert.Equal(t, `"0"`, string(bytes))
+	}
+	{
+		// As a nested object
+		type Object struct {
+			Decimal *Decimal `json:"decimal"`
+			Foo     string   `json:"foo"`
+		}
+
+		var obj Object
+		obj.Decimal = NewDecimal(numbers.MustParseDecimal("0"))
+		obj.Foo = "bar"
+
+		bytes, err := json.Marshal(obj)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"decimal":"0","foo":"bar"}`, string(bytes))
+	}
 }

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -1,6 +1,9 @@
 package ext
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type ExtendedTimeKindType string
 
@@ -37,6 +40,10 @@ var (
 type ExtendedTime struct {
 	ts         time.Time
 	nestedKind NestedKind
+}
+
+func (e ExtendedTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.String(""))
 }
 
 func NewExtendedTime(t time.Time, kindType ExtendedTimeKindType, originalFormat string) *ExtendedTime {

--- a/lib/typing/ext/time_test.go
+++ b/lib/typing/ext/time_test.go
@@ -1,0 +1,35 @@
+package ext
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtendedTime_MarshalJSON(t *testing.T) {
+	extTime := NewExtendedTime(time.Date(2025, time.September, 13, 0, 0, 0, 123456000, time.UTC), DateTimeKindType, RFC3339Millisecond)
+
+	{
+		// Single value
+		bytes, err := json.Marshal(extTime)
+		assert.NoError(t, err)
+		assert.Equal(t, `"2025-09-13T00:00:00.123Z"`, string(bytes))
+	}
+	{
+		// As a nested object
+		type Object struct {
+			ExtendedTime *ExtendedTime `json:"extendedTime"`
+			Foo          string        `json:"foo"`
+		}
+
+		var obj Object
+		obj.ExtendedTime = extTime
+		obj.Foo = "bar"
+
+		bytes, err := json.Marshal(obj)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"extendedTime":"2025-09-13T00:00:00.123Z","foo":"bar"}`, string(bytes))
+	}
+}

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -100,7 +100,7 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 			return castedColVal.String(), nil
 		}
 
-		return "", fmt.Errorf("colVal is not *decimal.Decimal type, type is: %T", colVal)
+		return "", fmt.Errorf("unexpected colVal type: %T", colVal)
 	}
 
 	return fmt.Sprint(colVal), nil

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -92,7 +92,7 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 		switch castedColVal := colVal.(type) {
 		// It's okay if it's not a *decimal.Decimal, so long as it's a float or string.
 		// By having the flexibility of handling both *decimal.Decimal and float64/float32/string values within the same batch will increase our ability for data digestion.
-		case float64, float32:
+		case int64, int32, float64, float32:
 			return fmt.Sprint(castedColVal), nil
 		case string:
 			return castedColVal, nil

--- a/lib/typing/values/string_test.go
+++ b/lib/typing/values/string_test.go
@@ -107,24 +107,41 @@ func TestToString(t *testing.T) {
 	}
 	{
 		// Extended Decimal
-		// Floats
-		val, err := ToString(float32(123.45), typing.EDecimal)
-		assert.NoError(t, err)
-		assert.Equal(t, "123.45", val)
-
-		val, err = ToString(123.45, typing.EDecimal)
-		assert.NoError(t, err)
-		assert.Equal(t, "123.45", val)
-
-		// String
-		val, err = ToString("123.45", typing.EDecimal)
-		assert.NoError(t, err)
-		assert.Equal(t, "123.45", val)
-
-		// Decimals
-		value := decimal.NewDecimalWithPrecision(numbers.MustParseDecimal("585692791691858.25"), 38)
-		val, err = ToString(value, typing.EDecimal)
-		assert.NoError(t, err)
-		assert.Equal(t, "585692791691858.25", val)
+		{
+			// Float32
+			val, err := ToString(float32(123.45), typing.EDecimal)
+			assert.NoError(t, err)
+			assert.Equal(t, "123.45", val)
+		}
+		{
+			// Float64
+			val, err := ToString(123.45, typing.EDecimal)
+			assert.NoError(t, err)
+			assert.Equal(t, "123.45", val)
+		}
+		{
+			// String
+			val, err := ToString("123.45", typing.EDecimal)
+			assert.NoError(t, err)
+			assert.Equal(t, "123.45", val)
+		}
+		{
+			// Decimal
+			val, err := ToString(decimal.NewDecimalWithPrecision(numbers.MustParseDecimal("585692791691858.25"), 38), typing.EDecimal)
+			assert.NoError(t, err)
+			assert.Equal(t, "585692791691858.25", val)
+		}
+		{
+			// Int32
+			val, err := ToString(int32(123), typing.EDecimal)
+			assert.NoError(t, err)
+			assert.Equal(t, "123", val)
+		}
+		{
+			// Int64
+			val, err := ToString(int64(123), typing.EDecimal)
+			assert.NoError(t, err)
+			assert.Equal(t, "123", val)
+		}
 	}
 }


### PR DESCRIPTION
Our custom data types (Decimal and ExtTime) previously did not implement JSON marshal. 

This caused issues as we can have nested objects in MongoDB that had these custom data types. When we then ran `JSON.marshal(...)`, these types would then provide a zero value.