### PR TITLE
[Typing] ParseFromInterface to take ExtendedTimeKindType

### DIFF
--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -174,7 +174,7 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 				return nil, fmt.Errorf("extended time details for column kind details is nil")
 			}
 
-			extTime, err := ext.ParseFromInterfaceNew(value, column.KindDetails.ExtendedTimeDetails.Type)
+			extTime, err := ext.ParseFromInterface(value, column.KindDetails.ExtendedTimeDetails.Type)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast value as time.Time, value: %v, err: %w", value, err)
 			}

--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -170,13 +170,13 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 
 			message.Set(field, protoreflect.ValueOfString(castedValue))
 		case typing.ETime.Kind:
-			extTime, err := ext.ParseFromInterface(value)
-			if err != nil {
-				return nil, fmt.Errorf("failed to cast value as time.Time, value: %v, err: %w", value, err)
-			}
-
 			if column.KindDetails.ExtendedTimeDetails == nil {
 				return nil, fmt.Errorf("extended time details for column kind details is nil")
+			}
+
+			extTime, err := ext.ParseFromInterfaceNew(value, column.KindDetails.ExtendedTimeDetails.Type)
+			if err != nil {
+				return nil, fmt.Errorf("failed to cast value as time.Time, value: %v, err: %w", value, err)
 			}
 
 			switch column.KindDetails.ExtendedTimeDetails.Type {

--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -170,8 +170,8 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 
 			message.Set(field, protoreflect.ValueOfString(castedValue))
 		case typing.ETime.Kind:
-			if column.KindDetails.ExtendedTimeDetails == nil {
-				return nil, fmt.Errorf("extended time details for column kind details is nil")
+			if err := column.KindDetails.EnsureExtendedTimeDetails(); err != nil {
+				return nil, err
 			}
 
 			extTime, err := ext.ParseFromInterface(value, column.KindDetails.ExtendedTimeDetails.Type)

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -28,8 +28,8 @@ func parseValue(colVal any, colKind columns.Column) (any, error) {
 	colValString := fmt.Sprint(colVal)
 	switch colKind.KindDetails.Kind {
 	case typing.ETime.Kind:
-		if colKind.KindDetails.ExtendedTimeDetails == nil {
-			return "", fmt.Errorf("column kind details for extended time details is not set")
+		if err := colKind.KindDetails.EnsureExtendedTimeDetails(); err != nil {
+			return "", err
 		}
 
 		extTime, err := ext.ParseFromInterface(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -32,7 +32,7 @@ func parseValue(colVal any, colKind columns.Column) (any, error) {
 			return "", fmt.Errorf("column kind details for extended time details is not set")
 		}
 
-		extTime, err := ext.ParseFromInterfaceNew(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)
+		extTime, err := ext.ParseFromInterface(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -28,7 +28,11 @@ func parseValue(colVal any, colKind columns.Column) (any, error) {
 	colValString := fmt.Sprint(colVal)
 	switch colKind.KindDetails.Kind {
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(colVal)
+		if colKind.KindDetails.ExtendedTimeDetails == nil {
+			return "", fmt.Errorf("column kind details for extended time details is not set")
+		}
+
+		extTime, err := ext.ParseFromInterfaceNew(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -27,7 +27,7 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 			return nil, fmt.Errorf("column kind details for extended time is not set")
 		}
 
-		extTime, err := ext.ParseFromInterfaceNew(column.DefaultValue(), column.KindDetails.ExtendedTimeDetails.Type)
+		extTime, err := ext.ParseFromInterface(column.DefaultValue(), column.KindDetails.ExtendedTimeDetails.Type)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", column.DefaultValue(), err)
 		}

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -24,10 +24,10 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 		return dialect.EscapeStruct(fmt.Sprint(column.DefaultValue())), nil
 	case typing.ETime.Kind:
 		if column.KindDetails.ExtendedTimeDetails == nil {
-			return nil, fmt.Errorf("column kind details for extended time is nil")
+			return nil, fmt.Errorf("column kind details for extended time is not set")
 		}
 
-		extTime, err := ext.ParseFromInterface(column.DefaultValue())
+		extTime, err := ext.ParseFromInterfaceNew(column.DefaultValue(), column.KindDetails.ExtendedTimeDetails.Type)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", column.DefaultValue(), err)
 		}

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -23,8 +23,8 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 	case typing.Struct.Kind, typing.Array.Kind:
 		return dialect.EscapeStruct(fmt.Sprint(column.DefaultValue())), nil
 	case typing.ETime.Kind:
-		if column.KindDetails.ExtendedTimeDetails == nil {
-			return nil, fmt.Errorf("column kind details for extended time is not set")
+		if err := column.KindDetails.EnsureExtendedTimeDetails(); err != nil {
+			return nil, err
 		}
 
 		extTime, err := ext.ParseFromInterface(column.DefaultValue(), column.KindDetails.ExtendedTimeDetails.Type)

--- a/clients/shared/default_value_test.go
+++ b/clients/shared/default_value_test.go
@@ -25,7 +25,7 @@ var dialects = []sql.Dialect{
 
 func TestColumn_DefaultValue(t *testing.T) {
 	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
-	birthdayExtDateTime, err := ext.ParseExtendedDateTimeNew(birthday.Format(ext.ISO8601), ext.DateTimeKindType)
+	birthdayExtDateTime, err := ext.ParseExtendedDateTime(birthday.Format(ext.ISO8601), ext.DateTimeKindType)
 	assert.NoError(t, err)
 
 	// date

--- a/clients/shared/default_value_test.go
+++ b/clients/shared/default_value_test.go
@@ -25,7 +25,7 @@ var dialects = []sql.Dialect{
 
 func TestColumn_DefaultValue(t *testing.T) {
 	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
-	birthdayExtDateTime, err := ext.ParseExtendedDateTime(birthday.Format(ext.ISO8601))
+	birthdayExtDateTime, err := ext.ParseExtendedDateTimeNew(birthday.Format(ext.ISO8601), ext.DateTimeKindType)
 	assert.NoError(t, err)
 
 	// date

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -202,7 +202,7 @@ func (t *TableData) DistinctDates(colName string) ([]string, error) {
 			return nil, fmt.Errorf("col: %v does not exist on row: %v", colName, row)
 		}
 
-		extTime, err := ext.ParseFromInterface(val)
+		extTime, err := ext.ParseFromInterfaceNew(val, ext.DateKindType)
 		if err != nil {
 			return nil, fmt.Errorf("col: %v is not a time column, value: %v, err: %w", colName, val, err)
 		}

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -202,7 +202,7 @@ func (t *TableData) DistinctDates(colName string) ([]string, error) {
 			return nil, fmt.Errorf("col: %v does not exist on row: %v", colName, row)
 		}
 
-		extTime, err := ext.ParseFromInterfaceNew(val, ext.DateKindType)
+		extTime, err := ext.ParseFromInterface(val, ext.DateKindType)
 		if err != nil {
 			return nil, fmt.Errorf("col: %v is not a time column, value: %v, err: %w", colName, val, err)
 		}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -21,8 +21,8 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 
 	switch colKind.KindDetails.Kind {
 	case typing.ETime.Kind:
-		if colKind.KindDetails.ExtendedTimeDetails == nil {
-			return "", fmt.Errorf("column kind details for extended time details is not set")
+		if err := colKind.KindDetails.EnsureExtendedTimeDetails(); err != nil {
+			return "", err
 		}
 
 		extTime, err := ext.ParseFromInterface(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -21,13 +21,13 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 
 	switch colKind.KindDetails.Kind {
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(colVal)
-		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
+		if colKind.KindDetails.ExtendedTimeDetails == nil {
+			return "", fmt.Errorf("column kind details for extended time details is not set")
 		}
 
-		if colKind.KindDetails.ExtendedTimeDetails == nil {
-			return "", fmt.Errorf("column kind details for extended time details is null")
+		extTime, err := ext.ParseFromInterfaceNew(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)
+		if err != nil {
+			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
 		if colKind.KindDetails.ExtendedTimeDetails.Type == ext.DateKindType || colKind.KindDetails.ExtendedTimeDetails.Type == ext.TimeKindType {

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -25,7 +25,7 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 			return "", fmt.Errorf("column kind details for extended time details is not set")
 		}
 
-		extTime, err := ext.ParseFromInterfaceNew(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)
+		extTime, err := ext.ParseFromInterface(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -20,14 +20,14 @@ func ParseTimeExactMatch(layout, value string) (time.Time, error) {
 	return ts, nil
 }
 
-func ParseFromInterfaceNew(val any, kindType ExtendedTimeKindType) (*ExtendedTime, error) {
+func ParseFromInterface(val any, kindType ExtendedTimeKindType) (*ExtendedTime, error) {
 	switch convertedVal := val.(type) {
 	case nil:
 		return nil, fmt.Errorf("val is nil")
 	case *ExtendedTime:
 		return convertedVal, nil
 	case string:
-		extendedTime, err := ParseExtendedDateTimeNew(convertedVal, kindType)
+		extendedTime, err := ParseExtendedDateTime(convertedVal, kindType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse colVal: %q, err: %w", val, err)
 		}
@@ -38,7 +38,7 @@ func ParseFromInterfaceNew(val any, kindType ExtendedTimeKindType) (*ExtendedTim
 	}
 }
 
-func ParseExtendedDateTimeNew(val string, kindType ExtendedTimeKindType) (*ExtendedTime, error) {
+func ParseExtendedDateTime(val string, kindType ExtendedTimeKindType) (*ExtendedTime, error) {
 	switch kindType {
 	case DateTimeKindType:
 		return parseDateTime(val)

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// TODO: Deprecate
 func ParseFromInterface(val any) (*ExtendedTime, error) {
 	switch convertedVal := val.(type) {
 	case nil:
@@ -38,8 +39,8 @@ func ParseTimeExactMatch(layout, value string) (time.Time, error) {
 	return ts, nil
 }
 
+// TODO: Deprecate
 func ParseExtendedDateTime(val string) (*ExtendedTime, error) {
-	// TODO: ExtendedTimeKindType so we can selectively parse.
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
 		if ts, err := ParseTimeExactMatch(supportedDateTimeLayout, val); err == nil {
 			return NewExtendedTime(ts, DateTimeKindType, supportedDateTimeLayout), nil
@@ -61,4 +62,83 @@ func ParseExtendedDateTime(val string) (*ExtendedTime, error) {
 	}
 
 	return nil, fmt.Errorf("unsupported value: %q", val)
+}
+
+func ParseFromInterfaceNew(val any, kindType ExtendedTimeKindType) (*ExtendedTime, error) {
+	switch convertedVal := val.(type) {
+	case nil:
+		return nil, fmt.Errorf("val is nil")
+	case *ExtendedTime:
+		return convertedVal, nil
+	case string:
+		extendedTime, err := ParseExtendedDateTimeNew(convertedVal, kindType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", val, err)
+		}
+
+		return extendedTime, nil
+	default:
+		return nil, fmt.Errorf("failed to parse colVal, expected type string or *ExtendedTime and got: %T", convertedVal)
+	}
+}
+
+func ParseExtendedDateTimeNew(val string, kindType ExtendedTimeKindType) (*ExtendedTime, error) {
+	switch kindType {
+	case DateTimeKindType:
+		return parseDateTime(val)
+	case DateKindType:
+		// Try date first
+		if et, err := parseDate(val); err == nil {
+			return et, nil
+		}
+
+		// If that doesn't work, try timestamp
+		if et, err := parseDateTime(val); err == nil {
+			et.nestedKind = Date
+			return et, nil
+		}
+	case TimeKindType:
+		// Try time first
+		if et, err := parseTime(val); err == nil {
+			return et, nil
+		}
+
+		// If that doesn't work, try timestamp
+		if et, err := parseDateTime(val); err == nil {
+			et.nestedKind = Time
+			return et, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unsupported value: %q, kindType: %q", val, kindType)
+}
+
+func parseDateTime(value string) (*ExtendedTime, error) {
+	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
+		if ts, err := ParseTimeExactMatch(supportedDateTimeLayout, value); err == nil {
+			return NewExtendedTime(ts, DateTimeKindType, supportedDateTimeLayout), nil
+		}
+	}
+
+	return nil, fmt.Errorf("unsupported value: %q", value)
+}
+
+func parseDate(value string) (*ExtendedTime, error) {
+	for _, supportedDateFormat := range supportedDateFormats {
+		if ts, err := ParseTimeExactMatch(supportedDateFormat, value); err == nil {
+			return NewExtendedTime(ts, DateKindType, supportedDateFormat), nil
+		}
+	}
+
+	return nil, fmt.Errorf("unsupported value: %q", value)
+}
+
+func parseTime(value string) (*ExtendedTime, error) {
+	for _, supportedTimeFormat := range SupportedTimeFormatsLegacy {
+		if ts, err := ParseTimeExactMatch(supportedTimeFormat, value); err == nil {
+			return NewExtendedTime(ts, TimeKindType, supportedTimeFormat), nil
+		}
+	}
+
+	return nil, fmt.Errorf("unsupported value: %q", value)
 }

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -66,7 +66,7 @@ func ParseExtendedDateTime(value string, kindType ExtendedTimeKindType) (*Extend
 		}
 	}
 
-	return nil, fmt.Errorf("unsupported value: %q, kindType: %q", val, kindType)
+	return nil, fmt.Errorf("unsupported value: %q, kindType: %q", value, kindType)
 }
 
 func parseDateTime(value string) (*ExtendedTime, error) {

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -5,25 +5,6 @@ import (
 	"time"
 )
 
-// TODO: Deprecate
-func ParseFromInterface(val any) (*ExtendedTime, error) {
-	switch convertedVal := val.(type) {
-	case nil:
-		return nil, fmt.Errorf("val is nil")
-	case *ExtendedTime:
-		return convertedVal, nil
-	case string:
-		extendedTime, err := ParseExtendedDateTime(convertedVal)
-		if err != nil {
-			return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", val, err)
-		}
-
-		return extendedTime, nil
-	default:
-		return nil, fmt.Errorf("failed to parse colVal, expected type string or *ExtendedTime and got: %T", convertedVal)
-	}
-}
-
 // ParseTimeExactMatch will return an error if it was not an exact match.
 // We need this function because things may parse correctly but actually truncate precision
 func ParseTimeExactMatch(layout, value string) (time.Time, error) {
@@ -37,31 +18,6 @@ func ParseTimeExactMatch(layout, value string) (time.Time, error) {
 	}
 
 	return ts, nil
-}
-
-// TODO: Deprecate
-func ParseExtendedDateTime(val string) (*ExtendedTime, error) {
-	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		if ts, err := ParseTimeExactMatch(supportedDateTimeLayout, val); err == nil {
-			return NewExtendedTime(ts, DateTimeKindType, supportedDateTimeLayout), nil
-		}
-	}
-
-	// Now check DATE formats, btw you can append nil arrays
-	for _, supportedDateFormat := range supportedDateFormats {
-		if ts, err := ParseTimeExactMatch(supportedDateFormat, val); err == nil {
-			return NewExtendedTime(ts, DateKindType, supportedDateFormat), nil
-		}
-	}
-
-	// Now check TIME formats
-	for _, supportedTimeFormat := range SupportedTimeFormatsLegacy {
-		if ts, err := ParseTimeExactMatch(supportedTimeFormat, val); err == nil {
-			return NewExtendedTime(ts, TimeKindType, supportedTimeFormat), nil
-		}
-	}
-
-	return nil, fmt.Errorf("unsupported value: %q", val)
 }
 
 func ParseFromInterfaceNew(val any, kindType ExtendedTimeKindType) (*ExtendedTime, error) {

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -73,7 +73,7 @@ func ParseFromInterfaceNew(val any, kindType ExtendedTimeKindType) (*ExtendedTim
 	case string:
 		extendedTime, err := ParseExtendedDateTimeNew(convertedVal, kindType)
 		if err != nil {
-			return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", val, err)
+			return nil, fmt.Errorf("failed to parse colVal: %q, err: %w", val, err)
 		}
 
 		return extendedTime, nil

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -38,29 +38,29 @@ func ParseFromInterface(val any, kindType ExtendedTimeKindType) (*ExtendedTime, 
 	}
 }
 
-func ParseExtendedDateTime(val string, kindType ExtendedTimeKindType) (*ExtendedTime, error) {
+func ParseExtendedDateTime(value string, kindType ExtendedTimeKindType) (*ExtendedTime, error) {
 	switch kindType {
 	case DateTimeKindType:
-		return parseDateTime(val)
+		return parseDateTime(value)
 	case DateKindType:
 		// Try date first
-		if et, err := parseDate(val); err == nil {
+		if et, err := parseDate(value); err == nil {
 			return et, nil
 		}
 
 		// If that doesn't work, try timestamp
-		if et, err := parseDateTime(val); err == nil {
+		if et, err := parseDateTime(value); err == nil {
 			et.nestedKind = Date
 			return et, nil
 		}
 	case TimeKindType:
 		// Try time first
-		if et, err := parseTime(val); err == nil {
+		if et, err := parseTime(value); err == nil {
 			return et, nil
 		}
 
 		// If that doesn't work, try timestamp
-		if et, err := parseDateTime(val); err == nil {
+		if et, err := parseDateTime(value); err == nil {
 			et.nestedKind = Time
 			return et, nil
 		}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -16,24 +16,24 @@ func TestParseFromInterface(t *testing.T) {
 		vals = append(vals, NewExtendedTime(time.Now().UTC(), TimeKindType, PostgresTimeFormat))
 
 		for _, val := range vals {
-			extTime, err := ParseFromInterface(val)
+			extTime, err := ParseFromInterfaceNew(val, DateTimeKindType)
 			assert.NoError(t, err)
 			assert.Equal(t, val, extTime)
 		}
 	}
 	{
 		// Nil
-		_, err := ParseFromInterface(nil)
+		_, err := ParseFromInterfaceNew(nil, DateTimeKindType)
 		assert.ErrorContains(t, err, "val is nil")
 	}
 	{
 		// True
-		_, err := ParseFromInterface(true)
+		_, err := ParseFromInterfaceNew(true, DateTimeKindType)
 		assert.ErrorContains(t, err, "failed to parse colVal, expected type string or *ExtendedTime and got: bool")
 	}
 	{
 		// False
-		_, err := ParseFromInterface(false)
+		_, err := ParseFromInterfaceNew(false, DateTimeKindType)
 		assert.ErrorContains(t, err, "failed to parse colVal, expected type string or *ExtendedTime and got: bool")
 	}
 }
@@ -41,7 +41,7 @@ func TestParseFromInterface(t *testing.T) {
 func TestParseFromInterfaceDateTime(t *testing.T) {
 	now := time.Now().In(time.UTC)
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		et, err := ParseFromInterface(now.Format(supportedDateTimeLayout))
+		et, err := ParseFromInterfaceNew(now.Format(supportedDateTimeLayout), DateTimeKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, DateTimeKindType, et.GetNestedKind().Type)
 		assert.Equal(t, et.String(""), now.Format(supportedDateTimeLayout))
@@ -51,7 +51,7 @@ func TestParseFromInterfaceDateTime(t *testing.T) {
 func TestParseFromInterfaceTime(t *testing.T) {
 	now := time.Now()
 	for _, supportedTimeFormat := range SupportedTimeFormatsLegacy {
-		et, err := ParseFromInterface(now.Format(supportedTimeFormat))
+		et, err := ParseFromInterfaceNew(now.Format(supportedTimeFormat), TimeKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, TimeKindType, et.GetNestedKind().Type)
 		// Without passing an override format, this should return the same preserved dt format.
@@ -62,7 +62,7 @@ func TestParseFromInterfaceTime(t *testing.T) {
 func TestParseFromInterfaceDate(t *testing.T) {
 	now := time.Now()
 	for _, supportedDateFormat := range supportedDateFormats {
-		et, err := ParseFromInterface(now.Format(supportedDateFormat))
+		et, err := ParseFromInterfaceNew(now.Format(supportedDateFormat), DateKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, DateKindType, et.GetNestedKind().Type)
 
@@ -73,7 +73,7 @@ func TestParseFromInterfaceDate(t *testing.T) {
 
 func TestParseExtendedDateTime_Timestamp(t *testing.T) {
 	tsString := "2023-04-24T17:29:05.69944Z"
-	extTime, err := ParseExtendedDateTime(tsString)
+	extTime, err := ParseExtendedDateTimeNew(tsString, DateTimeKindType)
 	assert.NoError(t, err)
 	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.String(""))
 }
@@ -83,7 +83,7 @@ func TestTimeLayout(t *testing.T) {
 
 	for _, supportedFormat := range SupportedTimeFormatsLegacy {
 		parsedTsString := ts.Format(supportedFormat)
-		extTime, err := ParseExtendedDateTime(parsedTsString)
+		extTime, err := ParseExtendedDateTimeNew(parsedTsString, TimeKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, parsedTsString, extTime.String(""))
 	}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -16,24 +16,24 @@ func TestParseFromInterface(t *testing.T) {
 		vals = append(vals, NewExtendedTime(time.Now().UTC(), TimeKindType, PostgresTimeFormat))
 
 		for _, val := range vals {
-			extTime, err := ParseFromInterfaceNew(val, DateTimeKindType)
+			extTime, err := ParseFromInterface(val, DateTimeKindType)
 			assert.NoError(t, err)
 			assert.Equal(t, val, extTime)
 		}
 	}
 	{
 		// Nil
-		_, err := ParseFromInterfaceNew(nil, DateTimeKindType)
+		_, err := ParseFromInterface(nil, DateTimeKindType)
 		assert.ErrorContains(t, err, "val is nil")
 	}
 	{
 		// True
-		_, err := ParseFromInterfaceNew(true, DateTimeKindType)
+		_, err := ParseFromInterface(true, DateTimeKindType)
 		assert.ErrorContains(t, err, "failed to parse colVal, expected type string or *ExtendedTime and got: bool")
 	}
 	{
 		// False
-		_, err := ParseFromInterfaceNew(false, DateTimeKindType)
+		_, err := ParseFromInterface(false, DateTimeKindType)
 		assert.ErrorContains(t, err, "failed to parse colVal, expected type string or *ExtendedTime and got: bool")
 	}
 }
@@ -41,7 +41,7 @@ func TestParseFromInterface(t *testing.T) {
 func TestParseFromInterfaceDateTime(t *testing.T) {
 	now := time.Now().In(time.UTC)
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		et, err := ParseFromInterfaceNew(now.Format(supportedDateTimeLayout), DateTimeKindType)
+		et, err := ParseFromInterface(now.Format(supportedDateTimeLayout), DateTimeKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, DateTimeKindType, et.GetNestedKind().Type)
 		assert.Equal(t, et.String(""), now.Format(supportedDateTimeLayout))
@@ -51,7 +51,7 @@ func TestParseFromInterfaceDateTime(t *testing.T) {
 func TestParseFromInterfaceTime(t *testing.T) {
 	now := time.Now()
 	for _, supportedTimeFormat := range SupportedTimeFormatsLegacy {
-		et, err := ParseFromInterfaceNew(now.Format(supportedTimeFormat), TimeKindType)
+		et, err := ParseFromInterface(now.Format(supportedTimeFormat), TimeKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, TimeKindType, et.GetNestedKind().Type)
 		// Without passing an override format, this should return the same preserved dt format.
@@ -62,7 +62,7 @@ func TestParseFromInterfaceTime(t *testing.T) {
 func TestParseFromInterfaceDate(t *testing.T) {
 	now := time.Now()
 	for _, supportedDateFormat := range supportedDateFormats {
-		et, err := ParseFromInterfaceNew(now.Format(supportedDateFormat), DateKindType)
+		et, err := ParseFromInterface(now.Format(supportedDateFormat), DateKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, DateKindType, et.GetNestedKind().Type)
 
@@ -73,7 +73,7 @@ func TestParseFromInterfaceDate(t *testing.T) {
 
 func TestParseExtendedDateTime_Timestamp(t *testing.T) {
 	tsString := "2023-04-24T17:29:05.69944Z"
-	extTime, err := ParseExtendedDateTimeNew(tsString, DateTimeKindType)
+	extTime, err := ParseExtendedDateTime(tsString, DateTimeKindType)
 	assert.NoError(t, err)
 	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.String(""))
 }
@@ -83,7 +83,7 @@ func TestTimeLayout(t *testing.T) {
 
 	for _, supportedFormat := range SupportedTimeFormatsLegacy {
 		parsedTsString := ts.Format(supportedFormat)
-		extTime, err := ParseExtendedDateTimeNew(parsedTsString, TimeKindType)
+		extTime, err := ParseExtendedDateTime(parsedTsString, TimeKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, parsedTsString, extTime.String(""))
 	}

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -2,6 +2,7 @@ package typing
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/artie-labs/transfer/lib/typing/decimal"
@@ -15,6 +16,14 @@ type KindDetails struct {
 
 	// Optional kind details metadata
 	OptionalStringPrecision *int32
+}
+
+func (k *KindDetails) EnsureExtendedTimeDetails() error {
+	if k.ExtendedTimeDetails == nil {
+		return fmt.Errorf("extended time details is not set")
+	}
+
+	return nil
 }
 
 // Summarized this from Snowflake + Reflect.

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -32,7 +32,7 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 			return "", fmt.Errorf("column kind details for extended time details is null")
 		}
 
-		extTime, err := ext.ParseFromInterfaceNew(colVal, colKind.ExtendedTimeDetails.Type)
+		extTime, err := ext.ParseFromInterface(colVal, colKind.ExtendedTimeDetails.Type)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -28,8 +28,8 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 
 	switch colKind.Kind {
 	case typing.ETime.Kind:
-		if colKind.ExtendedTimeDetails == nil {
-			return "", fmt.Errorf("column kind details for extended time details is null")
+		if err := colKind.EnsureExtendedTimeDetails(); err != nil {
+			return "", err
 		}
 
 		extTime, err := ext.ParseFromInterface(colVal, colKind.ExtendedTimeDetails.Type)

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -28,13 +28,13 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 
 	switch colKind.Kind {
 	case typing.ETime.Kind:
-		extTime, err := ext.ParseFromInterface(colVal)
-		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
-		}
-
 		if colKind.ExtendedTimeDetails == nil {
 			return "", fmt.Errorf("column kind details for extended time details is null")
+		}
+
+		extTime, err := ext.ParseFromInterfaceNew(colVal, colKind.ExtendedTimeDetails.Type)
+		if err != nil {
+			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
 		if colKind.ExtendedTimeDetails.Type == ext.TimeKindType {


### PR DESCRIPTION
In this PR, we are refactoring `ParseFromInterface` to take `ExtendedTimeKindType` so we know what we need to be parsing against.

This way, for `DateTime` types, we don't need to try and parse layouts that are targeted for `DATE` and `TIME`.