### PR TITLE
[BigQuery] Additional guardrails

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -1,19 +1,20 @@
 package bigquery
 
 import (
-	"cloud.google.com/go/bigquery"
-	"cloud.google.com/go/bigquery/storage/managedwriter"
-	"cloud.google.com/go/bigquery/storage/managedwriter/adapt"
 	"context"
 	"fmt"
-	_ "github.com/viant/bigquery"
-	"google.golang.org/api/option"
-	"google.golang.org/protobuf/proto"
 	"log/slog"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/bigquery/storage/managedwriter"
+	"cloud.google.com/go/bigquery/storage/managedwriter/adapt"
+	_ "github.com/viant/bigquery"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/artie-labs/transfer/clients/bigquery/dialect"
 	"github.com/artie-labs/transfer/clients/shared"
@@ -102,13 +103,13 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 	}
 
 	if s.auditRows {
-		return s.auditStagingTable(bqTempTableID, tableData)
+		return s.auditStagingTable(ctx, bqTempTableID, tableData)
 	}
 
 	return nil
 }
 
-func (s *Store) auditStagingTable(bqTempTableID dialect.TableIdentifier, tableData *optimization.TableData) error {
+func (s *Store) auditStagingTable(ctx context.Context, bqTempTableID dialect.TableIdentifier, tableData *optimization.TableData) error {
 	var stagingTableRowsCount uint64
 	expectedRowCount := uint64(len(tableData.Rows()))
 	// The streaming metadata does not appear right away, we'll wait up to 5s for it to appear.
@@ -116,7 +117,7 @@ func (s *Store) auditStagingTable(bqTempTableID dialect.TableIdentifier, tableDa
 		time.Sleep(500 * time.Millisecond)
 		resp, err := s.bqClient.Dataset(bqTempTableID.Dataset()).Table(bqTempTableID.Table()).Metadata(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to get %q metadata: %w", tempTableID.FullyQualifiedName(), err)
+			return fmt.Errorf("failed to get %q metadata: %w", bqTempTableID.FullyQualifiedName(), err)
 		}
 
 		if stagingTableRowsCount == 0 {

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -34,7 +34,7 @@ import (
 const (
 	GooglePathToCredentialsEnvKey = "GOOGLE_APPLICATION_CREDENTIALS"
 	// Storage Write API is limited to 10 MiB, subtract 400 KiB to account for request overhead.
-	maxRequestByteSize = (1 * 1024 * 1024) - (400 * 1024)
+	maxRequestByteSize = (10 * 1024 * 1024) - (400 * 1024)
 )
 
 type Store struct {
@@ -215,10 +215,7 @@ func (s *Store) putTable(ctx context.Context, bqTableID dialect.TableIdentifier,
 		return bytes, nil
 	}
 
-	var count int
 	return batch.BySize(tableData.Rows(), maxRequestByteSize, false, encoder, func(chunk [][]byte) error {
-		count += 1
-		fmt.Println(fmt.Sprintf("Count %d", count))
 		result, err := managedStream.AppendRows(ctx, chunk)
 		if err != nil {
 			return fmt.Errorf("failed to append rows: %w", err)

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -192,6 +192,10 @@ func (s *Store) putTable(ctx context.Context, bqTableID dialect.TableIdentifier,
 			return fmt.Errorf("failed to append rows: %s", status.String())
 		}
 
+		if rowErrs := resp.GetRowErrors(); len(rowErrs) > 0 {
+			return fmt.Errorf("failed to append rows, encountered %d errors", len(rowErrs))
+		}
+
 		return nil
 	})
 }

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -99,7 +99,6 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 		return fmt.Errorf("failed to put table: %w", err)
 	}
 
-	// Check if debug mode is on
 	if s.auditRows {
 		var tblRowCount int64
 		if err = s.QueryRow(`SELECT COUNT(*) FROM %s`, tempTableID.FullyQualifiedName()).Scan(&tblRowCount); err != nil {

--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -18,6 +18,7 @@ const (
 type Store interface {
 	Exec(query string, args ...any) (sql.Result, error)
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryRow(query string, args ...any) *sql.Row
 	Query(query string, args ...any) (*sql.Rows, error)
 	Begin() (*sql.Tx, error)
 	IsRetryableError(err error) bool
@@ -69,6 +70,10 @@ func (s *storeWrapper) Exec(query string, args ...any) (sql.Result, error) {
 		}
 	}
 	return result, err
+}
+
+func (s *storeWrapper) QueryRow(query string, args ...any) *sql.Row {
+	return s.DB.QueryRow(query, args...)
 }
 
 func (s *storeWrapper) Query(query string, args ...any) (*sql.Rows, error) {

--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -18,7 +18,6 @@ const (
 type Store interface {
 	Exec(query string, args ...any) (sql.Result, error)
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
-	QueryRow(query string, args ...any) *sql.Row
 	Query(query string, args ...any) (*sql.Rows, error)
 	Begin() (*sql.Tx, error)
 	IsRetryableError(err error) bool
@@ -70,10 +69,6 @@ func (s *storeWrapper) Exec(query string, args ...any) (sql.Result, error) {
 		}
 	}
 	return result, err
-}
-
-func (s *storeWrapper) QueryRow(query string, args ...any) *sql.Row {
-	return s.DB.QueryRow(query, args...)
 }
 
 func (s *storeWrapper) Query(query string, args ...any) (*sql.Rows, error) {


### PR DESCRIPTION
If `BQ_AUDIT_ROWS` is enabled, we will perform an additional check to make sure the staging table has more rows than the number of rows in our in-memory database.