### PR TITLE
[Typing] Improving our `IsJSON` function

### DIFF
--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -91,18 +91,13 @@ func NewDecimalDetailsFromTemplate(details KindDetails, decimalDetails decimal.D
 // This is an optimization since JSON string checking is expensive.
 func IsJSON(str string) bool {
 	str = strings.TrimSpace(str)
-	if len(str) < 2 {
+	if len(str) == 0 {
 		return false
 	}
 
-	valStringChars := []rune(str)
-	firstChar := string(valStringChars[0])
-	lastChar := string(valStringChars[len(valStringChars)-1])
-
-	if (firstChar == "{" && lastChar == "}") || (firstChar == "[" && lastChar == "]") {
-		var js json.RawMessage
-		return json.Unmarshal([]byte(str), &js) == nil
+	firstChar := str[0]
+	if firstChar != '{' && firstChar != '[' {
+		return false
 	}
-
-	return false
+	return json.Valid([]byte(str))
 }

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -1,6 +1,8 @@
 package typing
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +15,9 @@ func Test_IsJSON(t *testing.T) {
 			`{"hello": "world"}}`,
 			`{null}`,
 			"",
+			"foo",
 			"  ",
+			"12345",
 		}
 
 		for _, invalidValue := range invalidValues {
@@ -42,4 +46,41 @@ func Test_IsJSON(t *testing.T) {
 			assert.True(t, IsJSON(validValue), validValue)
 		}
 	}
+}
+
+func BenchmarkIsJSON(b *testing.B) {
+	values := []string{"hello world", `{"hello": "world"}`, `{"hello": "world"}}`, `{null}`, "", "foo", "  ", "12345"}
+	b.Run("OldMethod", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, value := range values {
+				oldIsJSON(value)
+			}
+		}
+	})
+
+	b.Run("NewMethod", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			for _, value := range values {
+				IsJSON(value)
+			}
+		}
+	})
+}
+
+func oldIsJSON(str string) bool {
+	str = strings.TrimSpace(str)
+	if len(str) < 2 {
+		return false
+	}
+
+	valStringChars := []rune(str)
+	firstChar := string(valStringChars[0])
+	lastChar := string(valStringChars[len(valStringChars)-1])
+
+	if (firstChar == "{" && lastChar == "}") || (firstChar == "[" && lastChar == "]") {
+		var js json.RawMessage
+		return json.Unmarshal([]byte(str), &js) == nil
+	}
+
+	return false
 }

--- a/lib/typing/typing_test.go
+++ b/lib/typing/typing_test.go
@@ -17,6 +17,8 @@ func Test_IsJSON(t *testing.T) {
 			"",
 			"foo",
 			"  ",
+			"{",
+			"[",
 			"12345",
 		}
 


### PR DESCRIPTION
There's a `json.Valid` function, let's use it.

It's also more performant.

```
goos: darwin
goarch: arm64
pkg: github.com/artie-labs/transfer/lib/typing
cpu: Apple M2 Max
BenchmarkIsJSON
BenchmarkIsJSON/OldMethod
BenchmarkIsJSON/OldMethod-12         	 1365619	       863.3 ns/op
BenchmarkIsJSON/NewMethod
BenchmarkIsJSON/NewMethod-12         	 2903380	       416.9 ns/op
PASS
```