### PR TITLE
[Debezium] Array item type safety

### DIFF
--- a/lib/debezium/converters/basic.go
+++ b/lib/debezium/converters/basic.go
@@ -115,13 +115,16 @@ func (a Array) Convert(value any) (any, error) {
 
 		convertedElements := make([]any, len(elements))
 		for i, element := range elements {
-			if castedElement, ok := element.(string); ok {
+			switch castedElement := element.(type) {
+			case string:
 				var obj any
 				if err := json.Unmarshal([]byte(castedElement), &obj); err != nil {
 					return nil, err
 				}
 
 				convertedElements[i] = obj
+			default:
+				return nil, fmt.Errorf("expected string, got %T, value '%v'", element, element)
 			}
 		}
 

--- a/lib/debezium/converters/basic_test.go
+++ b/lib/debezium/converters/basic_test.go
@@ -112,9 +112,22 @@ func TestArray_Convert(t *testing.T) {
 	}
 	{
 		// Array of JSON objects
-		value, err := NewArray(true).Convert([]any{"{\"body\": \"they are on to us\", \"sender\": \"pablo\"}"})
-		assert.NoError(t, err)
-		assert.Len(t, value.([]any), 1)
-		assert.Equal(t, map[string]any{"body": "they are on to us", "sender": "pablo"}, value.([]any)[0])
+		{
+			// Invalid json
+			_, err := NewArray(true).Convert([]any{"hello"})
+			assert.ErrorContains(t, err, "invalid character 'h' looking for beginning of value")
+		}
+		{
+			// Invalid data type
+			_, err := NewArray(true).Convert([]any{123})
+			assert.ErrorContains(t, err, "expected string, got int, value '123'")
+		}
+		{
+			// Valid
+			value, err := NewArray(true).Convert([]any{"{\"body\": \"they are on to us\", \"sender\": \"pablo\"}"})
+			assert.NoError(t, err)
+			assert.Len(t, value.([]any), 1)
+			assert.Equal(t, map[string]any{"body": "they are on to us", "sender": "pablo"}, value.([]any)[0])
+		}
 	}
 }


### PR DESCRIPTION
Items in a JSON array should all be strings, if it's not - let's explicitly fail here.