### PR TITLE
Supporting Iceberg - Part 1

### DIFF
--- a/clients/iceberg/dialect/data_types.go
+++ b/clients/iceberg/dialect/data_types.go
@@ -1,0 +1,21 @@
+package dialect
+
+import (
+	"github.com/artie-labs/transfer/lib/config"
+	"github.com/artie-labs/transfer/lib/typing"
+)
+
+func (IcebergDialect) DataTypeForKind(
+	kindDetails typing.KindDetails,
+	// Primary key doesn't matter for Iceberg
+	_ bool,
+	settings config.SharedDestinationColumnSettings,
+) string {
+	// TODO:
+	panic("not implemented")
+}
+
+func (IcebergDialect) KindForDataType(rawType string, _ string) (typing.KindDetails, error) {
+	// TODO:
+	panic("not implemented")
+}

--- a/clients/iceberg/dialect/dialect.go
+++ b/clients/iceberg/dialect/dialect.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/sql"
+	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
 type IcebergDialect struct{}
@@ -15,4 +17,76 @@ func (IcebergDialect) GetDefaultValueStrategy() sql.DefaultValueStrategy {
 
 func (IcebergDialect) QuoteIdentifier(identifier string) string {
 	return fmt.Sprintf("`%s`", strings.ReplaceAll(identifier, "`", ""))
+}
+
+func (IcebergDialect) EscapeStruct(value string) string {
+	return sql.QuoteLiteral(value)
+}
+
+func (IcebergDialect) IsColumnAlreadyExistsErr(err error) bool {
+	// TODO
+	panic("not implemented")
+}
+
+func (IcebergDialect) IsTableDoesNotExistErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.HasPrefix(err.Error(), "[TABLE_OR_VIEW_NOT_FOUND]")
+}
+
+func (id IcebergDialect) BuildIsNotToastValueExpression(tableAlias constants.TableAlias, column columns.Column) string {
+	colName := sql.QuoteTableAliasColumn(tableAlias, column, id)
+	return fmt.Sprintf(`CAST(%s AS STRING) NOT LIKE '%s'`, colName, "%"+constants.ToastUnavailableValuePlaceholder+"%")
+}
+
+func (id IcebergDialect) BuildDedupeTableQuery(tableID sql.TableIdentifier, primaryKeys []string) string {
+	// We don't need this because our loading method does not incur duplicates.
+	panic("not implemented")
+}
+
+func (id IcebergDialect) BuildDedupeQueries(tableID, stagingTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool) []string {
+	// TODO
+	panic("not implemented")
+}
+func (id IcebergDialect) BuildMergeQueries(tableID sql.TableIdentifier, subQuery string, primaryKeys []columns.Column, additionalEqualityStrings []string, cols []columns.Column, softDelete bool, _ bool) ([]string, error) {
+	// TODO
+	panic("not implemented")
+}
+
+// https://spark.apache.org/docs/3.5.3/sql-ref-syntax-ddl-alter-table.html#add-columns
+func (IcebergDialect) BuildAddColumnQuery(tableID sql.TableIdentifier, sqlPart string) string {
+	return fmt.Sprintf("ALTER TABLE %s ADD COLUMNS (%s)", tableID.FullyQualifiedName(), sqlPart)
+}
+
+// https://spark.apache.org/docs/3.5.3/sql-ref-syntax-ddl-alter-table.html#drop-columns
+func (IcebergDialect) BuildDropColumnQuery(tableID sql.TableIdentifier, colName string) string {
+	return fmt.Sprintf("ALTER TABLE %s DROP COLUMNS (%s)", tableID.FullyQualifiedName(), colName)
+}
+
+func (IcebergDialect) BuildDescribeTableQuery(tableID sql.TableIdentifier) (string, []interface{}, error) {
+	return fmt.Sprintf("DESCRIBE TABLE %s", tableID.FullyQualifiedName()), nil, nil
+}
+
+func (IcebergDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, colSQLParts []string) string {
+	// Iceberg does not support temporary tables.
+	// Format version is required: https://iceberg.apache.org/spec/#table-metadata-fields
+	return fmt.Sprintf(
+		"CREATE TABLE IF NOT EXISTS %s (%s) USING iceberg TBLPROPERTIES ('format-version'='2')",
+		// Table name
+		tableID.FullyQualifiedName(),
+		// Column definitions
+		strings.Join(colSQLParts, ", "),
+	)
+}
+
+func (IcebergDialect) BuildDropTableQuery(tableID sql.TableIdentifier) string {
+	return fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName())
+}
+
+func (IcebergDialect) BuildTruncateTableQuery(tableID sql.TableIdentifier) string {
+	// Spark 3.3 (released in 2023) supports TRUNCATE TABLE.
+	// If we need to support an older version later, we can use DELETE FROM.
+	return fmt.Sprintf("TRUNCATE TABLE %s", tableID.FullyQualifiedName())
 }

--- a/clients/iceberg/dialect/dialect.go
+++ b/clients/iceberg/dialect/dialect.go
@@ -1,0 +1,18 @@
+package dialect
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/artie-labs/transfer/lib/sql"
+)
+
+type IcebergDialect struct{}
+
+func (IcebergDialect) GetDefaultValueStrategy() sql.DefaultValueStrategy {
+	return sql.Native
+}
+
+func (IcebergDialect) QuoteIdentifier(identifier string) string {
+	return fmt.Sprintf("`%s`", strings.ReplaceAll(identifier, "`", ""))
+}

--- a/clients/iceberg/dialect/tableid.go
+++ b/clients/iceberg/dialect/tableid.go
@@ -1,0 +1,39 @@
+package dialect
+
+import (
+	"fmt"
+
+	"github.com/artie-labs/transfer/lib/sql"
+)
+
+var _dialect = IcebergDialect{}
+
+type TableIdentifier struct {
+	catalog   string
+	namespace string
+	table     string
+}
+
+func NewTableIdentifier(catalog, namespace, table string) TableIdentifier {
+	return TableIdentifier{catalog: catalog, namespace: namespace, table: table}
+}
+
+func (ti TableIdentifier) Namespace() string {
+	return ti.namespace
+}
+
+func (ti TableIdentifier) EscapedTable() string {
+	return _dialect.QuoteIdentifier(ti.table)
+}
+
+func (ti TableIdentifier) Table() string {
+	return ti.table
+}
+
+func (ti TableIdentifier) WithTable(table string) sql.TableIdentifier {
+	return NewTableIdentifier(ti.catalog, ti.namespace, table)
+}
+
+func (ti TableIdentifier) FullyQualifiedName() string {
+	return fmt.Sprintf("%s.%s.%s", _dialect.QuoteIdentifier(ti.catalog), _dialect.QuoteIdentifier(ti.namespace), ti.EscapedTable())
+}


### PR DESCRIPTION
This series of PRs is aimed to support Apache Iceberg as a destination. The main PR can be found here: https://github.com/artie-labs/transfer/pull/1133

This particular PR is adding the basic:

1. `TableIdentifier`
2. Parts of the `Dialect` implemented, with the rest left as a scaffold.