### PR TITLE
Removing TODO

### DIFF
--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -3,7 +3,6 @@ package converters
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"reflect"
 	"strings"
 	"time"
@@ -47,10 +46,8 @@ func GetStringConverter(kd typing.KindDetails) (Converter, error) {
 		return IntegerConverter{}, nil
 	case typing.Float.Kind:
 		return FloatConverter{}, nil
-
 	default:
-		slog.Warn("[GetStringConverter] - Unsupported type", slog.String("kind", kd.Kind))
-		return nil, nil
+		return nil, fmt.Errorf("unsupported type: %q", kd.Kind)
 	}
 }
 

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -82,7 +82,7 @@ func TestGetStringConverter(t *testing.T) {
 	{
 		// Invalid
 		converter, err := GetStringConverter(typing.Invalid)
-		assert.NoError(t, err)
+		assert.ErrorContains(t, err, `unsupported type: "invalid"`)
 		assert.Nil(t, converter)
 	}
 }

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -17,10 +17,5 @@ func ToString(colVal any, colKind typing.KindDetails) (string, error) {
 		return "", fmt.Errorf("failed to get string converter: %w", err)
 	}
 
-	// TODO: Simplify this block
-	if sv != nil {
-		return sv.Convert(colVal)
-	}
-
-	return fmt.Sprint(colVal), nil
+	return sv.Convert(colVal)
 }


### PR DESCRIPTION
This block has been here long enough and we have not had any encounters. As such, this PR removes the TODO and having it explicitly return an error if data type mapping fails. 
