### PR TITLE
[Redshift] Better handling of `SUPER` data types

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -23,8 +23,7 @@ const (
 func replaceExceededValues(colVal string, colKind typing.KindDetails, truncateExceededValue bool, expandStringPrecision bool) Result {
 	switch colKind.Kind {
 	case typing.Struct.Kind:
-		// If the value is a JSON object, we are then subjected to [maxSuperLength]
-		// Else, we'll default to [maxRedshiftLength]
+		// If the value is a JSON object, we will use [maxSuperLength], else we will use [maxStringLength]
 		// Ref: https://docs.aws.amazon.com/redshift/latest/dg/limitations-super.html
 		if typing.IsJSON(colVal) {
 			if len(colVal) > maxSuperLength {

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -16,8 +16,8 @@ type Result struct {
 }
 
 const (
-	maxRedshiftLength int32 = 65535
-	maxSuperLength          = 16 * 1024 * 1024
+	maxStringLength int32 = 65535
+	maxSuperLength        = 16 * 1024 * 1024
 )
 
 func replaceExceededValues(colVal string, colKind typing.KindDetails, truncateExceededValue bool, expandStringPrecision bool) Result {
@@ -37,10 +37,10 @@ func replaceExceededValues(colVal string, colKind typing.KindDetails, truncateEx
 		// Try again, but use [typing.String] instead.
 		return replaceExceededValues(colVal, typing.String, truncateExceededValue, expandStringPrecision)
 	case typing.String.Kind:
-		maxLength := typing.DefaultValueFromPtr[int32](colKind.OptionalStringPrecision, maxRedshiftLength)
+		maxLength := typing.DefaultValueFromPtr[int32](colKind.OptionalStringPrecision, maxStringLength)
 		colValLength := int32(len(colVal))
 		// If [expandStringPrecision] is enabled and the value is greater than the maximum length, and lte Redshift's max length.
-		if expandStringPrecision && colValLength > maxLength && colValLength <= maxRedshiftLength {
+		if expandStringPrecision && colValLength > maxLength && colValLength <= maxStringLength {
 			return Result{Value: colVal, NewLength: colValLength}
 		}
 
@@ -72,8 +72,6 @@ func castColValStaging(colVal any, colKind typing.KindDetails, truncateExceededV
 		return Result{}, err
 	}
 
-	return Result{Value: colValString}, nil
-
 	// Checks for DDL overflow needs to be done at the end in case there are any conversions that need to be done.
-	//return replaceExceededValues(colValString, colKind, truncateExceededValue, expandStringPrecision), nil
+	return replaceExceededValues(colValString, colKind, truncateExceededValue, expandStringPrecision), nil
 }

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -23,7 +23,7 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 			{
 				// Returns the full value since it's not a struct or string
 				// This is invalid and should not happen, but it's here to ensure we're only checking for structs and strings.
-				value := stringutil.Random(int(maxRedshiftLength + 1))
+				value := stringutil.Random(int(maxStringLength + 1))
 				result := replaceExceededValues(value, typing.Integer, false, false)
 				assert.Equal(r.T(), value, result.Value)
 				assert.Zero(r.T(), result.NewLength)
@@ -35,7 +35,7 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 				// String
 				{
 					// TruncateExceededValue = false
-					result := replaceExceededValues(stringutil.Random(int(maxRedshiftLength)+1), typing.String, false, false)
+					result := replaceExceededValues(stringutil.Random(int(maxStringLength)+1), typing.String, false, false)
 					assert.Equal(r.T(), constants.ExceededValueMarker, result.Value)
 					assert.Zero(r.T(), result.NewLength)
 				}
@@ -52,9 +52,9 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 				}
 				{
 					// TruncateExceededValue = true
-					superLongString := stringutil.Random(int(maxRedshiftLength) + 1)
+					superLongString := stringutil.Random(int(maxStringLength) + 1)
 					result := replaceExceededValues(superLongString, typing.String, true, false)
-					assert.Equal(r.T(), superLongString[:maxRedshiftLength], result.Value)
+					assert.Equal(r.T(), superLongString[:maxStringLength], result.Value)
 					assert.Zero(r.T(), result.NewLength)
 				}
 				{
@@ -70,10 +70,26 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 				}
 			}
 			{
-				// Struct and masked
-				result := replaceExceededValues(fmt.Sprintf(`{"foo": "%s"}`, stringutil.Random(int(maxRedshiftLength)+1)), typing.Struct, false, false)
-				assert.Equal(r.T(), fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker), result.Value)
-				assert.Zero(r.T(), result.NewLength)
+				// Super
+				{
+					// Masked (data type is a JSON object)
+					result := replaceExceededValues(fmt.Sprintf(`{"foo": "%s"}`, stringutil.Random(int(maxSuperLength)+1)), typing.Struct, false, false)
+					assert.Equal(r.T(), fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker), result.Value)
+					assert.Zero(r.T(), result.NewLength)
+				}
+				{
+					// Masked (data type is an array)
+					result := replaceExceededValues(fmt.Sprintf(`["%s"]`, stringutil.Random(int(maxSuperLength)+1)), typing.Struct, false, false)
+					assert.Equal(r.T(), fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker), result.Value)
+					assert.Zero(r.T(), result.NewLength)
+				}
+				{
+					// Masked (data type is a string)
+					result := replaceExceededValues(stringutil.Random(int(maxStringLength)+1), typing.String, false, false)
+					assert.Equal(r.T(), constants.ExceededValueMarker, result.Value)
+					assert.Zero(r.T(), result.NewLength)
+				}
+
 			}
 		}
 		{
@@ -81,14 +97,34 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 			{
 				// Not masked
 				{
-					result := replaceExceededValues(`{"foo": "bar"}`, typing.Struct, false, false)
-					assert.Equal(r.T(), `{"foo": "bar"}`, result.Value)
-					assert.Zero(r.T(), result.NewLength)
+					// String
+					{
+						result := replaceExceededValues(`{"foo": "bar"}`, typing.Struct, false, false)
+						assert.Equal(r.T(), `{"foo": "bar"}`, result.Value)
+						assert.Zero(r.T(), result.NewLength)
+					}
+					{
+						result := replaceExceededValues("hello world", typing.String, false, false)
+						assert.Equal(r.T(), "hello world", result.Value)
+						assert.Zero(r.T(), result.NewLength)
+					}
 				}
 				{
-					result := replaceExceededValues("hello world", typing.String, false, false)
-					assert.Equal(r.T(), "hello world", result.Value)
-					assert.Zero(r.T(), result.NewLength)
+					// SUPER
+					{
+						// Value is a struct
+						value := fmt.Sprintf(`{"foo": "%s"}`, stringutil.Random(int(maxSuperLength)-11))
+						result := replaceExceededValues(value, typing.Struct, false, false)
+						assert.Equal(r.T(), value, result.Value)
+						assert.Zero(r.T(), result.NewLength)
+					}
+					{
+						// Value is an array
+						value := fmt.Sprintf(`["%s"]`, stringutil.Random(int(maxSuperLength)-11))
+						result := replaceExceededValues(value, typing.Struct, false, false)
+						assert.Equal(r.T(), value, result.Value)
+						assert.Zero(r.T(), result.NewLength)
+					}
 				}
 			}
 		}
@@ -106,7 +142,7 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 			{
 				// Returns the full value since it's not a struct or string
 				// This is invalid and should not happen, but it's here to ensure we're only checking for structs and strings.
-				value := stringutil.Random(int(maxRedshiftLength + 1))
+				value := stringutil.Random(int(maxStringLength + 1))
 				result := replaceExceededValues(value, typing.Integer, false, true)
 				assert.Equal(r.T(), value, result.Value)
 				assert.Zero(r.T(), result.NewLength)
@@ -130,10 +166,10 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 			{
 				stringKd := typing.KindDetails{
 					Kind:                    typing.String.Kind,
-					OptionalStringPrecision: typing.ToPtr(maxRedshiftLength),
+					OptionalStringPrecision: typing.ToPtr(maxStringLength),
 				}
 
-				superLongString := stringutil.Random(int(maxRedshiftLength) + 1)
+				superLongString := stringutil.Random(int(maxStringLength) + 1)
 				result := replaceExceededValues(superLongString, stringKd, false, true)
 				assert.Equal(r.T(), constants.ExceededValueMarker, result.Value)
 				assert.Zero(r.T(), result.NewLength)

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -89,7 +89,6 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 					assert.Equal(r.T(), constants.ExceededValueMarker, result.Value)
 					assert.Zero(r.T(), result.NewLength)
 				}
-
 			}
 		}
 		{
@@ -123,6 +122,12 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 						value := fmt.Sprintf(`["%s"]`, stringutil.Random(int(maxSuperLength)-11))
 						result := replaceExceededValues(value, typing.Struct, false, false)
 						assert.Equal(r.T(), value, result.Value)
+						assert.Zero(r.T(), result.NewLength)
+					}
+					{
+						// Value is a string
+						result := replaceExceededValues("hello world", typing.Struct, false, false)
+						assert.Equal(r.T(), "hello world", result.Value)
 						assert.Zero(r.T(), result.NewLength)
 					}
 				}

