### PR TITLE
Replace `sort.Strings` with `slices.Sort`

### DIFF
--- a/clients/databricks/dialect/dialect_test.go
+++ b/clients/databricks/dialect/dialect_test.go
@@ -2,7 +2,7 @@ package dialect
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -135,7 +135,7 @@ func buildColumns(colTypesMap map[string]typing.KindDetails) *columns.Columns {
 		colNames = append(colNames, colName)
 	}
 	// Sort the column names alphabetically to ensure deterministic order
-	sort.Strings(colNames)
+	slices.Sort(colNames)
 
 	var cols columns.Columns
 	for _, colName := range colNames {

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -2,7 +2,7 @@ package dialect
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -277,7 +277,7 @@ func buildColumns(colTypesMap map[string]typing.KindDetails) *columns.Columns {
 		colNames = append(colNames, colName)
 	}
 	// Sort the column names alphabetically to ensure deterministic order
-	sort.Strings(colNames)
+	slices.Sort(colNames)
 
 	var cols columns.Columns
 	for _, colName := range colNames {

--- a/lib/destination/types/table_config_test.go
+++ b/lib/destination/types/table_config_test.go
@@ -2,7 +2,7 @@ package types_test
 
 import (
 	"math/rand"
-	"sort"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -173,7 +173,7 @@ func TestAuditColumnsToDelete(t *testing.T) {
 			actualCols = []string{}
 		}
 
-		sort.Strings(actualCols)
+		slices.Sort(actualCols)
 		assert.Equal(t, tc.expectedColsRemain, actualCols, idx)
 	}
 }

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -2,7 +2,7 @@ package optimization
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -98,8 +98,8 @@ func slicesEqualUnordered(s1, s2 []string) bool {
 		return false
 	}
 
-	sort.Strings(s1)
-	sort.Strings(s2)
+	slices.Sort(s1)
+	slices.Sort(s2)
 
 	for i, v := range s1 {
 		if v != s2[i] {

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -4,7 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"log/slog"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -153,7 +153,7 @@ func (e *Event) PrimaryKeys() []string {
 		keys = append(keys, key)
 	}
 
-	sort.Strings(keys)
+	slices.Sort(keys)
 	return keys
 }
 


### PR DESCRIPTION
Since Go 1.22 `sort.Strings` [just calls](https://github.com/golang/go/blob/ad7f736d8f51ea03166b698256385c869968ae3e/src/sort/sort.go#L178) `slices.Sort`.