### PR TITLE
[MongoDB] To not use Extended Time

### DIFF
--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -12,7 +12,6 @@ import (
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
-	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/artie-labs/transfer/lib/typing/mongo"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -192,11 +191,11 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc kafkalib.TopicConf
 	}
 
 	if tc.IncludeArtieUpdatedAt {
-		retMap[constants.UpdateColumnMarker] = ext.NewExtendedTime(time.Now().UTC(), ext.TimestampTZKindType, ext.ISO8601)
+		retMap[constants.UpdateColumnMarker] = time.Now().UTC()
 	}
 
 	if tc.IncludeDatabaseUpdatedAt {
-		retMap[constants.DatabaseUpdatedColumnMarker] = ext.NewExtendedTime(s.GetExecutionTime(), ext.TimestampTZKindType, ext.ISO8601)
+		retMap[constants.DatabaseUpdatedColumnMarker] = s.GetExecutionTime().UTC()
 	}
 
 	return retMap, nil

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/typing/ext"
-
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/debezium"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -179,11 +177,11 @@ func (m *MongoTestSuite) TestMongoDBEventCustomer() {
 	evtDataWithIncludedAt, err = evt.GetData(map[string]any{"_id": int64(1003)}, kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true, IncludeArtieUpdatedAt: true})
 	assert.NoError(m.T(), err)
 
-	assert.Equal(m.T(), ext.NewExtendedTime(time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC), ext.TimestampTZKindType, ext.ISO8601), evtDataWithIncludedAt[constants.DatabaseUpdatedColumnMarker])
+	assert.Equal(m.T(), time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC), evtDataWithIncludedAt[constants.DatabaseUpdatedColumnMarker])
 
-	updatedExtTime, isOk := evtDataWithIncludedAt[constants.UpdateColumnMarker].(*ext.ExtendedTime)
+	updatedTime, isOk := evtDataWithIncludedAt[constants.UpdateColumnMarker].(time.Time)
 	assert.True(m.T(), isOk)
-	assert.False(m.T(), updatedExtTime.GetTime().IsZero())
+	assert.False(m.T(), updatedTime.IsZero())
 
 	var nestedData map[string]any
 	err = json.Unmarshal([]byte(evtData["nested"].(string)), &nestedData)
@@ -314,7 +312,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 
 		updatedAt, isOk := evtData[constants.UpdateColumnMarker]
 		assert.True(m.T(), isOk)
-		_, isOk = updatedAt.(*ext.ExtendedTime)
+		_, isOk = updatedAt.(time.Time)
 		assert.True(m.T(), isOk)
 	}
 }

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -3,6 +3,7 @@ package ext
 import (
 	"cmp"
 	"fmt"
+	"log/slog"
 	"time"
 )
 
@@ -54,7 +55,9 @@ type ExtendedTime struct {
 // MarshalJSON is a custom JSON marshaller for ExtendedTime.
 // This is only used for nested MongoDB objects where there may be nested DateTime values.
 func (e ExtendedTime) MarshalJSON() ([]byte, error) {
-	// This is consistent with how MongoDB's Go driver marshals time.Time
+	// Delete this function once we delete [ExtendedTime].
+	// This should not be happening anymore since MongoDB is now using [time.Time]
+	slog.Error("Unexpected call to MarshalJSON()", slog.Any("ts", e.ts), slog.String("nestedKindType", string(e.nestedKind.Type)))
 	return e.ts.UTC().MarshalJSON()
 }
 

--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -11,8 +11,6 @@ import (
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-
-	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
 // JSONEToMap - Takes a JSON Extended string and converts it to a map[string]any
@@ -89,9 +87,9 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 func bsonValueToGoValue(value any) (any, error) {
 	switch v := value.(type) {
 	case primitive.DateTime:
-		return ext.NewExtendedTime(v.Time().UTC(), ext.TimestampTZKindType, ext.ISO8601), nil
+		return v.Time().UTC(), nil
 	case primitive.Timestamp:
-		return ext.NewExtendedTime(time.Unix(int64(v.T), 0).UTC(), ext.TimestampTZKindType, ext.ISO8601), nil
+		return time.Unix(int64(v.T), 0).UTC(), nil
 	case primitive.ObjectID:
 		return v.Hex(), nil
 	case primitive.Binary:

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -116,16 +116,16 @@ func TestJSONEToMap(t *testing.T) {
 	}
 	{
 		// Date
-		extendedTime, isOk := result["order_date"].(*ext.ExtendedTime)
+		ts, isOk := result["order_date"].(time.Time)
 		assert.True(t, isOk)
-		assert.Equal(t, ext.NewExtendedTime(time.Date(2016, time.February, 21, 0, 0, 0, 0, time.UTC), ext.TimestampTZKindType, ext.ISO8601), extendedTime)
+		assert.Equal(t, time.Date(2016, time.February, 21, 0, 0, 0, 0, time.UTC), ts)
 	}
 	{
 		// Timestamp
-		extendedTime, isOk := result["test_timestamp"]
+		ts, isOk := result["test_timestamp"]
 		assert.True(t, isOk)
-		assert.Equal(t, ext.NewExtendedTime(time.Date(2023, time.March, 16, 1, 18, 37, 0, time.UTC), ext.TimestampTZKindType, ext.ISO8601), extendedTime)
-		assert.Equal(t, "2023-03-16T01:18:37+00:00", extendedTime.(*ext.ExtendedTime).GetTime().Format(ext.ISO8601))
+		assert.Equal(t, time.Date(2023, time.March, 16, 1, 18, 37, 0, time.UTC), ts)
+		assert.Equal(t, "2023-03-16T01:18:37+00:00", ts.(time.Time).Format(ext.ISO8601))
 	}
 	{
 		// Boolean
@@ -220,10 +220,10 @@ func TestBsonValueToGoValue(t *testing.T) {
 		result, err := bsonValueToGoValue(dateTime)
 		assert.NoError(t, err)
 
-		extendedTime, isOk := result.(*ext.ExtendedTime)
+		ts, isOk := result.(time.Time)
 		assert.True(t, isOk)
-		assert.Equal(t, ext.NewExtendedTime(time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC), ext.TimestampTZKindType, ext.ISO8601), extendedTime)
-		assert.Equal(t, "2021-01-01T00:00:00+00:00", extendedTime.GetTime().Format(ext.ISO8601))
+		assert.Equal(t, time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC), ts)
+		assert.Equal(t, "2021-01-01T00:00:00+00:00", ts.Format(ext.ISO8601))
 	}
 	{
 		// primitive.ObjectID

--- a/lib/typing/parse.go
+++ b/lib/typing/parse.go
@@ -3,6 +3,7 @@ package typing
 import (
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
@@ -48,6 +49,8 @@ func ParseValue(key string, optionalSchema map[string]KindDetails, val any) (Kin
 			Kind:                   EDecimal.Kind,
 			ExtendedDecimalDetails: &extendedDetails,
 		}, nil
+	case time.Time:
+		return NewExtendedTimeDetails(ETime, ext.TimestampTZKindType, "")
 	case *ext.ExtendedTime:
 		nestedKind := convertedVal.GetNestedKind()
 		return KindDetails{

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -34,7 +34,7 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 
 		_time, err := ext.ParseFromInterface(colVal, colKind.ExtendedTimeDetails.Type)
 		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
+			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
 		}
 
 		if colKind.ExtendedTimeDetails.Type == ext.TimeKindType {


### PR DESCRIPTION
Refactoring MongoDB to use `time.Time` instead of `ExtendedTime`