### PR TITLE
[Typing] Support different Redshift Integers

### DIFF
--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -27,11 +27,11 @@ func (RedshiftDialect) DataTypeForKind(kd typing.KindDetails, _ bool) string {
 	switch kd.Kind {
 	case typing.Integer.Kind:
 		switch kd.OptionalIntKind {
-		case typing.SmallIntKind:
+		case typing.SmallIntegerKind:
 			return "INT2"
 		case typing.IntegerKind:
 			return "INT4"
-		case typing.NotSpecifiedKind, typing.BigIntKind:
+		case typing.NotSpecifiedKind, typing.BigIntegerKind:
 			fallthrough
 		default:
 			// By default, we are using a larger data type to avoid the possibility of an integer overflow.
@@ -98,7 +98,7 @@ func (RedshiftDialect) KindForDataType(rawType string, stringPrecision string) (
 	case "smallint":
 		return typing.KindDetails{
 			Kind:            typing.Integer.Kind,
-			OptionalIntKind: typing.SmallIntKind,
+			OptionalIntKind: typing.SmallIntegerKind,
 		}, nil
 	case "integer":
 		return typing.KindDetails{
@@ -108,7 +108,7 @@ func (RedshiftDialect) KindForDataType(rawType string, stringPrecision string) (
 	case "bigint":
 		return typing.KindDetails{
 			Kind:            typing.Integer.Kind,
-			OptionalIntKind: typing.BigIntKind,
+			OptionalIntKind: typing.BigIntegerKind,
 		}, nil
 	case "double precision":
 		return typing.Float, nil

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -26,17 +26,21 @@ func (RedshiftDialect) EscapeStruct(value string) string {
 func (RedshiftDialect) DataTypeForKind(kd typing.KindDetails, _ bool) string {
 	switch kd.Kind {
 	case typing.Integer.Kind:
-		switch kd.OptionalIntKind {
-		case typing.SmallIntegerKind:
-			return "INT2"
-		case typing.IntegerKind:
-			return "INT4"
-		case typing.NotSpecifiedKind, typing.BigIntegerKind:
-			fallthrough
-		default:
-			// By default, we are using a larger data type to avoid the possibility of an integer overflow.
-			return "INT8"
+		if kd.OptionalIntegerKind != nil {
+			switch *kd.OptionalIntegerKind {
+			case typing.SmallIntegerKind:
+				return "INT2"
+			case typing.IntegerKind:
+				return "INT4"
+			case typing.NotSpecifiedKind, typing.BigIntegerKind:
+				fallthrough
+			default:
+				// By default, we are using a larger data type to avoid the possibility of an integer overflow.
+				return "INT8"
+			}
 		}
+
+		return "INT8"
 	case typing.Struct.Kind:
 		return "SUPER"
 	case typing.Array.Kind:
@@ -97,18 +101,18 @@ func (RedshiftDialect) KindForDataType(rawType string, stringPrecision string) (
 		return typing.Struct, nil
 	case "smallint":
 		return typing.KindDetails{
-			Kind:            typing.Integer.Kind,
-			OptionalIntKind: typing.SmallIntegerKind,
+			Kind:                typing.Integer.Kind,
+			OptionalIntegerKind: typing.ToPtr(typing.SmallIntegerKind),
 		}, nil
 	case "integer":
 		return typing.KindDetails{
-			Kind:            typing.Integer.Kind,
-			OptionalIntKind: typing.IntegerKind,
+			Kind:                typing.Integer.Kind,
+			OptionalIntegerKind: typing.ToPtr(typing.IntegerKind),
 		}, nil
 	case "bigint":
 		return typing.KindDetails{
-			Kind:            typing.Integer.Kind,
-			OptionalIntKind: typing.BigIntegerKind,
+			Kind:                typing.Integer.Kind,
+			OptionalIntegerKind: typing.ToPtr(typing.BigIntegerKind),
 		}, nil
 	case "double precision":
 		return typing.Float, nil

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -33,19 +33,25 @@ func TestRedshiftDialect_DataTypeForKind(t *testing.T) {
 		// Integers
 		{
 			// Small int
-			assert.Equal(t, "INT2", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.SmallIntegerKind}, false))
+			assert.Equal(t, "INT2", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.SmallIntegerKind)}, false))
 		}
 		{
 			// Integer
-			assert.Equal(t, "INT4", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.IntegerKind}, false))
+			assert.Equal(t, "INT4", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.IntegerKind)}, false))
 		}
 		{
 			// Big integer
-			assert.Equal(t, "INT8", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.BigIntegerKind}, false))
+			assert.Equal(t, "INT8", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.BigIntegerKind)}, false))
 		}
 		{
 			// Not specified
-			assert.Equal(t, "INT8", RedshiftDialect{}.DataTypeForKind(typing.Integer, false))
+			{
+				// Literal
+				assert.Equal(t, "INT8", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.NotSpecifiedKind)}, false))
+			}
+			{
+				assert.Equal(t, "INT8", RedshiftDialect{}.DataTypeForKind(typing.Integer, false))
+			}
 		}
 	}
 }
