### PR TITLE
[Typing] Default Value

### DIFF
--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -39,6 +39,11 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 			return sql.QuoteLiteral(extTime.String(column.KindDetails.ExtendedTimeDetails.Format)), nil
 		}
 	case typing.EDecimal.Kind:
+		int64Value, err := typing.AssertType[int64](column.DefaultValue())
+		if err == nil {
+			return fmt.Sprint(int64Value), nil
+		}
+
 		decimalValue, err := typing.AssertType[*decimal.Decimal](column.DefaultValue())
 		if err != nil {
 			return nil, err

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -39,9 +39,11 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 			return sql.QuoteLiteral(extTime.String(column.KindDetails.ExtendedTimeDetails.Format)), nil
 		}
 	case typing.EDecimal.Kind:
-		int64Value, err := typing.AssertType[int64](column.DefaultValue())
-		if err == nil {
-			return fmt.Sprint(int64Value), nil
+		if column.KindDetails.ExtendedDecimalDetails.Scale() == 0 {
+			int64Value, err := typing.AssertType[int64](column.DefaultValue())
+			if err == nil {
+				return fmt.Sprint(int64Value), nil
+			}
 		}
 
 		decimalValue, err := typing.AssertType[*decimal.Decimal](column.DefaultValue())

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -40,9 +40,9 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 		}
 	case typing.EDecimal.Kind:
 		if column.KindDetails.ExtendedDecimalDetails.Scale() == 0 {
-			int64Value, err := typing.AssertType[int64](column.DefaultValue())
-			if err == nil {
-				return fmt.Sprint(int64Value), nil
+			switch column.DefaultValue().(type) {
+			case int, int8, int16, int32, int64:
+				return fmt.Sprint(column.DefaultValue()), nil
 			}
 		}
 

--- a/clients/shared/default_value_test.go
+++ b/clients/shared/default_value_test.go
@@ -111,21 +111,21 @@ func TestColumn_DefaultValue(t *testing.T) {
 		{
 			// Type *decimal.Decimal
 			decimalValue := decimal.NewDecimal(numbers.MustParseDecimal("3.14159"))
-			col := columns.NewColumnWithDefaultValue("", typing.EDecimal, decimalValue)
+			col := columns.NewColumnWithDefaultValue("", typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(7, 5)), decimalValue)
 			value, err := DefaultValue(col, redshiftDialect.RedshiftDialect{})
 			assert.NoError(t, err)
 			assert.Equal(t, "3.14159", value)
 		}
 		{
 			// Type int64
-			col := columns.NewColumnWithDefaultValue("", typing.EDecimal, int64(123))
+			col := columns.NewColumnWithDefaultValue("", typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(5, 0)), int64(123))
 			value, err := DefaultValue(col, redshiftDialect.RedshiftDialect{})
 			assert.NoError(t, err)
 			assert.Equal(t, "123", value)
 		}
 		{
 			// Wrong type (string)
-			col := columns.NewColumnWithDefaultValue("", typing.EDecimal, "hello")
+			col := columns.NewColumnWithDefaultValue("", typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(7, 5)), "hello")
 			_, err := DefaultValue(col, redshiftDialect.RedshiftDialect{})
 			assert.ErrorContains(t, err, "expected type *decimal.Decimal, got string")
 		}

--- a/clients/shared/default_value_test.go
+++ b/clients/shared/default_value_test.go
@@ -106,7 +106,6 @@ func TestColumn_DefaultValue(t *testing.T) {
 			assert.Equal(t, expectedValue, actualValue, fmt.Sprintf("%s %s", testCase.name, dialect))
 		}
 	}
-
 	{
 		// Decimal value
 		{
@@ -116,6 +115,13 @@ func TestColumn_DefaultValue(t *testing.T) {
 			value, err := DefaultValue(col, redshiftDialect.RedshiftDialect{})
 			assert.NoError(t, err)
 			assert.Equal(t, "3.14159", value)
+		}
+		{
+			// Type int64
+			col := columns.NewColumnWithDefaultValue("", typing.EDecimal, int64(123))
+			value, err := DefaultValue(col, redshiftDialect.RedshiftDialect{})
+			assert.NoError(t, err)
+			assert.Equal(t, "123", value)
 		}
 		{
 			// Wrong type (string)


### PR DESCRIPTION
With this PR: https://github.com/artie-labs/transfer/pull/893, we now treat columns that are `NUMERIC(p, 0)` which are integer columns as `ExtendedDecimal` type with scale of 0.

This means that we can have default values that are integers. This PR adds handling for that.