### PR TITLE
Extending merge to inform whether we should commit tx or not

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -15,23 +15,23 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
-func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
+func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (bool, error) {
 	var additionalEqualityStrings []string
 	if tableData.TopicConfig().BigQueryPartitionSettings != nil {
 		distinctDates, err := buildDistinctDates(tableData.TopicConfig().BigQueryPartitionSettings.PartitionField, tableData.Rows())
 		if err != nil {
-			return fmt.Errorf("failed to generate distinct dates: %w", err)
+			return false, fmt.Errorf("failed to generate distinct dates: %w", err)
 		}
 
 		mergeString, err := generateMergeString(tableData.TopicConfig().BigQueryPartitionSettings, s.Dialect(), distinctDates)
 		if err != nil {
-			return fmt.Errorf("failed to generate merge string: %w", err)
+			return false, fmt.Errorf("failed to generate merge string: %w", err)
 		}
 
 		additionalEqualityStrings = []string{mergeString}
 	}
 
-	return shared.Merge(ctx, s, tableData, types.MergeOpts{
+	err := shared.Merge(ctx, s, tableData, types.MergeOpts{
 		AdditionalEqualityStrings: additionalEqualityStrings,
 		ColumnSettings:            s.config.SharedDestinationSettings.ColumnSettings,
 		// BigQuery has DDL quotas.
@@ -39,6 +39,11 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) er
 		// We are using BigQuery's streaming API which doesn't guarantee exactly once semantics
 		SubQueryDedupe: true,
 	})
+	if err != nil {
+		return false, fmt.Errorf("failed to merge: %w", err)
+	}
+
+	return true, nil
 }
 
 func generateMergeString(bqSettings *partition.BigQuerySettings, dialect sql.Dialect, values []string) (string, error) {

--- a/clients/databricks/store.go
+++ b/clients/databricks/store.go
@@ -36,8 +36,12 @@ func (s Store) DropTable(_ context.Context, _ sql.TableIdentifier) error {
 	return fmt.Errorf("not supported")
 }
 
-func (s Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
-	return shared.Merge(ctx, s, tableData, types.MergeOpts{})
+func (s Store) Merge(ctx context.Context, tableData *optimization.TableData) (bool, error) {
+	if err := shared.Merge(ctx, s, tableData, types.MergeOpts{}); err != nil {
+		return false, fmt.Errorf("failed to merge: %w", err)
+	}
+
+	return true, nil
 }
 
 func (s Store) Append(ctx context.Context, tableData *optimization.TableData, useTempTable bool) error {

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -44,8 +44,12 @@ func (s *Store) dialect() dialect.MSSQLDialect {
 	return dialect.MSSQLDialect{}
 }
 
-func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
-	return shared.Merge(ctx, s, tableData, types.MergeOpts{})
+func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (bool, error) {
+	if err := shared.Merge(ctx, s, tableData, types.MergeOpts{}); err != nil {
+		return false, fmt.Errorf("failed to merge: %w", err)
+	}
+
+	return true, nil
 }
 
 func (s *Store) Append(ctx context.Context, tableData *optimization.TableData, _ bool) error {

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -102,7 +102,10 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 
 	s.stageStore.configMap.AddTableToConfig(s.identifierFor(tableData), types.NewDwhTableConfig(anotherCols, true))
 
-	assert.NoError(s.T(), s.stageStore.Merge(context.Background(), tableData))
+	commitTx, err := s.stageStore.Merge(context.Background(), tableData)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), commitTx)
+
 	_col, isOk := tableData.ReadOnlyInMemoryCols().GetColumn("first_name")
 	assert.True(s.T(), isOk)
 	assert.Equal(s.T(), _col.KindDetails, typing.String)
@@ -146,7 +149,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 	}
 
 	s.stageStore.configMap.AddTableToConfig(s.identifierFor(tableData), types.NewDwhTableConfig(cols.GetColumns(), true))
-	assert.NoError(s.T(), s.stageStore.Merge(context.Background(), tableData))
+	commitTx, err := s.stageStore.Merge(context.Background(), tableData)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), commitTx)
 	assert.Equal(s.T(), 4, s.fakeStageStore.ExecCallCount())
 	assert.Equal(s.T(), 1, s.fakeStageStore.ExecContextCallCount())
 }
@@ -193,8 +198,9 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 	tableID := s.identifierFor(tableData)
 	fqName := tableID.FullyQualifiedName()
 	s.stageStore.configMap.AddTableToConfig(tableID, types.NewDwhTableConfig(cols.GetColumns(), true))
-	err := s.stageStore.Merge(context.Background(), tableData)
-	assert.Nil(s.T(), err)
+	commitTx, err := s.stageStore.Merge(context.Background(), tableData)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), commitTx)
 	s.fakeStageStore.ExecReturns(nil, nil)
 	// CREATE TABLE IF NOT EXISTS customer.public.orders___artie_Mwv9YADmRy (id int,name string,__artie_delete boolean,created_at timestamp_tz) STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE) COMMENT='expires:2023-06-27 11:54:03 UTC'
 	_, createQuery, _ := s.fakeStageStore.ExecContextArgsForCall(0)
@@ -278,7 +284,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	_config := types.NewDwhTableConfig(sflkCols.GetColumns(), true)
 	s.stageStore.configMap.AddTableToConfig(s.identifierFor(tableData), _config)
 
-	assert.NoError(s.T(), s.stageStore.Merge(context.Background(), tableData))
+	commitTx, err := s.stageStore.Merge(context.Background(), tableData)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), commitTx)
 	s.fakeStageStore.ExecReturns(nil, nil)
 	assert.Equal(s.T(), 4, s.fakeStageStore.ExecCallCount())
 	assert.Equal(s.T(), 1, s.fakeStageStore.ExecContextCallCount())
