### PR TITLE
Remove any double quotes from the string in `SnowflakeDialect.QuoteIdentifier()`

### DIFF
--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -14,7 +14,7 @@ import (
 type SnowflakeDialect struct{}
 
 func (SnowflakeDialect) QuoteIdentifier(identifier string) string {
-	return fmt.Sprintf(`"%s"`, strings.ToUpper(identifier))
+	return fmt.Sprintf(`"%s"`, strings.ToUpper(strings.ReplaceAll(identifier, `"`, ``)))
 }
 
 func (SnowflakeDialect) EscapeStruct(value string) string {

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -16,6 +16,7 @@ func TestSnowflakeDialect_QuoteIdentifier(t *testing.T) {
 	dialect := SnowflakeDialect{}
 	assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("foo"))
 	assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("FOO"))
+	assert.Equal(t, `"FOO; BAD"`, dialect.QuoteIdentifier(`FOO"; BAD`))
 }
 
 func TestSnowflakeDialect_IsTableDoesNotExistErr(t *testing.T) {


### PR DESCRIPTION
To prevent sql injection so this is safe to be used on user-supplied values.