### PR TITLE
Prevent thundering herd

### DIFF
--- a/lib/cryptography/cryptography.go
+++ b/lib/cryptography/cryptography.go
@@ -1,12 +1,14 @@
 package cryptography
 
 import (
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"math/big"
 	"os"
 
 	"github.com/artie-labs/transfer/lib/typing"
@@ -49,4 +51,13 @@ func ParseRSAPrivateKey(keyBytes []byte) (*rsa.PrivateKey, error) {
 	}
 
 	return rsaKey, nil
+}
+
+func RandomInt64n(n int64) (int64, error) {
+	randN, err := rand.Int(rand.Reader, big.NewInt(n))
+	if err != nil {
+		return 0, fmt.Errorf("failed to generate random number: %w", err)
+	}
+
+	return randN.Int64(), nil
 }

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math/rand"
 	"os"
 	"strconv"
 	"sync"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/cryptography"
 	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/utils"
 	"github.com/artie-labs/transfer/lib/logger"
@@ -29,8 +29,12 @@ func main() {
 			logger.Fatal("Failed to parse sleep duration", slog.Any("err", err), slog.String("value", value))
 		}
 
-		randomSleepSeconds := rand.Int63n(castedValue)
-		duration := time.Duration(randomSleepSeconds) * time.Second
+		randomSeconds, err := cryptography.RandomInt64n(castedValue)
+		if err != nil {
+			logger.Fatal("Failed to generate random number", slog.Any("err", err))
+		}
+
+		duration := time.Duration(randomSeconds) * time.Second
 		slog.Info("Sleeping for", slog.String("duration", duration.String()))
 		time.Sleep(duration)
 	}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -20,6 +22,19 @@ import (
 )
 
 func main() {
+	// This is used to prevent all the instances from starting at the same time and causing a thundering herd problem
+	if value := os.Getenv("MAX_INIT_SLEEP_SECONDS"); value != "" {
+		castedValue, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			logger.Fatal("Failed to parse sleep duration", slog.Any("err", err), slog.String("value", value))
+		}
+
+		randomSleepSeconds := rand.Int63n(castedValue)
+		duration := time.Duration(randomSleepSeconds) * time.Second
+		slog.Info("Sleeping for", slog.String("duration", duration.String()))
+		time.Sleep(duration)
+	}
+
 	// Parse args into settings
 	settings, err := config.LoadSettings(os.Args, true)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 		}
 
 		duration := time.Duration(randomSeconds) * time.Second
-		slog.Info("Sleeping for", slog.String("duration", duration.String()))
+		slog.Info(fmt.Sprintf("Sleeping for %s before any data processing to prevent overwhelming Kafka", duration.String()))
 		time.Sleep(duration)
 	}
 


### PR DESCRIPTION
This is to prevent a thundering herd problem on our Kafka cluster where a large amount of consumer restarts at the same time and cause our Kafka brokers to rebalance based on new connections.