--- a/clients/redshift/redshift_bench_test.go
+++ b/clients/redshift/redshift_bench_test.go
@@ -34,13 +34,13 @@ func replaceExceededValuesOld(colVal any, colKind columns.Column) any {
 	colValString := fmt.Sprint(colVal)
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind:
-		if int32(len(colValString)) > maxRedshiftLength {
+		if int32(len(colValString)) > maxStringLength {
 			return map[string]any{
 				"key": constants.ExceededValueMarker,
 			}
 		}
 	case typing.String.Kind:
-		if int32(len(colValString)) > maxRedshiftLength {
+		if int32(len(colValString)) > maxStringLength {
 			return constants.ExceededValueMarker
 		}
 	}
@@ -53,13 +53,13 @@ func replaceExceededValuesNew(colVal any, colKind columns.Column) any {
 	colValBytes := int32(len(colValString))
 	switch colKind.KindDetails.Kind {
 	case typing.Struct.Kind:
-		if colValBytes > maxRedshiftLength {
+		if colValBytes > maxStringLength {
 			return map[string]any{
 				"key": constants.ExceededValueMarker,
 			}
 		}
 	case typing.String.Kind:
-		if colValBytes > maxRedshiftLength {
+		if colValBytes > maxStringLength {
 			return constants.ExceededValueMarker
 		}
 	}

--- a/lib/typing/ptr.go
+++ b/lib/typing/ptr.go
@@ -3,3 +3,11 @@ package typing
 func ToPtr[T any](v T) *T {
 	return &v
 }
+
+func DefaultValueFromPtr[T any](value *T, defaultValue T) T {
+	if value == nil {
+		return defaultValue
+	}
+
+	return *value
+}

--- a/lib/typing/ptr_test.go
+++ b/lib/typing/ptr_test.go
@@ -1,0 +1,18 @@
+package typing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultValueFromPtr(t *testing.T) {
+	{
+		// ptr is not set
+		assert.Equal(t, int32(5), DefaultValueFromPtr[int32](nil, int32(5)))
+	}
+	{
+		// ptr is set
+		assert.Equal(t, int32(10), DefaultValueFromPtr[int32](ToPtr(int32(10)), int32(5)))
+	}
+}


### PR DESCRIPTION
We can actually store rows up to 16mb in size into a Redshift SUPER column if the value is a JSON object or an array.

If we are storing other data types (such as string) into a SUPER column, then the native DDL limits will apply. In this case, if we stored a string value into a SUPER data type, we need to adhere to the 2^16 limit rather than the 16 mb limit.