### PR TITLE
[Snowflake] Escape schema and database for `FullyQualifiedName`

### DIFF
--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -49,14 +49,14 @@ func TestSnowflakeDialect_BuildCreateTableQuery(t *testing.T) {
 
 func TestSnowflakeDialect_BuildDropTableQuery(t *testing.T) {
 	assert.Equal(t,
-		`DROP TABLE IF EXISTS database1.schema1."TABLE1"`,
+		`DROP TABLE IF EXISTS "DATABASE1"."SCHEMA1"."TABLE1"`,
 		SnowflakeDialect{}.BuildDropTableQuery(NewTableIdentifier("database1", "schema1", "table1")),
 	)
 }
 
 func TestSnowflakeDialect_BuildTruncateTableQuery(t *testing.T) {
 	assert.Equal(t,
-		`TRUNCATE TABLE IF EXISTS database1.schema1."TABLE1"`,
+		`TRUNCATE TABLE IF EXISTS "DATABASE1"."SCHEMA1"."TABLE1"`,
 		SnowflakeDialect{}.BuildTruncateTableQuery(NewTableIdentifier("database1", "schema1", "table1")),
 	)
 }

--- a/clients/snowflake/dialect/tableid.go
+++ b/clients/snowflake/dialect/tableid.go
@@ -44,7 +44,7 @@ func (ti TableIdentifier) WithTable(table string) sql.TableIdentifier {
 }
 
 func (ti TableIdentifier) FullyQualifiedName() string {
-	return fmt.Sprintf("%s.%s.%s", ti.database, ti.schema, ti.EscapedTable())
+	return fmt.Sprintf("%s.%s.%s", _dialect.QuoteIdentifier(ti.database), _dialect.QuoteIdentifier(ti.schema), ti.EscapedTable())
 }
 
 func (ti TableIdentifier) WithDisableDropProtection(disableDropProtection bool) TableIdentifier {

--- a/clients/snowflake/dialect/tableid_test.go
+++ b/clients/snowflake/dialect/tableid_test.go
@@ -18,10 +18,10 @@ func TestTableIdentifier_WithTable(t *testing.T) {
 
 func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
 	// Table name that is not a reserved word:
-	assert.Equal(t, `database.schema."FOO"`, NewTableIdentifier("database", "schema", "foo").FullyQualifiedName())
+	assert.Equal(t, `"DATABASE"."SCHEMA"."FOO"`, NewTableIdentifier("database", "schema", "foo").FullyQualifiedName())
 
 	// Table name that is a reserved word:
-	assert.Equal(t, `database.schema."TABLE"`, NewTableIdentifier("database", "schema", "table").FullyQualifiedName())
+	assert.Equal(t, `"DATABASE"."SCHEMA"."TABLE"`, NewTableIdentifier("database", "schema", "table").FullyQualifiedName())
 }
 
 func TestTableIdentifier_EscapedTable(t *testing.T) {

--- a/clients/snowflake/snowflake_dedupe_test.go
+++ b/clients/snowflake/snowflake_dedupe_test.go
@@ -19,11 +19,11 @@ func TestGenerateDedupeQueries(t *testing.T) {
 		assert.Len(t, parts, 3)
 		assert.Equal(
 			t,
-			fmt.Sprintf(`CREATE OR REPLACE TRANSIENT TABLE %s AS (SELECT * FROM db.public."CUSTOMERS" QUALIFY ROW_NUMBER() OVER (PARTITION BY "ID" ORDER BY "ID" ASC) = 2)`, stagingTableID.FullyQualifiedName()),
+			fmt.Sprintf(`CREATE OR REPLACE TRANSIENT TABLE %s AS (SELECT * FROM "DB"."PUBLIC"."CUSTOMERS" QUALIFY ROW_NUMBER() OVER (PARTITION BY "ID" ORDER BY "ID" ASC) = 2)`, stagingTableID.FullyQualifiedName()),
 			parts[0],
 		)
-		assert.Equal(t, fmt.Sprintf(`DELETE FROM db.public."CUSTOMERS" t1 USING %s t2 WHERE t1."ID" = t2."ID"`, stagingTableID.FullyQualifiedName()), parts[1])
-		assert.Equal(t, fmt.Sprintf(`INSERT INTO db.public."CUSTOMERS" SELECT * FROM %s`, stagingTableID.FullyQualifiedName()), parts[2])
+		assert.Equal(t, fmt.Sprintf(`DELETE FROM "DB"."PUBLIC"."CUSTOMERS" t1 USING %s t2 WHERE t1."ID" = t2."ID"`, stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(t, fmt.Sprintf(`INSERT INTO "DB"."PUBLIC"."CUSTOMERS" SELECT * FROM %s`, stagingTableID.FullyQualifiedName()), parts[2])
 	}
 	{
 		// Dedupe with one primary key + `__artie_updated_at` flag.
@@ -34,11 +34,11 @@ func TestGenerateDedupeQueries(t *testing.T) {
 		assert.Len(t, parts, 3)
 		assert.Equal(
 			t,
-			fmt.Sprintf(`CREATE OR REPLACE TRANSIENT TABLE %s AS (SELECT * FROM db.public."CUSTOMERS" QUALIFY ROW_NUMBER() OVER (PARTITION BY "ID" ORDER BY "ID" ASC, "__ARTIE_UPDATED_AT" ASC) = 2)`, stagingTableID.FullyQualifiedName()),
+			fmt.Sprintf(`CREATE OR REPLACE TRANSIENT TABLE %s AS (SELECT * FROM "DB"."PUBLIC"."CUSTOMERS" QUALIFY ROW_NUMBER() OVER (PARTITION BY "ID" ORDER BY "ID" ASC, "__ARTIE_UPDATED_AT" ASC) = 2)`, stagingTableID.FullyQualifiedName()),
 			parts[0],
 		)
-		assert.Equal(t, fmt.Sprintf(`DELETE FROM db.public."CUSTOMERS" t1 USING %s t2 WHERE t1."ID" = t2."ID"`, stagingTableID.FullyQualifiedName()), parts[1])
-		assert.Equal(t, fmt.Sprintf(`INSERT INTO db.public."CUSTOMERS" SELECT * FROM %s`, stagingTableID.FullyQualifiedName()), parts[2])
+		assert.Equal(t, fmt.Sprintf(`DELETE FROM "DB"."PUBLIC"."CUSTOMERS" t1 USING %s t2 WHERE t1."ID" = t2."ID"`, stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(t, fmt.Sprintf(`INSERT INTO "DB"."PUBLIC"."CUSTOMERS" SELECT * FROM %s`, stagingTableID.FullyQualifiedName()), parts[2])
 	}
 	{
 		// Dedupe with composite keys + no `__artie_updated_at` flag.
@@ -49,11 +49,11 @@ func TestGenerateDedupeQueries(t *testing.T) {
 		assert.Len(t, parts, 3)
 		assert.Equal(
 			t,
-			fmt.Sprintf(`CREATE OR REPLACE TRANSIENT TABLE %s AS (SELECT * FROM db.public."USER_SETTINGS" QUALIFY ROW_NUMBER() OVER (PARTITION BY "USER_ID", "SETTINGS" ORDER BY "USER_ID" ASC, "SETTINGS" ASC) = 2)`, stagingTableID.FullyQualifiedName()),
+			fmt.Sprintf(`CREATE OR REPLACE TRANSIENT TABLE %s AS (SELECT * FROM "DB"."PUBLIC"."USER_SETTINGS" QUALIFY ROW_NUMBER() OVER (PARTITION BY "USER_ID", "SETTINGS" ORDER BY "USER_ID" ASC, "SETTINGS" ASC) = 2)`, stagingTableID.FullyQualifiedName()),
 			parts[0],
 		)
-		assert.Equal(t, fmt.Sprintf(`DELETE FROM db.public."USER_SETTINGS" t1 USING %s t2 WHERE t1."USER_ID" = t2."USER_ID" AND t1."SETTINGS" = t2."SETTINGS"`, stagingTableID.FullyQualifiedName()), parts[1])
-		assert.Equal(t, fmt.Sprintf(`INSERT INTO db.public."USER_SETTINGS" SELECT * FROM %s`, stagingTableID.FullyQualifiedName()), parts[2])
+		assert.Equal(t, fmt.Sprintf(`DELETE FROM "DB"."PUBLIC"."USER_SETTINGS" t1 USING %s t2 WHERE t1."USER_ID" = t2."USER_ID" AND t1."SETTINGS" = t2."SETTINGS"`, stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(t, fmt.Sprintf(`INSERT INTO "DB"."PUBLIC"."USER_SETTINGS" SELECT * FROM %s`, stagingTableID.FullyQualifiedName()), parts[2])
 	}
 	{
 		// Dedupe with composite keys + `__artie_updated_at` flag.
@@ -64,10 +64,10 @@ func TestGenerateDedupeQueries(t *testing.T) {
 		assert.Len(t, parts, 3)
 		assert.Equal(
 			t,
-			fmt.Sprintf(`CREATE OR REPLACE TRANSIENT TABLE %s AS (SELECT * FROM db.public."USER_SETTINGS" QUALIFY ROW_NUMBER() OVER (PARTITION BY "USER_ID", "SETTINGS" ORDER BY "USER_ID" ASC, "SETTINGS" ASC, "__ARTIE_UPDATED_AT" ASC) = 2)`, stagingTableID.FullyQualifiedName()),
+			fmt.Sprintf(`CREATE OR REPLACE TRANSIENT TABLE %s AS (SELECT * FROM "DB"."PUBLIC"."USER_SETTINGS" QUALIFY ROW_NUMBER() OVER (PARTITION BY "USER_ID", "SETTINGS" ORDER BY "USER_ID" ASC, "SETTINGS" ASC, "__ARTIE_UPDATED_AT" ASC) = 2)`, stagingTableID.FullyQualifiedName()),
 			parts[0],
 		)
-		assert.Equal(t, fmt.Sprintf(`DELETE FROM db.public."USER_SETTINGS" t1 USING %s t2 WHERE t1."USER_ID" = t2."USER_ID" AND t1."SETTINGS" = t2."SETTINGS"`, stagingTableID.FullyQualifiedName()), parts[1])
-		assert.Equal(t, fmt.Sprintf(`INSERT INTO db.public."USER_SETTINGS" SELECT * FROM %s`, stagingTableID.FullyQualifiedName()), parts[2])
+		assert.Equal(t, fmt.Sprintf(`DELETE FROM "DB"."PUBLIC"."USER_SETTINGS" t1 USING %s t2 WHERE t1."USER_ID" = t2."USER_ID" AND t1."SETTINGS" = t2."SETTINGS"`, stagingTableID.FullyQualifiedName()), parts[1])
+		assert.Equal(t, fmt.Sprintf(`INSERT INTO "DB"."PUBLIC"."USER_SETTINGS" SELECT * FROM %s`, stagingTableID.FullyQualifiedName()), parts[2])
 	}
 }

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -25,7 +25,7 @@ func (s *SnowflakeTestSuite) TestBuildRemoveFilesFromStage() {
 	table := dialect.NewTableIdentifier("db", "schema", "table")
 
 	query := s.stageStore.dialect().BuildRemoveFilesFromStage(addPrefixToTableName(table, "%"), "")
-	assert.Equal(s.T(), `REMOVE @db.schema."%TABLE"`, query)
+	assert.Equal(s.T(), `REMOVE @"DB"."SCHEMA"."%TABLE"`, query)
 }
 
 func (s *SnowflakeTestSuite) TestReplaceExceededValues() {
@@ -103,14 +103,14 @@ func (s *SnowflakeTestSuite) TestBackfillColumn() {
 		{
 			name:        "col that has default value that needs to be backfilled",
 			col:         needsBackfillCol,
-			backfillSQL: `UPDATE db.public."TABLENAME" as t SET t."FOO" = true WHERE t."FOO" IS NULL;`,
-			commentSQL:  `COMMENT ON COLUMN db.public."TABLENAME"."FOO" IS '{"backfilled": true}';`,
+			backfillSQL: `UPDATE "DB"."PUBLIC"."TABLENAME" as t SET t."FOO" = true WHERE t."FOO" IS NULL;`,
+			commentSQL:  `COMMENT ON COLUMN "DB"."PUBLIC"."TABLENAME"."FOO" IS '{"backfilled": true}';`,
 		},
 		{
 			name:        "default col that has default value that needs to be backfilled",
 			col:         needsBackfillColDefault,
-			backfillSQL: `UPDATE db.public."TABLENAME" as t SET t."DEFAULT" = true WHERE t."DEFAULT" IS NULL;`,
-			commentSQL:  `COMMENT ON COLUMN db.public."TABLENAME"."DEFAULT" IS '{"backfilled": true}';`,
+			backfillSQL: `UPDATE "DB"."PUBLIC"."TABLENAME" as t SET t."DEFAULT" = true WHERE t."DEFAULT" IS NULL;`,
+			commentSQL:  `COMMENT ON COLUMN "DB"."PUBLIC"."TABLENAME"."DEFAULT" IS '{"backfilled": true}';`,
 		},
 	}
 

--- a/clients/snowflake/util_test.go
+++ b/clients/snowflake/util_test.go
@@ -14,19 +14,19 @@ func TestAddPrefixToTableName(t *testing.T) {
 	const prefix = "%"
 	{
 		// Database, schema and table name
-		assert.Equal(t, `database.schema."%TABLENAME"`, addPrefixToTableName(dialect.NewTableIdentifier("database", "schema", "tableName"), prefix))
+		assert.Equal(t, `"DATABASE"."SCHEMA"."%TABLENAME"`, addPrefixToTableName(dialect.NewTableIdentifier("database", "schema", "tableName"), prefix))
 	}
 	{
 		// Table name
-		assert.Equal(t, `.."%ORDERS"`, addPrefixToTableName(dialect.NewTableIdentifier("", "", "orders"), prefix))
+		assert.Equal(t, `"".""."%ORDERS"`, addPrefixToTableName(dialect.NewTableIdentifier("", "", "orders"), prefix))
 	}
 	{
 		// Schema and table name
-		assert.Equal(t, `.public."%ORDERS"`, addPrefixToTableName(dialect.NewTableIdentifier("", "public", "orders"), prefix))
+		assert.Equal(t, `""."PUBLIC"."%ORDERS"`, addPrefixToTableName(dialect.NewTableIdentifier("", "public", "orders"), prefix))
 	}
 	{
 		// Database and table name
-		assert.Equal(t, `db.."%TABLENAME"`, addPrefixToTableName(dialect.NewTableIdentifier("db", "", "tableName"), prefix))
+		assert.Equal(t, `"DB".""."%TABLENAME"`, addPrefixToTableName(dialect.NewTableIdentifier("db", "", "tableName"), prefix))
 	}
 }
 

--- a/lib/destination/ddl/ddl_sflk_test.go
+++ b/lib/destination/ddl/ddl_sflk_test.go
@@ -31,7 +31,7 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 	assert.NoError(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.snowflakeStagesStore, tc, config.SharedDestinationColumnSettings{}, tableID, cols))
 	for i := 0; i < len(cols); i++ {
 		_, execQuery, _ := d.fakeSnowflakeStagesStore.ExecContextArgsForCall(i)
-		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s", `shop.public."COMPLEX_COLUMNS"`,
+		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS %s %s", `"SHOP"."PUBLIC"."COMPLEX_COLUMNS"`,
 			d.snowflakeStagesStore.Dialect().QuoteIdentifier(cols[i].Name()),
 			d.snowflakeStagesStore.Dialect().DataTypeForKind(cols[i].KindDetails, false, config.SharedDestinationColumnSettings{})), execQuery)
 	}
@@ -133,7 +133,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 		assert.Equal(d.T(), i+1, d.fakeSnowflakeStagesStore.ExecContextCallCount(), "tried to delete one column")
 
 		_, execArg, _ := d.fakeSnowflakeStagesStore.ExecContextArgsForCall(i)
-		assert.Equal(d.T(), execArg, fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s", `shop.public."USERS"`, d.snowflakeStagesStore.Dialect().QuoteIdentifier(cols[i].Name())))
+		assert.Equal(d.T(), execArg, fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s", `"SHOP"."PUBLIC"."USERS"`, d.snowflakeStagesStore.Dialect().QuoteIdentifier(cols[i].Name())))
 	}
 }
 

--- a/lib/destination/ddl/ddl_temp_test.go
+++ b/lib/destination/ddl/ddl_temp_test.go
@@ -23,7 +23,7 @@ func (d *DDLTestSuite) TestCreateTemporaryTable() {
 		tableID := dialect.NewTableIdentifier("db", "schema", "tempTableName")
 		query, err := ddl.BuildCreateTableSQL(config.SharedDestinationColumnSettings{}, d.snowflakeStagesStore.Dialect(), tableID, true, config.Replication, []columns.Column{columns.NewColumn("foo", typing.String), columns.NewColumn("bar", typing.Float), columns.NewColumn("start", typing.String)})
 		assert.NoError(d.T(), err)
-		assert.Equal(d.T(), query, `CREATE TABLE IF NOT EXISTS db.schema."TEMPTABLENAME" ("FOO" string,"BAR" float,"START" string) DATA_RETENTION_TIME_IN_DAYS = 0 STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE)`)
+		assert.Equal(d.T(), query, `CREATE TABLE IF NOT EXISTS "DB"."SCHEMA"."TEMPTABLENAME" ("FOO" string,"BAR" float,"START" string) DATA_RETENTION_TIME_IN_DAYS = 0 STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='\\N' EMPTY_FIELD_AS_NULL=FALSE)`)
 	}
 	{
 		// BigQuery


### PR DESCRIPTION
We were previously not escaping schema or database names. This PR adds that capability.