@@ -58,27 +64,27 @@ func TestRedshiftDialect_KindForDataType(t *testing.T) {
 			// Small integer
 			kd, err := dialect.KindForDataType("smallint", "")
 			assert.NoError(t, err)
-			assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.SmallIntegerKind}, kd)
+			assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.SmallIntegerKind)}, kd)
 		}
 		{
 			{
 				// Regular integers (upper)
 				kd, err := dialect.KindForDataType("INTEGER", "")
 				assert.NoError(t, err)
-				assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.IntegerKind}, kd)
+				assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.IntegerKind)}, kd)
 			}
 			{
 				// Regular integers (small)
 				kd, err := dialect.KindForDataType("integer", "")
 				assert.NoError(t, err)
-				assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.IntegerKind}, kd)
+				assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.IntegerKind)}, kd)
 			}
 		}
 		{
 			// Big integer
 			kd, err := dialect.KindForDataType("bigint", "")
 			assert.NoError(t, err)
-			assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.BigIntegerKind}, kd)
+			assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.BigIntegerKind)}, kd)
 		}
 	}
 	{

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -74,7 +74,7 @@ func TestRedshiftDialect_KindForDataType(t *testing.T) {
 				assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.IntegerKind)}, kd)
 			}
 			{
-				// Regular integers (small)
+				// Regular integers (lower)
 				kd, err := dialect.KindForDataType("integer", "")
 				assert.NoError(t, err)
 				assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.IntegerKind)}, kd)

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -29,6 +29,25 @@ func TestRedshiftDialect_DataTypeForKind(t *testing.T) {
 			assert.Equal(t, "VARCHAR(12345)", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.String.Kind, OptionalStringPrecision: typing.ToPtr(int32(12345))}, false))
 		}
 	}
+	{
+		// Integers
+		{
+			// Small int
+			assert.Equal(t, "INT2", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.SmallIntegerKind}, false))
+		}
+		{
+			// Integer
+			assert.Equal(t, "INT4", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.IntegerKind}, false))
+		}
+		{
+			// Big integer
+			assert.Equal(t, "INT8", RedshiftDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.BigIntegerKind}, false))
+		}
+		{
+			// Not specified
+			assert.Equal(t, "INT8", RedshiftDialect{}.DataTypeForKind(typing.Integer, false))
+		}
+	}
 }
 
 func TestRedshiftDialect_KindForDataType(t *testing.T) {

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -36,19 +36,30 @@ func TestRedshiftDialect_KindForDataType(t *testing.T) {
 	{
 		// Integers
 		{
-			kd, err := dialect.KindForDataType("integer", "")
+			// Small integer
+			kd, err := dialect.KindForDataType("smallint", "")
 			assert.NoError(t, err)
-			assert.Equal(t, typing.Integer, kd)
+			assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.SmallIntegerKind}, kd)
 		}
 		{
+			{
+				// Regular integers (upper)
+				kd, err := dialect.KindForDataType("INTEGER", "")
+				assert.NoError(t, err)
+				assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.IntegerKind}, kd)
+			}
+			{
+				// Regular integers (small)
+				kd, err := dialect.KindForDataType("integer", "")
+				assert.NoError(t, err)
+				assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.IntegerKind}, kd)
+			}
+		}
+		{
+			// Big integer
 			kd, err := dialect.KindForDataType("bigint", "")
 			assert.NoError(t, err)
-			assert.Equal(t, typing.Integer, kd)
-		}
-		{
-			kd, err := dialect.KindForDataType("INTEGER", "")
-			assert.NoError(t, err)
-			assert.Equal(t, typing.Integer, kd)
+			assert.Equal(t, typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntKind: typing.BigIntegerKind}, kd)
 		}
 	}
 	{

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -282,6 +282,9 @@ func (t *TableData) MergeColumnsFromDestination(destCols ...columns.Column) erro
 				inMemoryCol.KindDetails.OptionalStringPrecision = foundColumn.KindDetails.OptionalStringPrecision
 			}
 
