### PR TITLE
Refactor BySize

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -188,7 +188,7 @@ func (s *Store) putTable(ctx context.Context, bqTableID TableIdentifier, tableDa
 		return bytes, nil
 	}
 
-	return batch.BySize(tableData.Rows(), maxRequestByteSize, encoder, func(chunk [][]byte) error {
+	return batch.BySize(tableData.Rows(), maxRequestByteSize, true, encoder, func(chunk [][]byte) error {
 		result, err := managedStream.AppendRows(ctx, chunk)
 		if err != nil {
 			return fmt.Errorf("failed to append rows: %w", err)

--- a/lib/batch/batch.go
+++ b/lib/batch/batch.go
@@ -19,7 +19,7 @@ func hasKeyFunction[T any](item T) (KeyFunction, bool) {
 
 // BySize takes a series of elements [in], encodes them using [encode], groups them into batches of bytes that sum to at
 // most [maxSizeBytes], and then passes each batch to the [yield] function.
-func BySize[T any](in []T, maxSizeBytes int, failIfExceedMaxSizeBytes bool, encode func(T) ([]byte, error), yield func([][]byte) error) error {
+func BySize[T any](in []T, maxSizeBytes int, failIfRowExceedsMaxSizeBytes bool, encode func(T) ([]byte, error), yield func([][]byte) error) error {
 	var buffer [][]byte
 	var currentSizeBytes int
 
@@ -30,7 +30,7 @@ func BySize[T any](in []T, maxSizeBytes int, failIfExceedMaxSizeBytes bool, enco
 		}
 
 		if len(bytes) > maxSizeBytes {
-			if failIfExceedMaxSizeBytes {
+			if failIfRowExceedsMaxSizeBytes {
 				return fmt.Errorf("item %d is larger (%d bytes) than maxSizeBytes (%d bytes)", i, len(bytes), maxSizeBytes)
 			} else {
 				logFields := []any{slog.Int("index", i), slog.Int("bytes", len(bytes))}

--- a/lib/batch/batch.go
+++ b/lib/batch/batch.go
@@ -9,7 +9,7 @@ type KeyFunction interface {
 	Key() string
 }
 
-func checkHasKeyFunction[T any](item T) (KeyFunction, bool) {
+func hasKeyFunction[T any](item T) (KeyFunction, bool) {
 	if castedItem, isOk := any(item).(KeyFunction); isOk {
 		return castedItem, isOk
 	}
@@ -34,7 +34,7 @@ func BySize[T any](in []T, maxSizeBytes int, failIfExceedMaxSizeBytes bool, enco
 				return fmt.Errorf("item %d is larger (%d bytes) than maxSizeBytes (%d bytes)", i, len(bytes), maxSizeBytes)
 			} else {
 				logFields := []any{slog.Int("index", i), slog.Int("bytes", len(bytes))}
-				if stringItem, isOk := checkHasKeyFunction[T](item); isOk {
+				if stringItem, isOk := hasKeyFunction[T](item); isOk {
 					logFields = append(logFields, slog.String("key", stringItem.Key()))
 				}
 

--- a/lib/batch/batch.go
+++ b/lib/batch/batch.go
@@ -19,18 +19,17 @@ func BySize[T any](in []T, maxSizeBytes int, encode func(T) ([]byte, error), yie
 		}
 
 		currentSizeBytes += len(bytes)
-
 		if currentSizeBytes < maxSizeBytes {
 			buffer = append(buffer, bytes)
 		} else if currentSizeBytes == maxSizeBytes {
 			buffer = append(buffer, bytes)
-			if err := yield(buffer); err != nil {
+			if err = yield(buffer); err != nil {
 				return err
 			}
 			buffer = [][]byte{}
 			currentSizeBytes = 0
 		} else {
-			if err := yield(buffer); err != nil {
+			if err = yield(buffer); err != nil {
 				return err
 			}
 			buffer = [][]byte{bytes}

--- a/lib/batch/batch_test.go
+++ b/lib/batch/batch_test.go
@@ -45,9 +45,9 @@ func TestBySize(t *testing.T) {
 		return nil, fmt.Errorf("failed to encode %q", value)
 	}
 
-	testBySize := func(in []string, maxSizeBytes int, encoder func(value string) ([]byte, error)) ([][][]byte, error) {
+	testBySize := func(in []string, maxSizeBytes int, failIfRowExceedsMaxSizeBytes bool, encoder func(value string) ([]byte, error)) ([][][]byte, error) {
 		batches := [][][]byte{}
-		err := BySize(in, maxSizeBytes, true, encoder, func(batch [][]byte) error { batches = append(batches, batch); return nil })
+		err := BySize(in, maxSizeBytes, failIfRowExceedsMaxSizeBytes, encoder, func(batch [][]byte) error { batches = append(batches, batch); return nil })
 		return batches, err
 	}
 
@@ -61,13 +61,13 @@ func TestBySize(t *testing.T) {
 
 	{
 		// Empty slice:
-		batches, err := testBySize([]string{}, 10, panicEncoder)
+		batches, err := testBySize([]string{}, 10, true, panicEncoder)
 		assert.NoError(t, err)
 		assert.Empty(t, batches)
 	}
 	{
 		// Non-empty slice + bad encoder:
-		_, err := testBySize([]string{"foo", "bar"}, 10, badEncoder)
+		_, err := testBySize([]string{"foo", "bar"}, 10, true, badEncoder)
 		assert.ErrorContains(t, err, `failed to encode item 0: failed to encode "foo"`)
 	}
 	{
@@ -86,13 +86,22 @@ func TestBySize(t *testing.T) {
 		assert.ErrorContains(t, err, "yield failed for [foo]")
 	}
 	{
-		// Non-empty slice + item is larger than maxSizeBytes:
-		_, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar"}, 20, goodEncoder)
-		assert.ErrorContains(t, err, "item 1 is larger (23 bytes) than maxSizeBytes (20 bytes)")
+		// Non-empty slice + item is larger than maxSizeBytes
+		{
+			// failIfRowExceedsMaxSizeBytes = true
+			_, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar"}, 20, true, goodEncoder)
+			assert.ErrorContains(t, err, "item 1 is larger (23 bytes) than maxSizeBytes (20 bytes)")
+		}
+		{
+			// failIfRowExceedsMaxSizeBytes = false
+			batches, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar", "i-am-20-characters--"}, 20, false, goodEncoder)
+			assert.NoError(t, err)
+			assert.Len(t, batches, 2)
+		}
 	}
 	{
 		// Non-empty slice + item equal to maxSizeBytes:
-		batches, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar"}, 23, goodEncoder)
+		batches, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar"}, 23, true, goodEncoder)
 		assert.NoError(t, err)
 		assert.Len(t, batches, 3)
 		assert.Equal(t, [][]byte{[]byte("foo")}, batches[0])
@@ -101,21 +110,21 @@ func TestBySize(t *testing.T) {
 	}
 	{
 		// Non-empty slice + one item:
-		batches, err := testBySize([]string{"foo"}, 100, goodEncoder)
+		batches, err := testBySize([]string{"foo"}, 100, true, goodEncoder)
 		assert.NoError(t, err)
 		assert.Len(t, batches, 1)
 		assert.Equal(t, [][]byte{[]byte("foo")}, batches[0])
 	}
 	{
 		// Non-empty slice + all items exactly fit into one batch:
-		batches, err := testBySize([]string{"foo", "bar", "baz", "qux"}, 12, goodEncoder)
+		batches, err := testBySize([]string{"foo", "bar", "baz", "qux"}, 12, true, goodEncoder)
 		assert.NoError(t, err)
 		assert.Len(t, batches, 1)
 		assert.Equal(t, [][]byte{[]byte("foo"), []byte("bar"), []byte("baz"), []byte("qux")}, batches[0])
 	}
 	{
 		// Non-empty slice + all items exactly fit into just under one batch:
-		batches, err := testBySize([]string{"foo", "bar", "baz", "qux"}, 13, goodEncoder)
+		batches, err := testBySize([]string{"foo", "bar", "baz", "qux"}, 13, true, goodEncoder)
 		assert.NoError(t, err)
 		assert.Len(t, batches, 1)
 		assert.Equal(t, [][]byte{[]byte("foo"), []byte("bar"), []byte("baz"), []byte("qux")}, batches[0])

--- a/lib/batch/batch_test.go
+++ b/lib/batch/batch_test.go
@@ -22,7 +22,7 @@ func TestBySize(t *testing.T) {
 
 	testBySize := func(in []string, maxSizeBytes int, encoder func(value string) ([]byte, error)) ([][][]byte, error) {
 		batches := [][][]byte{}
-		err := BySize(in, maxSizeBytes, encoder, func(batch [][]byte) error { batches = append(batches, batch); return nil })
+		err := BySize(in, maxSizeBytes, true, encoder, func(batch [][]byte) error { batches = append(batches, batch); return nil })
 		return batches, err
 	}
 
@@ -47,17 +47,17 @@ func TestBySize(t *testing.T) {
 	}
 	{
 		// Non-empty slice + two items that are < maxSizeBytes + yield returns error.
-		err := BySize([]string{"foo", "bar"}, 10, goodEncoder, badYield)
+		err := BySize([]string{"foo", "bar"}, 10, true, goodEncoder, badYield)
 		assert.ErrorContains(t, err, "yield failed for [foo bar]")
 	}
 	{
 		// Non-empty slice + two items that are = maxSizeBytes + yield returns error.
-		err := BySize([]string{"foo", "bar"}, 6, goodEncoder, badYield)
+		err := BySize([]string{"foo", "bar"}, 6, true, goodEncoder, badYield)
 		assert.ErrorContains(t, err, "yield failed for [foo bar]")
 	}
 	{
 		// Non-empty slice + two items that are > maxSizeBytes + yield returns error.
-		err := BySize([]string{"foo", "bar-baz"}, 8, goodEncoder, badYield)
+		err := BySize([]string{"foo", "bar-baz"}, 8, true, goodEncoder, badYield)
 		assert.ErrorContains(t, err, "yield failed for [foo]")
 	}
 	{

--- a/lib/batch/batch_test.go
+++ b/lib/batch/batch_test.go
@@ -7,6 +7,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type key struct {
+	foo string
+}
+
+func (k key) Key() string {
+	return k.foo
+}
+
+func TestHasKeyFunction(t *testing.T) {
+	{
+		// False
+		type noKey struct{}
+		var _noKey noKey
+		_, isOk := hasKeyFunction[noKey](_noKey)
+		assert.False(t, isOk)
+	}
+	{
+		// True
+		_key := key{foo: "bar"}
+		castedKey, isOk := hasKeyFunction[key](_key)
+		assert.True(t, isOk)
+		assert.Equal(t, "bar", castedKey.Key())
+	}
+}
+
 func TestBySize(t *testing.T) {
 	goodEncoder := func(value string) ([]byte, error) {
 		return []byte(value), nil


### PR DESCRIPTION
* Right now, BySize will hard fail if a single row exceeds `maxSizeBytes`. 
* Added a flag called `failIfRowExceedsMaxSizeBytes` which will be set to `false` by Reader so that we can log the problematic row and keep going
* Added a method to check if the item contains a function called `Key()` so we can log the problematic row out if it exists.
