### PR TITLE
Allow RS credentials override

### DIFF
--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -137,11 +137,16 @@ func LoadRedshift(ctx context.Context, cfg config.Config, _store *db.Store) (*St
 		optionalS3Prefix:  cfg.Redshift.OptionalS3Prefix,
 		configMap:         &types.DestinationTableConfigMap{},
 		config:            cfg,
-
-		Store: store,
+		Store:             store,
 	}
 
 	if cfg.Redshift.RoleARN != "" {
+		for _, requiredEnv := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"} {
+			if os.Getenv(requiredEnv) == "" {
+				return nil, fmt.Errorf("required environment variable %q is not set", requiredEnv)
+			}
+		}
+
 		creds, err := awslib.GenerateSTSCredentials(ctx, os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), cfg.Redshift.RoleARN, "ArtieTransfer")
 		if err != nil {
 			return nil, err

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -31,6 +31,19 @@ type Store struct {
 	db.Store
 }
 
+func (s *Store) BuildCredentialsClause(ctx context.Context) (string, error) {
+	if s._awsCredentials == nil {
+		return s.credentialsClause, nil
+	}
+
+	creds, err := s._awsCredentials.BuildCredentials(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to build credentials: %w", err)
+	}
+
+	return fmt.Sprintf(`ACCESS_KEY_ID '%s' SECRET_ACCESS_KEY '%s' SESSION_TOKEN '%s'`, creds.Value.AccessKeyID, creds.Value.SecretAccessKey, creds.Value.SessionToken), nil
+}
+
 func (s *Store) DropTable(_ context.Context, _ sql.TableIdentifier) error {
 	return fmt.Errorf("not supported")
 }

--- a/clients/redshift/redshift_suite_test.go
+++ b/clients/redshift/redshift_suite_test.go
@@ -24,7 +24,7 @@ func (r *RedshiftTestSuite) SetupTest() {
 	r.fakeStore = &mocks.FakeStore{}
 	store := db.Store(r.fakeStore)
 	var err error
-	r.store, err = LoadRedshift(cfg, &store)
+	r.store, err = LoadRedshift(r.T().Context(), cfg, &store)
 	assert.NoError(r.T(), err)
 }
 

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -79,7 +79,12 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 		cols = append(cols, col.Name())
 	}
 
-	copyStmt := s.dialect().BuildCopyStatement(tempTableID, cols, s3Uri, s.credentialsClause)
+	credentialsClause, err := s.BuildCredentialsClause(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to build credentials clause: %w", err)
+	}
+
+	copyStmt := s.dialect().BuildCopyStatement(tempTableID, cols, s3Uri, credentialsClause)
 	if _, err = s.Exec(copyStmt); err != nil {
 		return fmt.Errorf("failed to run COPY for temporary table: %w", err)
 	}

--- a/lib/config/destination_types.go
+++ b/lib/config/destination_types.go
@@ -42,6 +42,7 @@ type Redshift struct {
 	OptionalS3Prefix string `yaml:"optionalS3Prefix"`
 	// https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html
 	CredentialsClause string `yaml:"credentialsClause"`
+	RoleARN           string `yaml:"roleARN"`
 }
 
 type S3Settings struct {

--- a/lib/destination/ddl/ddl_suite_test.go
+++ b/lib/destination/ddl/ddl_suite_test.go
@@ -52,10 +52,8 @@ func (d *DDLTestSuite) SetupTest() {
 
 	d.fakeRedshiftStore = &mocks.FakeStore{}
 	redshiftStore := db.Store(d.fakeRedshiftStore)
-	redshiftCfg := config.Config{
-		Redshift: &config.Redshift{},
-	}
-	d.redshiftStore, err = redshift.LoadRedshift(redshiftCfg, &redshiftStore)
+	redshiftCfg := config.Config{Redshift: &config.Redshift{}}
+	d.redshiftStore, err = redshift.LoadRedshift(d.T().Context(), redshiftCfg, &redshiftStore)
 	assert.NoError(d.T(), err)
 }
 

--- a/lib/destination/utils/load.go
+++ b/lib/destination/utils/load.go
@@ -52,7 +52,7 @@ func LoadDestination(ctx context.Context, cfg config.Config, store *db.Store) (d
 	case constants.MSSQL:
 		return mssql.LoadStore(cfg)
 	case constants.Redshift:
-		return redshift.LoadRedshift(cfg, store)
+		return redshift.LoadRedshift(ctx, cfg, store)
 	}
 
 	return nil, fmt.Errorf("invalid destination: %q", cfg.Output)


### PR DESCRIPTION
If role arn is passed in, we'll generate temporary credentials and inject it into Redshift's credentials clause.