+			// Copy over optional integer kind
+			inMemoryCol.KindDetails.OptionalIntKind = foundColumn.KindDetails.OptionalIntKind
+
 			// Copy over the time details
 			if foundColumn.KindDetails.ExtendedTimeDetails != nil {
 				if inMemoryCol.KindDetails.ExtendedTimeDetails == nil {

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -282,8 +282,10 @@ func (t *TableData) MergeColumnsFromDestination(destCols ...columns.Column) erro
 				inMemoryCol.KindDetails.OptionalStringPrecision = foundColumn.KindDetails.OptionalStringPrecision
 			}
 
-			// Copy over optional integer kind
-			inMemoryCol.KindDetails.OptionalIntKind = foundColumn.KindDetails.OptionalIntKind
+			// Copy over optional integer kind, if exists.
+			if foundColumn.KindDetails.OptionalIntegerKind != nil {
+				inMemoryCol.KindDetails.OptionalIntegerKind = foundColumn.KindDetails.OptionalIntegerKind
+			}
 
 			// Copy over the time details
 			if foundColumn.KindDetails.ExtendedTimeDetails != nil {

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -282,7 +282,7 @@ func (t *TableData) MergeColumnsFromDestination(destCols ...columns.Column) erro
 				inMemoryCol.KindDetails.OptionalStringPrecision = foundColumn.KindDetails.OptionalStringPrecision
 			}
 
-			// Copy over optional integer kind, if exists.
+			// Copy over integer kind, if exists.
 			if foundColumn.KindDetails.OptionalIntegerKind != nil {
 				inMemoryCol.KindDetails.OptionalIntegerKind = foundColumn.KindDetails.OptionalIntegerKind
 			}

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -13,9 +13,9 @@ type IntKind int
 
 const (
 	NotSpecifiedKind = iota
-	SmallIntKind
+	SmallIntegerKind
 	IntegerKind
-	BigIntKind
+	BigIntegerKind
 )
 
 type KindDetails struct {

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -9,6 +9,15 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
+type IntKind int
+
+const (
+	NotSpecifiedKind = iota
+	SmallIntKind
+	IntegerKind
+	BigIntKind
+)
+
 type KindDetails struct {
 	Kind                   string
 	ExtendedTimeDetails    *ext.NestedKind
@@ -16,6 +25,7 @@ type KindDetails struct {
 
 	// Optional kind details metadata
 	OptionalStringPrecision *int32
+	OptionalIntKind         IntKind
 }
 
 func (k *KindDetails) EnsureExtendedTimeDetails() error {
@@ -26,8 +36,6 @@ func (k *KindDetails) EnsureExtendedTimeDetails() error {
 	return nil
 }
 
-// Summarized this from Snowflake + Reflect.
-// In the future, we can support Geo objects.
 var (
 	Invalid = KindDetails{
 		Kind: "invalid",
@@ -38,7 +46,8 @@ var (
 	}
 
 	Integer = KindDetails{
-		Kind: "int",
+		Kind:            "int",
+		OptionalIntKind: NotSpecifiedKind,
 	}
 
 	EDecimal = KindDetails{

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -9,10 +9,10 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
-type IntKind int
+type OptionalIntegerKind int
 
 const (
-	NotSpecifiedKind = iota
+	NotSpecifiedKind OptionalIntegerKind = iota
 	SmallIntegerKind
 	IntegerKind
 	BigIntegerKind
@@ -25,7 +25,7 @@ type KindDetails struct {
 
 	// Optional kind details metadata
 	OptionalStringPrecision *int32
-	OptionalIntKind         IntKind
+	OptionalIntegerKind     *OptionalIntegerKind
 }
 
 func (k *KindDetails) EnsureExtendedTimeDetails() error {
@@ -46,8 +46,8 @@ var (
 	}
 
 	Integer = KindDetails{
-		Kind:            "int",
-		OptionalIntKind: NotSpecifiedKind,
+		Kind:                "int",
+		OptionalIntegerKind: ToPtr(NotSpecifiedKind),
 	}
 
 	EDecimal = KindDetails{


### PR DESCRIPTION
## Scope

This PR adds the ability for us to better infer different integer types within Redshift. Today, we are treating all integer kinds as `typing.Integer` and creating `INT8` columns for them.

This PR will add the ability for us to better detect `INT2` and `INT4` data types.