### PR TITLE
Simplify `GetData`

### DIFF
--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -19,7 +19,7 @@ type Event interface {
 	Operation() string
 	DeletePayload() bool
 	GetTableName() string
-	GetData(pkMap map[string]any, tc kafkalib.TopicConfig) (map[string]any, error)
+	GetData(tc kafkalib.TopicConfig) (map[string]any, error)
 	GetOptionalSchema() (map[string]typing.KindDetails, error)
 	// GetColumns will inspect the envelope's payload right now and return.
 	GetColumns() (*columns.Columns, error)

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -149,7 +149,7 @@ func (s *SchemaEventPayload) GetColumns() (*columns.Columns, error) {
 	return &cols, nil
 }
 
-func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc kafkalib.TopicConfig) (map[string]any, error) {
+func (s *SchemaEventPayload) GetData(tc kafkalib.TopicConfig) (map[string]any, error) {
 	var retMap map[string]any
 
 	switch s.Operation() {
@@ -169,9 +169,6 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc kafkalib.TopicConf
 		// If previous values for the other columns are in memory (not flushed yet), [TableData.InsertRow] will handle
 		// filling them in and setting this to false.
 		retMap[constants.OnlySetDeleteColumnMarker] = true
-		for k, v := range pkMap {
-			retMap[k] = v
-		}
 	case "r", "u", "c":
 		retMap = s.Payload.afterMap
 		retMap[constants.DeleteColumnMarker] = false

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -160,7 +160,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomer() {
 `
 	evt, err := m.Debezium.GetEventFromBytes([]byte(payload))
 	assert.NoError(m.T(), err)
-	evtData, err := evt.GetData(map[string]any{"_id": int64(1003)}, kafkalib.TopicConfig{})
+	evtData, err := evt.GetData(kafkalib.TopicConfig{})
 	assert.NoError(m.T(), err)
 	_, isOk := evtData[constants.UpdateColumnMarker]
 	assert.False(m.T(), isOk)
@@ -169,12 +169,12 @@ func (m *MongoTestSuite) TestMongoDBEventCustomer() {
 	assert.Equal(m.T(), evtData["last_name"], "Tang")
 	assert.Equal(m.T(), evtData["email"], "robin@example.com")
 
-	evtDataWithIncludedAt, err := evt.GetData(map[string]any{"_id": int64(1003)}, kafkalib.TopicConfig{})
+	evtDataWithIncludedAt, err := evt.GetData(kafkalib.TopicConfig{})
 	assert.NoError(m.T(), err)
 	_, isOk = evtDataWithIncludedAt[constants.UpdateColumnMarker]
 	assert.False(m.T(), isOk)
 
-	evtDataWithIncludedAt, err = evt.GetData(map[string]any{"_id": int64(1003)}, kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true, IncludeArtieUpdatedAt: true})
+	evtDataWithIncludedAt, err = evt.GetData(kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true, IncludeArtieUpdatedAt: true})
 	assert.NoError(m.T(), err)
 
 	assert.Equal(m.T(), time.Date(2022, time.November, 18, 6, 35, 21, 0, time.UTC), evtDataWithIncludedAt[constants.DatabaseUpdatedColumnMarker])
@@ -230,7 +230,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore_NoData() {
 	assert.NoError(m.T(), err)
 	{
 		// Making sure the `before` payload is set.
-		evtData, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{})
+		evtData, err := evt.GetData(kafkalib.TopicConfig{})
 		assert.NoError(m.T(), err)
 		assert.Equal(m.T(), "customers123", evt.GetTableName())
 
@@ -283,7 +283,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 	assert.NoError(m.T(), err)
 	{
 		// Making sure the `before` payload is set.
-		evtData, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{})
+		evtData, err := evt.GetData(kafkalib.TopicConfig{})
 		assert.NoError(m.T(), err)
 		assert.Equal(m.T(), "customers123", evt.GetTableName())
 
@@ -291,7 +291,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 		assert.False(m.T(), isOk)
 
 		expectedKeyToVal := map[string]any{
-			"_id":                               1003,
+			"_id":                               int64(1003),
 			constants.DeleteColumnMarker:        true,
 			constants.OnlySetDeleteColumnMarker: true,
 			"first_name":                        "Robin",
@@ -307,7 +307,7 @@ func (m *MongoTestSuite) TestMongoDBEventCustomerBefore() {
 	}
 	{
 		// Check `__artie_updated_at` is included
-		evtData, err := evt.GetData(map[string]any{"_id": 1003}, kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
+		evtData, err := evt.GetData(kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
 		assert.NoError(m.T(), err)
 
 		updatedAt, isOk := evtData[constants.UpdateColumnMarker]

--- a/lib/cdc/mongo/debezium_test.go
+++ b/lib/cdc/mongo/debezium_test.go
@@ -123,7 +123,7 @@ func (m *MongoTestSuite) TestMongoDBEvent_DeletedRow() {
 	payload := `{"schema":{"type":"","fields":null},"payload":{"before":"{\"_id\":\"abc\"}","after":"{\"_id\":\"abc\"}","source":{"connector":"","ts_ms":1728784382733,"db":"foo","collection":"bar"},"op":"d"}}`
 	evt, err := m.Debezium.GetEventFromBytes([]byte(payload))
 	assert.NoError(m.T(), err)
-	evtData, err := evt.GetData(map[string]any{"_id": "abc"}, kafkalib.TopicConfig{})
+	evtData, err := evt.GetData(kafkalib.TopicConfig{})
 	assert.NoError(m.T(), err)
 	assert.True(m.T(), evtData[constants.DeleteColumnMarker].(bool))
 }

--- a/lib/cdc/relational/debezium_test.go
+++ b/lib/cdc/relational/debezium_test.go
@@ -85,7 +85,7 @@ func (r *RelationTestSuite) TestPostgresEvent() {
 	assert.Nil(r.T(), err)
 	assert.False(r.T(), evt.DeletePayload())
 
-	evtData, err := evt.GetData(map[string]any{"id": 59}, kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true})
+	evtData, err := evt.GetData(kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true})
 	assert.NoError(r.T(), err)
 	assert.Equal(r.T(), float64(59), evtData["id"])
 	assert.Equal(r.T(), time.Date(2022, time.November, 16, 4, 1, 53, 308000000, time.UTC), evtData[constants.DatabaseUpdatedColumnMarker])
@@ -189,7 +189,7 @@ func (r *RelationTestSuite) TestPostgresEventWithSchemaAndTimestampNoTZ() {
 	assert.Nil(r.T(), err)
 	assert.False(r.T(), evt.DeletePayload())
 
-	evtData, err := evt.GetData(map[string]any{"id": 1001}, kafkalib.TopicConfig{})
+	evtData, err := evt.GetData(kafkalib.TopicConfig{})
 	assert.NoError(r.T(), err)
 
 	// Testing typing.
@@ -515,8 +515,7 @@ func (r *RelationTestSuite) TestGetEventFromBytes_MySQL() {
 	assert.NoError(r.T(), err)
 	assert.Equal(r.T(), typing.Struct, schema["custom_fields"])
 
-	kvMap := map[string]any{"id": 1001}
-	evtData, err := evt.GetData(kvMap, kafkalib.TopicConfig{})
+	evtData, err := evt.GetData(kafkalib.TopicConfig{})
 	assert.NoError(r.T(), err)
 
 	// Should have no Artie updated or database updated fields
@@ -526,7 +525,7 @@ func (r *RelationTestSuite) TestGetEventFromBytes_MySQL() {
 	_, isOk = evtData[constants.DatabaseUpdatedColumnMarker]
 	assert.False(r.T(), isOk)
 
-	evtData, err = evt.GetData(kvMap, kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true, IncludeArtieUpdatedAt: true})
+	evtData, err = evt.GetData(kafkalib.TopicConfig{IncludeDatabaseUpdatedAt: true, IncludeArtieUpdatedAt: true})
 	assert.NoError(r.T(), err)
 
 	assert.Equal(r.T(), time.Date(2023, time.March, 13, 19, 19, 24, 0, time.UTC), evtData[constants.DatabaseUpdatedColumnMarker])

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -79,7 +79,7 @@ func (s *SchemaEventPayload) GetTableName() string {
 	return s.Payload.Source.Table
 }
 
-func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc kafkalib.TopicConfig) (map[string]any, error) {
+func (s *SchemaEventPayload) GetData(tc kafkalib.TopicConfig) (map[string]any, error) {
 	var err error
 	var retMap map[string]any
 	switch s.Operation() {
@@ -101,9 +101,6 @@ func (s *SchemaEventPayload) GetData(pkMap map[string]any, tc kafkalib.TopicConf
 		// If previous values for the other columns are in memory (not flushed yet), [TableData.InsertRow] will handle
 		// filling them in and setting this to false.
 		retMap[constants.OnlySetDeleteColumnMarker] = true
-		for k, v := range pkMap {
-			retMap[k] = v
-		}
 	case "r", "u", "c":
 		retMap, err = s.parseAndMutateMapInPlace(s.Payload.After, debezium.After)
 		if err != nil {

--- a/lib/cdc/util/relational_event_decimal_test.go
+++ b/lib/cdc/util/relational_event_decimal_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/artie-labs/transfer/lib/kafkalib"
-
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 
 	"github.com/stretchr/testify/assert"
@@ -23,7 +22,7 @@ func TestSchemaEventPayload_MiscNumbers_GetData(t *testing.T) {
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
 
-	retMap, err := schemaEventPayload.GetData(nil, kafkalib.TopicConfig{})
+	retMap, err := schemaEventPayload.GetData(kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), retMap["smallint_test"])
 	assert.Equal(t, int64(2), retMap["smallserial_test"])
@@ -43,7 +42,7 @@ func TestSchemaEventPayload_Numeric_GetData(t *testing.T) {
 	var schemaEventPayload SchemaEventPayload
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
-	retMap, err := schemaEventPayload.GetData(nil, kafkalib.TopicConfig{})
+	retMap, err := schemaEventPayload.GetData(kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 
 	assert.Equal(t, "123456.789", retMap["numeric_test"].(*decimal.Decimal).String())
@@ -72,7 +71,7 @@ func TestSchemaEventPayload_Decimal_GetData(t *testing.T) {
 	var schemaEventPayload SchemaEventPayload
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
-	retMap, err := schemaEventPayload.GetData(nil, kafkalib.TopicConfig{})
+	retMap, err := schemaEventPayload.GetData(kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, "123.45", retMap["decimal_test"].(*decimal.Decimal).String())
 	decimalWithScaleMap := map[string]string{
@@ -98,7 +97,7 @@ func TestSchemaEventPayload_Money_GetData(t *testing.T) {
 	var schemaEventPayload SchemaEventPayload
 	err = json.Unmarshal(bytes, &schemaEventPayload)
 	assert.NoError(t, err)
-	retMap, err := schemaEventPayload.GetData(nil, kafkalib.TopicConfig{})
+	retMap, err := schemaEventPayload.GetData(kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 
 	decimalWithScaleMap := map[string]string{

--- a/lib/cdc/util/relational_event_test.go
+++ b/lib/cdc/util/relational_event_test.go
@@ -113,7 +113,7 @@ func TestGetDataTestInsert(t *testing.T) {
 
 	assert.False(t, schemaEventPayload.DeletePayload())
 
-	evtData, err := schemaEventPayload.GetData(map[string]any{"pk": 1}, kafkalib.TopicConfig{})
+	evtData, err := schemaEventPayload.GetData(kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, len(after), len(evtData), "has deletion flag")
 
@@ -131,7 +131,7 @@ func TestGetDataTestInsert(t *testing.T) {
 	delete(evtData, constants.OnlySetDeleteColumnMarker)
 	assert.Equal(t, after, evtData)
 
-	evtData, err = schemaEventPayload.GetData(map[string]any{"pk": 1}, kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
+	evtData, err = schemaEventPayload.GetData(kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
 	assert.NoError(t, err)
 
 	_, isOk = evtData[constants.UpdateColumnMarker]
@@ -149,13 +149,12 @@ func TestGetData_TestDelete(t *testing.T) {
 		constants.OnlySetDeleteColumnMarker: true,
 	}
 
-	kvMap := map[string]any{"pk": 1004}
 	{
 		// Postgres
 		var schemaEventPayload SchemaEventPayload
 		assert.NoError(t, json.Unmarshal([]byte(PostgresDelete), &schemaEventPayload))
 		assert.True(t, schemaEventPayload.DeletePayload())
-		data, err := schemaEventPayload.GetData(kvMap, tc)
+		data, err := schemaEventPayload.GetData(tc)
 		assert.NoError(t, err)
 		for expectedKey, expectedValue := range expectedKeyValues {
 			value, isOk := data[expectedKey]
@@ -168,7 +167,7 @@ func TestGetData_TestDelete(t *testing.T) {
 		var schemaEventPayload SchemaEventPayload
 		assert.NoError(t, json.Unmarshal([]byte(MySQLDelete), &schemaEventPayload))
 		assert.True(t, schemaEventPayload.DeletePayload())
-		data, err := schemaEventPayload.GetData(kvMap, tc)
+		data, err := schemaEventPayload.GetData(tc)
 		assert.NoError(t, err)
 		for expectedKey, expectedValue := range expectedKeyValues {
 			value, isOk := data[expectedKey]
@@ -206,9 +205,8 @@ func TestGetDataTestUpdate(t *testing.T) {
 	}
 
 	assert.False(t, schemaEventPayload.DeletePayload())
-	kvMap := map[string]any{"pk": 1}
 
-	evtData, err := schemaEventPayload.GetData(kvMap, kafkalib.TopicConfig{})
+	evtData, err := schemaEventPayload.GetData(kafkalib.TopicConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, len(after), len(evtData), "has deletion flag")
 
@@ -226,7 +224,7 @@ func TestGetDataTestUpdate(t *testing.T) {
 	delete(evtData, constants.OnlySetDeleteColumnMarker)
 	assert.Equal(t, after, evtData)
 
-	evtData, err = schemaEventPayload.GetData(kvMap, kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
+	evtData, err = schemaEventPayload.GetData(kafkalib.TopicConfig{IncludeArtieUpdatedAt: true})
 	assert.NoError(t, err)
 
 	_, isOk = evtData[constants.UpdateColumnMarker]

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -71,7 +71,7 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc kafkalib.TopicConfi
 		}
 	}
 
-	evtData, err := event.GetData(pkMap, tc)
+	evtData, err := event.GetData(tc)
 	if err != nil {
 		return Event{}, err
 	}


### PR DESCRIPTION
We shouldn't need to pass in `pkMap` into `GetData` and try to inject it. And with this PR being applied: https://github.com/artie-labs/transfer/pull/1167, Transfer will throw an error if the primary key doesn't exist in the event data.