### PR TITLE
[Parquet] Rename temporary file

### DIFF
--- a/clients/s3/s3_test.go
+++ b/clients/s3/s3_test.go
@@ -1,17 +1,24 @@
 package s3
 
 import (
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/config"
-
+	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
 )
+
+func TestBuildTemporaryFilePath(t *testing.T) {
+	ts := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	fp := buildTemporaryFilePath(&optimization.TableData{LatestCDCTs: ts})
+	assert.True(t, strings.HasPrefix(fp, "/tmp/1577836800000_"), fp)
+	assert.True(t, strings.HasSuffix(fp, ".parquet"), fp)
+}
 
 func TestObjectPrefix(t *testing.T) {
 	td := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{


### PR DESCRIPTION
Dropping the `.gz` suffix since it's misleading.

The file itself is not gzipped, however the contents are gzipped. Applications that are capable of reading Parquet will automatically handle decompressing as the compression format is within the file itself.