### PR TITLE
Reworking Redshift nulls

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -63,7 +63,7 @@ func castColValStaging(colVal any, colKind typing.KindDetails, truncateExceededV
 		}
 
 		// This matches the COPY clause for NULL terminator.
-		return Result{Value: `\N`}, nil
+		return Result{Value: constants.NullValuePlaceholder}, nil
 	}
 
 	colValString, err := values.ToString(colVal, colKind)

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -196,7 +196,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging() {
 			// Not struct
 			result, err := castColValStaging(nil, typing.String, false, false)
 			assert.NoError(r.T(), err)
-			assert.Equal(r.T(), `\N`, result.Value)
+			assert.Equal(r.T(), constants.NullValuePlaceholder, result.Value)
 		}
 	}
 }


### PR DESCRIPTION
Instead of using `\N` and have to deal with the complications of escaping vs. not escaping it, let's rely on a null value constant.