### PR TITLE
[Typing] MSSQL - Use `VARCHAR(MAX)` instead of `TEXT` for decimals that have exceeded precision

### DIFF
--- a/lib/typing/decimal/details.go
+++ b/lib/typing/decimal/details.go
@@ -55,7 +55,7 @@ func (d Details) SnowflakeKind() string {
 // MsSQLKind - Has the same limitation as Redshift
 // Spec: https://learn.microsoft.com/en-us/sql/t-sql/data-types/decimal-and-numeric-transact-sql?view=sql-server-ver16#arguments
 func (d Details) MsSQLKind() string {
-	return d.toKind(MaxPrecisionBeforeString, "TEXT")
+	return d.toKind(MaxPrecisionBeforeString, "VARCHAR(MAX)")
 }
 
 // RedshiftKind - is used to determine whether a NUMERIC data type should be a TEXT or NUMERIC(p, s).


### PR DESCRIPTION
TEXT doesn't exist, we should use VARCHAR(MAX)