### PR TITLE
Improve MongoDB datetime / timestamp parser

### DIFF
--- a/lib/typing/mongo/bson.go
+++ b/lib/typing/mongo/bson.go
@@ -87,9 +87,19 @@ func bsonBinaryValueToMap(value primitive.Binary) (any, error) {
 func bsonValueToGoValue(value any) (any, error) {
 	switch v := value.(type) {
 	case primitive.DateTime:
-		return v.Time().UTC(), nil
+		dt := v.Time().UTC()
+		if dt.Year() > 9999 {
+			return nil, nil
+		}
+
+		return dt, nil
 	case primitive.Timestamp:
-		return time.Unix(int64(v.T), 0).UTC(), nil
+		ts := time.Unix(int64(v.T), 0).UTC()
+		if ts.Year() > 9999 {
+			return nil, nil
+		}
+
+		return ts, nil
 	case primitive.ObjectID:
 		return v.Hex(), nil
 	case primitive.Binary:

--- a/lib/typing/mongo/bson_test.go
+++ b/lib/typing/mongo/bson_test.go
@@ -214,15 +214,37 @@ func TestBsonDocToMap(t *testing.T) {
 func TestBsonValueToGoValue(t *testing.T) {
 	{
 		// primitive.DateTime
-		_time := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
-		dateTime := primitive.NewDateTimeFromTime(_time)
-		result, err := bsonValueToGoValue(dateTime)
-		assert.NoError(t, err)
+		{
+			// Valid
+			_time := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+			dateTime := primitive.NewDateTimeFromTime(_time)
+			result, err := bsonValueToGoValue(dateTime)
+			assert.NoError(t, err)
 
-		ts, isOk := result.(time.Time)
-		assert.True(t, isOk)
-		assert.Equal(t, time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC), ts)
-		assert.Equal(t, "2021-01-01T00:00:00Z", ts.Format(time.RFC3339Nano))
+			ts, isOk := result.(time.Time)
+			assert.True(t, isOk)
+			assert.Equal(t, time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC), ts)
+			assert.Equal(t, "2021-01-01T00:00:00Z", ts.Format(time.RFC3339Nano))
+		}
+		{
+			// Invalid (year is above 9999)
+			_time := time.Date(27017, 1, 1, 0, 0, 0, 0, time.UTC)
+			dateTime := primitive.NewDateTimeFromTime(_time)
+			result, err := bsonValueToGoValue(dateTime)
+			assert.NoError(t, err)
+			assert.Nil(t, result)
+		}
+	}
+	{
+		// primitive.Timestamp
+		{
+			// Invalid (year is above 9999)
+			_time := time.Date(27017, 1, 1, 0, 0, 0, 0, time.UTC)
+			dateTime := primitive.NewDateTimeFromTime(_time)
+			result, err := bsonValueToGoValue(dateTime)
+			assert.NoError(t, err)
+			assert.Nil(t, result)
+		}
 	}
 	{
 		// primitive.ObjectID


### PR DESCRIPTION
Making our MongoDB parser more resilient to invalid years