### PR TITLE
[Redshift] Fixes around `TIMESTAMP`, `TIMESTAMP_NTZ`

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/converters"
+	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/artie-labs/transfer/lib/typing/values"
 )
 
@@ -66,7 +68,11 @@ func castColValStaging(colVal any, colKind typing.KindDetails, truncateExceededV
 		return Result{Value: constants.NullValuePlaceholder}, nil
 	}
 
-	colValString, err := values.ToString(colVal, colKind)
+	colValString, err := values.ToString(colVal, colKind, converters.GetStringConverterOpts{
+		TimestampTZLayoutOverride:  ext.RFC3339Microsecond,
+		TimestampNTZLayoutOverride: ext.RFC3339MicrosecondNoTZ,
+	})
+
 	if err != nil {
 		return Result{}, err
 	}

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -69,8 +69,8 @@ func castColValStaging(colVal any, colKind typing.KindDetails, truncateExceededV
 	}
 
 	colValString, err := values.ToStringOpts(colVal, colKind, converters.GetStringConverterOpts{
-		TimestampTZLayoutOverride:  ext.RFC3339Microsecond,
-		TimestampNTZLayoutOverride: ext.RFC3339MicrosecondNoTZ,
+		TimestampTZLayoutOverride:  ext.RFC3339MicroTZ,
+		TimestampNTZLayoutOverride: ext.RFC3339MicroTZNoTZ,
 	})
 
 	if err != nil {

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -68,6 +68,7 @@ func castColValStaging(colVal any, colKind typing.KindDetails, truncateExceededV
 		return Result{Value: constants.NullValuePlaceholder}, nil
 	}
 
+	// Redshift only allows up to microsecond precision: https://docs.aws.amazon.com/redshift/latest/dg/r_Datetime_types.html
 	colValString, err := values.ToStringOpts(colVal, colKind, converters.GetStringConverterOpts{
 		TimestampTZLayoutOverride:  ext.RFC3339MicroTZ,
 		TimestampNTZLayoutOverride: ext.RFC3339MicroTZNoTZ,

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -68,7 +68,7 @@ func castColValStaging(colVal any, colKind typing.KindDetails, truncateExceededV
 		return Result{Value: constants.NullValuePlaceholder}, nil
 	}
 
-	colValString, err := values.ToString(colVal, colKind, converters.GetStringConverterOpts{
+	colValString, err := values.ToStringOpts(colVal, colKind, converters.GetStringConverterOpts{
 		TimestampTZLayoutOverride:  ext.RFC3339Microsecond,
 		TimestampNTZLayoutOverride: ext.RFC3339MicrosecondNoTZ,
 	})

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -75,7 +75,7 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 }
 
 func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableID sql.TableIdentifier) (string, map[string]int32, error) {
-	filePath := fmt.Sprintf("/tmp/%s.csv.gz", newTableID.FullyQualifiedName())
+	filePath := fmt.Sprintf("/tmp/%s.csv.gz", shared.TempTableID(newTableID).Table())
 	gzipWriter, err := csvwriter.NewGzipWriter(filePath)
 	if err != nil {
 		return "", nil, err

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -75,7 +75,7 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 }
 
 func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableID sql.TableIdentifier) (string, map[string]int32, error) {
-	filePath := fmt.Sprintf("/tmp/%s.csv.gz", shared.TempTableID(newTableID).Table())
+	filePath := fmt.Sprintf("/tmp/%s.csv.gz", newTableID.FullyQualifiedName())
 	gzipWriter, err := csvwriter.NewGzipWriter(filePath)
 	if err != nil {
 		return "", nil, err

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -15,73 +15,76 @@ import (
 func TestGetStringConverter(t *testing.T) {
 	{
 		// Boolean
-		converter, err := GetStringConverter(typing.Boolean)
+		converter, err := GetStringConverter(typing.Boolean, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, BooleanConverter{}, converter)
 	}
 	{
 		// String
-		converter, err := GetStringConverter(typing.String)
+		converter, err := GetStringConverter(typing.String, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, StringConverter{}, converter)
 	}
 	{
 		// Date
-		converter, err := GetStringConverter(typing.Date)
+		converter, err := GetStringConverter(typing.Date, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, DateConverter{}, converter)
 	}
 	{
 		// Time
-		converter, err := GetStringConverter(typing.Time)
+		converter, err := GetStringConverter(typing.Time, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, TimeConverter{}, converter)
 	}
 	{
 		// TimestampNTZ
-		converter, err := GetStringConverter(typing.TimestampNTZ)
-		assert.NoError(t, err)
-		assert.IsType(t, TimestampNTZConverter{}, converter)
+		{
+			// No layout override
+			converter, err := GetStringConverter(typing.TimestampNTZ, GetStringConverterOpts{})
+			assert.NoError(t, err)
+			assert.IsType(t, TimestampNTZConverter{}, converter)
+		}
 	}
 	{
 		// TimestampTZ
-		converter, err := GetStringConverter(typing.TimestampTZ)
+		converter, err := GetStringConverter(typing.TimestampTZ, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, TimestampTZConverter{}, converter)
 	}
 	{
 		// Array
-		converter, err := GetStringConverter(typing.Array)
+		converter, err := GetStringConverter(typing.Array, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, ArrayConverter{}, converter)
 	}
 	{
 		// Struct
-		converter, err := GetStringConverter(typing.Struct)
+		converter, err := GetStringConverter(typing.Struct, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, StructConverter{}, converter)
 	}
 	{
 		// EDecimal
-		converter, err := GetStringConverter(typing.EDecimal)
+		converter, err := GetStringConverter(typing.EDecimal, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, DecimalConverter{}, converter)
 	}
 	{
 		// Integer
-		converter, err := GetStringConverter(typing.Integer)
+		converter, err := GetStringConverter(typing.Integer, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, IntegerConverter{}, converter)
 	}
 	{
 		// Float
-		converter, err := GetStringConverter(typing.Float)
+		converter, err := GetStringConverter(typing.Float, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, FloatConverter{}, converter)
 	}
 	{
 		// Invalid
-		converter, err := GetStringConverter(typing.Invalid)
+		converter, err := GetStringConverter(typing.Invalid, GetStringConverterOpts{})
 		assert.ErrorContains(t, err, `unsupported type: "invalid"`)
 		assert.Nil(t, converter)
 	}

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -39,12 +39,9 @@ func TestGetStringConverter(t *testing.T) {
 	}
 	{
 		// TimestampNTZ
-		{
-			// No layout override
-			converter, err := GetStringConverter(typing.TimestampNTZ, GetStringConverterOpts{})
-			assert.NoError(t, err)
-			assert.IsType(t, TimestampNTZConverter{}, converter)
-		}
+		converter, err := GetStringConverter(typing.TimestampNTZ, GetStringConverterOpts{})
+		assert.NoError(t, err)
+		assert.IsType(t, TimestampNTZConverter{}, converter)
 	}
 	{
 		// TimestampTZ

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -41,6 +41,10 @@ const TimezoneOffsetFormat = "Z07:00"
 
 // RFC3339 variants
 const (
+	// Max precision up to microseconds (will trim away the trailing zeros)
+	RFC3339MicroTZNoTZ = "2006-01-02T15:04:05.999999"
+	RFC3339MicroTZ     = RFC3339MicroTZNoTZ + TimezoneOffsetFormat
+
 	RFC3339NoTZ            = "2006-01-02T15:04:05.999999999"
 	RFC3339Millisecond     = "2006-01-02T15:04:05.000" + TimezoneOffsetFormat
 	RFC3339MillisecondNoTZ = "2006-01-02T15:04:05.000"

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -7,12 +7,12 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/converters"
 )
 
-func ToString(colVal any, colKind typing.KindDetails) (string, error) {
+func ToString(colVal any, colKind typing.KindDetails, opts converters.GetStringConverterOpts) (string, error) {
 	if colVal == nil {
 		return "", fmt.Errorf("colVal is nil")
 	}
 
-	sv, err := converters.GetStringConverter(colKind)
+	sv, err := converters.GetStringConverter(colKind, opts)
 	if err != nil {
 		return "", fmt.Errorf("failed to get string converter: %w", err)
 	}

--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -7,7 +7,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/converters"
 )
 
-func ToString(colVal any, colKind typing.KindDetails, opts converters.GetStringConverterOpts) (string, error) {
+func ToStringOpts(colVal any, colKind typing.KindDetails, opts converters.GetStringConverterOpts) (string, error) {
 	if colVal == nil {
 		return "", fmt.Errorf("colVal is nil")
 	}
@@ -18,4 +18,8 @@ func ToString(colVal any, colKind typing.KindDetails, opts converters.GetStringC
 	}
 
 	return sv.Convert(colVal)
+}
+
+func ToString(colVal any, colKind typing.KindDetails) (string, error) {
+	return ToStringOpts(colVal, colKind, converters.GetStringConverterOpts{})
 }

--- a/lib/typing/values/string_test.go
+++ b/lib/typing/values/string_test.go
@@ -9,9 +9,48 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/numbers"
 	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/converters"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
+
+func TestToStringOpts(t *testing.T) {
+	{
+		// TimestampNTZ
+		{
+			// No layout override
+			val, err := ToStringOpts(time.Date(2021, time.January, 1, 0, 0, 0, 999_999_999, time.UTC), typing.TimestampNTZ, converters.GetStringConverterOpts{})
+			assert.NoError(t, err)
+			assert.Equal(t, "2021-01-01T00:00:00.999999999", val)
+		}
+		{
+			// Layout override
+			val, err := ToStringOpts(time.Date(2021, time.January, 1, 0, 0, 0, 999_999_999, time.UTC), typing.TimestampNTZ, converters.GetStringConverterOpts{
+				TimestampNTZLayoutOverride: ext.RFC3339MicrosecondNoTZ,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, "2021-01-01T00:00:00.999999", val)
+		}
+	}
+	{
+		// Timestamp
+		{
+			// No layout override
+			val, err := ToStringOpts(time.Date(2021, time.January, 1, 0, 0, 0, 999_999_999, time.UTC), typing.TimestampTZ, converters.GetStringConverterOpts{})
+			assert.NoError(t, err)
+			assert.Equal(t, "2021-01-01T00:00:00.999999999Z", val)
+		}
+		{
+			// Layout override
+			val, err := ToStringOpts(time.Date(2021, time.January, 1, 0, 0, 0, 999_999_999, time.UTC), typing.TimestampTZ, converters.GetStringConverterOpts{
+				TimestampTZLayoutOverride: ext.RFC3339Microsecond,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, "2021-01-01T00:00:00.999999Z", val)
+		}
+	}
+
+}
 
 func TestToString(t *testing.T) {
 	{


### PR DESCRIPTION
* TIMESTAMP and TIMESTAMP_NTZ only allow up to microsecond precision
* We are sometimes running into an issue where we emit nanosecond values 