### PR TITLE
[DDL] Standing up `BuildCreateTableSQL`

### DIFF
--- a/clients/bigquery/partition_test.go
+++ b/clients/bigquery/partition_test.go
@@ -1,6 +1,7 @@
 package bigquery
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -38,7 +39,7 @@ func TestDistinctDates(t *testing.T) {
 			{"ts": time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)},
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"2020-01-01", "2020-01-02"}, dates)
+		equalLists(t, []string{"2020-01-01", "2020-01-02"}, dates)
 	}
 	{
 		// Three days, two unique
@@ -48,6 +49,13 @@ func TestDistinctDates(t *testing.T) {
 			{"ts": time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)},
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"2020-01-01", "2020-01-02"}, dates)
+		equalLists(t, []string{"2020-01-01", "2020-01-02"}, dates)
 	}
+}
+
+func equalLists(t *testing.T, list1 []string, list2 []string) {
+	// Sort the two lists prior to comparison
+	slices.Sort(list1)
+	slices.Sort(list2)
+	assert.Equal(t, list1, list2)
 }

--- a/lib/destination/ddl/ddl_test.go
+++ b/lib/destination/ddl/ddl_test.go
@@ -3,6 +3,8 @@ package ddl
 import (
 	"testing"
 
+	bigQueryDialect "github.com/artie-labs/transfer/clients/bigquery/dialect"
+
 	"github.com/artie-labs/transfer/clients/redshift/dialect"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +58,20 @@ func TestBuildCreateTableSQL(t *testing.T) {
 				})
 				assert.NoError(t, err)
 				assert.Equal(t, `CREATE TABLE IF NOT EXISTS schema."table" ("pk1" VARCHAR(MAX),"pk2" VARCHAR(MAX),"bar" VARCHAR(MAX),PRIMARY KEY ("pk1", "pk2"));`, sql)
+			}
+		}
+		{
+			//  BigQuery
+			{
+				// With primary key
+				pk := columns.NewColumn("pk", typing.String)
+				pk.SetPrimaryKeyForTest(true)
+				sql, err := BuildCreateTableSQL(bigQueryDialect.BigQueryDialect{}, bigQueryDialect.NewTableIdentifier("projectID", "dataset", "table"), false, config.Replication, []columns.Column{
+					pk,
+					columns.NewColumn("bar", typing.String),
+				})
+				assert.NoError(t, err)
+				assert.Equal(t, "CREATE TABLE IF NOT EXISTS `projectID`.`dataset`.`table` (`pk` string,`bar` string,PRIMARY KEY (`pk`) NOT ENFORCED)", sql)
 			}
 		}
 	}

--- a/lib/destination/ddl/ddl_test.go
+++ b/lib/destination/ddl/ddl_test.go
@@ -3,12 +3,10 @@ package ddl
 import (
 	"testing"
 
-	bigQueryDialect "github.com/artie-labs/transfer/clients/bigquery/dialect"
-
-	"github.com/artie-labs/transfer/clients/redshift/dialect"
-
 	"github.com/stretchr/testify/assert"
 
+	bigQueryDialect "github.com/artie-labs/transfer/clients/bigquery/dialect"
+	"github.com/artie-labs/transfer/clients/redshift/dialect"
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"

--- a/lib/destination/ddl/ddl_test.go
+++ b/lib/destination/ddl/ddl_test.go
@@ -3,12 +3,64 @@ package ddl
 import (
 	"testing"
 
+	"github.com/artie-labs/transfer/clients/redshift/dialect"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
 )
+
+func TestBuildCreateTableSQL(t *testing.T) {
+	{
+		// No columns provided
+		_, err := BuildCreateTableSQL(nil, nil, false, config.Replication, []columns.Column{})
+		assert.ErrorContains(t, err, "no columns provided")
+	}
+	{
+		// Valid
+		{
+			// Redshift
+			{
+				// No primary key
+				sql, err := BuildCreateTableSQL(dialect.RedshiftDialect{}, dialect.NewTableIdentifier("schema", "table"), false, config.Replication, []columns.Column{
+					columns.NewColumn("foo", typing.String),
+					columns.NewColumn("bar", typing.String),
+				})
+				assert.NoError(t, err)
+				assert.Equal(t, `CREATE TABLE IF NOT EXISTS schema."table" ("foo" VARCHAR(MAX),"bar" VARCHAR(MAX));`, sql)
+			}
+			{
+				// With primary key
+				pk := columns.NewColumn("pk", typing.String)
+				pk.SetPrimaryKeyForTest(true)
+				sql, err := BuildCreateTableSQL(dialect.RedshiftDialect{}, dialect.NewTableIdentifier("schema", "table"), false, config.Replication, []columns.Column{
+					pk,
+					columns.NewColumn("bar", typing.String),
+				})
+				assert.NoError(t, err)
+				assert.Equal(t, `CREATE TABLE IF NOT EXISTS schema."table" ("pk" VARCHAR(MAX),"bar" VARCHAR(MAX),PRIMARY KEY ("pk"));`, sql)
+			}
+			{
+				// With more than one primary key
+				pk1 := columns.NewColumn("pk1", typing.String)
+				pk1.SetPrimaryKeyForTest(true)
+				pk2 := columns.NewColumn("pk2", typing.String)
+				pk2.SetPrimaryKeyForTest(true)
+
+				sql, err := BuildCreateTableSQL(dialect.RedshiftDialect{}, dialect.NewTableIdentifier("schema", "table"), false, config.Replication, []columns.Column{
+					pk1,
+					pk2,
+					columns.NewColumn("bar", typing.String),
+				})
+				assert.NoError(t, err)
+				assert.Equal(t, `CREATE TABLE IF NOT EXISTS schema."table" ("pk1" VARCHAR(MAX),"pk2" VARCHAR(MAX),"bar" VARCHAR(MAX),PRIMARY KEY ("pk1", "pk2"));`, sql)
+			}
+		}
+	}
+
+}
 
 func TestShouldCreatePrimaryKey(t *testing.T) {
 	pk := columns.NewColumn("foo", typing.String)


### PR DESCRIPTION
Standing up `BuildCreateTableSQL` so it's more modular

* Easier to test
* No massive struct
* Ability to import `BuildCreateTableSQL` into Reader