### PR TITLE
Refactor Event Primary Keys

### DIFF
--- a/models/event/event.go
+++ b/models/event/event.go
@@ -156,6 +156,9 @@ func (e *Event) Validate() error {
 	return nil
 }
 
+// GetPrimaryKeys is returned in a sorted manner to be safe.
+// We use PrimaryKeyValue() as our internal identifier within our db
+// It is critical to make sure `PrimaryKeyValue()` is a deterministic call.
 func (e *Event) GetPrimaryKeys() []string {
 	slices.Sort(e.primaryKeys)
 	return e.primaryKeys

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -23,17 +23,23 @@ import (
 )
 
 type Event struct {
-	Table         string
-	PrimaryKeyMap map[string]any
-	Data          map[string]any // json serialized column data
+	Table string
+	Data  map[string]any // json serialized column data
 
 	OptionalSchema map[string]typing.KindDetails
 	Columns        *columns.Columns
 	Deleted        bool
 
+	// private metadata:
+	primaryKeys []string
+
 	// When the database event was executed
 	executionTime time.Time
 	mode          config.Mode
+}
+
+func (e *Event) SetPrimaryKeysForTest(primaryKeys []string) {
+	e.primaryKeys = primaryKeys
 }
 
 func hashData(data map[string]any, tc kafkalib.TopicConfig) map[string]any {
@@ -92,11 +98,17 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc kafkalib.TopicConfi
 		return Event{}, err
 	}
 
+	var primaryKeys []string
+	for key := range pkMap {
+		primaryKeys = append(primaryKeys, key)
+	}
+
 	_event := Event{
-		executionTime:  event.GetExecutionTime(),
-		mode:           cfgMode,
+		executionTime: event.GetExecutionTime(),
+		mode:          cfgMode,
+		primaryKeys:   primaryKeys,
+
 		Table:          tblName,
-		PrimaryKeyMap:  pkMap,
 		OptionalSchema: optionalSchema,
 		Columns:        cols,
 		Data:           hashData(evtData, tc),
@@ -123,8 +135,8 @@ func (e *Event) Validate() error {
 		return fmt.Errorf("table name is empty")
 	}
 
-	if len(e.PrimaryKeyMap) == 0 {
-		return fmt.Errorf("primary key map is empty")
+	if len(e.primaryKeys) == 0 {
+		return fmt.Errorf("primary keys are empty")
 	}
 
 	if len(e.Data) == 0 {
@@ -144,24 +156,16 @@ func (e *Event) Validate() error {
 	return nil
 }
 
-// PrimaryKeys is returned in a sorted manner to be safe.
-// We use PrimaryKeyValue() as our internal identifier within our db
-// It is critical to make sure `PrimaryKeyValue()` is a deterministic call.
-func (e *Event) PrimaryKeys() []string {
-	var keys []string
-	for key := range e.PrimaryKeyMap {
-		keys = append(keys, key)
-	}
-
-	slices.Sort(keys)
-	return keys
+func (e *Event) GetPrimaryKeys() []string {
+	slices.Sort(e.primaryKeys)
+	return e.primaryKeys
 }
 
 // PrimaryKeyValue - as per above, this needs to return a deterministic k/v string.
 func (e *Event) PrimaryKeyValue() string {
 	var key string
-	for _, pk := range e.PrimaryKeys() {
-		key += fmt.Sprintf("%s=%v", pk, e.PrimaryKeyMap[pk])
+	for _, pk := range e.GetPrimaryKeys() {
+		key += fmt.Sprintf("%s=%v", pk, e.Data[pk])
 	}
 
 	return key
@@ -184,7 +188,7 @@ func (e *Event) Save(cfg config.Config, inMemDB *models.DatabaseData, tc kafkali
 			cols = e.Columns
 		}
 
-		td.SetTableData(optimization.NewTableData(cols, cfg.Mode, e.PrimaryKeys(), tc, e.Table))
+		td.SetTableData(optimization.NewTableData(cols, cfg.Mode, e.GetPrimaryKeys(), tc, e.Table))
 	} else {
 		if e.Columns != nil {
 			// Iterate over this again just in case.

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -38,10 +38,6 @@ type Event struct {
 	mode          config.Mode
 }
 
-func (e *Event) SetPrimaryKeysForTest(primaryKeys []string) {
-	e.primaryKeys = primaryKeys
-}
-
 func hashData(data map[string]any, tc kafkalib.TopicConfig) map[string]any {
 	for _, columnToHash := range tc.ColumnsToHash {
 		if value, isOk := data[columnToHash]; isOk {

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -29,11 +29,10 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	anotherLowerCol := "dusty__the__mini__aussie"
 
 	event := Event{
-		Table: "foo",
-		PrimaryKeyMap: map[string]any{
-			"id": "123",
-		},
+		Table:       "foo",
+		primaryKeys: []string{"id"},
 		Data: map[string]any{
+			"id":                                "123",
 			constants.DeleteColumnMarker:        true,
 			constants.OnlySetDeleteColumnMarker: true,
 			expectedCol:                         "dusty",
@@ -61,11 +60,10 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	assert.Equal(e.T(), 2, found, optimization.ReadOnlyInMemoryCols)
 	badColumn := "other"
 	edgeCaseEvent := Event{
-		Table: "foo",
-		PrimaryKeyMap: map[string]any{
-			"id": "12344",
-		},
+		Table:       "foo",
+		primaryKeys: []string{"id"},
 		Data: map[string]any{
+			"id":                                "12344",
 			constants.DeleteColumnMarker:        true,
 			constants.OnlySetDeleteColumnMarker: true,
 			expectedCol:                         "dusty",
@@ -86,10 +84,8 @@ func (e *EventsTestSuite) TestSaveEvent() {
 
 func (e *EventsTestSuite) TestEvent_SaveCasing() {
 	event := Event{
-		Table: "foo",
-		PrimaryKeyMap: map[string]any{
-			"id": "123",
-		},
+		Table:       "foo",
+		primaryKeys: []string{"id"},
 		Data: map[string]any{
 			"id":                                "123",
 			constants.DeleteColumnMarker:        true,
@@ -120,11 +116,10 @@ func (e *EventsTestSuite) TestEvent_SaveCasing() {
 
 func (e *EventsTestSuite) TestEventSaveOptionalSchema() {
 	event := Event{
-		Table: "foo",
-		PrimaryKeyMap: map[string]any{
-			"id": "123",
-		},
+		Table:       "foo",
+		primaryKeys: []string{"id"},
 		Data: map[string]any{
+			"id":                                "123",
 			constants.DeleteColumnMarker:        true,
 			constants.OnlySetDeleteColumnMarker: true,
 			"randomCol":                         "dusty",
@@ -185,9 +180,7 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 			constants.DeleteColumnMarker:        true,
 			constants.OnlySetDeleteColumnMarker: true,
 		},
-		PrimaryKeyMap: map[string]any{
-			"col_1": "123",
-		},
+		primaryKeys: []string{"col_1"},
 	}
 
 	kafkaMsg := kafka.Message{}
@@ -236,12 +229,11 @@ func (e *EventsTestSuite) TestEventSaveColumns() {
 	cols.AddColumn(columns.NewColumn("anotherCOL", typing.Invalid))
 	cols.AddColumn(columns.NewColumn("created_at_date_string", typing.Invalid))
 	event := Event{
-		Table:   "foo",
-		Columns: &cols,
-		PrimaryKeyMap: map[string]any{
-			"id": "123",
-		},
+		Table:       "foo",
+		Columns:     &cols,
+		primaryKeys: []string{"id"},
 		Data: map[string]any{
+			"id":                                "123",
 			constants.DeleteColumnMarker:        true,
 			constants.OnlySetDeleteColumnMarker: true,
 			"randomCol":                         "dusty",
@@ -289,11 +281,10 @@ func (e *EventsTestSuite) TestEventSaveColumns() {
 
 func (e *EventsTestSuite) TestEventSaveTestDeleteFlag() {
 	event := Event{
-		Table: "foo",
-		PrimaryKeyMap: map[string]any{
-			"id": "123",
-		},
+		Table:       "foo",
+		primaryKeys: []string{"id"},
 		Data: map[string]any{
+			"id":                                "123",
 			constants.DeleteColumnMarker:        true,
 			constants.OnlySetDeleteColumnMarker: true,
 		},

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -201,7 +201,7 @@ func (e *EventsTestSuite) TestPrimaryKeyValueDeterministic() {
 		},
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 50_000; i++ {
 		assert.Equal(e.T(), evt.PrimaryKeyValue(), "aa=1bb=5dusty=mini aussiegg=artiezz=ff")
 	}
 }

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/artie"
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/mocks"
 	"github.com/artie-labs/transfer/lib/telemetry/metrics"
 	"github.com/artie-labs/transfer/models/event"
 )
@@ -23,26 +25,31 @@ var topicConfig = kafkalib.TopicConfig{
 }
 
 func (f *FlushTestSuite) TestMemoryBasic() {
-	for i := 0; i < 5; i++ {
-		evt := event.Event{
-			Table: "foo",
-			Data: map[string]any{
-				"id":                                fmt.Sprintf("pk-%d", i),
-				constants.DeleteColumnMarker:        true,
-				constants.OnlySetDeleteColumnMarker: true,
-				"abc":                               "def",
-				"hi":                                "hello",
-			},
-		}
+	mockEvent := &mocks.FakeEvent{}
+	mockEvent.GetTableNameReturns("foo")
 
-		evt.SetPrimaryKeysForTest([]string{"id"})
+	for i := 0; i < 5; i++ {
+		mockEvent.GetDataReturns(map[string]any{
+			"id":                                fmt.Sprintf("pk-%d", i),
+			constants.DeleteColumnMarker:        true,
+			constants.OnlySetDeleteColumnMarker: true,
+			"abc":                               "def",
+			"hi":                                "hello",
+		}, nil)
+
+		evt, err := event.ToMemoryEvent(mockEvent, map[string]any{"id": fmt.Sprintf("pk-%d", i)}, kafkalib.TopicConfig{}, config.Replication)
+		assert.NoError(f.T(), err)
+
 		kafkaMsg := kafka.Message{Partition: 1, Offset: 1}
-		_, _, err := evt.Save(f.cfg, f.db, topicConfig, artie.NewMessage(&kafkaMsg, kafkaMsg.Topic))
+
+		_, _, err = evt.Save(f.cfg, f.db, topicConfig, artie.NewMessage(&kafkaMsg, kafkaMsg.Topic))
 		assert.Nil(f.T(), err)
 
 		td := f.db.GetOrCreateTableData("foo")
 		assert.Equal(f.T(), int(td.NumberOfRows()), i+1)
 	}
+
+	assert.Equal(f.T(), uint(5), f.db.GetOrCreateTableData("foo").NumberOfRows())
 }
 
 func (f *FlushTestSuite) TestShouldFlush() {
@@ -50,21 +57,20 @@ func (f *FlushTestSuite) TestShouldFlush() {
 	var flushReason string
 
 	for i := 0; i < int(float64(f.cfg.BufferRows)*1.5); i++ {
-		evt := event.Event{
-			Table: "postgres",
-			Data: map[string]any{
-				"id":                                fmt.Sprintf("pk-%d", i),
-				constants.DeleteColumnMarker:        true,
-				constants.OnlySetDeleteColumnMarker: true,
-				"pk":                                fmt.Sprintf("pk-%d", i),
-				"foo":                               "bar",
-				"cat":                               "dog",
-			},
-		}
+		mockEvent := &mocks.FakeEvent{}
+		mockEvent.GetTableNameReturns("postgres")
+		mockEvent.GetDataReturns(map[string]any{
+			"id":                                fmt.Sprintf("pk-%d", i),
+			constants.DeleteColumnMarker:        true,
+			constants.OnlySetDeleteColumnMarker: true,
+			"pk":                                fmt.Sprintf("pk-%d", i),
+			"foo":                               "bar",
+			"cat":                               "dog",
+		}, nil)
 
-		evt.SetPrimaryKeysForTest([]string{"id"})
+		evt, err := event.ToMemoryEvent(mockEvent, map[string]any{"id": fmt.Sprintf("pk-%d", i)}, kafkalib.TopicConfig{}, config.Replication)
+		assert.NoError(f.T(), err)
 
-		var err error
 		kafkaMsg := kafka.Message{Partition: 1, Offset: int64(i)}
 		flush, flushReason, err = evt.Save(f.cfg, f.db, topicConfig, artie.NewMessage(&kafkaMsg, kafkaMsg.Topic))
 		assert.Nil(f.T(), err)
@@ -88,21 +94,22 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 		go func(tableName string) {
 			defer wg.Done()
 			for i := 0; i < 5; i++ {
-				evt := event.Event{
-					Table: tableName,
-					Data: map[string]any{
-						"id":                                fmt.Sprintf("pk-%d", i),
-						constants.DeleteColumnMarker:        true,
-						constants.OnlySetDeleteColumnMarker: true,
-						"pk":                                fmt.Sprintf("pk-%d", i),
-						"foo":                               "bar",
-						"cat":                               "dog",
-					},
-				}
+				mockEvent := &mocks.FakeEvent{}
+				mockEvent.GetTableNameReturns(tableName)
+				mockEvent.GetDataReturns(map[string]any{
+					"id":                                fmt.Sprintf("pk-%d", i),
+					constants.DeleteColumnMarker:        true,
+					constants.OnlySetDeleteColumnMarker: true,
+					"pk":                                fmt.Sprintf("pk-%d", i),
+					"foo":                               "bar",
+					"cat":                               "dog",
+				}, nil)
 
-				evt.SetPrimaryKeysForTest([]string{"id"})
+				evt, err := event.ToMemoryEvent(mockEvent, map[string]any{"id": fmt.Sprintf("pk-%d", i)}, kafkalib.TopicConfig{}, config.Replication)
+				assert.NoError(f.T(), err)
+
 				kafkaMsg := kafka.Message{Partition: 1, Offset: int64(i)}
-				_, _, err := evt.Save(f.cfg, f.db, topicConfig, artie.NewMessage(&kafkaMsg, kafkaMsg.Topic))
+				_, _, err = evt.Save(f.cfg, f.db, topicConfig, artie.NewMessage(&kafkaMsg, kafkaMsg.Topic))
 				assert.Nil(f.T(), err)
 			}
 		}(tableNames[idx])


### PR DESCRIPTION
This PR removes the need for us to store `pkMap`, which is storing both the primary key(s) and their value(s), which is separate from event data.

Instead, we can store just the list of primary keys and defer the primary key values to be whatever is in the event data.