### PR TITLE
Consider `time.Time` as a default value

### DIFF
--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -89,23 +90,29 @@ func toInt64(value any) (int64, error) {
 	return 0, fmt.Errorf("failed to cast value '%v' with type '%T' to int64", value, value)
 }
 
+func isTimeSet(ts time.Time) bool {
+	// Most of Debezium's time types uses Unix time, so we can check for zero value by comparing it to be zero.
+	if ts.Unix() == 0 {
+		return false
+	}
+
+	// If time value did not get set, it will return true for [IsZero]
+	if ts.IsZero() {
+		return false
+	}
+
+	return true
+}
+
 // ShouldSetDefaultValue will filter out computed fields that cannot be properly set with a default value
 func (f Field) ShouldSetDefaultValue(defaultValue any) bool {
 	switch castedDefaultValue := defaultValue.(type) {
 	case nil:
 		return false
+	case time.Time:
+		return isTimeSet(castedDefaultValue)
 	case *ext.ExtendedTime:
-		// Most of Debezium's time types uses Unix time, so we can check for zero value by comparing it to be zero.
-		if castedDefaultValue.GetTime().Unix() == 0 {
-			return false
-		}
-
-		// If time value did not get set, it will return true for [IsZero]
-		if castedDefaultValue.GetTime().IsZero() {
-			return false
-		}
-
-		return true
+		return isTimeSet(castedDefaultValue.GetTime())
 	case string:
 		if f.DebeziumType == UUID && castedDefaultValue == uuid.Nil.String() {
 			return false

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -55,6 +55,14 @@ func TestField_ShouldSetDefaultValue(t *testing.T) {
 		var ts time.Time
 		assert.False(t, field.ShouldSetDefaultValue(ext.NewExtendedTime(ts, ext.TimestampTZKindType, ext.RFC3339Millisecond)))
 	}
+	{
+		// time.Time
+		field := Field{}
+		assert.True(t, field.ShouldSetDefaultValue(time.Now()))
+
+		assert.False(t, field.ShouldSetDefaultValue(time.Time{}))
+		assert.False(t, field.ShouldSetDefaultValue(time.Unix(0, 0)))
+	}
 }
 
 func TestToInt64(t *testing.T) {


### PR DESCRIPTION
Now that we are passing in native `time.Time`, our default logic should check for that as well.