### PR TITLE
Adding missing types to Parquet

### DIFF
--- a/clients/databricks/dialect/dialect_test.go
+++ b/clients/databricks/dialect/dialect_test.go
@@ -150,7 +150,7 @@ func TestDatabricksDialect_BuildMergeQueries_SoftDelete(t *testing.T) {
 	_cols := buildColumns(map[string]typing.KindDetails{
 		"id":                                typing.String,
 		"bar":                               typing.String,
-		"updated_at":                        typing.ETime,
+		"updated_at":                        typing.TimestampTZ,
 		constants.DeleteColumnMarker:        typing.Boolean,
 		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 	})

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -163,7 +163,7 @@ func getBasicColumnsForTest(compositeKey bool) result {
 	cols.AddColumn(emailCol)
 	cols.AddColumn(columns.NewColumn("first_name", typing.String))
 	cols.AddColumn(columns.NewColumn("last_name", typing.String))
-	cols.AddColumn(columns.NewColumn("created_at", typing.ETime))
+	cols.AddColumn(columns.NewColumn("created_at", typing.TimestampNTZ))
 	cols.AddColumn(textToastCol)
 	cols.AddColumn(columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
 	cols.AddColumn(columns.NewColumn(constants.OnlySetDeleteColumnMarker, typing.Boolean))

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -291,7 +291,7 @@ func TestSnowflakeDialect_BuildMergeQueries_SoftDelete(t *testing.T) {
 	_cols := buildColumns(map[string]typing.KindDetails{
 		"id":                                typing.String,
 		"bar":                               typing.String,
-		"updated_at":                        typing.ETime,
+		"updated_at":                        typing.TimestampNTZ,
 		constants.DeleteColumnMarker:        typing.Boolean,
 		constants.OnlySetDeleteColumnMarker: typing.Boolean,
 	})

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -93,7 +93,7 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 				Type:   ToPtr("FLOAT"),
 			}.String(),
 		}, nil
-	case Integer.Kind, ETime.Kind:
+	case Integer.Kind, TimestampNTZ.Kind, TimestampTZ.Kind:
 		// Parquet doesn't have native time types, so we are using int64 and casting the value as UNIX ts.
 		return &Field{
 			Tag: FieldTag{

--- a/lib/typing/parquet_test.go
+++ b/lib/typing/parquet_test.go
@@ -25,4 +25,21 @@ func TestKindDetails_ParquetAnnotation(t *testing.T) {
 			)
 		}
 	}
+	{
+		// Integers
+		for _, kd := range []KindDetails{Integer, TimestampTZ, TimestampNTZ} {
+			field, err := kd.ParquetAnnotation("foo")
+			assert.NoError(t, err)
+			assert.Equal(t,
+				Field{
+					Tag: FieldTag{
+						Name:   "foo",
+						InName: ToPtr("foo"),
+						Type:   ToPtr("INT64"),
+					}.String(),
+				},
+				*field,
+			)
+		}
+	}
 }

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -75,10 +75,6 @@ var (
 	TimestampTZ = KindDetails{
 		Kind: "timestamp_tz",
 	}
-
-	ETime = KindDetails{
-		Kind: "extended_time",
-	}
 )
 
 func NewDecimalDetailsFromTemplate(details KindDetails, decimalDetails decimal.Details) KindDetails {


### PR DESCRIPTION
Missed adding TimestampTZ and TimestampNTZ when they got pulled out into separate data types.

Additional changes

1. Removed `typing.ETime`
2. Added tests