### PR TITLE
`KindForDataType` should return error if unable to map data types

### DIFF
--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -64,10 +64,6 @@ func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool) s
 }
 
 func (BigQueryDialect) KindForDataType(rawBqType string, _ string) (typing.KindDetails, error) {
-	if len(rawBqType) == 0 {
-		return typing.Invalid, fmt.Errorf("empty data type")
-	}
-
 	bqType, parameters, err := sql.ParseDataTypeDefinition(strings.ToLower(rawBqType))
 	if err != nil {
 		return typing.Invalid, err

--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -110,7 +110,7 @@ func (BigQueryDialect) KindForDataType(rawBqType string, _ string) (typing.KindD
 	case "date":
 		return typing.Date, nil
 	default:
-		return typing.Invalid, nil
+		return typing.Invalid, fmt.Errorf("unsupported data type: %q", rawBqType)
 	}
 }
 

--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -65,7 +65,7 @@ func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool) s
 
 func (BigQueryDialect) KindForDataType(rawBqType string, _ string) (typing.KindDetails, error) {
 	if len(rawBqType) == 0 {
-		return typing.Invalid, nil
+		return typing.Invalid, fmt.Errorf("empty data type")
 	}
 
 	bqType, parameters, err := sql.ParseDataTypeDefinition(strings.ToLower(rawBqType))

--- a/clients/bigquery/dialect/dialect_test.go
+++ b/clients/bigquery/dialect/dialect_test.go
@@ -103,7 +103,7 @@ func TestBigQueryDialect_KindForDataType(t *testing.T) {
 	}
 	{
 		// Integers
-		for _, intKind := range []string{"int", "integer", "int64"} {
+		for _, intKind := range []string{"int", "integer", "inT64"} {
 			kd, err := dialect.KindForDataType(intKind, "")
 			assert.NoError(t, err)
 			assert.Equal(t, typing.Integer, kd, intKind)

--- a/clients/bigquery/dialect/dialect_test.go
+++ b/clients/bigquery/dialect/dialect_test.go
@@ -95,10 +95,6 @@ func TestBigQueryDialect_KindForDataType(t *testing.T) {
 		"timestamp": typing.TimestampTZ,
 		"time":      typing.Time,
 		"date":      typing.Date,
-		//Invalid
-		"foo":    typing.Invalid,
-		"foofoo": typing.Invalid,
-		"":       typing.Invalid,
 	}
 
 	for bqCol, expectedKind := range bqColToExpectedKind {
@@ -124,6 +120,18 @@ func TestBigQueryDialect_KindForDataType(t *testing.T) {
 		assert.Equal(t, typing.EDecimal.Kind, kd.Kind)
 		assert.Equal(t, int32(5), kd.ExtendedDecimalDetails.Precision())
 		assert.Equal(t, int32(2), kd.ExtendedDecimalDetails.Scale())
+	}
+	{
+		// Invalid
+		kd, err := dialect.KindForDataType("", "")
+		assert.ErrorContains(t, err, "empty data type")
+		assert.Equal(t, typing.Invalid, kd)
+	}
+	{
+		// Invalid
+		kd, err := dialect.KindForDataType("foo", "")
+		assert.ErrorContains(t, err, `unsupported data type: "foo"`)
+		assert.Equal(t, typing.Invalid, kd)
 	}
 }
 

--- a/clients/bigquery/dialect/dialect_test.go
+++ b/clients/bigquery/dialect/dialect_test.go
@@ -124,7 +124,7 @@ func TestBigQueryDialect_KindForDataType(t *testing.T) {
 	{
 		// Invalid
 		kd, err := dialect.KindForDataType("", "")
-		assert.ErrorContains(t, err, "empty data type")
+		assert.ErrorContains(t, err, `unsupported data type: ""`)
 		assert.Equal(t, typing.Invalid, kd)
 	}
 	{

--- a/clients/databricks/dialect/typing.go
+++ b/clients/databricks/dialect/typing.go
@@ -73,7 +73,7 @@ func (DatabricksDialect) KindForDataType(rawType string, _ string) (typing.KindD
 		return typing.TimestampTZ, nil
 	case "timestamp_ntz":
 		return typing.TimestampNTZ, nil
+	default:
+		return typing.Invalid, fmt.Errorf("unsupported data type: %q", rawType)
 	}
-
-	return typing.Invalid, fmt.Errorf("unsupported data type: %q", rawType)
 }

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -123,9 +123,9 @@ func (MSSQLDialect) KindForDataType(rawType string, stringPrecision string) (typ
 		return typing.Boolean, nil
 	case "text":
 		return typing.String, nil
+	default:
+		return typing.Invalid, fmt.Errorf("unsupported data type: %q", rawType)
 	}
-
-	return typing.Invalid, nil
 }
 
 func (MSSQLDialect) IsColumnAlreadyExistsErr(err error) bool {

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -111,7 +111,7 @@ func (RedshiftDialect) KindForDataType(rawType string, stringPrecision string) (
 		return typing.Date, nil
 	case "boolean":
 		return typing.Boolean, nil
+	default:
+		return typing.Invalid, fmt.Errorf("unsupported data type: %q", rawType)
 	}
-
-	return typing.Invalid, fmt.Errorf("unsupported data type: %q", rawType)
 }

--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -102,7 +102,7 @@ func (SnowflakeDialect) KindForDataType(snowflakeType string, _ string) (typing.
 	case "date":
 		return typing.Date, nil
 	default:
-		return typing.Invalid, nil
+		return typing.Invalid, fmt.Errorf("unsupported data type: %q", snowflakeType)
 	}
 }
 

--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -48,7 +48,7 @@ func (SnowflakeDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool) 
 // Following this spec: https://docs.snowflake.com/en/sql-reference/intro-summary-data-types.html
 func (SnowflakeDialect) KindForDataType(snowflakeType string, _ string) (typing.KindDetails, error) {
 	if len(snowflakeType) == 0 {
-		return typing.Invalid, nil
+		return typing.Invalid, fmt.Errorf("empty data type")
 	}
 
 	// We need to strip away the variable

--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -47,10 +47,6 @@ func (SnowflakeDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool) 
 // KindForDataType converts a Snowflake type to a KindDetails.
 // Following this spec: https://docs.snowflake.com/en/sql-reference/intro-summary-data-types.html
 func (SnowflakeDialect) KindForDataType(snowflakeType string, _ string) (typing.KindDetails, error) {
-	if len(snowflakeType) == 0 {
-		return typing.Invalid, fmt.Errorf("empty data type")
-	}
-
 	// We need to strip away the variable
 	// For example, a Column can look like: TEXT, or Number(38, 0) or VARCHAR(255).
 	// We need to strip out all the content from ( ... )

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -79,7 +79,7 @@ func TestSnowflakeDialect_KindForDataType(t *testing.T) {
 		// Invalid
 		{
 			kd, err := SnowflakeDialect{}.KindForDataType("", "")
-			assert.ErrorContains(t, err, "empty data type")
+			assert.ErrorContains(t, err, `unsupported data type: ""`)
 			assert.Equal(t, typing.Invalid, kd)
 		}
 		{

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -79,12 +79,12 @@ func TestSnowflakeDialect_KindForDataType(t *testing.T) {
 		// Invalid
 		{
 			kd, err := SnowflakeDialect{}.KindForDataType("", "")
-			assert.NoError(t, err)
+			assert.ErrorContains(t, err, "empty data type")
 			assert.Equal(t, typing.Invalid, kd)
 		}
 		{
 			kd, err := SnowflakeDialect{}.KindForDataType("abc123", "")
-			assert.NoError(t, err)
+			assert.ErrorContains(t, err, `unsupported data type: "abc123"`)
 			assert.Equal(t, typing.Invalid, kd)
 		}
 	}


### PR DESCRIPTION
We were being inconsistent in mapping data types that we get from the destination