@@ -302,7 +310,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 		break
 	}
 
-	assert.NoError(s.T(), s.stageStore.Merge(context.Background(), tableData))
+	commitTx, err = s.stageStore.Merge(context.Background(), tableData)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), commitTx)
 	s.fakeStageStore.ExecReturns(nil, nil)
 	assert.Equal(s.T(), 8, s.fakeStageStore.ExecCallCount())
 	assert.Equal(s.T(), 2, s.fakeStageStore.ExecContextCallCount())
@@ -313,7 +323,9 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 func (s *SnowflakeTestSuite) TestExecuteMergeExitEarly() {
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{}, "foo")
-	assert.NoError(s.T(), s.stageStore.Merge(context.Background(), tableData))
+	commitTx, err := s.stageStore.Merge(context.Background(), tableData)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), commitTx)
 }
 
 func (s *SnowflakeTestSuite) TestStore_AdditionalEqualityStrings() {

--- a/clients/snowflake/writes.go
+++ b/clients/snowflake/writes.go
@@ -2,6 +2,7 @@ package snowflake
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/artie-labs/transfer/clients/shared"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -27,8 +28,14 @@ func (s *Store) additionalEqualityStrings(tableData *optimization.TableData) []s
 	return sql.BuildColumnComparisons(cols, constants.TargetAlias, constants.StagingAlias, sql.Equal, s.Dialect())
 }
 
-func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) error {
-	return shared.Merge(ctx, s, tableData, types.MergeOpts{
+func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (bool, error) {
+	err := shared.Merge(ctx, s, tableData, types.MergeOpts{
 		AdditionalEqualityStrings: s.additionalEqualityStrings(tableData),
 	})
+
+	if err != nil {
+		return false, fmt.Errorf("failed to merge: %w", err)
+	}
+
+	return true, nil
 }

--- a/lib/destination/dwh.go
+++ b/lib/destination/dwh.go
@@ -33,7 +33,7 @@ type DataWarehouse interface {
 }
 
 type Baseline interface {
-	Merge(ctx context.Context, tableData *optimization.TableData) error
+	Merge(ctx context.Context, tableData *optimization.TableData) (commitTransaction bool, err error)
 	Append(ctx context.Context, tableData *optimization.TableData, useTempTable bool) error
 	IsRetryableError(err error) bool
 	IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sqllib.TableIdentifier

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -89,14 +89,11 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 			}
 
 			what, err := retry.WithRetriesAndResult(retryCfg, func(_ int, _ error) (string, error) {
-				return flush(ctx, dest, _tableData)
+				return flush(ctx, dest, _tableData, tableName, action, inMemDB.ClearTableConfig)
 			})
 
 			if err != nil {
 				slog.Error(fmt.Sprintf("Failed to %s", action), slog.Any("err", err), slog.String("tableName", _tableName))
-			} else {
-				slog.Info(fmt.Sprintf("%s success, clearing memory...", stringutil.CapitalizeFirstLetter(action)), slog.String("tableName", _tableName))
-				inMemDB.ClearTableConfig(_tableName)
 			}
 
 			tags["what"] = what
@@ -108,24 +105,32 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 	return nil
 }
 
-func flush(ctx context.Context, dest destination.Baseline, _tableData *models.TableData) (string, error) {
+func flush(ctx context.Context, dest destination.Baseline, _tableData *models.TableData, _tableName string, action string, clearTableConfig func(string)) (string, error) {
 	// This is added so that we have a new temporary table suffix for each merge / append.
 	_tableData.ResetTempTableSuffix()
 
 	// Merge or Append depending on the mode.
 	var err error
+	commitTransaction := true
 	if _tableData.Mode() == config.History {
 		err = dest.Append(ctx, _tableData.TableData, false)
 	} else {
-		_, err = dest.Merge(ctx, _tableData.TableData)
+		commitTransaction, err = dest.Merge(ctx, _tableData.TableData)
 	}
 
 	if err != nil {
 		return "merge_fail", fmt.Errorf("failed to flush: %w", err)
 	}
 
-	if err = commitOffset(ctx, _tableData.TopicConfig().Topic, _tableData.PartitionsToLastMessage); err != nil {
-		return "commit_fail", fmt.Errorf("failed to commit kafka offset: %w", err)
+	if commitTransaction {
+		if err = commitOffset(ctx, _tableData.TopicConfig().Topic, _tableData.PartitionsToLastMessage); err != nil {
+			return "commit_fail", fmt.Errorf("failed to commit kafka offset: %w", err)
+		}
+
+		slog.Info(fmt.Sprintf("%s success, clearing memory...", stringutil.CapitalizeFirstLetter(action)), slog.String("tableName", _tableName))
+		clearTableConfig(_tableName)
+	} else {
+		slog.Info(fmt.Sprintf("%s success, not committing offset yet", stringutil.CapitalizeFirstLetter(action)), slog.String("tableName", _tableName))
 	}
 
 	return "success", nil

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -117,7 +117,7 @@ func flush(ctx context.Context, dest destination.Baseline, _tableData *models.Ta
 	if _tableData.Mode() == config.History {
 		err = dest.Append(ctx, _tableData.TableData, false)
 	} else {
-		err = dest.Merge(ctx, _tableData.TableData)
+		_, err = dest.Merge(ctx, _tableData.TableData)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR does 2 things.

1. Changes the signature of merge by adding a flag on whether we should commit the transaction or not
2. Commit the transaction based on ^

Committing the transaction means that we'll commit our Kafka offset and clear our in-memory data.

