### PR TITLE
Rename parse functions

### DIFF
--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -212,7 +212,7 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 
 			message.Set(field, protoreflect.ValueOfInt64(encodePacked64TimeMicros(_time)))
 		case typing.TimestampNTZ.Kind:
-			_time, err := ext.ParseTimestampNTZFromInterface(value)
+			_time, err := ext.ParseTimestampNTZFromAny(value)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast value as time.Time, value: '%v', err: %w", value, err)
 			}

--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -219,7 +219,7 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 
 			message.Set(field, protoreflect.ValueOfInt64(encodePacked64DatetimeMicros(_time)))
 		case typing.TimestampTZ.Kind:
-			_time, err := ext.ParseTimestampTZFromInterface(value)
+			_time, err := ext.ParseTimestampTZFromAny(value)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast value as time.Time, value: '%v', err: %w", value, err)
 			}

--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -205,7 +205,7 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 			daysSinceEpoch := _time.Unix() / (60 * 60 * 24)
 			message.Set(field, protoreflect.ValueOfInt32(int32(daysSinceEpoch)))
 		case typing.Time.Kind:
-			_time, err := ext.ParseTimeFromInterface(value)
+			_time, err := ext.ParseTimeFromAny(value)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast value as time.Time, value: '%v', err: %w", value, err)
 			}

--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -197,7 +197,7 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 
 			message.Set(field, protoreflect.ValueOfString(castedValue))
 		case typing.Date.Kind:
-			_time, err := ext.ParseDateFromInterface(value)
+			_time, err := ext.ParseDateFromAny(value)
 			if err != nil {
 				return nil, fmt.Errorf("failed to cast value as time.Time, value: '%v', err: %w", value, err)
 			}

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -42,7 +42,7 @@ func parseValue(colVal any, colKind columns.Column) (any, error) {
 
 		return _time, nil
 	case typing.TimestampNTZ.Kind:
-		_time, err := ext.ParseTimestampNTZFromInterface(colVal)
+		_time, err := ext.ParseTimestampNTZFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
 		}

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -35,7 +35,7 @@ func parseValue(colVal any, colKind columns.Column) (any, error) {
 
 		return _time, nil
 	case typing.Time.Kind:
-		_time, err := ext.ParseTimeFromInterface(colVal)
+		_time, err := ext.ParseTimeFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
 		}

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -28,7 +28,7 @@ func parseValue(colVal any, colKind columns.Column) (any, error) {
 	colValString := fmt.Sprint(colVal)
 	switch colKind.KindDetails.Kind {
 	case typing.Date.Kind:
-		_time, err := ext.ParseDateFromInterface(colVal)
+		_time, err := ext.ParseDateFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
 		}

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -49,7 +49,7 @@ func parseValue(colVal any, colKind columns.Column) (any, error) {
 
 		return _time, nil
 	case typing.TimestampTZ.Kind:
-		_time, err := ext.ParseTimestampTZFromInterface(colVal)
+		_time, err := ext.ParseTimestampTZFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
 		}

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -23,7 +23,7 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 	case typing.Struct.Kind, typing.Array.Kind:
 		return dialect.EscapeStruct(fmt.Sprint(column.DefaultValue())), nil
 	case typing.Date.Kind:
-		_time, err := ext.ParseDateFromInterface(column.DefaultValue())
+		_time, err := ext.ParseDateFromAny(column.DefaultValue())
 		if err != nil {
 			return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)
 		}

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -37,7 +37,7 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 
 		return sql.QuoteLiteral(_time.Format(ext.PostgresTimeFormatNoTZ)), nil
 	case typing.TimestampNTZ.Kind:
-		_time, err := ext.ParseTimestampNTZFromInterface(column.DefaultValue())
+		_time, err := ext.ParseTimestampNTZFromAny(column.DefaultValue())
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)
 		}

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -30,7 +30,7 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 
 		return sql.QuoteLiteral(_time.Format(ext.PostgresDateFormat)), nil
 	case typing.Time.Kind:
-		_time, err := ext.ParseTimeFromInterface(column.DefaultValue())
+		_time, err := ext.ParseTimeFromAny(column.DefaultValue())
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)
 		}

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -44,7 +44,7 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 
 		return sql.QuoteLiteral(_time.Format(ext.RFC3339NoTZ)), nil
 	case typing.TimestampTZ.Kind:
-		_time, err := ext.ParseTimestampTZFromInterface(column.DefaultValue())
+		_time, err := ext.ParseTimestampTZFromAny(column.DefaultValue())
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)
 		}

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -201,7 +201,7 @@ func (t *TableData) DistinctDates(colName string) ([]string, error) {
 			return nil, fmt.Errorf("col: %v does not exist on row: %v", colName, row)
 		}
 
-		_time, err := ext.ParseDateFromInterface(val)
+		_time, err := ext.ParseDateFromAny(val)
 		if err != nil {
 			return nil, fmt.Errorf("col: %v is not a time column, value: %v, err: %w", colName, val, err)
 		}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -35,7 +35,7 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 
 		return _time.Format(ext.PostgresTimeFormat), nil
 	case typing.TimestampNTZ.Kind:
-		_time, err := ext.ParseTimestampNTZFromInterface(colVal)
+		_time, err := ext.ParseTimestampNTZFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -21,7 +21,7 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 
 	switch colKind.KindDetails.Kind {
 	case typing.Date.Kind:
-		_time, err := ext.ParseDateFromInterface(colVal)
+		_time, err := ext.ParseDateFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -42,7 +42,7 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 
 		return _time.UnixMilli(), nil
 	case typing.TimestampTZ.Kind:
-		_time, err := ext.ParseTimestampTZFromInterface(colVal)
+		_time, err := ext.ParseTimestampTZFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -28,7 +28,7 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 
 		return _time.Format(ext.PostgresDateFormat), nil
 	case typing.Time.Kind:
-		_time, err := ext.ParseTimeFromInterface(colVal)
+		_time, err := ext.ParseTimeFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -46,7 +46,7 @@ func ParseTimeFromAny(val any) (time.Time, error) {
 	}
 }
 
