### PR TITLE
Remove quotes when quoting identifiers for remaining dialects

### DIFF
--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -25,7 +25,7 @@ type BigQueryDialect struct{}
 
 func (BigQueryDialect) QuoteIdentifier(identifier string) string {
 	// BigQuery needs backticks to quote.
-	return fmt.Sprintf("`%s`", identifier)
+	return fmt.Sprintf("`%s`", strings.ReplaceAll(identifier, "`", ""))
 }
 
 func (BigQueryDialect) EscapeStruct(value string) string {

--- a/clients/bigquery/dialect/dialect_test.go
+++ b/clients/bigquery/dialect/dialect_test.go
@@ -17,6 +17,7 @@ func TestBigQueryDialect_QuoteIdentifier(t *testing.T) {
 	dialect := BigQueryDialect{}
 	assert.Equal(t, "`foo`", dialect.QuoteIdentifier("foo"))
 	assert.Equal(t, "`FOO`", dialect.QuoteIdentifier("FOO"))
+	assert.Equal(t, "`FOO; BAD`", dialect.QuoteIdentifier("FOO`; BAD"))
 }
 
 func TestBigQueryDialect_IsColumnAlreadyExistsErr(t *testing.T) {

--- a/clients/databricks/dialect/dialect.go
+++ b/clients/databricks/dialect/dialect.go
@@ -15,7 +15,7 @@ import (
 type DatabricksDialect struct{}
 
 func (DatabricksDialect) QuoteIdentifier(identifier string) string {
-	return fmt.Sprintf("`%s`", identifier)
+	return fmt.Sprintf("`%s`", strings.ReplaceAll(identifier, "`", ""))
 }
 
 func (DatabricksDialect) EscapeStruct(value string) string {

--- a/clients/databricks/dialect/dialect_test.go
+++ b/clients/databricks/dialect/dialect_test.go
@@ -18,6 +18,7 @@ func TestDatabricksDialect_QuoteIdentifier(t *testing.T) {
 	dialect := DatabricksDialect{}
 	assert.Equal(t, "`foo`", dialect.QuoteIdentifier("foo"))
 	assert.Equal(t, "`FOO`", dialect.QuoteIdentifier("FOO"))
+	assert.Equal(t, "`FOO; BAD`", dialect.QuoteIdentifier("FOO`; BAD"))
 }
 
 func TestDatabricksDialect_IsColumnAlreadyExistsErr(t *testing.T) {

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -15,7 +15,7 @@ import (
 type MSSQLDialect struct{}
 
 func (MSSQLDialect) QuoteIdentifier(identifier string) string {
-	return fmt.Sprintf(`"%s"`, identifier)
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(identifier, `"`, ``))
 }
 
 func (MSSQLDialect) EscapeStruct(value string) string {

--- a/clients/mssql/dialect/dialect_test.go
+++ b/clients/mssql/dialect/dialect_test.go
@@ -15,6 +15,7 @@ func TestMSSQLDialect_QuoteIdentifier(t *testing.T) {
 	dialect := MSSQLDialect{}
 	assert.Equal(t, `"foo"`, dialect.QuoteIdentifier("foo"))
 	assert.Equal(t, `"FOO"`, dialect.QuoteIdentifier("FOO"))
+	assert.Equal(t, `"FOO; BAD"`, dialect.QuoteIdentifier(`FOO"; BAD`))
 }
 
 func TestMSSQLDialect_IsColumnAlreadyExistsErr(t *testing.T) {

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -14,7 +14,7 @@ type RedshiftDialect struct{}
 
 func (rd RedshiftDialect) QuoteIdentifier(identifier string) string {
 	// Preserve the existing behavior of Redshift identifiers being lowercased due to not being quoted.
-	return fmt.Sprintf(`"%s"`, strings.ToLower(identifier))
+	return fmt.Sprintf(`"%s"`, strings.ToLower(strings.ReplaceAll(identifier, `"`, ``)))
 }
 
 func (RedshiftDialect) EscapeStruct(value string) string {

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -16,6 +16,7 @@ func TestRedshiftDialect_QuoteIdentifier(t *testing.T) {
 	dialect := RedshiftDialect{}
 	assert.Equal(t, `"foo"`, dialect.QuoteIdentifier("foo"))
 	assert.Equal(t, `"foo"`, dialect.QuoteIdentifier("FOO"))
+	assert.Equal(t, `"foo; bad"`, dialect.QuoteIdentifier(`FOO"; BAD`))
 }
 
 func TestRedshiftDialect_IsColumnAlreadyExistsErr(t *testing.T) {


### PR DESCRIPTION
Same as https://github.com/artie-labs/transfer/pull/1103, for the rest of the dialects.