### PR TITLE
Pulling `DATE` out of `ExtendedTime` and into a separate data type

### DIFF
--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -47,6 +47,8 @@ func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool) s
 	case typing.Struct.Kind:
 		// Struct is a tighter version of JSON that requires type casting like Struct<int64>
 		return "json"
+	case typing.Date.Kind:
+		return "date"
 	case typing.ETime.Kind:
 		switch kindDetails.ExtendedTimeDetails.Type {
 		case ext.TimestampTZKindType:
@@ -55,8 +57,6 @@ func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool) s
 			return "timestamp"
 		case ext.TimestampNTZKindType:
 			return "datetime"
-		case ext.DateKindType:
-			return "date"
 		case ext.TimeKindType:
 			return "time"
 		}
@@ -112,7 +112,7 @@ func (BigQueryDialect) KindForDataType(rawBqType string, _ string) (typing.KindD
 	case "time":
 		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")
 	case "date":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")
+		return typing.Date, nil
 	default:
 		return typing.Invalid, nil
 	}

--- a/clients/bigquery/dialect/dialect_test.go
+++ b/clients/bigquery/dialect/dialect_test.go
@@ -95,7 +95,7 @@ func TestBigQueryDialect_KindForDataType(t *testing.T) {
 		"datetime":  typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 		"timestamp": typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 		"time":      typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
-		"date":      typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		"date":      typing.Date,
 		//Invalid
 		"foo":    typing.Invalid,
 		"foofoo": typing.Invalid,
@@ -132,7 +132,7 @@ func TestBigQueryDialect_KindForDataType_NoDataLoss(t *testing.T) {
 	kindDetails := []typing.KindDetails{
 		typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 		typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
-		typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		typing.Date,
 		typing.String,
 		typing.Boolean,
 		typing.Struct,

--- a/clients/bigquery/storagewrite_test.go
+++ b/clients/bigquery/storagewrite_test.go
@@ -49,8 +49,8 @@ func TestColumnToTableFieldSchema(t *testing.T) {
 		assert.Equal(t, storagepb.TableFieldSchema_TIME, fieldSchema.Type)
 	}
 	{
-		// ETime - Date:
-		fieldSchema, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")))
+		// Date
+		fieldSchema, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.Date))
 		assert.NoError(t, err)
 		assert.Equal(t, storagepb.TableFieldSchema_DATE, fieldSchema.Type)
 	}
@@ -168,7 +168,7 @@ func TestRowToMessage(t *testing.T) {
 		columns.NewColumn("c_string", typing.String),
 		columns.NewColumn("c_string_decimal", typing.String),
 		columns.NewColumn("c_time", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")),
-		columns.NewColumn("c_date", typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")),
+		columns.NewColumn("c_date", typing.Date),
 		columns.NewColumn("c_datetime", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, "")),
 		columns.NewColumn("c_struct", typing.Struct),
 		columns.NewColumn("c_array", typing.Array),
@@ -188,7 +188,7 @@ func TestRowToMessage(t *testing.T) {
 		"c_string":         "foo bar",
 		"c_string_decimal": decimal.NewDecimal(numbers.MustParseDecimal("1.61803")),
 		"c_time":           ext.NewExtendedTime(time.Date(0, 0, 0, 4, 5, 6, 7, time.UTC), ext.TimeKindType, ""),
-		"c_date":           ext.NewExtendedTime(time.Date(2001, 2, 3, 0, 0, 0, 0, time.UTC), ext.DateKindType, ""),
+		"c_date":           time.Date(2001, 2, 3, 0, 0, 0, 0, time.UTC),
 		"c_datetime":       ext.NewExtendedTime(time.Date(2001, 2, 3, 4, 5, 6, 7, time.UTC), ext.TimestampTZKindType, ""),
 		"c_struct":         map[string]any{"baz": []string{"foo", "bar"}},
 		"c_array":          []string{"foo", "bar"},

--- a/clients/databricks/dialect/typing.go
+++ b/clients/databricks/dialect/typing.go
@@ -24,6 +24,8 @@ func (DatabricksDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool)
 		return "STRING"
 	case typing.Boolean.Kind:
 		return "BOOLEAN"
+	case typing.Date.Kind:
+		return "DATE"
 	case typing.ETime.Kind:
 		switch kindDetails.ExtendedTimeDetails.Type {
 		case ext.TimestampTZKindType:
@@ -32,8 +34,6 @@ func (DatabricksDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool)
 			// This is currently in public preview, to use this, the customer will need to enable [timestampNtz] in their delta tables.
 			// Ref: https://docs.databricks.com/en/sql/language-manual/data-types/timestamp-ntz-type.html
 			return "TIMESTAMP_NTZ"
-		case ext.DateKindType:
-			return "DATE"
 		case ext.TimeKindType:
 			return "STRING"
 		}
@@ -66,7 +66,7 @@ func (DatabricksDialect) KindForDataType(rawType string, _ string) (typing.KindD
 	case "boolean":
 		return typing.Boolean, nil
 	case "date":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")
+		return typing.Date, nil
 	case "double", "float":
 		return typing.Float, nil
 	case "int":

--- a/clients/databricks/dialect/typing_test.go
+++ b/clients/databricks/dialect/typing_test.go
@@ -115,7 +115,7 @@ func TestDatabricksDialect_KindForDataType(t *testing.T) {
 		// Date
 		kd, err := DatabricksDialect{}.KindForDataType("DATE", "")
 		assert.NoError(t, err)
-		assert.Equal(t, typing.Date.Kind, kd)
+		assert.Equal(t, typing.Date, kd)
 	}
 	{
 		// Double

--- a/clients/databricks/dialect/typing_test.go
+++ b/clients/databricks/dialect/typing_test.go
@@ -38,7 +38,7 @@ func TestDatabricksDialect_DataTypeForKind(t *testing.T) {
 		// Times
 		{
 			// Date
-			assert.Equal(t, "DATE", DatabricksDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.ETime.Kind, ExtendedTimeDetails: &ext.NestedKind{Type: ext.DateKindType}}, false))
+			assert.Equal(t, "DATE", DatabricksDialect{}.DataTypeForKind(typing.Date, false))
 		}
 		{
 			// Timestamp
@@ -115,7 +115,7 @@ func TestDatabricksDialect_KindForDataType(t *testing.T) {
 		// Date
 		kd, err := DatabricksDialect{}.KindForDataType("DATE", "")
 		assert.NoError(t, err)
-		assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""), kd)
+		assert.Equal(t, typing.Date.Kind, kd)
 	}
 	{
 		// Double

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -53,6 +53,8 @@ func (MSSQLDialect) DataTypeForKind(kindDetails typing.KindDetails, isPk bool) s
 		return "VARCHAR(MAX)"
 	case typing.Boolean.Kind:
 		return "BIT"
+	case typing.Date.Kind:
+		return "DATE"
 	case typing.ETime.Kind:
 		switch kindDetails.ExtendedTimeDetails.Type {
 		case ext.TimestampTZKindType:
@@ -60,8 +62,6 @@ func (MSSQLDialect) DataTypeForKind(kindDetails typing.KindDetails, isPk bool) s
 		case ext.TimestampNTZKindType:
 			// Using datetime2 because it's the recommendation, and it provides more precision: https://stackoverflow.com/a/1884088
 			return "datetime2"
-		case ext.DateKindType:
-			return "date"
 		case ext.TimeKindType:
 			return "time"
 		}
@@ -122,7 +122,7 @@ func (MSSQLDialect) KindForDataType(rawType string, stringPrecision string) (typ
 	case "time":
 		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")
 	case "date":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")
+		return typing.Date, nil
 	case "bit":
 		return typing.Boolean, nil
 	case "text":

--- a/clients/mssql/dialect/dialect_test.go
+++ b/clients/mssql/dialect/dialect_test.go
@@ -62,7 +62,7 @@ func TestMSSQLDialect_KindForDataType(t *testing.T) {
 		"float":     typing.Float,
 		"real":      typing.Float,
 		"bit":       typing.Boolean,
-		"date":      typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		"date":      typing.Date,
 		"time":      typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
 		"datetime":  typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 		"datetime2": typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -45,14 +45,14 @@ func (RedshiftDialect) DataTypeForKind(kd typing.KindDetails, _ bool) string {
 	case typing.Boolean.Kind:
 		// We need to append `NULL` to let Redshift know that NULL is an acceptable data type.
 		return "BOOLEAN NULL"
+	case typing.Date.Kind:
+		return "DATE"
 	case typing.ETime.Kind:
 		switch kd.ExtendedTimeDetails.Type {
 		case ext.TimestampTZKindType:
 			return "timestamp with time zone"
 		case ext.TimestampNTZKindType:
 			return "timestamp without time zone"
-		case ext.DateKindType:
-			return "date"
 		case ext.TimeKindType:
 			return "time"
 		}
@@ -112,7 +112,7 @@ func (RedshiftDialect) KindForDataType(rawType string, stringPrecision string) (
 	case "time without time zone":
 		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")
 	case "date":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")
+		return typing.Date, nil
 	case "boolean":
 		return typing.Boolean, nil
 	}

--- a/clients/redshift/dialect/typing_test.go
+++ b/clients/redshift/dialect/typing_test.go
@@ -152,8 +152,7 @@ func TestRedshiftDialect_KindForDataType(t *testing.T) {
 		{
 			kd, err := dialect.KindForDataType("date", "")
 			assert.NoError(t, err)
-			assert.Equal(t, typing.ETime.Kind, kd.Kind)
-			assert.Equal(t, ext.DateKindType, kd.ExtendedTimeDetails.Type)
+			assert.Equal(t, typing.Date, kd)
 		}
 	}
 }

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -21,6 +21,13 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 	switch column.KindDetails.Kind {
 	case typing.Struct.Kind, typing.Array.Kind:
 		return dialect.EscapeStruct(fmt.Sprint(column.DefaultValue())), nil
+	case typing.Date.Kind:
+		_time, err := ext.ParseDateFromInterface(column.DefaultValue())
+		if err != nil {
+			return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)
+		}
+
+		return sql.QuoteLiteral(_time.Format(ext.PostgresDateFormat)), nil
 	case typing.ETime.Kind:
 		if err := column.KindDetails.EnsureExtendedTimeDetails(); err != nil {
 			return nil, err

--- a/clients/shared/default_value_test.go
+++ b/clients/shared/default_value_test.go
@@ -28,12 +28,6 @@ func TestColumn_DefaultValue(t *testing.T) {
 	birthdayDateTime, err := ext.ParseDateTime(birthday.Format(ext.ISO8601), ext.TimestampTZKindType)
 	assert.NoError(t, err)
 
-	// date
-	dateKind := typing.ETime
-	dateNestedKind, err := ext.NewNestedKind(ext.DateKindType, "")
-	assert.NoError(t, err)
-	dateKind.ExtendedTimeDetails = &dateNestedKind
-
 	// time
 	timeKind := typing.ETime
 	timeNestedKind, err := ext.NewNestedKind(ext.TimeKindType, "")
@@ -85,7 +79,7 @@ func TestColumn_DefaultValue(t *testing.T) {
 		},
 		{
 			name:          "date",
-			col:           columns.NewColumnWithDefaultValue("", dateKind, birthdayDateTime),
+			col:           columns.NewColumnWithDefaultValue("", typing.Date, birthdayDateTime),
 			expectedValue: "'2022-09-06'",
 		},
 		{

--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -30,14 +30,14 @@ func (SnowflakeDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool) 
 		return "variant"
 	case typing.Boolean.Kind:
 		return "boolean"
+	case typing.Date.Kind:
+		return "date"
 	case typing.ETime.Kind:
 		switch kindDetails.ExtendedTimeDetails.Type {
 		case ext.TimestampTZKindType:
 			return "timestamp_tz"
 		case ext.TimestampNTZKindType:
 			return "timestamp_ntz"
-		case ext.DateKindType:
-			return "date"
 		case ext.TimeKindType:
 			return "time"
 		}
@@ -104,7 +104,7 @@ func (SnowflakeDialect) KindForDataType(snowflakeType string, _ string) (typing.
 	case "time":
 		return typing.NewExtendedTimeDetails(typing.ETime, ext.TimeKindType, "")
 	case "date":
-		return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, "")
+		return typing.Date, nil
 	default:
 		return typing.Invalid, nil
 	}

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -198,7 +198,7 @@ func TestSnowflakeDialect_KindForDataType_NoDataLoss(t *testing.T) {
 	kindDetails := []typing.KindDetails{
 		typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 		typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""),
-		typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		typing.Date,
 		typing.String,
 		typing.Boolean,
 		typing.Struct,

--- a/lib/debezium/converters/date.go
+++ b/lib/debezium/converters/date.go
@@ -15,7 +15,7 @@ func (Date) layout() string {
 }
 
 func (d Date) ToKindDetails() (typing.KindDetails, error) {
-	return typing.NewExtendedTimeDetails(typing.ETime, ext.DateKindType, d.layout())
+	return typing.Date, nil
 }
 
 func (d Date) Convert(value any) (any, error) {
@@ -25,5 +25,5 @@ func (d Date) Convert(value any) (any, error) {
 	}
 
 	// Represents the number of days since the epoch.
-	return ext.NewExtendedTime(time.UnixMilli(0).In(time.UTC).AddDate(0, 0, int(valueInt64)), ext.DateKindType, d.layout()), nil
+	return time.UnixMilli(0).In(time.UTC).AddDate(0, 0, int(valueInt64)), nil
 }

--- a/lib/debezium/converters/date_test.go
+++ b/lib/debezium/converters/date_test.go
@@ -2,8 +2,7 @@ package converters
 
 import (
 	"testing"
-
-	"github.com/artie-labs/transfer/lib/typing/ext"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -18,16 +17,16 @@ func TestDate_Convert(t *testing.T) {
 		val, err := Date{}.Convert(int64(19401))
 		assert.NoError(t, err)
 
-		extTime, isOk := val.(*ext.ExtendedTime)
+		date, isOk := val.(time.Time)
 		assert.True(t, isOk)
-		assert.Equal(t, "2023-02-13", extTime.GetTime().Format(Date{}.layout()))
+		assert.Equal(t, "2023-02-13", date.Format(Date{}.layout()))
 	}
 	{
 		val, err := Date{}.Convert(int64(19429))
 		assert.NoError(t, err)
 
-		extTime, isOk := val.(*ext.ExtendedTime)
+		date, isOk := val.(time.Time)
 		assert.True(t, isOk)
-		assert.Equal(t, "2023-03-13", extTime.GetTime().Format(Date{}.layout()))
+		assert.Equal(t, "2023-03-13", date.Format(Date{}.layout()))
 	}
 }

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -249,7 +249,7 @@ func TestField_ToKindDetails(t *testing.T) {
 		for _, dbzType := range []SupportedDebeziumType{Date, DateKafkaConnect} {
 			kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
 			assert.NoError(t, err)
-			assert.Equal(t, typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ext.PostgresDateFormat), kd)
+			assert.Equal(t, typing.Date, kd)
 		}
 	}
 	{

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -202,7 +202,7 @@ func (t *TableData) DistinctDates(colName string) ([]string, error) {
 			return nil, fmt.Errorf("col: %v does not exist on row: %v", colName, row)
 		}
 
-		_time, err := ext.ParseFromInterface(val, ext.DateKindType)
+		_time, err := ext.ParseDateFromInterface(val)
 		if err != nil {
 			return nil, fmt.Errorf("col: %v is not a time column, value: %v, err: %w", colName, val, err)
 		}

--- a/lib/optimization/table_data_merge_columns_test.go
+++ b/lib/optimization/table_data_merge_columns_test.go
@@ -53,21 +53,12 @@ func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 	{
 		// In-memory column is a string and the destination column is a Date
 		tableData.AddInMemoryCol(columns.NewColumn("foo", typing.String))
-
-		extTime := typing.ETime
-		nestedKind, err := ext.NewNestedKind(ext.DateKindType, "")
-		assert.NoError(t, err)
-
-		extTime.ExtendedTimeDetails = &nestedKind
-		tsCol := columns.NewColumn("foo", extTime)
+		tsCol := columns.NewColumn("foo", typing.Date)
 		assert.NoError(t, tableData.MergeColumnsFromDestination(tsCol))
 
 		updatedColumn, isOk := tableData.inMemoryColumns.GetColumn("foo")
 		assert.True(t, isOk)
-		assert.Equal(t, typing.ETime.Kind, updatedColumn.KindDetails.Kind)
-		assert.Equal(t, ext.DateKindType, updatedColumn.KindDetails.ExtendedTimeDetails.Type)
-		// Format is copied over.
-		assert.Equal(t, ext.PostgresDateFormat, updatedColumn.KindDetails.ExtendedTimeDetails.Format)
+		assert.Equal(t, typing.Date, updatedColumn.KindDetails)
 	}
 	{
 		// In-memory column is NUMERIC and destination column is an INTEGER
@@ -138,13 +129,12 @@ func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 		}
 
 		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_time", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimeKindType, ""))))
-		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_date", typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""))))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_date", typing.Date)))
 		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn("ext_datetime", typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""))))
 
 		dateCol, isOk := tableData.inMemoryColumns.GetColumn("ext_date")
 		assert.True(t, isOk)
-		assert.NotNil(t, dateCol.KindDetails.ExtendedTimeDetails)
-		assert.Equal(t, ext.DateKindType, dateCol.KindDetails.ExtendedTimeDetails.Type)
+		assert.Equal(t, typing.Date, dateCol.KindDetails)
 
 		timeCol, isOk := tableData.inMemoryColumns.GetColumn("ext_time")
 		assert.True(t, isOk)

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -134,7 +134,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 		"FOO":                  typing.String,
 		"bar":                  typing.Invalid,
 		"CHANGE_me":            typing.String,
-		"do_not_change_format": typing.MustNewExtendedTimeDetails(typing.ETime, ext.DateKindType, ""),
+		"do_not_change_format": typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 	} {
 		_cols.AddColumn(columns.NewColumn(colName, colKind))
 	}
@@ -155,7 +155,7 @@ func TestTableData_UpdateInMemoryColumns(t *testing.T) {
 		"bar":                  typing.Boolean,
 		"do_not_change_format": typing.MustNewExtendedTimeDetails(typing.ETime, ext.TimestampTZKindType, ""),
 	} {
-		tableData.MergeColumnsFromDestination(columns.NewColumn(name, colKindDetails))
+		assert.NoError(t, tableData.MergeColumnsFromDestination(columns.NewColumn(name, colKindDetails)))
 	}
 
 	// It's saved back in the original format.

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -20,6 +20,13 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 	}
 
 	switch colKind.KindDetails.Kind {
+	case typing.Date.Kind:
+		_time, err := ext.ParseDateFromInterface(colVal)
+		if err != nil {
+			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
+		}
+
+		return _time.Format(ext.PostgresDateFormat), nil
 	case typing.ETime.Kind:
 		if err := colKind.KindDetails.EnsureExtendedTimeDetails(); err != nil {
 			return "", err
@@ -30,7 +37,7 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
-		if colKind.KindDetails.ExtendedTimeDetails.Type == ext.DateKindType || colKind.KindDetails.ExtendedTimeDetails.Type == ext.TimeKindType {
+		if colKind.KindDetails.ExtendedTimeDetails.Type == ext.TimeKindType {
 			return _time.Format(colKind.KindDetails.ExtendedTimeDetails.Format), nil
 		}
 

--- a/lib/parquetutil/parse_values_test.go
+++ b/lib/parquetutil/parse_values_test.go
@@ -68,12 +68,7 @@ func TestParseValue(t *testing.T) {
 	}
 	{
 		// Date
-		eDate := typing.ETime
-		nestedKind, err := ext.NewNestedKind(ext.DateKindType, "")
-		assert.NoError(t, err)
-
-		eDate.ExtendedTimeDetails = &nestedKind
-		value, err := ParseValue("2022-12-25", columns.NewColumn("", eDate))
+		value, err := ParseValue("2022-12-25", columns.NewColumn("", typing.Date))
 		assert.NoError(t, err)
 		assert.Equal(t, "2022-12-25", value)
 	}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -11,7 +11,7 @@ func TestParseFromInterface(t *testing.T) {
 	{
 		// Extended time
 		var vals []*ExtendedTime
-		vals = append(vals, NewExtendedTime(time.Now().UTC(), DateKindType, PostgresDateFormat))
+		vals = append(vals, NewExtendedTime(time.Now().UTC(), TimestampNTZKindType, RFC3339NoTZ))
 		vals = append(vals, NewExtendedTime(time.Now().UTC(), TimestampTZKindType, ISO8601))
 		vals = append(vals, NewExtendedTime(time.Now().UTC(), TimeKindType, PostgresTimeFormat))
 
@@ -74,10 +74,10 @@ func TestParseFromInterfaceTime(t *testing.T) {
 	}
 }
 
-func TestParseFromInterfaceDate(t *testing.T) {
+func TestParseDateFromInterface(t *testing.T) {
 	now := time.Now()
 	for _, supportedDateFormat := range supportedDateFormats {
-		_time, err := ParseFromInterface(now.Format(supportedDateFormat), DateKindType)
+		_time, err := ParseDateFromInterface(now.Format(supportedDateFormat))
 		assert.NoError(t, err)
 		assert.Equal(t, _time.Format(supportedDateFormat), now.Format(supportedDateFormat))
 	}

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -11,7 +11,6 @@ type ExtendedTimeKindType string
 const (
 	TimestampTZKindType  ExtendedTimeKindType = "timestamp_tz"
 	TimestampNTZKindType ExtendedTimeKindType = "timestamp_ntz"
-	DateKindType         ExtendedTimeKindType = "date"
 	TimeKindType         ExtendedTimeKindType = "time"
 )
 

--- a/lib/typing/ext/time.go
+++ b/lib/typing/ext/time.go
@@ -21,8 +21,6 @@ func (e ExtendedTimeKindType) defaultLayout() (string, error) {
 		return time.RFC3339Nano, nil
 	case TimestampNTZKindType:
 		return RFC3339NoTZ, nil
-	case DateKindType:
-		return PostgresDateFormat, nil
 	case TimeKindType:
 		return PostgresTimeFormat, nil
 	default:

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -70,11 +70,14 @@ type Field struct {
 
 func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 	var stringKind bool
-	if k.ExtendedTimeDetails != nil {
-		// If it's a date or time, it should be a STRING annotation.
-		if k.ExtendedTimeDetails.Type == ext.DateKindType || k.ExtendedTimeDetails.Type == ext.TimeKindType {
-			stringKind = true
-		}
+
+	// If it's a date or time, it should be a STRING annotation.
+	if k.Kind == Date.Kind {
+		stringKind = true
+	}
+
+	if k.ExtendedTimeDetails != nil && k.ExtendedTimeDetails.Type == ext.TimeKindType {
+		stringKind = true
 	}
 
 	if k.Kind == String.Kind || k.Kind == Struct.Kind || stringKind {

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -74,6 +74,11 @@ var (
 		Kind: "string",
 	}
 
+	// Time data types
+	Date = KindDetails{
+		Kind: "date",
+	}
+
 	ETime = KindDetails{
 		Kind: "extended_time",
 	}


### PR DESCRIPTION
As the title suggests, we're now pulling `DATE` out of `ExtendedTime`. 

Once merged, we'll pull `TIME`, with the goal of completely deprecating `ExtendedTime`