### PR TITLE
Supporting Databricks - Part one

### DIFF
--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -67,13 +67,15 @@ const (
 type DestinationKind string
 
 const (
-	BigQuery  DestinationKind = "bigquery"
-	MSSQL     DestinationKind = "mssql"
-	Redshift  DestinationKind = "redshift"
-	S3        DestinationKind = "s3"
-	Snowflake DestinationKind = "snowflake"
+	BigQuery   DestinationKind = "bigquery"
+	Databricks DestinationKind = "databricks"
+	MSSQL      DestinationKind = "mssql"
+	Redshift   DestinationKind = "redshift"
+	S3         DestinationKind = "s3"
+	Snowflake  DestinationKind = "snowflake"
 )
 
+// TODO: Add Databricks to this list once it's ready
 var ValidDestinations = []DestinationKind{
 	BigQuery,
 	MSSQL,

--- a/lib/config/destination_types.go
+++ b/lib/config/destination_types.go
@@ -11,6 +11,14 @@ type BigQuery struct {
 	Location          string `yaml:"location"`
 }
 
+type Databricks struct {
+	Host                string `yaml:"host"`
+	HttpPath            string `json:"httpPath"`
+	Port                int    `yaml:"port"`
+	Catalog             string `yaml:"catalog"`
+	PersonalAccessToken string `yaml:"personalAccessToken"`
+}
+
 type MSSQL struct {
 	Host     string `yaml:"host"`
 	Port     int    `yaml:"port"`

--- a/lib/config/destinations.go
+++ b/lib/config/destinations.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"cmp"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/artie-labs/transfer/lib/cryptography"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -71,4 +73,17 @@ func (s Snowflake) ToConfig() (*gosnowflake.Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func (d Databricks) DSN() string {
+	query := url.Values{}
+	query.Add("catalog", d.Catalog)
+	u := &url.URL{
+		Path:     d.HttpPath,
+		User:     url.UserPassword("token", d.PersonalAccessToken),
+		Host:     fmt.Sprintf("%s:%d", d.Host, cmp.Or(d.Port, 443)),
+		RawQuery: query.Encode(),
+	}
+
+	return strings.TrimPrefix(u.String(), "//")
 }

--- a/lib/config/destinations_test.go
+++ b/lib/config/destinations_test.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDatabricks_DSN(t *testing.T) {
+	d := Databricks{
+		Host:                "foo",
+		HttpPath:            "/api/def",
+		Port:                443,
+		Catalog:             "catalogName",
+		PersonalAccessToken: "pat",
+	}
+
+	assert.Equal(t, "token:pat@foo:443/api/def?catalog=catalogName", d.DSN())
+}

--- a/lib/config/types.go
+++ b/lib/config/types.go
@@ -61,11 +61,12 @@ type Config struct {
 	Kafka  *Kafka  `yaml:"kafka,omitempty"`
 
 	// Supported destinations
-	MSSQL     *MSSQL      `yaml:"mssql,omitempty"`
-	BigQuery  *BigQuery   `yaml:"bigquery,omitempty"`
-	Snowflake *Snowflake  `yaml:"snowflake,omitempty"`
-	Redshift  *Redshift   `yaml:"redshift,omitempty"`
-	S3        *S3Settings `yaml:"s3,omitempty"`
+	BigQuery   *BigQuery   `yaml:"bigquery,omitempty"`
+	Databricks *Databricks `yaml:"databricks,omitempty"`
+	MSSQL      *MSSQL      `yaml:"mssql,omitempty"`
+	Snowflake  *Snowflake  `yaml:"snowflake,omitempty"`
+	Redshift   *Redshift   `yaml:"redshift,omitempty"`
+	S3         *S3Settings `yaml:"s3,omitempty"`
 
 	SharedDestinationSettings SharedDestinationSettings `yaml:"sharedDestinationSettings"`
 	Reporting                 Reporting                 `yaml:"reporting"`


### PR DESCRIPTION
## Background

The goal of these PRs is to add Databricks as a supported destination. The main working PR can be found here https://github.com/artie-labs/transfer/pull/937

## Scope

This PR adds the basic Databricks config and tests. 