### PR TITLE
[Redshift] Fix TOAST

### DIFF
--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -40,12 +40,12 @@ func (rd RedshiftDialect) BuildIsNotToastValueExpression(tableAlias constants.Ta
 		// If the value is greater than 500 characters, it's likely not going to be toasted, so we can skip the check.
 		return fmt.Sprintf(`
 COALESCE(
-	CASE
-		WHEN JSON_SIZE(%s) < 500 THEN JSON_SERIALIZE(%s) NOT LIKE '%s'
-	ELSE
-		TRUE
-	END,
-	TRUE
+    CASE
+        WHEN JSON_SIZE(%s) < 500 THEN JSON_SERIALIZE(%s) NOT LIKE '%s'
+    ELSE
+        TRUE
+    END,
+    TRUE
 )`, colName, colName, toastedValue)
 	default:
 		return fmt.Sprintf(`COALESCE(%s NOT LIKE '%s', TRUE)`, colName, toastedValue)

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -36,6 +36,8 @@ func (rd RedshiftDialect) BuildIsNotToastValueExpression(tableAlias constants.Ta
 
 	switch column.KindDetails {
 	case typing.Struct, typing.Array:
+		// We need to use JSON_SIZE to check if the column can be serialized into a VARCHAR
+		// If the value is greater than 500 characters, it's likely not going to be toasted, so we can skip the check.
 		return fmt.Sprintf(`
 COALESCE(
 	CASE

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -92,12 +92,12 @@ func TestRedshiftDialect_BuildIsNotToastValueExpression(t *testing.T) {
 		assert.Equal(t,
 			`
 COALESCE(
-	CASE
-		WHEN JSON_SIZE(tbl."foo") < 500 THEN JSON_SERIALIZE(tbl."foo") NOT LIKE '%__debezium_unavailable_value%'
-	ELSE
-		TRUE
-	END,
-	TRUE
+    CASE
+        WHEN JSON_SIZE(tbl."foo") < 500 THEN JSON_SERIALIZE(tbl."foo") NOT LIKE '%__debezium_unavailable_value%'
+    ELSE
+        TRUE
+    END,
+    TRUE
 )`, RedshiftDialect{}.BuildIsNotToastValueExpression("tbl", columns.NewColumn("foo", typing.Struct)),
 		)
 	}
@@ -106,12 +106,12 @@ COALESCE(
 		assert.Equal(t,
 			`
 COALESCE(
-	CASE
-		WHEN JSON_SIZE(tbl."foo") < 500 THEN JSON_SERIALIZE(tbl."foo") NOT LIKE '%__debezium_unavailable_value%'
-	ELSE
-		TRUE
-	END,
-	TRUE
+    CASE
+        WHEN JSON_SIZE(tbl."foo") < 500 THEN JSON_SERIALIZE(tbl."foo") NOT LIKE '%__debezium_unavailable_value%'
+    ELSE
+        TRUE
+    END,
+    TRUE
 )`, RedshiftDialect{}.BuildIsNotToastValueExpression("tbl", columns.NewColumn("foo", typing.Array)),
 		)
 	}

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -90,15 +90,29 @@ func TestRedshiftDialect_BuildIsNotToastValueExpression(t *testing.T) {
 	{
 		// Struct
 		assert.Equal(t,
-			`COALESCE(JSON_SERIALIZE(tbl."foo") NOT LIKE '%__debezium_unavailable_value%', TRUE)`,
-			RedshiftDialect{}.BuildIsNotToastValueExpression("tbl", columns.NewColumn("foo", typing.Struct)),
+			`
+COALESCE(
+	CASE
+		WHEN JSON_SIZE(tbl."foo") < 500 THEN JSON_SERIALIZE(tbl."foo") NOT LIKE '%__debezium_unavailable_value%'
+	ELSE
+		TRUE
+	END,
+	TRUE
+)`, RedshiftDialect{}.BuildIsNotToastValueExpression("tbl", columns.NewColumn("foo", typing.Struct)),
 		)
 	}
 	{
 		// Array
 		assert.Equal(t,
-			`COALESCE(JSON_SERIALIZE(tbl."foo") NOT LIKE '%__debezium_unavailable_value%', TRUE)`,
-			RedshiftDialect{}.BuildIsNotToastValueExpression("tbl", columns.NewColumn("foo", typing.Array)),
+			`
+COALESCE(
+	CASE
+		WHEN JSON_SIZE(tbl."foo") < 500 THEN JSON_SERIALIZE(tbl."foo") NOT LIKE '%__debezium_unavailable_value%'
+	ELSE
+		TRUE
+	END,
+	TRUE
+)`, RedshiftDialect{}.BuildIsNotToastValueExpression("tbl", columns.NewColumn("foo", typing.Array)),
 		)
 	}
 	{

--- a/lib/sql/tests/columns_test.go
+++ b/lib/sql/tests/columns_test.go
@@ -155,9 +155,17 @@ func TestBuildColumnsUpdateFragment_Redshift(t *testing.T) {
 			expectedString: `"foo"=stg."foo","bar"=stg."bar"`,
 		},
 		{
-			name:           "struct, string and toast string",
-			columns:        lastCaseColTypes,
-			expectedString: `"a1"= CASE WHEN COALESCE(JSON_SERIALIZE(stg."a1") NOT LIKE '%__debezium_unavailable_value%', TRUE) THEN stg."a1" ELSE tgt."a1" END,"b2"= CASE WHEN COALESCE(stg."b2" NOT LIKE '%__debezium_unavailable_value%', TRUE) THEN stg."b2" ELSE tgt."b2" END,"c3"=stg."c3"`,
+			name:    "struct, string and toast string",
+			columns: lastCaseColTypes,
+			expectedString: `"a1"= CASE WHEN 
+COALESCE(
+	CASE
+		WHEN JSON_SIZE(stg."a1") < 500 THEN JSON_SERIALIZE(stg."a1") NOT LIKE '%__debezium_unavailable_value%'
+	ELSE
+		TRUE
+	END,
+	TRUE
+) THEN stg."a1" ELSE tgt."a1" END,"b2"= CASE WHEN COALESCE(stg."b2" NOT LIKE '%__debezium_unavailable_value%', TRUE) THEN stg."b2" ELSE tgt."b2" END,"c3"=stg."c3"`,
 		},
 	}
 

--- a/lib/sql/tests/columns_test.go
+++ b/lib/sql/tests/columns_test.go
@@ -159,12 +159,12 @@ func TestBuildColumnsUpdateFragment_Redshift(t *testing.T) {
 			columns: lastCaseColTypes,
 			expectedString: `"a1"= CASE WHEN 
 COALESCE(
-	CASE
-		WHEN JSON_SIZE(stg."a1") < 500 THEN JSON_SERIALIZE(stg."a1") NOT LIKE '%__debezium_unavailable_value%'
-	ELSE
-		TRUE
-	END,
-	TRUE
+    CASE
+        WHEN JSON_SIZE(stg."a1") < 500 THEN JSON_SERIALIZE(stg."a1") NOT LIKE '%__debezium_unavailable_value%'
+    ELSE
+        TRUE
+    END,
+    TRUE
 ) THEN stg."a1" ELSE tgt."a1" END,"b2"= CASE WHEN COALESCE(stg."b2" NOT LIKE '%__debezium_unavailable_value%', TRUE) THEN stg."b2" ELSE tgt."b2" END,"c3"=stg."c3"`,
 		},
 	}


### PR DESCRIPTION
Accounting for the fact that we may not be able to run `JSON_SERIALIZE` on a SUPER data type if the resulting value will exceed the DDL limit for a VARCHAR column. 