### PR TITLE
[Extended Time] Additional follow up

### DIFF
--- a/clients/bigquery/converters/converters.go
+++ b/clients/bigquery/converters/converters.go
@@ -33,7 +33,7 @@ func (s StringConverter) Convert(value any) (any, error) {
 		case typing.TimestampNTZ:
 			return castedValue.Format(ext.RFC3339NoTZ), nil
 		default:
-			return nil, fmt.Errorf("unexpected kind details: %T", s.kd)
+			return nil, fmt.Errorf("unexpected kind details: %q", s.kd.Kind)
 		}
 	case *ext.ExtendedTime:
 		if err := s.kd.EnsureExtendedTimeDetails(); err != nil {

--- a/clients/bigquery/converters/converters.go
+++ b/clients/bigquery/converters/converters.go
@@ -3,6 +3,7 @@ package converters
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
@@ -25,6 +26,15 @@ func (s StringConverter) Convert(value any) (any, error) {
 		return castedValue.String(), nil
 	case bool, int64:
 		return fmt.Sprint(castedValue), nil
+	case time.Time:
+		switch s.kd {
+		case typing.Date:
+			return castedValue.Format(ext.PostgresDateFormat), nil
+		case typing.TimestampNTZ:
+			return castedValue.Format(ext.RFC3339NoTZ), nil
+		default:
+			return nil, fmt.Errorf("unexpected kind details: %T", s.kd)
+		}
 	case *ext.ExtendedTime:
 		if err := s.kd.EnsureExtendedTimeDetails(); err != nil {
 			return nil, err

--- a/clients/bigquery/converters/converters.go
+++ b/clients/bigquery/converters/converters.go
@@ -42,7 +42,7 @@ func (s StringConverter) Convert(value any) (any, error) {
 
 		return castedValue.GetTime().Format(s.kd.ExtendedTimeDetails.Format), nil
 	default:
-		return nil, fmt.Errorf("expected string/*decimal.Decimal/bool/int64 received %T with value %v", value, value)
+		return nil, fmt.Errorf("unexpected data type: %T with value: %v", value, value)
 	}
 }
 

--- a/clients/bigquery/converters/converters_test.go
+++ b/clients/bigquery/converters/converters_test.go
@@ -40,7 +40,7 @@ func TestStringConverter_Convert(t *testing.T) {
 	{
 		// Invalid
 		_, err := NewStringConverter(typing.Integer).Convert(123)
-		assert.ErrorContains(t, err, "expected string/*decimal.Decimal/bool/int64 received int with value 123")
+		assert.ErrorContains(t, err, "unexpected data type: int with value: 123")
 	}
 	{
 		// time.Time

--- a/clients/bigquery/converters/converters_test.go
+++ b/clients/bigquery/converters/converters_test.go
@@ -43,6 +43,18 @@ func TestStringConverter_Convert(t *testing.T) {
 		assert.ErrorContains(t, err, "expected string/*decimal.Decimal/bool/int64 received int with value 123")
 	}
 	{
+		// Date
+		val, err := NewStringConverter(typing.Date).Convert(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01", val)
+	}
+	{
+		// Timestamp NTZ
+		val, err := NewStringConverter(typing.TimestampNTZ).Convert(time.Date(2021, 1, 1, 9, 10, 12, 400_123_991, time.UTC))
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01T09:10:12.400123991", val)
+	}
+	{
 		// Extended time
 		val, err := NewStringConverter(typing.MustNewExtendedTimeDetails(typing.String, ext.TimestampTZKindType, "")).Convert(
 			ext.NewExtendedTime(

--- a/clients/bigquery/converters/converters_test.go
+++ b/clients/bigquery/converters/converters_test.go
@@ -43,16 +43,24 @@ func TestStringConverter_Convert(t *testing.T) {
 		assert.ErrorContains(t, err, "expected string/*decimal.Decimal/bool/int64 received int with value 123")
 	}
 	{
-		// Date
-		val, err := NewStringConverter(typing.Date).Convert(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
-		assert.NoError(t, err)
-		assert.Equal(t, "2021-01-01", val)
-	}
-	{
-		// Timestamp NTZ
-		val, err := NewStringConverter(typing.TimestampNTZ).Convert(time.Date(2021, 1, 1, 9, 10, 12, 400_123_991, time.UTC))
-		assert.NoError(t, err)
-		assert.Equal(t, "2021-01-01T09:10:12.400123991", val)
+		// time.Time
+		{
+			// Date
+			val, err := NewStringConverter(typing.Date).Convert(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC))
+			assert.NoError(t, err)
+			assert.Equal(t, "2021-01-01", val)
+		}
+		{
+			// Timestamp NTZ
+			val, err := NewStringConverter(typing.TimestampNTZ).Convert(time.Date(2021, 1, 1, 9, 10, 12, 400_123_991, time.UTC))
+			assert.NoError(t, err)
+			assert.Equal(t, "2021-01-01T09:10:12.400123991", val)
+		}
+		{
+			// Invalid
+			_, err := NewStringConverter(typing.String).Convert(time.Date(2021, 1, 1, 9, 10, 12, 400_123_991, time.UTC))
+			assert.ErrorContains(t, err, `unexpected kind details: "string"`)
+		}
 	}
 	{
 		// Extended time


### PR DESCRIPTION
Adding support for `DATE` and `TIMESTAMP_NTZ` when the column type is a `STRING` in BigQuery