### PR TITLE
github: run tests just once

### DIFF
--- a/.github/workflows/gha-go-test.yml
+++ b/.github/workflows/gha-go-test.yml
@@ -20,9 +20,7 @@ jobs:
           make static
       - name: Run vet
         run: make vet
-      - name: Run tests
-        run: make test
-      - name: Run race condition check
+      - name: Run tests + race condition check
         run: make race
       - name: Check Go files are properly formatted
         run: test -z $(gofmt -l .)

--- a/.github/workflows/gha-go-test.yml
+++ b/.github/workflows/gha-go-test.yml
@@ -12,7 +12,7 @@ jobs:
           go-version: 1.23
       - name: Run staticcheck
         env:
-          SC_VERSION: "2024.1"
+          SC_VERSION: "2024.1.1"
         run: |
           make generate
           SC_URL="https://github.com/dominikh/go-tools/releases/download/$SC_VERSION/staticcheck_linux_amd64.tar.gz"


### PR DESCRIPTION
`make race` already runs tests, so we don't need to run tests a second time.