### PR TITLE
Use `time.Time` in more places

### DIFF
--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -174,22 +174,22 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 				return nil, err
 			}
 
-			extTime, err := ext.ParseFromInterface(value, column.KindDetails.ExtendedTimeDetails.Type)
+			_time, err := ext.ParseFromInterface(value, column.KindDetails.ExtendedTimeDetails.Type)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast value as time.Time, value: %v, err: %w", value, err)
 			}
 
 			switch column.KindDetails.ExtendedTimeDetails.Type {
 			case ext.TimeKindType:
-				message.Set(field, protoreflect.ValueOfInt64(encodePacked64TimeMicros(extTime.GetTime())))
+				message.Set(field, protoreflect.ValueOfInt64(encodePacked64TimeMicros(_time)))
 			case ext.DateKindType:
-				daysSinceEpoch := extTime.GetTime().Unix() / (60 * 60 * 24)
+				daysSinceEpoch := _time.Unix() / (60 * 60 * 24)
 				message.Set(field, protoreflect.ValueOfInt32(int32(daysSinceEpoch)))
 			case ext.TimestampTZKindType:
-				if err := timestamppb.New(extTime.GetTime()).CheckValid(); err != nil {
+				if err := timestamppb.New(_time).CheckValid(); err != nil {
 					return nil, err
 				}
-				message.Set(field, protoreflect.ValueOfInt64(extTime.GetTime().UnixMicro()))
+				message.Set(field, protoreflect.ValueOfInt64(_time.UnixMicro()))
 			default:
 				return nil, fmt.Errorf("unsupported extended time details: %q", column.KindDetails.ExtendedTimeDetails.Type)
 			}

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -32,12 +32,12 @@ func parseValue(colVal any, colKind columns.Column) (any, error) {
 			return "", err
 		}
 
-		extTime, err := ext.ParseFromInterface(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)
+		_time, err := ext.ParseFromInterface(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
-		return extTime.GetTime(), nil
+		return _time, nil
 	case typing.String.Kind:
 		isArray := reflect.ValueOf(colVal).Kind() == reflect.Slice
 		_, isMap := colVal.(map[string]any)

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -26,16 +26,16 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 			return nil, err
 		}
 
-		extTime, err := ext.ParseFromInterface(column.DefaultValue(), column.KindDetails.ExtendedTimeDetails.Type)
+		_time, err := ext.ParseFromInterface(column.DefaultValue(), column.KindDetails.ExtendedTimeDetails.Type)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", column.DefaultValue(), err)
 		}
 
 		switch column.KindDetails.ExtendedTimeDetails.Type {
 		case ext.TimeKindType:
-			return sql.QuoteLiteral(extTime.String(ext.PostgresTimeFormatNoTZ)), nil
+			return sql.QuoteLiteral(_time.Format(ext.PostgresTimeFormatNoTZ)), nil
 		default:
-			return sql.QuoteLiteral(extTime.String(column.KindDetails.ExtendedTimeDetails.Format)), nil
+			return sql.QuoteLiteral(_time.Format(column.KindDetails.ExtendedTimeDetails.Format)), nil
 		}
 	case typing.EDecimal.Kind:
 		if column.KindDetails.ExtendedDecimalDetails.Scale() == 0 {

--- a/clients/shared/default_value_test.go
+++ b/clients/shared/default_value_test.go
@@ -25,7 +25,7 @@ var dialects = []sql.Dialect{
 
 func TestColumn_DefaultValue(t *testing.T) {
 	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
-	birthdayExtDateTime, err := ext.ParseDateTime(birthday.Format(ext.ISO8601), ext.TimestampTZKindType)
+	birthdayDateTime, err := ext.ParseDateTime(birthday.Format(ext.ISO8601), ext.TimestampTZKindType)
 	assert.NoError(t, err)
 
 	// date
@@ -85,17 +85,17 @@ func TestColumn_DefaultValue(t *testing.T) {
 		},
 		{
 			name:          "date",
-			col:           columns.NewColumnWithDefaultValue("", dateKind, birthdayExtDateTime),
+			col:           columns.NewColumnWithDefaultValue("", dateKind, birthdayDateTime),
 			expectedValue: "'2022-09-06'",
 		},
 		{
 			name:          "time",
-			col:           columns.NewColumnWithDefaultValue("", timeKind, birthdayExtDateTime),
+			col:           columns.NewColumnWithDefaultValue("", timeKind, birthdayDateTime),
 			expectedValue: "'03:19:24.942'",
 		},
 		{
 			name:          "datetime",
-			col:           columns.NewColumnWithDefaultValue("", dateTimeKind, birthdayExtDateTime),
+			col:           columns.NewColumnWithDefaultValue("", dateTimeKind, birthdayDateTime),
 			expectedValue: "'2022-09-06T03:19:24.942Z'",
 		},
 	}

--- a/clients/shared/default_value_test.go
+++ b/clients/shared/default_value_test.go
@@ -25,7 +25,7 @@ var dialects = []sql.Dialect{
 
 func TestColumn_DefaultValue(t *testing.T) {
 	birthday := time.Date(2022, time.September, 6, 3, 19, 24, 942000000, time.UTC)
-	birthdayExtDateTime, err := ext.ParseExtendedDateTime(birthday.Format(ext.ISO8601), ext.TimestampTZKindType)
+	birthdayExtDateTime, err := ext.ParseDateTime(birthday.Format(ext.ISO8601), ext.TimestampTZKindType)
 	assert.NoError(t, err)
 
 	// date

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -201,12 +201,12 @@ func (t *TableData) DistinctDates(colName string) ([]string, error) {
 			return nil, fmt.Errorf("col: %v does not exist on row: %v", colName, row)
 		}
 
-		extTime, err := ext.ParseFromInterface(val, ext.DateKindType)
+		_time, err := ext.ParseFromInterface(val, ext.DateKindType)
 		if err != nil {
 			return nil, fmt.Errorf("col: %v is not a time column, value: %v, err: %w", colName, val, err)
 		}
 
-		retMap[extTime.String(ext.PostgresDateFormat)] = true
+		retMap[_time.Format(ext.PostgresDateFormat)] = true
 	}
 
 	var distinctDates []string

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -25,16 +25,16 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 			return "", err
 		}
 
-		extTime, err := ext.ParseFromInterface(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)
+		_time, err := ext.ParseFromInterface(colVal, colKind.KindDetails.ExtendedTimeDetails.Type)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
 		if colKind.KindDetails.ExtendedTimeDetails.Type == ext.DateKindType || colKind.KindDetails.ExtendedTimeDetails.Type == ext.TimeKindType {
-			return extTime.String(colKind.KindDetails.ExtendedTimeDetails.Format), nil
+			return _time.Format(colKind.KindDetails.ExtendedTimeDetails.Format), nil
 		}
 
-		return extTime.GetTime().UnixMilli(), nil
+		return _time.UnixMilli(), nil
 	case typing.String.Kind:
 		return colVal, nil
 	case typing.Struct.Kind:

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -29,7 +29,7 @@ func ParseFromInterface(val any, kindType ExtendedTimeKindType) (time.Time, erro
 	case *ExtendedTime:
 		return convertedVal.GetTime(), nil
 	case string:
-		ts, err := ParseExtendedDateTime(convertedVal, kindType)
+		ts, err := ParseDateTime(convertedVal, kindType)
 		if err != nil {
 			return time.Time{}, fmt.Errorf("failed to parse colVal: %q, err: %w", val, err)
 		}
@@ -40,7 +40,8 @@ func ParseFromInterface(val any, kindType ExtendedTimeKindType) (time.Time, erro
 	}
 }
 
-func ParseExtendedDateTime(value string, kindType ExtendedTimeKindType) (time.Time, error) {
+func ParseDateTime(value string, kindType ExtendedTimeKindType) (time.Time, error) {
+	// TODO: Support TimestampNTZKindType
 	switch kindType {
 	case TimestampTZKindType:
 		return parseDateTime(value)

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -20,91 +20,81 @@ func ParseTimeExactMatch(layout, value string) (time.Time, error) {
 	return ts, nil
 }
 
-func ParseFromInterface(val any, kindType ExtendedTimeKindType) (*ExtendedTime, error) {
+func ParseFromInterface(val any, kindType ExtendedTimeKindType) (time.Time, error) {
 	switch convertedVal := val.(type) {
 	case nil:
-		return nil, fmt.Errorf("val is nil")
-	case *ExtendedTime:
+		return time.Time{}, fmt.Errorf("val is nil")
+	case time.Time:
 		return convertedVal, nil
+	case *ExtendedTime:
+		return convertedVal.GetTime(), nil
 	case string:
-		extendedTime, err := ParseExtendedDateTime(convertedVal, kindType)
+		ts, err := ParseExtendedDateTime(convertedVal, kindType)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse colVal: %q, err: %w", val, err)
+			return time.Time{}, fmt.Errorf("failed to parse colVal: %q, err: %w", val, err)
 		}
 
-		return extendedTime, nil
+		return ts, nil
 	default:
-		return nil, fmt.Errorf("failed to parse colVal, expected type string or *ExtendedTime and got: %T", convertedVal)
+		return time.Time{}, fmt.Errorf("failed to parse colVal, expected type string or *ExtendedTime and got: %T", convertedVal)
 	}
 }
 
-func ParseExtendedDateTime(value string, kindType ExtendedTimeKindType) (*ExtendedTime, error) {
+func ParseExtendedDateTime(value string, kindType ExtendedTimeKindType) (time.Time, error) {
 	switch kindType {
 	case TimestampTZKindType:
 		return parseDateTime(value)
 	case DateKindType:
 		// Try date first
-		if et, err := parseDate(value); err == nil {
-			return et, nil
+		if ts, err := parseDate(value); err == nil {
+			return ts, nil
 		}
 
 		// If that doesn't work, try timestamp
-		if et, err := parseDateTime(value); err == nil {
-			nestedKind, err := NewNestedKind(DateKindType, "")
-			if err != nil {
-				return nil, err
-			}
-
-			et.nestedKind = nestedKind
-			return et, nil
+		if ts, err := parseDateTime(value); err == nil {
+			return ts, nil
 		}
 	case TimeKindType:
 		// Try time first
-		if et, err := parseTime(value); err == nil {
-			return et, nil
+		if ts, err := parseTime(value); err == nil {
+			return ts, nil
 		}
 
 		// If that doesn't work, try timestamp
-		if et, err := parseDateTime(value); err == nil {
-			nestedKind, err := NewNestedKind(TimeKindType, "")
-			if err != nil {
-				return nil, err
-			}
-
-			et.nestedKind = nestedKind
-			return et, nil
+		if ts, err := parseDateTime(value); err == nil {
+			return ts, nil
 		}
 	}
 
-	return nil, fmt.Errorf("unsupported value: %q, kindType: %q", value, kindType)
+	return time.Time{}, fmt.Errorf("unsupported value: %q, kindType: %q", value, kindType)
 }
 
-func parseDateTime(value string) (*ExtendedTime, error) {
+func parseDateTime(value string) (time.Time, error) {
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
 		if ts, err := ParseTimeExactMatch(supportedDateTimeLayout, value); err == nil {
-			return NewExtendedTime(ts, TimestampTZKindType, supportedDateTimeLayout), nil
+			return ts, nil
 		}
 	}
 
-	return nil, fmt.Errorf("unsupported value: %q", value)
+	return time.Time{}, fmt.Errorf("unsupported value: %q", value)
 }
 
-func parseDate(value string) (*ExtendedTime, error) {
+func parseDate(value string) (time.Time, error) {
 	for _, supportedDateFormat := range supportedDateFormats {
 		if ts, err := ParseTimeExactMatch(supportedDateFormat, value); err == nil {
-			return NewExtendedTime(ts, DateKindType, supportedDateFormat), nil
+			return ts, nil
 		}
 	}
 
-	return nil, fmt.Errorf("unsupported value: %q", value)
+	return time.Time{}, fmt.Errorf("unsupported value: %q", value)
 }
 
-func parseTime(value string) (*ExtendedTime, error) {
+func parseTime(value string) (time.Time, error) {
 	for _, supportedTimeFormat := range SupportedTimeFormats {
 		if ts, err := ParseTimeExactMatch(supportedTimeFormat, value); err == nil {
-			return NewExtendedTime(ts, TimeKindType, supportedTimeFormat), nil
+			return ts, nil
 		}
 	}
 
-	return nil, fmt.Errorf("unsupported value: %q", value)
+	return time.Time{}, fmt.Errorf("unsupported value: %q", value)
 }

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -10,15 +10,15 @@ import (
 func TestParseFromInterface(t *testing.T) {
 	{
 		// Extended time
-		var vals []any
+		var vals []*ExtendedTime
 		vals = append(vals, NewExtendedTime(time.Now().UTC(), DateKindType, PostgresDateFormat))
 		vals = append(vals, NewExtendedTime(time.Now().UTC(), TimestampTZKindType, ISO8601))
 		vals = append(vals, NewExtendedTime(time.Now().UTC(), TimeKindType, PostgresTimeFormat))
 
 		for _, val := range vals {
-			extTime, err := ParseFromInterface(val, TimestampTZKindType)
+			_time, err := ParseFromInterface(val, TimestampTZKindType)
 			assert.NoError(t, err)
-			assert.Equal(t, val.(*ExtendedTime).GetTime(), extTime)
+			assert.Equal(t, val.GetTime(), _time)
 		}
 	}
 	{
@@ -70,7 +70,6 @@ func TestParseFromInterfaceTime(t *testing.T) {
 	for _, supportedTimeFormat := range SupportedTimeFormats {
 		_time, err := ParseFromInterface(now.Format(supportedTimeFormat), TimeKindType)
 		assert.NoError(t, err)
-		// Without passing an override format, this should return the same preserved dt format.
 		assert.Equal(t, _time.Format(supportedTimeFormat), now.Format(supportedTimeFormat))
 	}
 }
@@ -80,8 +79,6 @@ func TestParseFromInterfaceDate(t *testing.T) {
 	for _, supportedDateFormat := range supportedDateFormats {
 		_time, err := ParseFromInterface(now.Format(supportedDateFormat), DateKindType)
 		assert.NoError(t, err)
-
-		// Without passing an override format, this should return the same preserved dt format.
 		assert.Equal(t, _time.Format(supportedDateFormat), now.Format(supportedDateFormat))
 	}
 }

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -88,7 +88,7 @@ func TestParseFromInterfaceDate(t *testing.T) {
 
 func TestParseExtendedDateTime_Timestamp(t *testing.T) {
 	tsString := "2023-04-24T17:29:05.69944Z"
-	extTime, err := ParseExtendedDateTime(tsString, TimestampTZKindType)
+	extTime, err := ParseDateTime(tsString, TimestampTZKindType)
 	assert.NoError(t, err)
 	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.Format(time.RFC3339Nano))
 }
@@ -98,7 +98,7 @@ func TestTimeLayout(t *testing.T) {
 
 	for _, supportedFormat := range SupportedTimeFormats {
 		parsedTsString := ts.Format(supportedFormat)
-		extTime, err := ParseExtendedDateTime(parsedTsString, TimeKindType)
+		extTime, err := ParseDateTime(parsedTsString, TimeKindType)
 		assert.NoError(t, err)
 		assert.Equal(t, parsedTsString, extTime.Format(supportedFormat))
 	}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -18,7 +18,7 @@ func TestParseFromInterface(t *testing.T) {
 		for _, val := range vals {
 			extTime, err := ParseFromInterface(val, TimestampTZKindType)
 			assert.NoError(t, err)
-			assert.Equal(t, val, extTime)
+			assert.Equal(t, val.(*ExtendedTime).GetTime(), extTime)
 		}
 	}
 	{
@@ -40,55 +40,49 @@ func TestParseFromInterface(t *testing.T) {
 		// String - RFC3339MillisecondUTC
 		value, err := ParseFromInterface("2024-09-19T16:05:18.630Z", TimestampTZKindType)
 		assert.NoError(t, err)
-		assert.Equal(t, "2024-09-19T16:05:18.630Z", value.String(""))
-		assert.Equal(t, RFC3339MillisecondUTC, value.nestedKind.Format)
+		assert.Equal(t, "2024-09-19T16:05:18.630Z", value.Format(RFC3339MillisecondUTC))
 	}
 	{
 		// String - RFC3339MicrosecondUTC
 		value, err := ParseFromInterface("2024-09-19T16:05:18.630000Z", TimestampTZKindType)
 		assert.NoError(t, err)
-		assert.Equal(t, "2024-09-19T16:05:18.630000Z", value.String(""))
-		assert.Equal(t, RFC3339MicrosecondUTC, value.nestedKind.Format)
+		assert.Equal(t, "2024-09-19T16:05:18.630000Z", value.Format(RFC3339MicrosecondUTC))
 	}
 	{
 		// String - RFC3339NanosecondUTC
 		value, err := ParseFromInterface("2024-09-19T16:05:18.630000000Z", TimestampTZKindType)
 		assert.NoError(t, err)
-		assert.Equal(t, "2024-09-19T16:05:18.630000000Z", value.String(""))
-		assert.Equal(t, RFC3339NanosecondUTC, value.nestedKind.Format)
+		assert.Equal(t, "2024-09-19T16:05:18.630000000Z", value.Format(RFC3339NanosecondUTC))
 	}
 }
 
 func TestParseFromInterfaceDateTime(t *testing.T) {
 	now := time.Now().In(time.UTC)
 	for _, supportedDateTimeLayout := range supportedDateTimeLayouts {
-		et, err := ParseFromInterface(now.Format(supportedDateTimeLayout), TimestampTZKindType)
+		_time, err := ParseFromInterface(now.Format(supportedDateTimeLayout), TimestampTZKindType)
 		assert.NoError(t, err)
-		assert.Equal(t, TimestampTZKindType, et.GetNestedKind().Type)
-		assert.Equal(t, et.String(""), now.Format(supportedDateTimeLayout))
+		assert.Equal(t, _time.Format(supportedDateTimeLayout), now.Format(supportedDateTimeLayout))
 	}
 }
 
 func TestParseFromInterfaceTime(t *testing.T) {
 	now := time.Now()
 	for _, supportedTimeFormat := range SupportedTimeFormats {
-		et, err := ParseFromInterface(now.Format(supportedTimeFormat), TimeKindType)
+		_time, err := ParseFromInterface(now.Format(supportedTimeFormat), TimeKindType)
 		assert.NoError(t, err)
-		assert.Equal(t, TimeKindType, et.GetNestedKind().Type)
 		// Without passing an override format, this should return the same preserved dt format.
-		assert.Equal(t, et.String(""), now.Format(supportedTimeFormat))
+		assert.Equal(t, _time.Format(supportedTimeFormat), now.Format(supportedTimeFormat))
 	}
 }
 
 func TestParseFromInterfaceDate(t *testing.T) {
 	now := time.Now()
 	for _, supportedDateFormat := range supportedDateFormats {
-		et, err := ParseFromInterface(now.Format(supportedDateFormat), DateKindType)
+		_time, err := ParseFromInterface(now.Format(supportedDateFormat), DateKindType)
 		assert.NoError(t, err)
-		assert.Equal(t, DateKindType, et.GetNestedKind().Type)
 
 		// Without passing an override format, this should return the same preserved dt format.
-		assert.Equal(t, et.String(""), now.Format(supportedDateFormat))
+		assert.Equal(t, _time.Format(supportedDateFormat), now.Format(supportedDateFormat))
 	}
 }
 
@@ -96,7 +90,7 @@ func TestParseExtendedDateTime_Timestamp(t *testing.T) {
 	tsString := "2023-04-24T17:29:05.69944Z"
 	extTime, err := ParseExtendedDateTime(tsString, TimestampTZKindType)
 	assert.NoError(t, err)
-	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.String(""))
+	assert.Equal(t, "2023-04-24T17:29:05.69944Z", extTime.Format(time.RFC3339Nano))
 }
 
 func TestTimeLayout(t *testing.T) {
@@ -106,6 +100,6 @@ func TestTimeLayout(t *testing.T) {
 		parsedTsString := ts.Format(supportedFormat)
 		extTime, err := ParseExtendedDateTime(parsedTsString, TimeKindType)
 		assert.NoError(t, err)
-		assert.Equal(t, parsedTsString, extTime.String(""))
+		assert.Equal(t, parsedTsString, extTime.Format(supportedFormat))
 	}
 }

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -32,15 +32,15 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 			return "", err
 		}
 
-		extTime, err := ext.ParseFromInterface(colVal, colKind.ExtendedTimeDetails.Type)
+		_time, err := ext.ParseFromInterface(colVal, colKind.ExtendedTimeDetails.Type)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
 		if colKind.ExtendedTimeDetails.Type == ext.TimeKindType {
-			return extTime.String(ext.PostgresTimeFormatNoTZ), nil
+			return _time.Format(ext.PostgresTimeFormatNoTZ), nil
 		}
-		return extTime.String(colKind.ExtendedTimeDetails.Format), nil
+		return _time.Format(colKind.ExtendedTimeDetails.Format), nil
 	case typing.String.Kind:
 		isArray := reflect.ValueOf(colVal).Kind() == reflect.Slice
 		_, isMap := colVal.(map[string]any)

--- a/lib/typing/values/string_test.go
+++ b/lib/typing/values/string_test.go
@@ -46,7 +46,10 @@ func TestToString(t *testing.T) {
 				dustyBirthday := time.Date(2019, time.December, 31, 0, 0, 0, 0, time.UTC)
 				extendedTime := ext.NewExtendedTime(dustyBirthday, ext.TimestampTZKindType, "2006-01-02T15:04:05Z07:00")
 
-				eTimeCol.KindDetails.ExtendedTimeDetails = &ext.NestedKind{Type: ext.TimestampTZKindType}
+				nestedKind, err := ext.NewNestedKind(ext.TimestampTZKindType, "")
+				assert.NoError(t, err)
+
+				eTimeCol.KindDetails.ExtendedTimeDetails = &nestedKind
 				actualValue, err := ToString(extendedTime, eTimeCol.KindDetails)
 				assert.NoError(t, err)
 				assert.Equal(t, extendedTime.String(""), actualValue)


### PR DESCRIPTION
As the title states. The goal is to eventually get rid of `ExtendedTime` altogether.