### PR TITLE
[ExtendedTime] Remove references for `OldNewExtendedTimeDetails`

### DIFF
--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -106,13 +106,13 @@ func (BigQueryDialect) KindForDataType(rawBqType string, _ string) (typing.KindD
 	case "array":
 		return typing.Array, nil
 	case "timestamp":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")
 	case "datetime":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, "")
 	case "time":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")
 	case "date":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")
 	default:
 		return typing.Invalid, nil
 	}

--- a/clients/bigquery/dialect/dialect_test.go
+++ b/clients/bigquery/dialect/dialect_test.go
@@ -92,10 +92,10 @@ func TestBigQueryDialect_KindForDataType(t *testing.T) {
 		"record":             typing.Struct,
 		"json":               typing.Struct,
 		// Datetime
-		"datetime":  typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
-		"timestamp": typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
-		"time":      typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
-		"date":      typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		"datetime":  typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"timestamp": typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"time":      typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
+		"date":      typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
 		//Invalid
 		"foo":    typing.Invalid,
 		"foofoo": typing.Invalid,
@@ -130,9 +130,9 @@ func TestBigQueryDialect_KindForDataType(t *testing.T) {
 
 func TestBigQueryDialect_KindForDataType_NoDataLoss(t *testing.T) {
 	kindDetails := []typing.KindDetails{
-		typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
-		typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
-		typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
+		typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
 		typing.String,
 		typing.Boolean,
 		typing.Struct,

--- a/clients/bigquery/storagewrite_test.go
+++ b/clients/bigquery/storagewrite_test.go
@@ -44,26 +44,29 @@ func TestColumnToTableFieldSchema(t *testing.T) {
 	}
 	{
 		// ETime - Time:
-		fieldSchema, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")))
+		fieldSchema, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")))
 		assert.NoError(t, err)
 		assert.Equal(t, storagepb.TableFieldSchema_TIME, fieldSchema.Type)
 	}
 	{
 		// ETime - Date:
-		fieldSchema, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")))
+		fieldSchema, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")))
 		assert.NoError(t, err)
 		assert.Equal(t, storagepb.TableFieldSchema_DATE, fieldSchema.Type)
 	}
 	{
 		// ETime - TimestampTZ:
-		fieldSchema, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")))
+		fieldSchema, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")))
 		assert.NoError(t, err)
 		assert.Equal(t, storagepb.TableFieldSchema_TIMESTAMP, fieldSchema.Type)
 	}
 	{
 		// ETime - Invalid:
-		_, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.NewExtendedTimeDetails(typing.ETime, "", "")))
-		assert.ErrorContains(t, err, "unsupported extended time details type:")
+		nestedKind, err := typing.NewExtendedTimeDetails(typing.ETime, "", "")
+		assert.ErrorContains(t, err, "unknown kind type")
+
+		_, err = columnToTableFieldSchema(columns.NewColumn("foo", nestedKind))
+		assert.ErrorContains(t, err, `unsupported column kind: "invalid"`)
 	}
 	{
 		// Struct:
@@ -112,9 +115,9 @@ func TestRowToMessage(t *testing.T) {
 		columns.NewColumn("c_numeric", typing.EDecimal),
 		columns.NewColumn("c_string", typing.String),
 		columns.NewColumn("c_string_decimal", typing.String),
-		columns.NewColumn("c_time", typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")),
-		columns.NewColumn("c_date", typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")),
-		columns.NewColumn("c_datetime", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
+		columns.NewColumn("c_time", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")),
+		columns.NewColumn("c_date", typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")),
+		columns.NewColumn("c_datetime", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
 		columns.NewColumn("c_struct", typing.Struct),
 		columns.NewColumn("c_array", typing.Array),
 	}

--- a/clients/databricks/dialect/typing.go
+++ b/clients/databricks/dialect/typing.go
@@ -66,7 +66,7 @@ func (DatabricksDialect) KindForDataType(rawType string, _ string) (typing.KindD
 	case "boolean":
 		return typing.Boolean, nil
 	case "date":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")
 	case "double", "float":
 		return typing.Float, nil
 	case "int":
@@ -74,9 +74,9 @@ func (DatabricksDialect) KindForDataType(rawType string, _ string) (typing.KindD
 	case "smallint", "tinyint":
 		return typing.KindDetails{Kind: typing.Integer.Kind, OptionalIntegerKind: typing.ToPtr(typing.SmallIntegerKind)}, nil
 	case "timestamp":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")
 	case "timestamp_ntz":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, "")
 	}
 
 	return typing.Invalid, fmt.Errorf("unsupported data type: %q", rawType)

--- a/clients/databricks/dialect/typing_test.go
+++ b/clients/databricks/dialect/typing_test.go
@@ -115,13 +115,7 @@ func TestDatabricksDialect_KindForDataType(t *testing.T) {
 		// Date
 		kd, err := DatabricksDialect{}.KindForDataType("DATE", "")
 		assert.NoError(t, err)
-		assert.Equal(t, typing.KindDetails{
-			Kind: typing.ETime.Kind,
-			ExtendedTimeDetails: &ext.NestedKind{
-				Type:   ext.DateKindType,
-				Format: ext.PostgresDateFormat,
-			},
-		}, kd)
+		assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""), kd)
 	}
 	{
 		// Double

--- a/clients/databricks/dialect/typing_test.go
+++ b/clients/databricks/dialect/typing_test.go
@@ -115,7 +115,13 @@ func TestDatabricksDialect_KindForDataType(t *testing.T) {
 		// Date
 		kd, err := DatabricksDialect{}.KindForDataType("DATE", "")
 		assert.NoError(t, err)
-		assert.Equal(t, typing.KindDetails{Kind: typing.ETime.Kind, ExtendedTimeDetails: &ext.NestedKind{Type: ext.DateKindType}}, kd)
+		assert.Equal(t, typing.KindDetails{
+			Kind: typing.ETime.Kind,
+			ExtendedTimeDetails: &ext.NestedKind{
+				Type:   ext.DateKindType,
+				Format: ext.PostgresDateFormat,
+			},
+		}, kd)
 	}
 	{
 		// Double
@@ -145,13 +151,13 @@ func TestDatabricksDialect_KindForDataType(t *testing.T) {
 		// Timestamp
 		kd, err := DatabricksDialect{}.KindForDataType("TIMESTAMP", "")
 		assert.NoError(t, err)
-		assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""), kd)
+		assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""), kd)
 	}
 	{
 		// Timestamp NTZ
 		kd, err := DatabricksDialect{}.KindForDataType("TIMESTAMP_NTZ", "")
 		assert.NoError(t, err)
-		assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ""), kd)
+		assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ""), kd)
 	}
 	{
 		// Variant

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -116,13 +116,13 @@ func (MSSQLDialect) KindForDataType(rawType string, stringPrecision string) (typ
 	case
 		"datetime",
 		"datetime2":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, "")
 	case "datetimeoffset":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")
 	case "time":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")
 	case "date":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")
 	case "bit":
 		return typing.Boolean, nil
 	case "text":

--- a/clients/mssql/dialect/dialect_test.go
+++ b/clients/mssql/dialect/dialect_test.go
@@ -62,10 +62,10 @@ func TestMSSQLDialect_KindForDataType(t *testing.T) {
 		"float":     typing.Float,
 		"real":      typing.Float,
 		"bit":       typing.Boolean,
-		"date":      typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
-		"time":      typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
-		"datetime":  typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
-		"datetime2": typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"date":      typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		"time":      typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
+		"datetime":  typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"datetime2": typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 	}
 
 	for col, expectedKind := range colToExpectedKind {

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -106,13 +106,13 @@ func (RedshiftDialect) KindForDataType(rawType string, stringPrecision string) (
 	case "double precision":
 		return typing.Float, nil
 	case "timestamp", "timestamp without time zone":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, "")
 	case "timestamp with time zone":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")
 	case "time without time zone":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")
 	case "date":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")
 	case "boolean":
 		return typing.Boolean, nil
 	}

--- a/clients/redshift/dialect/typing_test.go
+++ b/clients/redshift/dialect/typing_test.go
@@ -47,11 +47,11 @@ func TestRedshiftDialect_DataTypeForKind(t *testing.T) {
 		// Timestamps
 		{
 			// With timezone
-			assert.Equal(t, "timestamp with time zone", RedshiftDialect{}.DataTypeForKind(typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""), false))
+			assert.Equal(t, "timestamp with time zone", RedshiftDialect{}.DataTypeForKind(typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""), false))
 		}
 		{
 			// Without timezone
-			assert.Equal(t, "timestamp without time zone", RedshiftDialect{}.DataTypeForKind(typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ""), false))
+			assert.Equal(t, "timestamp without time zone", RedshiftDialect{}.DataTypeForKind(typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ""), false))
 		}
 	}
 }

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -29,7 +29,7 @@ func (s *SnowflakeTestSuite) TestMutateColumnsWithMemoryCacheDeletions() {
 		"customer_id": typing.Integer,
 		"price":       typing.Float,
 		"name":        typing.String,
-		"created_at":  typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"created_at":  typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 	} {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
@@ -58,7 +58,7 @@ func (s *SnowflakeTestSuite) TestShouldDeleteColumn() {
 		"customer_id": typing.Integer,
 		"price":       typing.Float,
 		"name":        typing.String,
-		"created_at":  typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"created_at":  typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 	} {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
@@ -97,7 +97,7 @@ func (s *SnowflakeTestSuite) TestManipulateShouldDeleteColumn() {
 		"customer_id": typing.Integer,
 		"price":       typing.Float,
 		"name":        typing.String,
-		"created_at":  typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"created_at":  typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 	} {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}

--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -98,13 +98,13 @@ func (SnowflakeDialect) KindForDataType(snowflakeType string, _ string) (typing.
 	case "array":
 		return typing.Array, nil
 	case "timestamp_ltz", "timestamp_tz":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")
 	case "timestamp", "datetime", "timestamp_ntz":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, "")
 	case "time":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")
 	case "date":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""), nil
+		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")
 	default:
 		return typing.Invalid, nil
 	}

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -196,9 +196,9 @@ func TestSnowflakeDialect_KindForDataType_DateTime(t *testing.T) {
 
 func TestSnowflakeDialect_KindForDataType_NoDataLoss(t *testing.T) {
 	kindDetails := []typing.KindDetails{
-		typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
-		typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
-		typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
+		typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
 		typing.String,
 		typing.Boolean,
 		typing.Struct,

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -240,7 +240,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 	snowflakeColToKindDetailsMap := map[string]typing.KindDetails{
 		"id":                                typing.Integer,
-		"created_at":                        typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"created_at":                        typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 		"name":                              typing.String,
 		constants.DeleteColumnMarker:        typing.Boolean,
 		constants.OnlySetDeleteColumnMarker: typing.Boolean,

--- a/lib/debezium/converters/date.go
+++ b/lib/debezium/converters/date.go
@@ -15,7 +15,7 @@ func (Date) layout() string {
 }
 
 func (d Date) ToKindDetails() typing.KindDetails {
-	return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, d.layout())
+	return typing.OldNewExtendedTimeDetails(typing.ETime, ext.DateKindType, d.layout())
 }
 
 func (d Date) Convert(value any) (any, error) {

--- a/lib/debezium/converters/time.go
+++ b/lib/debezium/converters/time.go
@@ -16,7 +16,7 @@ func (Time) layout() string {
 }
 
 func (t Time) ToKindDetails() typing.KindDetails {
-	return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, t.layout())
+	return typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, t.layout())
 }
 
 func (t Time) Convert(val any) (any, error) {
@@ -36,7 +36,7 @@ func (NanoTime) layout() string {
 }
 
 func (n NanoTime) ToKindDetails() typing.KindDetails {
-	return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, n.layout())
+	return typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, n.layout())
 }
 
 func (n NanoTime) Convert(value any) (any, error) {
@@ -56,7 +56,7 @@ func (MicroTime) layout() string {
 }
 
 func (m MicroTime) ToKindDetails() typing.KindDetails {
-	return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, m.layout())
+	return typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, m.layout())
 }
 
 func (m MicroTime) Convert(value any) (any, error) {
@@ -76,7 +76,7 @@ func (ZonedTimestamp) layout() string {
 }
 
 func (z ZonedTimestamp) ToKindDetails() typing.KindDetails {
-	return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, z.layout())
+	return typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, z.layout())
 }
 
 func (z ZonedTimestamp) Convert(value any) (any, error) {
@@ -112,7 +112,7 @@ func (t TimeWithTimezone) layout() string {
 }
 
 func (t TimeWithTimezone) ToKindDetails() typing.KindDetails {
-	return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, t.layout())
+	return typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, t.layout())
 }
 
 func (t TimeWithTimezone) Convert(value any) (any, error) {

--- a/lib/debezium/converters/time_test.go
+++ b/lib/debezium/converters/time_test.go
@@ -143,7 +143,7 @@ func TestTime_Convert(t *testing.T) {
 }
 
 func TestNanoTime_Converter(t *testing.T) {
-	assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, NanoTime{}.layout()), NanoTime{}.ToKindDetails())
+	assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, NanoTime{}.layout()), NanoTime{}.ToKindDetails())
 	{
 		// Invalid data
 		_, err := NanoTime{}.Convert("123")
@@ -158,7 +158,7 @@ func TestNanoTime_Converter(t *testing.T) {
 }
 
 func TestMicroTime_Converter(t *testing.T) {
-	assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, MicroTime{}.layout()), MicroTime{}.ToKindDetails())
+	assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, MicroTime{}.layout()), MicroTime{}.ToKindDetails())
 	{
 		// Invalid data
 		_, err := MicroTime{}.Convert("123")

--- a/lib/debezium/converters/time_test.go
+++ b/lib/debezium/converters/time_test.go
@@ -143,7 +143,7 @@ func TestTime_Convert(t *testing.T) {
 }
 
 func TestNanoTime_Converter(t *testing.T) {
-	assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, NanoTime{}.layout()), NanoTime{}.ToKindDetails())
+	assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, NanoTime{}.layout()), NanoTime{}.ToKindDetails())
 	{
 		// Invalid data
 		_, err := NanoTime{}.Convert("123")
@@ -158,7 +158,7 @@ func TestNanoTime_Converter(t *testing.T) {
 }
 
 func TestMicroTime_Converter(t *testing.T) {
-	assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, MicroTime{}.layout()), MicroTime{}.ToKindDetails())
+	assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, MicroTime{}.layout()), MicroTime{}.ToKindDetails())
 	{
 		// Invalid data
 		_, err := MicroTime{}.Convert("123")

--- a/lib/debezium/converters/timestamp.go
+++ b/lib/debezium/converters/timestamp.go
@@ -14,7 +14,7 @@ func (Timestamp) layout() string {
 }
 
 func (t Timestamp) ToKindDetails() typing.KindDetails {
-	return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, t.layout())
+	return typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, t.layout())
 }
 
 func (t Timestamp) Convert(value any) (any, error) {
@@ -34,7 +34,7 @@ func (MicroTimestamp) layout() string {
 }
 
 func (mt MicroTimestamp) ToKindDetails() typing.KindDetails {
-	return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, mt.layout())
+	return typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, mt.layout())
 }
 
 func (mt MicroTimestamp) Convert(value any) (any, error) {
@@ -50,7 +50,7 @@ func (mt MicroTimestamp) Convert(value any) (any, error) {
 type NanoTimestamp struct{}
 
 func (nt NanoTimestamp) ToKindDetails() typing.KindDetails {
-	return typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, nt.layout())
+	return typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, nt.layout())
 }
 
 func (NanoTimestamp) layout() string {

--- a/lib/debezium/converters/timestamp_test.go
+++ b/lib/debezium/converters/timestamp_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTimestamp_Converter(t *testing.T) {
-	assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MillisecondNoTZ), Timestamp{}.ToKindDetails())
+	assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MillisecondNoTZ), Timestamp{}.ToKindDetails())
 	{
 		// Invalid conversion
 		_, err := Timestamp{}.Convert("invalid")
@@ -30,7 +30,7 @@ func TestTimestamp_Converter(t *testing.T) {
 }
 
 func TestMicroTimestamp_Converter(t *testing.T) {
-	assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MicrosecondNoTZ), MicroTimestamp{}.ToKindDetails())
+	assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MicrosecondNoTZ), MicroTimestamp{}.ToKindDetails())
 	{
 		// Invalid conversion
 		_, err := MicroTimestamp{}.Convert("invalid")
@@ -51,7 +51,7 @@ func TestMicroTimestamp_Converter(t *testing.T) {
 }
 
 func TestNanoTimestamp_Converter(t *testing.T) {
-	assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339NanosecondNoTZ), NanoTimestamp{}.ToKindDetails())
+	assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339NanosecondNoTZ), NanoTimestamp{}.ToKindDetails())
 	{
 		// Invalid conversion
 		_, err := NanoTimestamp{}.Convert("invalid")

--- a/lib/debezium/converters/timestamp_test.go
+++ b/lib/debezium/converters/timestamp_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTimestamp_Converter(t *testing.T) {
-	assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MillisecondNoTZ), Timestamp{}.ToKindDetails())
+	assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MillisecondNoTZ), Timestamp{}.ToKindDetails())
 	{
 		// Invalid conversion
 		_, err := Timestamp{}.Convert("invalid")
@@ -30,7 +30,7 @@ func TestTimestamp_Converter(t *testing.T) {
 }
 
 func TestMicroTimestamp_Converter(t *testing.T) {
-	assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MicrosecondNoTZ), MicroTimestamp{}.ToKindDetails())
+	assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MicrosecondNoTZ), MicroTimestamp{}.ToKindDetails())
 	{
 		// Invalid conversion
 		_, err := MicroTimestamp{}.Convert("invalid")
@@ -51,7 +51,7 @@ func TestMicroTimestamp_Converter(t *testing.T) {
 }
 
 func TestNanoTimestamp_Converter(t *testing.T) {
-	assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339NanosecondNoTZ), NanoTimestamp{}.ToKindDetails())
+	assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339NanosecondNoTZ), NanoTimestamp{}.ToKindDetails())
 	{
 		// Invalid conversion
 		_, err := NanoTimestamp{}.Convert("invalid")

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -233,7 +233,7 @@ func TestField_ToKindDetails(t *testing.T) {
 		for _, dbzType := range []SupportedDebeziumType{ZonedTimestamp} {
 			kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
 			assert.NoError(t, err)
-			assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "2006-01-02T15:04:05.999999999Z"), kd)
+			assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "2006-01-02T15:04:05.999999999Z"), kd)
 		}
 	}
 	{
@@ -250,7 +250,7 @@ func TestField_ToKindDetails(t *testing.T) {
 		for _, dbzType := range []SupportedDebeziumType{Date, DateKafkaConnect} {
 			kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
 			assert.NoError(t, err)
-			assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ext.PostgresDateFormat), kd)
+			assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ext.PostgresDateFormat), kd)
 		}
 	}
 	{
@@ -259,7 +259,7 @@ func TestField_ToKindDetails(t *testing.T) {
 			for _, dbzType := range []SupportedDebeziumType{TimeWithTimezone} {
 				kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
 				assert.NoError(t, err)
-				assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.999999Z"), kd, dbzType)
+				assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.999999Z"), kd, dbzType)
 			}
 		}
 		{
@@ -267,20 +267,20 @@ func TestField_ToKindDetails(t *testing.T) {
 			for _, dbzType := range []SupportedDebeziumType{Time, TimeKafkaConnect} {
 				kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
 				assert.NoError(t, err)
-				assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000"), kd, dbzType)
+				assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000"), kd, dbzType)
 			}
 		}
 		{
 			// Micro time
 			kd, err := Field{DebeziumType: MicroTime}.ToKindDetails()
 			assert.NoError(t, err)
-			assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000000"), kd)
+			assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000000"), kd)
 		}
 		{
 			// Nano time
 			kd, err := Field{DebeziumType: NanoTime}.ToKindDetails()
 			assert.NoError(t, err)
-			assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000000000"), kd)
+			assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000000000"), kd)
 		}
 	}
 	{

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -233,7 +233,7 @@ func TestField_ToKindDetails(t *testing.T) {
 		for _, dbzType := range []SupportedDebeziumType{ZonedTimestamp} {
 			kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
 			assert.NoError(t, err)
-			assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "2006-01-02T15:04:05.999999999Z"), kd)
+			assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "2006-01-02T15:04:05.999999999Z"), kd)
 		}
 	}
 	{
@@ -250,7 +250,7 @@ func TestField_ToKindDetails(t *testing.T) {
 		for _, dbzType := range []SupportedDebeziumType{Date, DateKafkaConnect} {
 			kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
 			assert.NoError(t, err)
-			assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ext.PostgresDateFormat), kd)
+			assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ext.PostgresDateFormat), kd)
 		}
 	}
 	{
@@ -259,7 +259,7 @@ func TestField_ToKindDetails(t *testing.T) {
 			for _, dbzType := range []SupportedDebeziumType{TimeWithTimezone} {
 				kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
 				assert.NoError(t, err)
-				assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.999999Z"), kd, dbzType)
+				assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.999999Z"), kd, dbzType)
 			}
 		}
 		{
@@ -267,20 +267,20 @@ func TestField_ToKindDetails(t *testing.T) {
 			for _, dbzType := range []SupportedDebeziumType{Time, TimeKafkaConnect} {
 				kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
 				assert.NoError(t, err)
-				assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000"), kd, dbzType)
+				assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000"), kd, dbzType)
 			}
 		}
 		{
 			// Micro time
 			kd, err := Field{DebeziumType: MicroTime}.ToKindDetails()
 			assert.NoError(t, err)
-			assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000000"), kd)
+			assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000000"), kd)
 		}
 		{
 			// Nano time
 			kd, err := Field{DebeziumType: NanoTime}.ToKindDetails()
 			assert.NoError(t, err)
-			assert.Equal(t, typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000000000"), kd)
+			assert.Equal(t, typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "15:04:05.000000000"), kd)
 		}
 	}
 	{

--- a/lib/destination/ddl/ddl_sflk_test.go
+++ b/lib/destination/ddl/ddl_sflk_test.go
@@ -51,7 +51,7 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 
 func (d *DDLTestSuite) TestAlterIdempotency() {
 	cols := []columns.Column{
-		columns.NewColumn("created_at", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
+		columns.NewColumn("created_at", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
 		columns.NewColumn("id", typing.Integer),
 		columns.NewColumn("order_name", typing.String),
 		columns.NewColumn("start", typing.String),
@@ -81,7 +81,7 @@ func (d *DDLTestSuite) TestAlterIdempotency() {
 func (d *DDLTestSuite) TestAlterTableAdd() {
 	// Test adding a bunch of columns
 	cols := []columns.Column{
-		columns.NewColumn("created_at", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
+		columns.NewColumn("created_at", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
 		columns.NewColumn("id", typing.Integer),
 		columns.NewColumn("order_name", typing.String),
 		columns.NewColumn("start", typing.String),
@@ -123,7 +123,7 @@ func (d *DDLTestSuite) TestAlterTableAdd() {
 func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	// Test adding a bunch of columns
 	cols := []columns.Column{
-		columns.NewColumn("created_at", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
+		columns.NewColumn("created_at", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
 		columns.NewColumn("id", typing.Integer),
 		columns.NewColumn("name", typing.String),
 		columns.NewColumn("start", typing.String),
@@ -180,7 +180,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 func (d *DDLTestSuite) TestAlterTableDelete() {
 	// Test adding a bunch of columns
 	cols := []columns.Column{
-		columns.NewColumn("created_at", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
+		columns.NewColumn("created_at", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
 		columns.NewColumn("id", typing.Integer),
 		columns.NewColumn("name", typing.String),
 		columns.NewColumn("col_to_delete", typing.String),

--- a/lib/destination/ddl/ddl_sflk_test.go
+++ b/lib/destination/ddl/ddl_sflk_test.go
@@ -51,7 +51,7 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 
 func (d *DDLTestSuite) TestAlterIdempotency() {
 	cols := []columns.Column{
-		columns.NewColumn("created_at", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
+		columns.NewColumn("created_at", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
 		columns.NewColumn("id", typing.Integer),
 		columns.NewColumn("order_name", typing.String),
 		columns.NewColumn("start", typing.String),
@@ -81,7 +81,7 @@ func (d *DDLTestSuite) TestAlterIdempotency() {
 func (d *DDLTestSuite) TestAlterTableAdd() {
 	// Test adding a bunch of columns
 	cols := []columns.Column{
-		columns.NewColumn("created_at", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
+		columns.NewColumn("created_at", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
 		columns.NewColumn("id", typing.Integer),
 		columns.NewColumn("order_name", typing.String),
 		columns.NewColumn("start", typing.String),
@@ -123,7 +123,7 @@ func (d *DDLTestSuite) TestAlterTableAdd() {
 func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	// Test adding a bunch of columns
 	cols := []columns.Column{
-		columns.NewColumn("created_at", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
+		columns.NewColumn("created_at", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
 		columns.NewColumn("id", typing.Integer),
 		columns.NewColumn("name", typing.String),
 		columns.NewColumn("start", typing.String),
@@ -180,7 +180,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 func (d *DDLTestSuite) TestAlterTableDelete() {
 	// Test adding a bunch of columns
 	cols := []columns.Column{
-		columns.NewColumn("created_at", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
+		columns.NewColumn("created_at", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
 		columns.NewColumn("id", typing.Integer),
 		columns.NewColumn("name", typing.String),
 		columns.NewColumn("col_to_delete", typing.String),

--- a/lib/optimization/table_data_merge_columns_test.go
+++ b/lib/optimization/table_data_merge_columns_test.go
@@ -14,9 +14,9 @@ func TestTableData_UpdateInMemoryColumnsFromDestination_Tz(t *testing.T) {
 	{
 		// In memory and destination columns are both timestamp_tz
 		tableData := &TableData{inMemoryColumns: &columns.Columns{}}
-		tableData.AddInMemoryCol(columns.NewColumn("foo", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")))
+		tableData.AddInMemoryCol(columns.NewColumn("foo", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")))
 
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("foo", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("foo", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
 		updatedColumn, isOk := tableData.inMemoryColumns.GetColumn("foo")
 		assert.True(t, isOk)
 		assert.Equal(t, ext.TimestampTZKindType, updatedColumn.KindDetails.ExtendedTimeDetails.Type)
@@ -27,11 +27,11 @@ func TestTableData_UpdateInMemoryColumnsFromDestination_Tz(t *testing.T) {
 		tableData.AddInMemoryCol(
 			columns.NewColumn(
 				"foo",
-				typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MillisecondNoTZ),
+				typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MillisecondNoTZ),
 			),
 		)
 
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("foo", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("foo", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
 		updatedColumn, isOk := tableData.inMemoryColumns.GetColumn("foo")
 		assert.True(t, isOk)
 		assert.Equal(t, ext.TimestampTZKindType, updatedColumn.KindDetails.ExtendedTimeDetails.Type)
@@ -137,9 +137,9 @@ func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 			assert.Nil(t, col.KindDetails.ExtendedTimeDetails, extTimeDetailsCol)
 		}
 
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_time", typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""))))
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_date", typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""))))
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_datetime", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_time", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_date", typing.OldNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_datetime", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
 
 		dateCol, isOk := tableData.inMemoryColumns.GetColumn("ext_date")
 		assert.True(t, isOk)

--- a/lib/optimization/table_data_merge_columns_test.go
+++ b/lib/optimization/table_data_merge_columns_test.go
@@ -14,9 +14,9 @@ func TestTableData_UpdateInMemoryColumnsFromDestination_Tz(t *testing.T) {
 	{
 		// In memory and destination columns are both timestamp_tz
 		tableData := &TableData{inMemoryColumns: &columns.Columns{}}
-		tableData.AddInMemoryCol(columns.NewColumn("foo", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")))
+		tableData.AddInMemoryCol(columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")))
 
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("foo", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
 		updatedColumn, isOk := tableData.inMemoryColumns.GetColumn("foo")
 		assert.True(t, isOk)
 		assert.Equal(t, ext.TimestampTZKindType, updatedColumn.KindDetails.ExtendedTimeDetails.Type)
@@ -27,11 +27,11 @@ func TestTableData_UpdateInMemoryColumnsFromDestination_Tz(t *testing.T) {
 		tableData.AddInMemoryCol(
 			columns.NewColumn(
 				"foo",
-				typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MillisecondNoTZ),
+				typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampNTZKindType, ext.RFC3339MillisecondNoTZ),
 			),
 		)
 
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("foo", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
 		updatedColumn, isOk := tableData.inMemoryColumns.GetColumn("foo")
 		assert.True(t, isOk)
 		assert.Equal(t, ext.TimestampTZKindType, updatedColumn.KindDetails.ExtendedTimeDetails.Type)
@@ -137,9 +137,9 @@ func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 			assert.Nil(t, col.KindDetails.ExtendedTimeDetails, extTimeDetailsCol)
 		}
 
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_time", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""))))
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_date", typing.OldNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""))))
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_datetime", typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_time", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_date", typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_datetime", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
 
 		dateCol, isOk := tableData.inMemoryColumns.GetColumn("ext_date")
 		assert.True(t, isOk)

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -133,7 +133,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 		"FOO":                  typing.String,
 		"bar":                  typing.Invalid,
 		"CHANGE_me":            typing.String,
-		"do_not_change_format": typing.OldNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		"do_not_change_format": typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
 	} {
 		_cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
@@ -150,9 +150,9 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 
 	for name, colKindDetails := range map[string]typing.KindDetails{
 		"foo":                  typing.String,
-		"change_me":            typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"change_me":            typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 		"bar":                  typing.Boolean,
-		"do_not_change_format": typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"do_not_change_format": typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 	} {
 		tableData.MergeColumnsFromDestination(columns.NewColumn(name, colKindDetails))
 	}

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -133,7 +133,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 		"FOO":                  typing.String,
 		"bar":                  typing.Invalid,
 		"CHANGE_me":            typing.String,
-		"do_not_change_format": typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		"do_not_change_format": typing.OldNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
 	} {
 		_cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
@@ -150,9 +150,9 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 
 	for name, colKindDetails := range map[string]typing.KindDetails{
 		"foo":                  typing.String,
-		"change_me":            typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"change_me":            typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 		"bar":                  typing.Boolean,
-		"do_not_change_format": typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
+		"do_not_change_format": typing.OldNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 	} {
 		tableData.MergeColumnsFromDestination(columns.NewColumn(name, colKindDetails))
 	}

--- a/lib/typing/columns/diff_test.go
+++ b/lib/typing/columns/diff_test.go
@@ -249,8 +249,8 @@ func TestDiffDeterministic(t *testing.T) {
 func TestCopyColMap(t *testing.T) {
 	var cols Columns
 	cols.AddColumn(NewColumn("hello", typing.String))
-	cols.AddColumn(NewColumn("created_at", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")))
-	cols.AddColumn(NewColumn("updated_at", typing.NewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")))
+	cols.AddColumn(NewColumn("created_at", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")))
+	cols.AddColumn(NewColumn("updated_at", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")))
 
 	copiedCols := CloneColumns(&cols)
 	assert.Equal(t, copiedCols, &cols)

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -83,7 +83,27 @@ func NewDecimalDetailsFromTemplate(details KindDetails, decimalDetails decimal.D
 	return details
 }
 
-func NewExtendedTimeDetails(details KindDetails, extendedType ext.ExtendedTimeKindType, format string) KindDetails {
+// MustNewExtendedTimeDetails - calls NewExtendedTimeDetails and panics if there is an error returned. This is used for tests.
+func MustNewExtendedTimeDetails(details KindDetails, extendedType ext.ExtendedTimeKindType, optionalFormat string) KindDetails {
+	nestedKind, err := NewExtendedTimeDetails(details, extendedType, optionalFormat)
+	if err != nil {
+		panic(err)
+	}
+
+	return nestedKind
+}
+
+func NewExtendedTimeDetails(details KindDetails, extendedType ext.ExtendedTimeKindType, optionalFormat string) (KindDetails, error) {
+	nestedKind, err := ext.NewNestedKind(extendedType, optionalFormat)
+	if err != nil {
+		return Invalid, err
+	}
+
+	details.ExtendedTimeDetails = &nestedKind
+	return details, nil
+}
+
+func OldNewExtendedTimeDetails(details KindDetails, extendedType ext.ExtendedTimeKindType, format string) KindDetails {
 	// TODO: If format is not set, we should use the default format
 	details.ExtendedTimeDetails = &ext.NestedKind{
 		Type:   extendedType,


### PR DESCRIPTION
So we can standardize on the new method in which it will set a default layout if one is not provided.

Once this is merged, the only places where we will be calling `OldNewExtendedTimeDetails` is in the Debezium converters and that will be cleaned up in a separate PR.