### PR TITLE
[Redshift] Simplify nulls

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -63,7 +63,7 @@ func castColValStaging(colVal any, colKind typing.KindDetails, truncateExceededV
 		}
 
 		// This matches the COPY clause for NULL terminator.
-		return Result{Value: `\N`}, nil
+		return Result{Value: constants.NullValuePlaceholder}, nil
 	}
 
 	colValString, err := values.ToString(colVal, colKind)

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -196,7 +196,7 @@ func (r *RedshiftTestSuite) TestCastColValStaging() {
 			// Not struct
 			result, err := castColValStaging(nil, typing.String, false, false)
 			assert.NoError(r.T(), err)
-			assert.Equal(r.T(), `\N`, result.Value)
+			assert.Equal(r.T(), constants.NullValuePlaceholder, result.Value)
 		}
 	}
 }

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -228,10 +228,12 @@ func (rd RedshiftDialect) BuildCopyStatement(tableID sql.TableIdentifier, cols [
 		quotedColumns[i] = rd.QuoteIdentifier(col)
 	}
 
-	return fmt.Sprintf(`COPY %s (%s) FROM %s DELIMITER '\t' NULL AS '\\N' GZIP FORMAT CSV %s dateformat 'auto' timeformat 'auto';`,
+	return fmt.Sprintf(`COPY %s (%s) FROM %s DELIMITER '\t' NULL AS %s GZIP FORMAT CSV %s dateformat 'auto' timeformat 'auto';`,
 		// COPY
 		tableID.FullyQualifiedName(), strings.Join(quotedColumns, ","),
-		// File path and CSV option
-		sql.QuoteLiteral(s3URI), credentialsClause,
+		// Filepath
+		sql.QuoteLiteral(s3URI),
+		// CSV option and credential clause
+		sql.QuoteLiteral(constants.NullValuePlaceholder), credentialsClause,
 	)
 }

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -418,7 +418,7 @@ func TestRedshiftDialect_BuildCopyStatement(t *testing.T) {
 	credentialsClause := "{{credentials}}"
 
 	assert.Equal(t,
-		`COPY public.tableName ("id","email","first_name") FROM '{{s3_uri}}' DELIMITER '\t' NULL AS '\\N' GZIP FORMAT CSV {{credentials}} dateformat 'auto' timeformat 'auto';`,
+		fmt.Sprintf(`COPY public.tableName ("id","email","first_name") FROM '{{s3_uri}}' DELIMITER '\t' NULL AS '%s' GZIP FORMAT CSV {{credentials}} dateformat 'auto' timeformat 'auto';`, constants.NullValuePlaceholder),
 		RedshiftDialect{}.BuildCopyStatement(fakeTableID, cols, s3URI, credentialsClause),
 	)
 }

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -66,9 +66,6 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 		cols = append(cols, col.Name())
 	}
 
-	// COPY table_name FROM '/path/to/local/file' DELIMITER '\t' NULL '\\N' FORMAT csv;
-	// Note, we need to specify `\\N` here and in `CastColVal(..)` we are only doing `\N`, this is because Redshift treats backslashes as an escape character.
-	// So, it'll convert `\N` => `\\N` during COPY.
 	copyStmt := s.dialect().BuildCopyStatement(tempTableID, cols, s3Uri, s.credentialsClause)
 	if _, err = s.Exec(copyStmt); err != nil {
 		return fmt.Errorf("failed to run COPY for temporary table: %w", err)


### PR DESCRIPTION
Use a constant instead of hardcoding `\N` and `\\N` and having to worry about escaping.