### PR TITLE
[Debezium] Better support around JSON arrays

### DIFF
--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -259,6 +259,7 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 // MongoDB will return the native objects back such as `map[string]any{"hello": "world"}`
 // Relational will return a string representation of the struct such as `{"hello": "world"}`
 func encodeStructToJSONString(value any) (string, error) {
+	fmt.Println("value", value, fmt.Sprintf("type %T", value))
 	if stringValue, isOk := value.(string); isOk {
 		if strings.Contains(stringValue, constants.ToastUnavailableValuePlaceholder) {
 			return fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder), nil
@@ -271,5 +272,6 @@ func encodeStructToJSONString(value any) (string, error) {
 		return "", fmt.Errorf("failed to marshal value: %w", err)
 	}
 
+	fmt.Println("string(bytes)", string(bytes))
 	return string(bytes), nil
 }

--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -259,7 +259,6 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 // MongoDB will return the native objects back such as `map[string]any{"hello": "world"}`
 // Relational will return a string representation of the struct such as `{"hello": "world"}`
 func encodeStructToJSONString(value any) (string, error) {
-	fmt.Println("value", value, fmt.Sprintf("type %T", value))
 	if stringValue, isOk := value.(string); isOk {
 		if strings.Contains(stringValue, constants.ToastUnavailableValuePlaceholder) {
 			return fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder), nil
@@ -272,6 +271,5 @@ func encodeStructToJSONString(value any) (string, error) {
 		return "", fmt.Errorf("failed to marshal value: %w", err)
 	}
 
-	fmt.Println("string(bytes)", string(bytes))
 	return string(bytes), nil
 }

--- a/lib/debezium/converters/basic.go
+++ b/lib/debezium/converters/basic.go
@@ -110,7 +110,7 @@ func (a Array) Convert(value any) (any, error) {
 		// Debezium will give us a list of JSON strings. We will then need to convert them to JSON objects.
 		elements, ok := value.([]any)
 		if !ok {
-			return nil, fmt.Errorf("expected []interface{}, got %T", value)
+			return nil, fmt.Errorf("expected []any, got %T", value)
 		}
 
 		convertedElements := make([]any, len(elements))

--- a/lib/debezium/converters/basic.go
+++ b/lib/debezium/converters/basic.go
@@ -106,9 +106,8 @@ func (a Array) Convert(value any) (any, error) {
 		return constants.ToastUnavailableValuePlaceholder, nil
 	}
 
-	// Convert value which is an array of []interface{} to array of JSON objects.
 	if a.json {
-		// Parse the individual elements
+		// Debezium will give us a list of JSON strings. We will then need to convert them to JSON objects.
 		elements, ok := value.([]any)
 		if !ok {
 			return nil, fmt.Errorf("expected []interface{}, got %T", value)
@@ -118,8 +117,7 @@ func (a Array) Convert(value any) (any, error) {
 		for i, element := range elements {
 			if castedElement, ok := element.(string); ok {
 				var obj any
-				err := json.Unmarshal([]byte(castedElement), &obj)
-				if err != nil {
+				if err := json.Unmarshal([]byte(castedElement), &obj); err != nil {
 					return nil, err
 				}
 

--- a/lib/debezium/converters/basic_test.go
+++ b/lib/debezium/converters/basic_test.go
@@ -110,4 +110,11 @@ func TestArray_Convert(t *testing.T) {
 			assert.Equal(t, constants.ToastUnavailableValuePlaceholder, value)
 		}
 	}
+	{
+		// Array of JSON objects
+		value, err := NewArray(true).Convert([]any{"{\"body\": \"they are on to us\", \"sender\": \"pablo\"}"})
+		assert.NoError(t, err)
+		assert.Len(t, value.([]any), 1)
+		assert.Equal(t, map[string]any{"body": "they are on to us", "sender": "pablo"}, value.([]any)[0])
+	}
 }

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -66,8 +66,8 @@ type Field struct {
 	FieldName    string                `json:"field"`
 	DebeziumType SupportedDebeziumType `json:"name"`
 	Parameters   map[string]any        `json:"parameters"`
-	// [Items] is only populated if the literal type is an array.
-	Items Item `json:"items"`
+	// [ItemsMetadata] is only populated if the literal type is an array.
+	ItemsMetadata Item `json:"items"`
 }
 
 func (f Field) GetScaleAndPrecision() (int32, *int32, error) {
@@ -146,7 +146,7 @@ func (f Field) ToValueConverter() (converters.ValueConverter, error) {
 
 		switch f.Type {
 		case Array:
-			return converters.NewArray(f.Items.DebeziumType == JSON), nil
+			return converters.NewArray(f.ItemsMetadata.DebeziumType == JSON), nil
 		case Double, Float:
 			return converters.Float64{}, nil
 		}

--- a/lib/debezium/schema.go
+++ b/lib/debezium/schema.go
@@ -53,6 +53,12 @@ const (
 	Map     FieldType = "map"
 )
 
+type Item struct {
+	Type         FieldType             `json:"type"`
+	Optional     bool                  `json:"optional"`
+	DebeziumType SupportedDebeziumType `json:"name"`
+}
+
 type Field struct {
 	Type         FieldType             `json:"type"`
 	Optional     bool                  `json:"optional"`
@@ -60,6 +66,8 @@ type Field struct {
 	FieldName    string                `json:"field"`
 	DebeziumType SupportedDebeziumType `json:"name"`
 	Parameters   map[string]any        `json:"parameters"`
+	// [Items] is only populated if the literal type is an array.
+	Items Item `json:"items"`
 }
 
 func (f Field) GetScaleAndPrecision() (int32, *int32, error) {
@@ -138,7 +146,7 @@ func (f Field) ToValueConverter() (converters.ValueConverter, error) {
 
 		switch f.Type {
 		case Array:
-			return converters.Array{}, nil
+			return converters.NewArray(f.Items.DebeziumType == JSON), nil
 		case Double, Float:
 			return converters.Float64{}, nil
 		}

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -174,7 +174,7 @@ func TestField_ParseValue(t *testing.T) {
 	}
 	{
 		// Array
-		field := Field{Type: Array, Items: Item{DebeziumType: JSON}}
+		field := Field{Type: Array, ItemsMetadata: Item{DebeziumType: JSON}}
 		value, err := field.ParseValue([]any{`{"foo": "bar", "foo": "bar"}`, `{"hello": "world"}`})
 		assert.NoError(t, err)
 		assert.Len(t, value.([]any), 2)

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -173,6 +173,15 @@ func TestField_ParseValue(t *testing.T) {
 		}
 	}
 	{
+		// Array
+		field := Field{Type: Array, Items: Item{DebeziumType: JSON}}
+		value, err := field.ParseValue([]any{`{"foo": "bar", "foo": "bar"}`, `{"hello": "world"}`})
+		assert.NoError(t, err)
+		assert.Len(t, value.([]any), 2)
+		assert.Equal(t, map[string]any{"foo": "bar"}, value.([]any)[0])
+		assert.Equal(t, map[string]any{"hello": "world"}, value.([]any)[1])
+	}
+	{
 		// Int32
 		value, err := Field{Type: Int32}.ParseValue(float64(3))
 		assert.NoError(t, err)


### PR DESCRIPTION
Debezium will emit

```json
{
    "type": "array",
    "items": {
        "type": "string",
        "optional": true,
        "name": "io.debezium.data.Json",
        "version": 1
    },
    "optional": true,
    "field": "attributes"
}
``` 

As the field object if the value contains an array of JSON objects. We were previously not doing anything with this information.

As such, we were mainly returning an array of JSON strings (which is what Debezium emits). This PR adds the ability for us to check the `items.name` and if it's JSON, we'll add an additional step to parse the JSON string into an object.