### PR TITLE
Threading context to `LoadStore`

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -261,7 +261,7 @@ func (s *Store) SweepTemporaryTables(_ context.Context) error {
 	return nil
 }
 
-func LoadBigQuery(cfg config.Config, _store *db.Store) (*Store, error) {
+func LoadBigQuery(ctx context.Context, cfg config.Config, _store *db.Store) (*Store, error) {
 	if _store != nil {
 		// Used for tests.
 		return &Store{
@@ -280,7 +280,7 @@ func LoadBigQuery(cfg config.Config, _store *db.Store) (*Store, error) {
 		}
 	}
 
-	bqClient, err := bigquery.NewClient(context.Background(), cfg.BigQuery.ProjectID,
+	bqClient, err := bigquery.NewClient(ctx, cfg.BigQuery.ProjectID,
 		option.WithCredentialsFile(os.Getenv(GooglePathToCredentialsEnvKey)),
 	)
 	if err != nil {

--- a/clients/bigquery/bigquery_suite_test.go
+++ b/clients/bigquery/bigquery_suite_test.go
@@ -27,7 +27,7 @@ func (b *BigQueryTestSuite) SetupTest() {
 	b.fakeStore = &mocks.FakeStore{}
 	store := db.Store(b.fakeStore)
 	var err error
-	b.store, err = LoadBigQuery(cfg, &store)
+	b.store, err = LoadBigQuery(b.T().Context(), cfg, &store)
 	assert.NoError(b.T(), err)
 }
 

--- a/lib/destination/ddl/ddl_suite_test.go
+++ b/lib/destination/ddl/ddl_suite_test.go
@@ -39,7 +39,7 @@ func (d *DDLTestSuite) SetupTest() {
 	bqStore := db.Store(d.fakeBigQueryStore)
 
 	var err error
-	d.bigQueryStore, err = bigquery.LoadBigQuery(d.bigQueryCfg, &bqStore)
+	d.bigQueryStore, err = bigquery.LoadBigQuery(d.T().Context(), d.bigQueryCfg, &bqStore)
 	assert.NoError(d.T(), err)
 
 	d.fakeSnowflakeStagesStore = &mocks.FakeStore{}

--- a/lib/destination/utils/load.go
+++ b/lib/destination/utils/load.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/artie-labs/transfer/clients/bigquery"
@@ -40,12 +41,12 @@ func LoadBaseline(cfg config.Config) (destination.Baseline, error) {
 	return nil, fmt.Errorf("invalid baseline output source specified: %q", cfg.Output)
 }
 
-func LoadDestination(cfg config.Config, store *db.Store) (destination.Destination, error) {
+func LoadDestination(ctx context.Context, cfg config.Config, store *db.Store) (destination.Destination, error) {
 	switch cfg.Output {
 	case constants.Snowflake:
 		return snowflake.LoadSnowflake(cfg, store)
 	case constants.BigQuery:
-		return bigquery.LoadBigQuery(cfg, store)
+		return bigquery.LoadBigQuery(ctx, cfg, store)
 	case constants.Databricks:
 		return databricks.LoadStore(cfg)
 	case constants.MSSQL:

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 			logger.Fatal("Unable to load baseline destination", slog.Any("err", err))
 		}
 	} else {
-		_dest, err := utils.LoadDestination(settings.Config, nil)
+		_dest, err := utils.LoadDestination(ctx, settings.Config, nil)
 		if err != nil {
 			logger.Fatal("Unable to load destination", slog.Any("err", err))
 		}

--- a/processes/consumer/flush_suite_test.go
+++ b/processes/consumer/flush_suite_test.go
@@ -62,7 +62,7 @@ func (f *FlushTestSuite) SetupTest() {
 	}
 
 	var err error
-	f.dest, err = utils.LoadDestination(f.cfg, &store)
+	f.dest, err = utils.LoadDestination(f.T().Context(), f.cfg, &store)
 	assert.NoError(f.T(), err)
 
 	f.db = models.NewMemoryDB()


### PR DESCRIPTION
As the PR title suggests. This will reduce usage of `context.Background()`