-func ParseTimestampNTZFromInterface(val any) (time.Time, error) {
+func ParseTimestampNTZFromAny(val any) (time.Time, error) {
 	switch convertedVal := val.(type) {
 	case nil:
 		return time.Time{}, fmt.Errorf("val is nil")

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -33,7 +33,7 @@ func ParseDateFromAny(val any) (time.Time, error) {
 	}
 }
 
-func ParseTimeFromInterface(val any) (time.Time, error) {
+func ParseTimeFromAny(val any) (time.Time, error) {
 	switch convertedVal := val.(type) {
 	case nil:
 		return time.Time{}, fmt.Errorf("val is nil")

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -20,7 +20,7 @@ func ParseTimeExactMatch(layout, value string) (time.Time, error) {
 	return ts, nil
 }
 
-func ParseDateFromInterface(val any) (time.Time, error) {
+func ParseDateFromAny(val any) (time.Time, error) {
 	switch convertedVal := val.(type) {
 	case nil:
 		return time.Time{}, fmt.Errorf("val is nil")

--- a/lib/typing/ext/parse.go
+++ b/lib/typing/ext/parse.go
@@ -59,7 +59,7 @@ func ParseTimestampNTZFromAny(val any) (time.Time, error) {
 	}
 }
 
-func ParseTimestampTZFromInterface(val any) (time.Time, error) {
+func ParseTimestampTZFromAny(val any) (time.Time, error) {
 	switch convertedVal := val.(type) {
 	case nil:
 		return time.Time{}, fmt.Errorf("val is nil")

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseDateFromInterface(t *testing.T) {
 	now := time.Now()
 	for _, supportedDateFormat := range supportedDateFormats {
-		_time, err := ParseDateFromInterface(now.Format(supportedDateFormat))
+		_time, err := ParseDateFromAny(now.Format(supportedDateFormat))
 		assert.NoError(t, err)
 		assert.Equal(t, _time.Format(supportedDateFormat), now.Format(supportedDateFormat))
 	}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -37,43 +37,43 @@ func TestParseTimeFromInterface(t *testing.T) {
 func TestParseTimestampTZFromInterface(t *testing.T) {
 	{
 		// Nil
-		_, err := ParseTimestampTZFromInterface(nil)
+		_, err := ParseTimestampTZFromAny(nil)
 		assert.ErrorContains(t, err, "val is nil")
 	}
 	{
 		// Boolean
 		{
 			// True
-			_, err := ParseTimestampTZFromInterface(true)
+			_, err := ParseTimestampTZFromAny(true)
 			assert.ErrorContains(t, err, "unsupported type: bool")
 		}
 		{
 			// False
-			_, err := ParseTimestampTZFromInterface(false)
+			_, err := ParseTimestampTZFromAny(false)
 			assert.ErrorContains(t, err, "unsupported type: bool")
 		}
 	}
 	{
 		// time.Time
-		value, err := ParseTimestampTZFromInterface(time.Date(2024, 9, 19, 16, 5, 18, 123_456_789, time.UTC))
+		value, err := ParseTimestampTZFromAny(time.Date(2024, 9, 19, 16, 5, 18, 123_456_789, time.UTC))
 		assert.NoError(t, err)
 		assert.Equal(t, "2024-09-19T16:05:18.123456789Z", value.Format(time.RFC3339Nano))
 	}
 	{
 		// String - RFC3339MillisecondUTC
-		value, err := ParseTimestampTZFromInterface("2024-09-19T16:05:18.631Z")
+		value, err := ParseTimestampTZFromAny("2024-09-19T16:05:18.631Z")
 		assert.NoError(t, err)
 		assert.Equal(t, "2024-09-19T16:05:18.631Z", value.Format(time.RFC3339Nano))
 	}
 	{
 		// String - RFC3339MicrosecondUTC
-		value, err := ParseTimestampTZFromInterface("2024-09-19T16:05:18.630001Z")
+		value, err := ParseTimestampTZFromAny("2024-09-19T16:05:18.630001Z")
 		assert.NoError(t, err)
 		assert.Equal(t, "2024-09-19T16:05:18.630001Z", value.Format(time.RFC3339Nano))
 	}
 	{
 		// String - RFC3339NanosecondUTC
-		value, err := ParseTimestampTZFromInterface("2024-09-19T16:05:18.630000002Z")
+		value, err := ParseTimestampTZFromAny("2024-09-19T16:05:18.630000002Z")
 		assert.NoError(t, err)
 		assert.Equal(t, "2024-09-19T16:05:18.630000002Z", value.Format(time.RFC3339Nano))
 	}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -83,28 +83,28 @@ func TestParseTimestampNTZFromInterface(t *testing.T) {
 	{
 		// No fractional seconds
 		tsString := "2023-04-24T17:29:05"
-		ts, err := ParseTimestampNTZFromInterface(tsString)
+		ts, err := ParseTimestampNTZFromAny(tsString)
 		assert.NoError(t, err)
 		assert.Equal(t, tsString, ts.Format(RFC3339NoTZ))
 	}
 	{
 		// ms
 		tsString := "2023-04-24T17:29:05.123"
-		ts, err := ParseTimestampNTZFromInterface(tsString)
+		ts, err := ParseTimestampNTZFromAny(tsString)
 		assert.NoError(t, err)
 		assert.Equal(t, tsString, ts.Format(RFC3339NoTZ))
 	}
 	{
 		// microseconds
 		tsString := "2023-04-24T17:29:05.123456"
-		ts, err := ParseTimestampNTZFromInterface(tsString)
+		ts, err := ParseTimestampNTZFromAny(tsString)
 		assert.NoError(t, err)
 		assert.Equal(t, tsString, ts.Format(RFC3339NoTZ))
 	}
 	{
 		// ns
 		tsString := "2023-04-24T17:29:05.123456789"
-		ts, err := ParseTimestampNTZFromInterface(tsString)
+		ts, err := ParseTimestampNTZFromAny(tsString)
 		assert.NoError(t, err)
 		assert.Equal(t, tsString, ts.Format(RFC3339NoTZ))
 	}

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseDateFromInterface(t *testing.T) {
+func TestParseDateFromAny(t *testing.T) {
 	now := time.Now()
 	for _, supportedDateFormat := range supportedDateFormats {
 		_time, err := ParseDateFromAny(now.Format(supportedDateFormat))
@@ -16,7 +16,7 @@ func TestParseDateFromInterface(t *testing.T) {
 	}
 }
 
-func TestParseTimeFromInterface(t *testing.T) {
+func TestParseTimeFromAny(t *testing.T) {
 	now := time.Now()
 	{
 		// String
@@ -34,7 +34,7 @@ func TestParseTimeFromInterface(t *testing.T) {
 	}
 }
 
-func TestParseTimestampTZFromInterface(t *testing.T) {
+func TestParseTimestampTZFromAny(t *testing.T) {
 	{
 		// Nil
 		_, err := ParseTimestampTZFromAny(nil)
@@ -79,7 +79,7 @@ func TestParseTimestampTZFromInterface(t *testing.T) {
 	}
 }
 
-func TestParseTimestampNTZFromInterface(t *testing.T) {
+func TestParseTimestampNTZFromAny(t *testing.T) {
 	{
 		// No fractional seconds
 		tsString := "2023-04-24T17:29:05"

--- a/lib/typing/ext/parse_test.go
+++ b/lib/typing/ext/parse_test.go
@@ -21,14 +21,14 @@ func TestParseTimeFromInterface(t *testing.T) {
 	{
 		// String
 		for _, supportedTimeFormat := range SupportedTimeFormats {
-			_time, err := ParseTimeFromInterface(now.Format(supportedTimeFormat))
+			_time, err := ParseTimeFromAny(now.Format(supportedTimeFormat))
 			assert.NoError(t, err)
 			assert.Equal(t, _time.Format(supportedTimeFormat), now.Format(supportedTimeFormat))
 		}
 	}
 	{
 		// time.Time
-		_time, err := ParseTimeFromInterface(now)
+		_time, err := ParseTimeFromAny(now)
 		assert.NoError(t, err)
 		assert.Equal(t, now, _time)
 	}

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -43,7 +43,7 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 
 		return _time.Format(ext.PostgresTimeFormatNoTZ), nil
 	case typing.TimestampNTZ.Kind:
-		_time, err := ext.ParseTimestampNTZFromInterface(colVal)
+		_time, err := ext.ParseTimestampNTZFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
 		}

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -36,7 +36,7 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 
 		return _time.Format(ext.PostgresDateFormat), nil
 	case typing.Time.Kind:
-		_time, err := ext.ParseTimeFromInterface(colVal)
+		_time, err := ext.ParseTimeFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
 		}

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -50,7 +50,7 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 
 		return _time.Format(ext.RFC3339NoTZ), nil
 	case typing.TimestampTZ.Kind:
-		_time, err := ext.ParseTimestampTZFromInterface(colVal)
+		_time, err := ext.ParseTimestampTZFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
 		}

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -29,7 +29,7 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 
 	switch colKind.Kind {
 	case typing.Date.Kind:
-		_time, err := ext.ParseDateFromInterface(colVal)
+		_time, err := ext.ParseDateFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
 		}


### PR DESCRIPTION
`ParseXFromInterface()`-> `ParseXFromAny()`