### PR TITLE
Adding an additional timestamp layout.

### DIFF
--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -40,6 +40,7 @@ func TestParseFromInterface(t *testing.T) {
 		value, err := ParseFromInterface("2024-09-19T16:05:18.630Z", TimestampTzKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, "2024-09-19T16:05:18.630Z", value.String(""))
+		assert.Equal(t, RFC3339MillisecondUTC, value.nestedKind.Format)
 	}
 }
 

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -37,10 +37,25 @@ func TestParseFromInterface(t *testing.T) {
 		assert.ErrorContains(t, err, "failed to parse colVal, expected type string or *ExtendedTime and got: bool")
 	}
 	{
+		// String - RFC3339MillisecondUTC
 		value, err := ParseFromInterface("2024-09-19T16:05:18.630Z", TimestampTzKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, "2024-09-19T16:05:18.630Z", value.String(""))
 		assert.Equal(t, RFC3339MillisecondUTC, value.nestedKind.Format)
+	}
+	{
+		// String - RFC3339MicrosecondUTC
+		value, err := ParseFromInterface("2024-09-19T16:05:18.630000Z", TimestampTzKindType)
+		assert.NoError(t, err)
+		assert.Equal(t, "2024-09-19T16:05:18.630000Z", value.String(""))
+		assert.Equal(t, RFC3339MicrosecondUTC, value.nestedKind.Format)
+	}
+	{
+		// String - RFC3339NanosecondUTC
+		value, err := ParseFromInterface("2024-09-19T16:05:18.630000000Z", TimestampTzKindType)
+		assert.NoError(t, err)
+		assert.Equal(t, "2024-09-19T16:05:18.630000000Z", value.String(""))
+		assert.Equal(t, RFC3339NanosecondUTC, value.nestedKind.Format)
 	}
 }
 

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -1,6 +1,7 @@
 package ext
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -35,6 +36,11 @@ func TestParseFromInterface(t *testing.T) {
 		// False
 		_, err := ParseFromInterface(false, TimestampTzKindType)
 		assert.ErrorContains(t, err, "failed to parse colVal, expected type string or *ExtendedTime and got: bool")
+	}
+	{
+		value, err := ParseFromInterface("2024-09-19T16:05:18.630Z", TimestampTzKindType)
+		assert.NoError(t, err)
+		fmt.Println("value", value)
 	}
 }
 

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -1,7 +1,6 @@
 package ext
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -40,7 +39,7 @@ func TestParseFromInterface(t *testing.T) {
 	{
 		value, err := ParseFromInterface("2024-09-19T16:05:18.630Z", TimestampTzKindType)
 		assert.NoError(t, err)
-		fmt.Println("value", value)
+		assert.Equal(t, "2024-09-19T16:05:18.630Z", value.String(""))
 	}
 }
 

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -11,8 +11,16 @@ const (
 )
 
 var supportedDateTimeLayouts = []string{
+	// UTC
 	RFC3339MillisecondUTC,
+	RFC3339MicrosecondUTC,
+	RFC3339NanosecondUTC,
+	// RFC 3339
+	RFC3339Millisecond,
+	RFC3339Microsecond,
+	RFC3339Nanosecond,
 	time.RFC3339Nano,
+	// Others
 	ISO8601,
 	time.Layout,
 	time.ANSIC,
@@ -39,6 +47,8 @@ var SupportedTimeFormats = []string{
 // RFC3339 variants
 const (
 	RFC3339MillisecondUTC = "2006-01-02T15:04:05.000Z"
+	RFC3339MicrosecondUTC = "2006-01-02T15:04:05.000000Z"
+	RFC3339NanosecondUTC  = "2006-01-02T15:04:05.000000000Z"
 	RFC3339Millisecond    = "2006-01-02T15:04:05.000Z07:00"
 	RFC3339Microsecond    = "2006-01-02T15:04:05.000000Z07:00"
 	RFC3339Nanosecond     = "2006-01-02T15:04:05.000000000Z07:00"

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -12,6 +12,8 @@ const (
 
 var supportedDateTimeLayouts = []string{
 	time.RFC3339Nano,
+	// TODO: This should be pulled into `TIMESTAMP_NTZ`
+	"2006-01-02T15:04:05.000Z", // RFC 3339 without timezone
 	ISO8601,
 	time.Layout,
 	time.ANSIC,

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -11,9 +11,8 @@ const (
 )
 
 var supportedDateTimeLayouts = []string{
+	RFC3339MillisecondUTC,
 	time.RFC3339Nano,
-	// TODO: This should be pulled into `TIMESTAMP_NTZ`
-	"2006-01-02T15:04:05.000Z", // RFC 3339 without timezone
 	ISO8601,
 	time.Layout,
 	time.ANSIC,
@@ -39,7 +38,8 @@ var SupportedTimeFormats = []string{
 
 // RFC3339 variants
 const (
-	RFC3339Millisecond = "2006-01-02T15:04:05.000Z07:00"
-	RFC3339Microsecond = "2006-01-02T15:04:05.000000Z07:00"
-	RFC3339Nanosecond  = "2006-01-02T15:04:05.000000000Z07:00"
+	RFC3339MillisecondUTC = "2006-01-02T15:04:05.000Z"
+	RFC3339Millisecond    = "2006-01-02T15:04:05.000Z07:00"
+	RFC3339Microsecond    = "2006-01-02T15:04:05.000000Z07:00"
+	RFC3339Nanosecond     = "2006-01-02T15:04:05.000000000Z07:00"
 )


### PR DESCRIPTION
After this PR: https://github.com/artie-labs/transfer/pull/896, we are now strict about time parsing.

As such, this PR adds support for [UTC layout](https://www.utctime.net/z-time-now)