### PR TITLE
Simplifying Merge Columns

### DIFF
--- a/lib/optimization/table_data_merge_columns_test.go
+++ b/lib/optimization/table_data_merge_columns_test.go
@@ -14,49 +14,48 @@ const strCol = "string"
 
 func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 	{
+		// Trying to merge an invalid destination column
 		tableDataCols := &columns.Columns{}
-		tableData := &TableData{
-			inMemoryColumns: tableDataCols,
-		}
-
+		tableData := &TableData{inMemoryColumns: tableDataCols}
 		tableData.AddInMemoryCol(columns.NewColumn("foo", typing.String))
 		invalidCol := columns.NewColumn("foo", typing.Invalid)
 		assert.ErrorContains(t, tableData.MergeColumnsFromDestination(invalidCol), `column "foo" is invalid`)
 	}
 	{
-		// If the in-memory column is a string and the destination column is Date
-		// We should mark the in-memory column as date and try to parse it accordingly.
+		// In-memory column is a string and the destination column is a Date
 		tableDataCols := &columns.Columns{}
-		tableData := &TableData{
-			inMemoryColumns: tableDataCols,
-		}
-
+		tableData := &TableData{inMemoryColumns: tableDataCols}
 		tableData.AddInMemoryCol(columns.NewColumn("foo", typing.String))
 
 		extTime := typing.ETime
-		extTime.ExtendedTimeDetails = &ext.NestedKind{
-			Type: ext.DateKindType,
-		}
-
+		extTime.ExtendedTimeDetails = &ext.Date
 		tsCol := columns.NewColumn("foo", extTime)
 		assert.NoError(t, tableData.MergeColumnsFromDestination(tsCol))
 
-		col, isOk := tableData.inMemoryColumns.GetColumn("foo")
+		updatedColumn, isOk := tableData.inMemoryColumns.GetColumn("foo")
 		assert.True(t, isOk)
-		assert.Equal(t, typing.ETime.Kind, col.KindDetails.Kind)
-		assert.Equal(t, ext.DateKindType, col.KindDetails.ExtendedTimeDetails.Type)
-		assert.Equal(t, extTime.ExtendedTimeDetails, col.KindDetails.ExtendedTimeDetails)
+		assert.Equal(t, typing.ETime.Kind, updatedColumn.KindDetails.Kind)
+		assert.Equal(t, ext.DateKindType, updatedColumn.KindDetails.ExtendedTimeDetails.Type)
+		// Format is not copied over.
+		assert.Equal(t, "", updatedColumn.KindDetails.ExtendedTimeDetails.Format)
 	}
 	{
 		tableDataCols := &columns.Columns{}
-		tableData := &TableData{
-			inMemoryColumns: tableDataCols,
+		tableData := &TableData{inMemoryColumns: tableDataCols}
+
+		{
+			// In-memory column is NUMERIC and destination column is an INTEGER
+			tableDataCols.AddColumn(columns.NewColumn("numeric_test", typing.EDecimal))
+			assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("numeric_test", typing.Integer)))
+
+			numericCol, isOk := tableData.inMemoryColumns.GetColumn("numeric_test")
+			assert.True(t, isOk)
+			assert.Equal(t, typing.Integer.Kind, numericCol.KindDetails.Kind)
 		}
 
 		tableDataCols.AddColumn(columns.NewColumn("name", typing.String))
 		tableDataCols.AddColumn(columns.NewColumn("bool_backfill", typing.Boolean))
 		tableDataCols.AddColumn(columns.NewColumn("prev_invalid", typing.Invalid))
-		tableDataCols.AddColumn(columns.NewColumn("numeric_test", typing.EDecimal))
 
 		// Casting these as STRING so tableColumn via this f(x) will set it correctly.
 		tableDataCols.AddColumn(columns.NewColumn("ext_date", typing.String))
@@ -81,12 +80,6 @@ func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 			_, isOk := tableData.inMemoryColumns.GetColumn(nonExistentTableCol)
 			assert.False(t, isOk, nonExistentTableCol)
 		}
-
-		// Making sure it's still numeric
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("numeric_test", typing.Integer)))
-		numericCol, isOk := tableData.inMemoryColumns.GetColumn("numeric_test")
-		assert.True(t, isOk)
-		assert.Equal(t, typing.EDecimal.Kind, numericCol.KindDetails.Kind, "numeric_test")
 
 		// Testing to make sure we're copying the kindDetails over.
 		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("prev_invalid", typing.String)))
@@ -169,20 +162,18 @@ func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 		assert.Equal(t, int32(2), extDecColFilled.KindDetails.ExtendedDecimalDetails.Scale())
 	}
 	{
+		// String (precision being copied over)
 		tableDataCols := &columns.Columns{}
-		tableData := &TableData{
-			inMemoryColumns: tableDataCols,
-		}
+		tableData := &TableData{inMemoryColumns: tableDataCols}
 
 		tableDataCols.AddColumn(columns.NewColumn(strCol, typing.String))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn(strCol,
+			typing.KindDetails{
+				Kind:                    typing.String.Kind,
+				OptionalStringPrecision: typing.ToPtr(int32(123)),
+			}),
+		))
 
-		// Testing string precision
-		stringKindWithPrecision := typing.KindDetails{
-			Kind:                    typing.String.Kind,
-			OptionalStringPrecision: typing.ToPtr(int32(123)),
-		}
-
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn(strCol, stringKindWithPrecision)))
 		foundStrCol, isOk := tableData.inMemoryColumns.GetColumn(strCol)
 		assert.True(t, isOk)
 		assert.Equal(t, typing.String.Kind, foundStrCol.KindDetails.Kind)

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+// TODO: This package should have a concept of default formats for each type.
+
 type ExtendedTimeKindType string
 
 const (


### PR DESCRIPTION
We have not see the warning "Skipping columns" in our logs, so we should be safe to simplify the logic.

In doing so, I also refactored some of our tests.