### PR TITLE
Adding `GetTypeFromMap` to `maputil`

### DIFF
--- a/clients/databricks/file.go
+++ b/clients/databricks/file.go
@@ -16,12 +16,12 @@ type File struct {
 }
 
 func NewFile(fileRow map[string]any) (File, error) {
-	name, err := maputil.GetStringFromMap(fileRow, "name")
+	name, err := maputil.GetTypeFromMap[string](fileRow, "name")
 	if err != nil {
 		return File{}, err
 	}
 
-	fp, err := maputil.GetStringFromMap(fileRow, "path")
+	fp, err := maputil.GetTypeFromMap[string](fileRow, "path")
 	if err != nil {
 		return File{}, err
 	}

--- a/lib/maputil/map.go
+++ b/lib/maputil/map.go
@@ -38,11 +38,12 @@ func GetInt32FromMap(obj map[string]any, key string) (int32, error) {
 	return int32(val), nil
 }
 
-func GetStringFromMap(obj map[string]any, key string) (string, error) {
+func GetTypeFromMap[T any](obj map[string]any, key string) (T, error) {
 	value, isOk := obj[key]
 	if !isOk {
-		return "", fmt.Errorf("key: %q does not exist in object", key)
+		var zero T
+		return zero, fmt.Errorf("key: %q does not exist in object", key)
 	}
 
-	return typing.AssertType[string](value)
+	return typing.AssertType[T](value)
 }

--- a/lib/maputil/map_test.go
+++ b/lib/maputil/map_test.go
@@ -115,33 +115,58 @@ func TestGetInt32FromMap(t *testing.T) {
 	}
 }
 
-func TestGetStringFromMap(t *testing.T) {
+func TestGetTypeFromMap(t *testing.T) {
 	{
-		// Not valid (key doesn't exist)
+		// String
 		{
-			// Key does not exist
-			object := map[string]any{"abc": 123}
-			_, err := GetStringFromMap(object, "foo")
-			assert.ErrorContains(t, err, `key: "foo" does not exist in object`)
+			// Not valid (key doesn't exist)
+			{
+				// Key does not exist
+				object := map[string]any{"abc": 123}
+				_, err := GetTypeFromMap[string](object, "foo")
+				assert.ErrorContains(t, err, `key: "foo" does not exist in object`)
+			}
+			{
+				// nil map
+				_, err := GetTypeFromMap[string](nil, "foo")
+				assert.ErrorContains(t, err, `key: "foo" does not exist in object`)
+			}
+			{
+				// Not type string
+				object := map[string]any{"abc": 123}
+				_, err := GetTypeFromMap[string](object, "abc")
+				assert.ErrorContains(t, err, "expected type string, got int")
+			}
 		}
 		{
-			// nil map
-			_, err := GetStringFromMap(nil, "foo")
-			assert.ErrorContains(t, err, `key: "foo" does not exist in object`)
-		}
-		{
-			// Not type string
-			object := map[string]any{"abc": 123}
-			_, err := GetStringFromMap(object, "abc")
-			assert.ErrorContains(t, err, "expected type string, got int")
+			// Valid
+			object := map[string]any{"abc": "123"}
+			value, err := GetTypeFromMap[string](object, "abc")
+			assert.NoError(t, err)
+			assert.Equal(t, "123", value)
 		}
 	}
 	{
-		// Valid
-		object := map[string]any{"abc": "123"}
-		value, err := GetStringFromMap(object, "abc")
-		assert.NoError(t, err)
-		assert.Equal(t, "123", value)
+		// Boolean
+		{
+			// Not valid (key does not exist)
+			object := map[string]any{"def": true}
+			_, err := GetTypeFromMap[bool](object, "foo")
+			assert.ErrorContains(t, err, `key: "foo" does not exist in object`)
+		}
+		{
+			// Not valid (wrong type)
+			object := map[string]any{"def": 123}
+			_, err := GetTypeFromMap[bool](object, "def")
+			assert.ErrorContains(t, err, "expected type bool, got int")
+		}
+		{
+			// Valid
+			object := map[string]any{"def": true}
+			value, err := GetTypeFromMap[bool](object, "def")
+			assert.NoError(t, err)
+			assert.True(t, value)
+		}
 	}
 
 }


### PR DESCRIPTION
This way, we can handle generic types and use it more broadly across our codebase.