### PR TITLE
[MongoDB] Return error instead of logging a warning on primary key presence in `retData`

### DIFF
--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -173,6 +173,16 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc kafkalib.TopicConf
 		}
 	} else {
 		retMap = s.Payload.afterMap
+		// TODO: Remove this code.
+		for key, value := range pkMap {
+			retData, isOk := retMap[key]
+			if !isOk {
+				return nil, fmt.Errorf("key %q not found in data", key)
+			} else if retData != value {
+				return nil, fmt.Errorf("value mismatch for key %q: expected %v, got %v", key, retData, value)
+			}
+		}
+
 		retMap[constants.DeleteColumnMarker] = false
 		retMap[constants.OnlySetDeleteColumnMarker] = false
 	}

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -154,7 +154,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomer() {
 
 	evt, err := m.Debezium.GetEventFromBytes([]byte(payload))
 	assert.NoError(m.T(), err)
-	evtData, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{})
+	evtData, err := evt.GetData(map[string]any{"_id": int64(1003)}, kafkalib.TopicConfig{})
 	assert.NoError(m.T(), err)
 	_, isOk := evtData[constants.UpdateColumnMarker]
 	assert.False(m.T(), isOk)
@@ -163,12 +163,12 @@ func (m *MongoTestSuite) TestMongoDBEventCustomer() {
 	assert.Equal(m.T(), evtData["last_name"], "Tang")
 	assert.Equal(m.T(), evtData["email"], "robin@example.com")
 
-	evtDataWithIncludedAt, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{})
+	evtDataWithIncludedAt, err := evt.GetData(map[string]any{"_id": int64(1003)}, kafkalib.TopicConfig{})
 	assert.NoError(m.T(), err)
 	_, isOk = evtDataWithIncludedAt[constants.UpdateColumnMarker]
 	assert.False(m.T(), isOk)
 
-	evtDataWithIncludedAt, err = evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true, IncludeArtieUpdatedAt: true})
+	evtDataWithIncludedAt, err = evt.GetData(map[string]any{"_id": int64(1003)}, kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true, IncludeArtieUpdatedAt: true})
 	assert.NoError(m.T(), err)
 
 	assert.Equal(m.T(), ext.NewExtendedTime(time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC), ext.TimestampTzKindType, ext.ISO8601), evtDataWithIncludedAt[constants.DatabaseUpdatedColumnMarker])

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -158,7 +158,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomer() {
 	assert.NoError(m.T(), err)
 	_, isOk := evtData[constants.UpdateColumnMarker]
 	assert.False(m.T(), isOk)
-	assert.Equal(m.T(), evtData["_id"], 1003)
+	assert.Equal(m.T(), evtData["_id"], int64(1003))
 	assert.Equal(m.T(), evtData["first_name"], "Robin")
 	assert.Equal(m.T(), evtData["last_name"], "Tang")
 	assert.Equal(m.T(), evtData["email"], "robin@example.com")

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -134,7 +134,7 @@ func TestProcessMessageFailures(t *testing.T) {
 	},
 	"payload": {
 		"before": null,
-		"after": "{\"_id\": {\"$numberLong\": \"1004\"},\"first_name\": \"Anne\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}",
+		"after": "{\"_id\": \"1004\"},\"first_name\": \"Anne\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}",
 		"patch": null,
 		"filter": null,
 		"updateDescription": null,
@@ -177,7 +177,7 @@ func TestProcessMessageFailures(t *testing.T) {
 
 	var rowData map[string]any
 	for _, row := range td.Rows() {
-		if row["_id"] == int64(1004) {
+		if row["_id"] == "1004" {
 			rowData = row
 		}
 	}

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -160,11 +160,9 @@ func TestProcessMessageFailures(t *testing.T) {
 }`,
 	}
 
-	idx := 0
 	memoryDB := memDB
 	for _, val := range vals {
-		idx += 1
-		msg.KafkaMsg.Key = []byte(fmt.Sprintf("Struct{id=%v}", idx))
+		msg.KafkaMsg.Key = []byte(fmt.Sprintf("Struct{id=%v}", 1004))
 		if val != "" {
 			msg.KafkaMsg.Value = []byte(val)
 		}
@@ -181,14 +179,14 @@ func TestProcessMessageFailures(t *testing.T) {
 
 		td := memoryDB.GetOrCreateTableData(table)
 		// Check that there are corresponding row(s) in the memory DB
-		assert.Len(t, td.Rows(), idx)
+		assert.Len(t, td.Rows(), 1)
 	}
 
 	td := memoryDB.GetOrCreateTableData(table)
 
 	var rowData map[string]any
 	for _, row := range td.Rows() {
-		if row["_id"] == "1" {
+		if row["_id"] == int64(1004) {
 			rowData = row
 		}
 	}


### PR DESCRIPTION
1. We don't see anything in our logs in the past 15d. 
2. I've also tested this and it works as expected.

To be extra safe, let's have it return an error if the primary key doesn't exist or there's a value mismatch in the payload. After some time, we can then remove it.