### PR TITLE
Refactor how we qualify a deleted row in `relational_event`

### DIFF
--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -77,10 +77,11 @@ func (s *SchemaEventPayload) GetTableName() string {
 }
 
 func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc kafkalib.TopicConfig) (map[string]any, error) {
+	var err error
 	var retMap map[string]any
-	if len(s.Payload.After) == 0 {
+	switch s.Operation() {
+	case "d":
 		if len(s.Payload.Before) > 0 {
-			var err error
 			retMap, err = s.parseAndMutateMapInPlace(s.Payload.Before, debezium.Before)
 			if err != nil {
 				return nil, err
@@ -100,8 +101,7 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc kafkalib.TopicConf
 		for k, v := range pkMap {
 			retMap[k] = v
 		}
-	} else {
-		var err error
+	case "r", "u", "c":
 		retMap, err = s.parseAndMutateMapInPlace(s.Payload.After, debezium.After)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Following the same pattern as https://github.com/artie-labs/transfer/pull/964.

This will make it more explicit and rely less on the implied behavior from Debezium