### PR TITLE
[Extended Time] Remove NestedKind

### DIFF
--- a/clients/bigquery/converters/converters.go
+++ b/clients/bigquery/converters/converters.go
@@ -3,6 +3,7 @@ package converters
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
@@ -25,6 +26,12 @@ func (s StringConverter) Convert(value any) (any, error) {
 		return castedValue.String(), nil
 	case bool:
 		return fmt.Sprint(castedValue), nil
+	case time.Time:
+		if err := s.kd.EnsureExtendedTimeDetails(); err != nil {
+			return nil, err
+		}
+
+		return castedValue.Format(s.kd.ExtendedTimeDetails.Format), nil
 	case *ext.ExtendedTime:
 		if err := s.kd.EnsureExtendedTimeDetails(); err != nil {
 			return nil, err

--- a/clients/bigquery/converters/converters_test.go
+++ b/clients/bigquery/converters/converters_test.go
@@ -48,6 +48,14 @@ func TestStringConverter_Convert(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "2021-01-01T00:00:00Z", val)
 	}
+	{
+		// time.Time
+		val, err := NewStringConverter(typing.MustNewExtendedTimeDetails(typing.String, ext.TimestampTZKindType, "")).Convert(
+			time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		)
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01T00:00:00Z", val)
+	}
 }
 
 func TestInt64Converter_Convert(t *testing.T) {

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -282,7 +282,6 @@ func (t *TableData) MergeColumnsFromDestination(destCols ...columns.Column) erro
 
 // mergeColumn - This function will merge the in-memory column with the destination column.
 func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Column {
-	// Copy over the kind
 	inMemoryCol.KindDetails.Kind = destCol.KindDetails.Kind
 	// Copy over backfilled
 	inMemoryCol.SetBackfilled(destCol.Backfilled())
@@ -295,11 +294,6 @@ func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Col
 	// Copy over integer kind, if exists.
 	if destCol.KindDetails.OptionalIntegerKind != nil {
 		inMemoryCol.KindDetails.OptionalIntegerKind = destCol.KindDetails.OptionalIntegerKind
-	}
-
-	// Copy over the decimal details
-	if destCol.KindDetails.ExtendedDecimalDetails != nil && inMemoryCol.KindDetails.ExtendedDecimalDetails == nil {
-		inMemoryCol.KindDetails.ExtendedDecimalDetails = destCol.KindDetails.ExtendedDecimalDetails
 	}
 
 	// Copy over the time details
@@ -320,6 +314,11 @@ func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Col
 		// If the in-memory column has no format, we should use the format from the destination.
 		inMemoryCol.KindDetails.ExtendedTimeDetails.Format = cmp.Or(inMemoryCol.KindDetails.ExtendedTimeDetails.Format, destCol.KindDetails.ExtendedTimeDetails.Format)
 
+	}
+
+	// Copy over the decimal details
+	if destCol.KindDetails.ExtendedDecimalDetails != nil && inMemoryCol.KindDetails.ExtendedDecimalDetails == nil {
+		inMemoryCol.KindDetails.ExtendedDecimalDetails = destCol.KindDetails.ExtendedDecimalDetails
 	}
 
 	return inMemoryCol

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/typing/decimal"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/config"
@@ -15,6 +13,7 @@ import (
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
@@ -380,6 +379,14 @@ func TestMergeColumn(t *testing.T) {
 			col := mergeColumn(timestampNTZColumn, timestampTZColumn)
 			assert.Equal(t, ext.TimestampTZKindType, col.KindDetails.ExtendedTimeDetails.Type)
 			assert.Equal(t, "2006-01-02T15:04:05.999999999Z07:00", col.KindDetails.ExtendedTimeDetails.Format)
+		}
+		{
+			// Copy the dest column format if in-mem column format is empty.
+			inMemoryColumn := columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))
+			// Clearing the format
+			inMemoryColumn.KindDetails.ExtendedTimeDetails.Format = ""
+			destinationColumn := columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))
+			assert.Equal(t, destinationColumn.KindDetails.ExtendedTimeDetails.Format, mergeColumn(inMemoryColumn, destinationColumn).KindDetails.ExtendedTimeDetails.Format)
 		}
 	}
 }

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -6,14 +6,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/artie-labs/transfer/lib/typing/decimal"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/config"
+	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 	"github.com/artie-labs/transfer/lib/typing/ext"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDistinctDates(t *testing.T) {
@@ -329,5 +331,55 @@ func TestTableData_InsertRowSoftDelete(t *testing.T) {
 		assert.Equal(t, "dana-new", td.Rows()[0]["name"])
 		assert.Nil(t, td.Rows()[0]["foo"])
 		assert.Equal(t, false, td.Rows()[0][constants.DeleteColumnMarker])
+	}
+}
+
+func TestMergeColumn(t *testing.T) {
+	{
+		// Make sure it copies the kind over
+		col := mergeColumn(columns.NewColumn("foo", typing.String), columns.NewColumn("foo", typing.Boolean))
+		assert.Equal(t, typing.Boolean, col.KindDetails)
+	}
+	{
+		// Make sure it copies the backfill over
+		backfilledCol := columns.NewColumn("foo", typing.String)
+		backfilledCol.SetBackfilled(true)
+		cols := mergeColumn(columns.NewColumn("foo", typing.String), backfilledCol)
+		assert.True(t, cols.Backfilled())
+	}
+	{
+		// Make sure the string precision gets copied over
+		columnWithStringPrecision := columns.NewColumn("foo", typing.String)
+		columnWithStringPrecision.KindDetails.OptionalStringPrecision = typing.ToPtr(int32(5))
+		col := mergeColumn(columns.NewColumn("foo", typing.String), columnWithStringPrecision)
+		assert.Equal(t, int32(5), *col.KindDetails.OptionalStringPrecision)
+	}
+	{
+		// Integer kind gets copied over
+		intCol := columns.NewColumn("foo", typing.Integer)
+		intCol.KindDetails.OptionalIntegerKind = typing.ToPtr(typing.SmallIntegerKind)
+		col := mergeColumn(columns.NewColumn("foo", typing.String), intCol)
+		assert.Equal(t, typing.SmallIntegerKind, *col.KindDetails.OptionalIntegerKind)
+	}
+	{
+		// Decimal details get copied over
+		decimalCol := columns.NewColumn("foo", typing.EDecimal)
+		details := decimal.NewDetails(5, 2)
+		decimalCol.KindDetails.ExtendedDecimalDetails = &details
+
+		col := mergeColumn(columns.NewColumn("foo", typing.String), decimalCol)
+		assert.Equal(t, details, *col.KindDetails.ExtendedDecimalDetails)
+	}
+	{
+		// Time details get copied over
+		{
+			// Testing for backwards compatibility
+			// in-memory column is TimestampNTZ, destination column is TimestampTZ
+			timestampNTZColumn := columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))
+			timestampTZColumn := columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))
+			col := mergeColumn(timestampNTZColumn, timestampTZColumn)
+			assert.Equal(t, ext.TimestampTZKindType, col.KindDetails.ExtendedTimeDetails.Type)
+			assert.Equal(t, "2006-01-02T15:04:05.999999999Z07:00", col.KindDetails.ExtendedTimeDetails.Format)
+		}
 	}
 }

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -47,8 +47,7 @@ func NewNestedKind(kindType ExtendedTimeKindType, optionalFormat string) (Nested
 // ExtendedTime is created because Golang's time.Time does not allow us to explicitly cast values as a date, or time
 // and only allows timestamp expressions.
 type ExtendedTime struct {
-	ts         time.Time
-	nestedKind NestedKind
+	ts time.Time
 }
 
 // MarshalJSON is a custom JSON marshaller for ExtendedTime.
@@ -58,26 +57,12 @@ func (e ExtendedTime) MarshalJSON() ([]byte, error) {
 	return e.ts.UTC().MarshalJSON()
 }
 
-// TODO: Have this return an error instead of nil
 func NewExtendedTime(t time.Time, kindType ExtendedTimeKindType, originalFormat string) *ExtendedTime {
-	defaultLayout, err := kindType.defaultLayout()
-	if err != nil {
-		return nil
-	}
-
 	return &ExtendedTime{
 		ts: t,
-		nestedKind: NestedKind{
-			Type:   kindType,
-			Format: cmp.Or(originalFormat, defaultLayout),
-		},
 	}
 }
 
 func (e *ExtendedTime) GetTime() time.Time {
 	return e.ts
-}
-
-func (e *ExtendedTime) GetNestedKind() NestedKind {
-	return e.nestedKind
 }

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -11,8 +11,6 @@ import (
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-
-	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
 // JSONEToMap - Takes a JSON Extended string and converts it to a map[string]any
@@ -89,9 +87,9 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 func bsonValueToGoValue(value any) (any, error) {
 	switch v := value.(type) {
 	case primitive.DateTime:
-		return ext.NewExtendedTime(v.Time().UTC(), ext.TimestampTZKindType, ext.ISO8601), nil
+		return v.Time().UTC(), nil
 	case primitive.Timestamp:
-		return ext.NewExtendedTime(time.Unix(int64(v.T), 0).UTC(), ext.TimestampTZKindType, ext.ISO8601), nil
+		return time.Unix(int64(v.T), 0).UTC(), nil
 	case primitive.ObjectID:
 		return v.Hex(), nil
 	case primitive.Binary:

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -116,16 +116,13 @@ func TestJSONEToMap(t *testing.T) {
 	}
 	{
 		// Date
-		extendedTime, isOk := result["order_date"].(*ext.ExtendedTime)
-		assert.True(t, isOk)
-		assert.Equal(t, ext.NewExtendedTime(time.Date(2016, time.February, 21, 0, 0, 0, 0, time.UTC), ext.TimestampTZKindType, ext.ISO8601), extendedTime)
+		assert.Equal(t, time.Date(2016, time.February, 21, 0, 0, 0, 0, time.UTC), result["order_date"].(time.Time))
 	}
 	{
 		// Timestamp
-		extendedTime, isOk := result["test_timestamp"]
-		assert.True(t, isOk)
-		assert.Equal(t, ext.NewExtendedTime(time.Date(2023, time.March, 16, 1, 18, 37, 0, time.UTC), ext.TimestampTZKindType, ext.ISO8601), extendedTime)
-		assert.Equal(t, "2023-03-16T01:18:37+00:00", extendedTime.(*ext.ExtendedTime).GetTime().Format(ext.ISO8601))
+		_ts := result["test_timestamp"].(time.Time)
+		assert.Equal(t, time.Date(2023, time.March, 16, 1, 18, 37, 0, time.UTC), _ts)
+		assert.Equal(t, "2023-03-16T01:18:37+00:00", _ts.Format(ext.ISO8601))
 	}
 	{
 		// Boolean
@@ -220,10 +217,9 @@ func TestBsonValueToGoValue(t *testing.T) {
 		result, err := bsonValueToGoValue(dateTime)
 		assert.NoError(t, err)
 
-		extendedTime, isOk := result.(*ext.ExtendedTime)
-		assert.True(t, isOk)
-		assert.Equal(t, ext.NewExtendedTime(time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC), ext.TimestampTZKindType, ext.ISO8601), extendedTime)
-		assert.Equal(t, "2021-01-01T00:00:00+00:00", extendedTime.GetTime().Format(ext.ISO8601))
+		_ts := result.(time.Time)
+		assert.Equal(t, time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC), _ts)
+		assert.Equal(t, "2021-01-01T00:00:00+00:00", _ts.Format(ext.ISO8601))
 	}
 	{
 		// primitive.ObjectID

--- a/lib/typing/parse.go
+++ b/lib/typing/parse.go
@@ -3,6 +3,7 @@ package typing
 import (
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
@@ -48,12 +49,10 @@ func ParseValue(key string, optionalSchema map[string]KindDetails, val any) (Kin
 			Kind:                   EDecimal.Kind,
 			ExtendedDecimalDetails: &extendedDetails,
 		}, nil
-	case *ext.ExtendedTime:
-		nestedKind := convertedVal.GetNestedKind()
-		return KindDetails{
-			Kind:                ETime.Kind,
-			ExtendedTimeDetails: &nestedKind,
-		}, nil
+	case time.Time:
+		// time.Time should only appear for bson.Timestamp and bson.DateTime
+		// All other sources will have an optional schema
+		return NewExtendedTimeDetails(ETime, ext.TimestampTZKindType, "")
 	default:
 		// Check if the val is one of our custom-types
 		if reflect.TypeOf(val).Kind() == reflect.Slice {


### PR DESCRIPTION
Extended Time is now just a pure wrapper around `time.Time`.