### PR TITLE
Tweak `maxRequestByteSize` for BigQuery

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -31,8 +31,8 @@ import (
 
 const (
 	GooglePathToCredentialsEnvKey = "GOOGLE_APPLICATION_CREDENTIALS"
-	// Storage Write API is limited to 10 MiB, subtract 250 KiB to account for request overhead.
-	maxRequestByteSize = (10 * 1024 * 1024) - (250 * 1024)
+	// Storage Write API is limited to 10 MiB, subtract 400 KiB to account for request overhead.
+	maxRequestByteSize = (10 * 1024 * 1024) - (400 * 1024)
 )
 
 type Store struct {


### PR DESCRIPTION
Had a failing `AppendRow` request where we were off by 27kb. Bumped from 250 kb to 400 kb so we have a healthy buffer, so we don't have to keep tweaking this.