### PR TITLE
Refactor Event `PrimaryKeyValue`

### DIFF
--- a/models/event/event.go
+++ b/models/event/event.go
@@ -157,7 +157,6 @@ func (e *Event) PrimaryKeyValue() (string, error) {
 	var key string
 	for _, pk := range e.GetPrimaryKeys() {
 		escapedPrimaryKey := columns.EscapeName(pk)
-
 		value, ok := e.Data[escapedPrimaryKey]
 		if !ok {
 			return "", fmt.Errorf("primary key %q not found in data: %v", escapedPrimaryKey, e.Data)

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -153,13 +153,20 @@ func (e *Event) GetPrimaryKeys() []string {
 }
 
 // PrimaryKeyValue - as per above, this needs to return a deterministic k/v string.
-func (e *Event) PrimaryKeyValue() string {
+func (e *Event) PrimaryKeyValue() (string, error) {
 	var key string
 	for _, pk := range e.GetPrimaryKeys() {
-		key += fmt.Sprintf("%s=%v", pk, e.Data[pk])
+		escapedPrimaryKey := columns.EscapeName(pk)
+
+		value, ok := e.Data[escapedPrimaryKey]
+		if !ok {
+			return "", fmt.Errorf("primary key %q not found in data: %v", escapedPrimaryKey, e.Data)
+		}
+
+		key += fmt.Sprintf("%s=%v", escapedPrimaryKey, value)
 	}
 
-	return key
+	return key, nil
 }
 
 // Save will save the event into our in memory event
@@ -259,7 +266,13 @@ func (e *Event) Save(cfg config.Config, inMemDB *models.DatabaseData, tc kafkali
 
 	// Swap out sanitizedData <> data.
 	e.Data = sanitizedData
-	td.InsertRow(e.PrimaryKeyValue(), e.Data, e.Deleted)
+
+	pkValueString, err := e.PrimaryKeyValue()
+	if err != nil {
+		return false, "", fmt.Errorf("failed to retrieve primary key value: %w", err)
+	}
+
+	td.InsertRow(pkValueString, e.Data, e.Deleted)
 	// If the message is Kafka, then we only need the latest one
 	if message.Kind() == artie.Kafka {
 		td.PartitionsToLastMessage[message.Partition()] = message

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -180,6 +180,20 @@ func (e *EventsTestSuite) TestEventPrimaryKeys() {
 	}
 
 	assert.Equal(e.T(), len(partsMap), 1)
+
+	// If the value doesn't exist in the event payload
+	{
+		mockEvent := &mocks.FakeEvent{}
+		mockEvent.GetTableNameReturns("foo")
+		mockEvent.GetDataReturns(map[string]any{"course_id": 2}, nil)
+
+		evt, err := ToMemoryEvent(mockEvent, map[string]any{"id": 123}, kafkalib.TopicConfig{}, config.Replication)
+		assert.NoError(e.T(), err)
+
+		pkValue, err := evt.PrimaryKeyValue()
+		assert.ErrorContains(e.T(), err, `primary key "id" not found in data: map[course_id:2]`)
+		assert.Equal(e.T(), "", pkValue)
+	}
 }
 
 func (e *EventsTestSuite) TestPrimaryKeyValueDeterministic() {

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -166,12 +166,17 @@ func (e *EventsTestSuite) TestEventPrimaryKeys() {
 
 	anotherEvt, err := ToMemoryEvent(mockEvent, map[string]any{"id": 1, "course_id": 2}, kafkalib.TopicConfig{}, config.Replication)
 	assert.NoError(e.T(), err)
-	assert.Equal(e.T(), "course_id=2id=1", anotherEvt.PrimaryKeyValue())
+
+	pkValue, err := anotherEvt.PrimaryKeyValue()
+	assert.NoError(e.T(), err)
+	assert.Equal(e.T(), "course_id=2id=1", pkValue)
 
 	// Make sure the ordering for the pk is deterministic.
 	partsMap := make(map[string]bool)
 	for i := 0; i < 100; i++ {
-		partsMap[anotherEvt.PrimaryKeyValue()] = true
+		pkValue, err := anotherEvt.PrimaryKeyValue()
+		assert.NoError(e.T(), err)
+		partsMap[pkValue] = true
 	}
 
 	assert.Equal(e.T(), len(partsMap), 1)
@@ -197,6 +202,8 @@ func (e *EventsTestSuite) TestPrimaryKeyValueDeterministic() {
 	}, kafkalib.TopicConfig{}, config.Replication)
 	assert.NoError(e.T(), err)
 	for i := 0; i < 50_000; i++ {
-		assert.Equal(e.T(), evt.PrimaryKeyValue(), "aa=1bb=5dusty=mini aussiegg=artiezz=ff")
+		pkValue, err := evt.PrimaryKeyValue()
+		assert.NoError(e.T(), err)
+		assert.Equal(e.T(), "aa=1bb=5dusty=mini aussiegg=artiezz=ff", pkValue)
 	}
 }


### PR DESCRIPTION
This function was susceptible to two errors:


1. It did not escape column names, even though it should since it gets escaped during `event.Save()`
2. If the primary key value didn't exist in the payload, it wouldn't error. 