### PR TITLE
[BigQuery] Skip large rows

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -185,7 +185,7 @@ func (s *Store) putTable(ctx context.Context, bqTableID dialect.TableIdentifier,
 		return bytes, nil
 	}
 
-	return batch.BySize(tableData.Rows(), maxRequestByteSize, true, encoder, func(chunk [][]byte) error {
+	return batch.BySize(tableData.Rows(), maxRequestByteSize, false, encoder, func(chunk [][]byte) error {
 		result, err := managedStream.AppendRows(ctx, chunk)
 		if err != nil {
 			return fmt.Errorf("failed to append rows: %w", err)


### PR DESCRIPTION
We should not hard fail on large rows as this causes a pipeline blockage for a deterministic failure case.

Instead, we should skip the row and log