### PR TITLE
Remove `error` from `ToKindDetails`

### DIFF
--- a/lib/debezium/converters/basic.go
+++ b/lib/debezium/converters/basic.go
@@ -24,14 +24,14 @@ func (JSON) Convert(value any) (any, error) {
 	return jsonutil.SanitizePayload(valueString)
 }
 
-func (JSON) ToKindDetails() (typing.KindDetails, error) {
-	return typing.Struct, nil
+func (JSON) ToKindDetails() typing.KindDetails {
+	return typing.Struct
 }
 
 type Int64Passthrough struct{}
 
-func (Int64Passthrough) ToKindDetails() (typing.KindDetails, error) {
-	return typing.Integer, nil
+func (Int64Passthrough) ToKindDetails() typing.KindDetails {
+	return typing.Integer
 }
 
 func (Int64Passthrough) Convert(value any) (any, error) {
@@ -44,9 +44,9 @@ func (Int64Passthrough) Convert(value any) (any, error) {
 
 type Base64 struct{}
 
-func (Base64) ToKindDetails() (typing.KindDetails, error) {
+func (Base64) ToKindDetails() typing.KindDetails {
 	// We're returning this back as a base64 encoded string.
-	return typing.String, nil
+	return typing.String
 }
 
 func (Base64) Convert(value any) (any, error) {

--- a/lib/debezium/converters/converters.go
+++ b/lib/debezium/converters/converters.go
@@ -5,6 +5,6 @@ import (
 )
 
 type ValueConverter interface {
-	ToKindDetails() (typing.KindDetails, error)
+	ToKindDetails() typing.KindDetails
 	Convert(value any) (any, error)
 }

--- a/lib/debezium/converters/date.go
+++ b/lib/debezium/converters/date.go
@@ -14,8 +14,8 @@ func (Date) layout() string {
 	return ext.PostgresDateFormat
 }
 
-func (d Date) ToKindDetails() (typing.KindDetails, error) {
-	return typing.Date, nil
+func (d Date) ToKindDetails() typing.KindDetails {
+	return typing.Date
 }
 
 func (d Date) Convert(value any) (any, error) {

--- a/lib/debezium/converters/decimal.go
+++ b/lib/debezium/converters/decimal.go
@@ -86,8 +86,8 @@ type VariableDecimal struct {
 	details decimal.Details
 }
 
-func (v VariableDecimal) ToKindDetails() (typing.KindDetails, error) {
-	return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, v.details), nil
+func (v VariableDecimal) ToKindDetails() typing.KindDetails {
+	return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, v.details)
 }
 
 func (v VariableDecimal) Convert(value any) (any, error) {
@@ -134,8 +134,8 @@ func NewDecimal(details decimal.Details) Decimal {
 	return Decimal{details: details}
 }
 
-func (d Decimal) ToKindDetails() (typing.KindDetails, error) {
-	return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, d.details), nil
+func (d Decimal) ToKindDetails() typing.KindDetails {
+	return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, d.details)
 }
 
 func (d Decimal) Convert(value any) (any, error) {

--- a/lib/debezium/converters/geometry.go
+++ b/lib/debezium/converters/geometry.go
@@ -31,8 +31,8 @@ const Point GeometricShapes = "Point"
 
 type GeometryPoint struct{}
 
-func (GeometryPoint) ToKindDetails() (typing.KindDetails, error) {
-	return typing.Struct, nil
+func (GeometryPoint) ToKindDetails() typing.KindDetails {
+	return typing.Struct
 }
 
 // Convert takes in a map[string]any and returns a GeoJSON string. This function does not use WKB or SRID and leverages X, Y.
@@ -71,9 +71,9 @@ func (GeometryPoint) Convert(value any) (any, error) {
 
 type Geometry struct{}
 
-func (Geometry) ToKindDetails() (typing.KindDetails, error) {
+func (Geometry) ToKindDetails() typing.KindDetails {
 	// We will return this in GeoJSON format.
-	return typing.Struct, nil
+	return typing.Struct
 }
 
 func (Geometry) Convert(value any) (any, error) {

--- a/lib/debezium/converters/string.go
+++ b/lib/debezium/converters/string.go
@@ -13,6 +13,6 @@ func (StringPassthrough) Convert(value any) (any, error) {
 	return castedValue, nil
 }
 
-func (StringPassthrough) ToKindDetails() (typing.KindDetails, error) {
-	return typing.String, nil
+func (StringPassthrough) ToKindDetails() typing.KindDetails {
+	return typing.String
 }

--- a/lib/debezium/converters/time.go
+++ b/lib/debezium/converters/time.go
@@ -11,8 +11,8 @@ import (
 
 type Time struct{}
 
-func (t Time) ToKindDetails() (typing.KindDetails, error) {
-	return typing.Time, nil
+func (t Time) ToKindDetails() typing.KindDetails {
+	return typing.Time
 }
 
 func (t Time) Convert(val any) (any, error) {
@@ -27,8 +27,8 @@ func (t Time) Convert(val any) (any, error) {
 
 type NanoTime struct{}
 
-func (n NanoTime) ToKindDetails() (typing.KindDetails, error) {
-	return typing.Time, nil
+func (n NanoTime) ToKindDetails() typing.KindDetails {
+	return typing.Time
 }
 
 func (n NanoTime) Convert(value any) (any, error) {
@@ -43,8 +43,8 @@ func (n NanoTime) Convert(value any) (any, error) {
 
 type MicroTime struct{}
 
-func (m MicroTime) ToKindDetails() (typing.KindDetails, error) {
-	return typing.Time, nil
+func (m MicroTime) ToKindDetails() typing.KindDetails {
+	return typing.Time
 }
 
 func (m MicroTime) Convert(value any) (any, error) {
@@ -59,8 +59,8 @@ func (m MicroTime) Convert(value any) (any, error) {
 
 type ZonedTimestamp struct{}
 
-func (z ZonedTimestamp) ToKindDetails() (typing.KindDetails, error) {
-	return typing.TimestampTZ, nil
+func (z ZonedTimestamp) ToKindDetails() typing.KindDetails {
+	return typing.TimestampTZ
 }
 
 func (z ZonedTimestamp) Convert(value any) (any, error) {
@@ -95,8 +95,8 @@ func (t TimeWithTimezone) layout() string {
 	return "15:04:05.999999" + ext.TimezoneOffsetFormat
 }
 
-func (t TimeWithTimezone) ToKindDetails() (typing.KindDetails, error) {
-	return typing.Time, nil
+func (t TimeWithTimezone) ToKindDetails() typing.KindDetails {
+	return typing.Time
 }
 
 func (t TimeWithTimezone) Convert(value any) (any, error) {

--- a/lib/debezium/converters/time_test.go
+++ b/lib/debezium/converters/time_test.go
@@ -125,12 +125,10 @@ func TestTime_Convert(t *testing.T) {
 }
 
 func TestNanoTime_Converter(t *testing.T) {
-	kd, err := NanoTime{}.ToKindDetails()
-	assert.NoError(t, err)
-	assert.Equal(t, typing.Time, kd)
+	assert.Equal(t, typing.Time, NanoTime{}.ToKindDetails())
 	{
 		// Invalid data
-		_, err = NanoTime{}.Convert("123")
+		_, err := NanoTime{}.Convert("123")
 		assert.ErrorContains(t, err, "expected type int64, got string")
 	}
 	{
@@ -142,9 +140,7 @@ func TestNanoTime_Converter(t *testing.T) {
 }
 
 func TestMicroTime_Converter(t *testing.T) {
-	kd, err := MicroTime{}.ToKindDetails()
-	assert.NoError(t, err)
-	assert.Equal(t, typing.Time, kd)
+	assert.Equal(t, typing.Time, MicroTime{}.ToKindDetails())
 	{
 		// Invalid data
 		_, err := MicroTime{}.Convert("123")

--- a/lib/debezium/converters/timestamp.go
+++ b/lib/debezium/converters/timestamp.go
@@ -8,8 +8,8 @@ import (
 
 type Timestamp struct{}
 
-func (t Timestamp) ToKindDetails() (typing.KindDetails, error) {
-	return typing.TimestampNTZ, nil
+func (t Timestamp) ToKindDetails() typing.KindDetails {
+	return typing.TimestampNTZ
 }
 
 func (t Timestamp) Convert(value any) (any, error) {
@@ -24,8 +24,8 @@ func (t Timestamp) Convert(value any) (any, error) {
 
 type MicroTimestamp struct{}
 
-func (mt MicroTimestamp) ToKindDetails() (typing.KindDetails, error) {
-	return typing.TimestampNTZ, nil
+func (mt MicroTimestamp) ToKindDetails() typing.KindDetails {
+	return typing.TimestampNTZ
 }
 
 func (mt MicroTimestamp) Convert(value any) (any, error) {
@@ -40,8 +40,8 @@ func (mt MicroTimestamp) Convert(value any) (any, error) {
 
 type NanoTimestamp struct{}
 
-func (nt NanoTimestamp) ToKindDetails() (typing.KindDetails, error) {
-	return typing.TimestampNTZ, nil
+func (nt NanoTimestamp) ToKindDetails() typing.KindDetails {
+	return typing.TimestampNTZ
 }
 
 func (nt NanoTimestamp) Convert(value any) (any, error) {

--- a/lib/debezium/converters/timestamp_test.go
+++ b/lib/debezium/converters/timestamp_test.go
@@ -10,12 +10,10 @@ import (
 )
 
 func TestTimestamp_Converter(t *testing.T) {
-	kd, err := Timestamp{}.ToKindDetails()
-	assert.NoError(t, err)
-	assert.Equal(t, typing.TimestampNTZ, kd)
+	assert.Equal(t, typing.TimestampNTZ, Timestamp{}.ToKindDetails())
 	{
 		// Invalid conversion
-		_, err = Timestamp{}.Convert("invalid")
+		_, err := Timestamp{}.Convert("invalid")
 		assert.ErrorContains(t, err, "expected type int64, got string")
 	}
 	{
@@ -27,12 +25,10 @@ func TestTimestamp_Converter(t *testing.T) {
 }
 
 func TestMicroTimestamp_Converter(t *testing.T) {
-	kd, err := MicroTimestamp{}.ToKindDetails()
-	assert.NoError(t, err)
-	assert.Equal(t, typing.TimestampNTZ, kd)
+	assert.Equal(t, typing.TimestampNTZ, MicroTimestamp{}.ToKindDetails())
 	{
 		// Invalid conversion
-		_, err = MicroTimestamp{}.Convert("invalid")
+		_, err := MicroTimestamp{}.Convert("invalid")
 		assert.ErrorContains(t, err, "expected type int64, got string")
 	}
 	{
@@ -44,12 +40,10 @@ func TestMicroTimestamp_Converter(t *testing.T) {
 }
 
 func TestNanoTimestamp_Converter(t *testing.T) {
-	kd, err := NanoTimestamp{}.ToKindDetails()
-	assert.NoError(t, err)
-	assert.Equal(t, typing.TimestampNTZ, kd)
+	assert.Equal(t, typing.TimestampNTZ, NanoTimestamp{}.ToKindDetails())
 	{
 		// Invalid conversion
-		_, err = NanoTimestamp{}.Convert("invalid")
+		_, err := NanoTimestamp{}.Convert("invalid")
 		assert.ErrorContains(t, err, "expected type int64, got string")
 	}
 	{

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -148,7 +148,7 @@ func (f Field) ToKindDetails() (typing.KindDetails, error) {
 	}
 
 	if converter != nil {
-		return converter.ToKindDetails()
+		return converter.ToKindDetails(), nil
 	}
 
 	switch f.Type {


### PR DESCRIPTION
`ToKindDetails` will no longer error since we got rid of extended time