### PR TITLE
Address TODO

### DIFF
--- a/clients/bigquery/converters/converters.go
+++ b/clients/bigquery/converters/converters.go
@@ -3,11 +3,9 @@ package converters
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
-	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/artie-labs/transfer/lib/typing/values"
 )
 
@@ -20,34 +18,7 @@ func NewStringConverter(kd typing.KindDetails) StringConverter {
 }
 
 func (s StringConverter) Convert(value any) (any, error) {
-	// TODO: This should use values.ToString().
-	switch castedValue := value.(type) {
-	case string:
-		return castedValue, nil
-	case *decimal.Decimal:
-		return castedValue.String(), nil
-	case bool, int64:
-		return fmt.Sprint(castedValue), nil
-	case float32:
-		return values.Float32ToString(castedValue), nil
-	case float64:
-		return values.Float64ToString(castedValue), nil
-	case time.Time:
-		switch s.kd {
-		case typing.Date:
-			return castedValue.Format(ext.PostgresDateFormat), nil
-		case typing.Time:
-			return castedValue.Format(ext.PostgresTimeFormat), nil
-		case typing.TimestampNTZ:
-			return castedValue.Format(ext.RFC3339NoTZ), nil
-		case typing.TimestampTZ:
-			return castedValue.Format(time.RFC3339Nano), nil
-		default:
-			return nil, fmt.Errorf("unexpected kind details: %q", s.kd.Kind)
-		}
-	default:
-		return nil, fmt.Errorf("unexpected data type: %T with value: %v", value, value)
-	}
+	return values.ToString(value, s.kd)
 }
 
 type Int64Converter struct{}

--- a/clients/bigquery/converters/converters_test.go
+++ b/clients/bigquery/converters/converters_test.go
@@ -32,10 +32,19 @@ func TestStringConverter_Convert(t *testing.T) {
 		assert.Equal(t, "true", val)
 	}
 	{
-		// int64
-		val, err := NewStringConverter(typing.Integer).Convert(int64(123))
-		assert.NoError(t, err)
-		assert.Equal(t, "123", val)
+		// Integer column
+		{
+			// int64 value
+			val, err := NewStringConverter(typing.Integer).Convert(int64(123))
+			assert.NoError(t, err)
+			assert.Equal(t, "123", val)
+		}
+		{
+			// int value
+			val, err := NewStringConverter(typing.Integer).Convert(123)
+			assert.NoError(t, err)
+			assert.Equal(t, "123", val)
+		}
 	}
 	{
 		// float64
@@ -65,11 +74,6 @@ func TestStringConverter_Convert(t *testing.T) {
 		}
 	}
 	{
-		// Invalid
-		_, err := NewStringConverter(typing.Integer).Convert(123)
-		assert.ErrorContains(t, err, "unexpected data type: int with value: 123")
-	}
-	{
 		// time.Time
 		{
 			// Date
@@ -81,7 +85,7 @@ func TestStringConverter_Convert(t *testing.T) {
 			// Time
 			val, err := NewStringConverter(typing.Time).Convert(time.Date(2021, 1, 1, 9, 10, 11, 123_456_789, time.UTC))
 			assert.NoError(t, err)
-			assert.Equal(t, "09:10:11.123456Z", val)
+			assert.Equal(t, "09:10:11.123456", val)
 		}
 		{
 			// Timestamp NTZ
@@ -97,8 +101,10 @@ func TestStringConverter_Convert(t *testing.T) {
 		}
 		{
 			// Invalid
-			_, err := NewStringConverter(typing.String).Convert(time.Date(2021, 1, 1, 9, 10, 12, 400_123_991, time.UTC))
-			assert.ErrorContains(t, err, `unexpected kind details: "string"`)
+			ts := time.Date(2021, 1, 1, 9, 10, 12, 400_123_991, time.UTC)
+			val, err := NewStringConverter(typing.String).Convert(ts)
+			assert.NoError(t, err)
+			assert.Equal(t, ts.String(), val)
 		}
 	}
 }

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -103,6 +103,13 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 		}
 
 		return string(colValBytes), nil
+	case typing.Float.Kind:
+		switch parsedVal := colVal.(type) {
+		case float32:
+			return Float32ToString(parsedVal), nil
+		case float64:
+			return Float64ToString(parsedVal), nil
+		}
 	case typing.Integer.Kind:
 		switch parsedVal := colVal.(type) {
 		case float32:


### PR DESCRIPTION
Addressing the TODO from #1024, which is to consolidate how we are casting `value any` into a `string`.