### PR TITLE
Small BQ audit optimization

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -111,7 +111,7 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 
 func (s *Store) auditStagingTable(ctx context.Context, bqTempTableID dialect.TableIdentifier, tableData *optimization.TableData) error {
 	var stagingTableRowsCount uint64
-	expectedRowCount := uint64(len(tableData.Rows()))
+	expectedRowCount := uint64(tableData.NumberOfRows())
 	// The streaming metadata does not appear right away, we'll wait up to 5s for it to appear.
 	for i := 0; i < 10; i++ {
 		time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
Instead of calling `.Rows()` which will iterate over the in-memory database and append rows for which we just call `len()` on, we can call `NumberOfRows` which will return us the number of rows and skip the intermediary object.

Code ref: https://github.com/artie-labs/transfer/blob/91fa45294ebcd918eaa14e95fd76eace7c0db653/lib/optimization/table_data.go#L168-L193