### PR TITLE
[Redshift] Remove `buildAlterColumnQuery`

### DIFF
--- a/clients/redshift/dialect/ddl.go
+++ b/clients/redshift/dialect/ddl.go
@@ -41,18 +41,14 @@ WHERE
 }
 
 func (rd RedshiftDialect) BuildAddColumnQuery(tableID sql.TableIdentifier, sqlPart string) string {
-	return rd.buildAlterColumnQuery(tableID, constants.Add, sqlPart)
+	return fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s", tableID.FullyQualifiedName(), sqlPart)
 }
 
 func (rd RedshiftDialect) BuildDropColumnQuery(tableID sql.TableIdentifier, colName string) string {
-	return rd.buildAlterColumnQuery(tableID, constants.Delete, colName)
+	return fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", tableID.FullyQualifiedName(), colName)
 }
 
 func (RedshiftDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, colSQLParts []string) string {
 	// Redshift uses the same syntax for temporary and permanent tables.
 	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s);", tableID.FullyQualifiedName(), strings.Join(colSQLParts, ","))
-}
-
-func (RedshiftDialect) buildAlterColumnQuery(tableID sql.TableIdentifier, columnOp constants.ColumnOperation, colSQLPart string) string {
-	return fmt.Sprintf("ALTER TABLE %s %s COLUMN %s", tableID.FullyQualifiedName(), columnOp, colSQLPart)
 }

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -50,7 +50,7 @@ func TestRedshiftDialect_BuildAddColumnQuery(t *testing.T) {
 	fakeTableID.FullyQualifiedNameReturns("{TABLE}")
 
 	assert.Equal(t,
-		"ALTER TABLE {TABLE} add COLUMN {SQL_PART}",
+		"ALTER TABLE {TABLE} ADD COLUMN {SQL_PART}",
 		RedshiftDialect{}.BuildAddColumnQuery(fakeTableID, "{SQL_PART}"),
 	)
 }
@@ -60,7 +60,7 @@ func TestRedshiftDialect_BuildDropColumnQuery(t *testing.T) {
 	fakeTableID.FullyQualifiedNameReturns("{TABLE}")
 
 	assert.Equal(t,
-		"ALTER TABLE {TABLE} drop COLUMN {SQL_PART}",
+		"ALTER TABLE {TABLE} DROP COLUMN {SQL_PART}",
 		RedshiftDialect{}.BuildDropColumnQuery(fakeTableID, "{SQL_PART}"),
 	)
 }

--- a/lib/destination/ddl/ddl_test.go
+++ b/lib/destination/ddl/ddl_test.go
@@ -118,7 +118,7 @@ func TestBuildAlterTableAddColumns(t *testing.T) {
 		sqlParts, err := BuildAlterTableAddColumns(config.SharedDestinationColumnSettings{}, dialect.RedshiftDialect{}, dialect.NewTableIdentifier("schema", "table"), []columns.Column{col})
 		assert.NoError(t, err)
 		assert.Len(t, sqlParts, 1)
-		assert.Equal(t, `ALTER TABLE schema."table" add COLUMN "dusty" VARCHAR(MAX)`, sqlParts[0])
+		assert.Equal(t, `ALTER TABLE schema."table" ADD COLUMN "dusty" VARCHAR(MAX)`, sqlParts[0])
 	}
 	{
 		// Two columns, one invalid, it will error.
@@ -141,9 +141,9 @@ func TestBuildAlterTableAddColumns(t *testing.T) {
 		sqlParts, err := BuildAlterTableAddColumns(config.SharedDestinationColumnSettings{}, dialect.RedshiftDialect{}, dialect.NewTableIdentifier("schema", "table"), []columns.Column{col1, col2, col3})
 		assert.NoError(t, err)
 		assert.Len(t, sqlParts, 3)
-		assert.Equal(t, `ALTER TABLE schema."table" add COLUMN "aussie" VARCHAR(MAX)`, sqlParts[0])
-		assert.Equal(t, `ALTER TABLE schema."table" add COLUMN "doge" VARCHAR(MAX)`, sqlParts[1])
-		assert.Equal(t, `ALTER TABLE schema."table" add COLUMN "age" INT8`, sqlParts[2])
+		assert.Equal(t, `ALTER TABLE schema."table" ADD COLUMN "aussie" VARCHAR(MAX)`, sqlParts[0])
+		assert.Equal(t, `ALTER TABLE schema."table" ADD COLUMN "doge" VARCHAR(MAX)`, sqlParts[1])
+		assert.Equal(t, `ALTER TABLE schema."table" ADD COLUMN "age" INT8`, sqlParts[2])
 	}
 }
 
@@ -157,6 +157,6 @@ func TestAlterTableDropColumns(t *testing.T) {
 		// Valid column
 		sql, err := BuildAlterTableDropColumns(dialect.RedshiftDialect{}, dialect.NewTableIdentifier("schema", "table"), columns.NewColumn("dusty", typing.String))
 		assert.NoError(t, err)
-		assert.Equal(t, `ALTER TABLE schema."table" drop COLUMN "dusty"`, sql)
+		assert.Equal(t, `ALTER TABLE schema."table" DROP COLUMN "dusty"`, sql)
 	}
 }


### PR DESCRIPTION
Implementing adding and dropping columns directly in the function.