### PR TITLE
Refactor `batch.BySize` to yield both the casted rows and encoded bytes.

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -223,7 +223,7 @@ func (s *Store) putTable(ctx context.Context, bqTableID dialect.TableIdentifier,
 		return bytes, nil
 	}
 
-	return batch.BySize(tableData.Rows(), maxRequestByteSize, false, encoder, func(chunk [][]byte) error {
+	return batch.BySize(tableData.Rows(), maxRequestByteSize, false, encoder, func(chunk [][]byte, _ []map[string]any) error {
 		result, err := managedStream.AppendRows(ctx, chunk)
 		if err != nil {
 			return fmt.Errorf("failed to append rows: %w", err)

--- a/lib/batch/batch_test.go
+++ b/lib/batch/batch_test.go
@@ -107,6 +107,9 @@ func TestBySize(t *testing.T) {
 			// First batch should have foo and bar
 			assert.Equal(t, [][]byte{[]byte("foo"), []byte("bar")}, batches[0])
 			assert.Equal(t, []string{"foo", "bar"}, items[0])
+			// Second batch should have i-am-20-characters--
+			assert.Equal(t, [][]byte{[]byte("i-am-20-characters--")}, batches[1])
+			assert.Equal(t, []string{"i-am-20-characters--"}, items[1])
 		}
 	}
 	{

--- a/lib/batch/batch_test.go
+++ b/lib/batch/batch_test.go
@@ -45,13 +45,18 @@ func TestBySize(t *testing.T) {
 		return nil, fmt.Errorf("failed to encode %q", value)
 	}
 
-	testBySize := func(in []string, maxSizeBytes int, failIfRowExceedsMaxSizeBytes bool, encoder func(value string) ([]byte, error)) ([][][]byte, error) {
+	testBySize := func(in []string, maxSizeBytes int, failIfRowExceedsMaxSizeBytes bool, encoder func(value string) ([]byte, error)) ([][][]byte, [][]string, error) {
 		batches := [][][]byte{}
-		err := BySize(in, maxSizeBytes, failIfRowExceedsMaxSizeBytes, encoder, func(batch [][]byte) error { batches = append(batches, batch); return nil })
-		return batches, err
+		items := [][]string{}
+		err := BySize(in, maxSizeBytes, failIfRowExceedsMaxSizeBytes, encoder, func(batch [][]byte, batchItems []string) error {
+			batches = append(batches, batch)
+			items = append(items, batchItems)
+			return nil
+		})
+		return batches, items, err
 	}
 
-	badYield := func(batch [][]byte) error {
+	badYield := func(batch [][]byte, items []string) error {
 		out := make([]string, len(batch))
 		for i, bytes := range batch {
 			out[i] = string(bytes)
@@ -61,13 +66,14 @@ func TestBySize(t *testing.T) {
 
 	{
 		// Empty slice:
-		batches, err := testBySize([]string{}, 10, true, panicEncoder)
+		batches, items, err := testBySize([]string{}, 10, true, panicEncoder)
 		assert.NoError(t, err)
 		assert.Empty(t, batches)
+		assert.Empty(t, items)
 	}
 	{
 		// Non-empty slice + bad encoder:
-		_, err := testBySize([]string{"foo", "bar"}, 10, true, badEncoder)
+		_, _, err := testBySize([]string{"foo", "bar"}, 10, true, badEncoder)
 		assert.ErrorContains(t, err, `failed to encode item 0: failed to encode "foo"`)
 	}
 	{
@@ -89,44 +95,58 @@ func TestBySize(t *testing.T) {
 		// Non-empty slice + item is larger than maxSizeBytes
 		{
 			// failIfRowExceedsMaxSizeBytes = true
-			_, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar"}, 20, true, goodEncoder)
+			_, _, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar"}, 20, true, goodEncoder)
 			assert.ErrorContains(t, err, "item 1 is larger (23 bytes) than maxSizeBytes (20 bytes)")
 		}
 		{
 			// failIfRowExceedsMaxSizeBytes = false
-			batches, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar", "i-am-20-characters--"}, 20, false, goodEncoder)
+			batches, items, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar", "i-am-20-characters--"}, 20, false, goodEncoder)
 			assert.NoError(t, err)
 			assert.Len(t, batches, 2)
+			assert.Len(t, items, 2)
+			// First batch should have foo and bar
+			assert.Equal(t, [][]byte{[]byte("foo"), []byte("bar")}, batches[0])
+			assert.Equal(t, []string{"foo", "bar"}, items[0])
 		}
 	}
 	{
 		// Non-empty slice + item equal to maxSizeBytes:
-		batches, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar"}, 23, true, goodEncoder)
+		batches, items, err := testBySize([]string{"foo", "i-am-23-characters-long", "bar"}, 23, true, goodEncoder)
 		assert.NoError(t, err)
 		assert.Len(t, batches, 3)
+		assert.Len(t, items, 3)
 		assert.Equal(t, [][]byte{[]byte("foo")}, batches[0])
+		assert.Equal(t, []string{"foo"}, items[0])
 		assert.Equal(t, [][]byte{[]byte("i-am-23-characters-long")}, batches[1])
+		assert.Equal(t, []string{"i-am-23-characters-long"}, items[1])
 		assert.Equal(t, [][]byte{[]byte("bar")}, batches[2])
+		assert.Equal(t, []string{"bar"}, items[2])
 	}
 	{
 		// Non-empty slice + one item:
-		batches, err := testBySize([]string{"foo"}, 100, true, goodEncoder)
+		batches, items, err := testBySize([]string{"foo"}, 100, true, goodEncoder)
 		assert.NoError(t, err)
 		assert.Len(t, batches, 1)
+		assert.Len(t, items, 1)
 		assert.Equal(t, [][]byte{[]byte("foo")}, batches[0])
+		assert.Equal(t, []string{"foo"}, items[0])
 	}
 	{
 		// Non-empty slice + all items exactly fit into one batch:
-		batches, err := testBySize([]string{"foo", "bar", "baz", "qux"}, 12, true, goodEncoder)
+		batches, items, err := testBySize([]string{"foo", "bar", "baz", "qux"}, 12, true, goodEncoder)
 		assert.NoError(t, err)
 		assert.Len(t, batches, 1)
+		assert.Len(t, items, 1)
 		assert.Equal(t, [][]byte{[]byte("foo"), []byte("bar"), []byte("baz"), []byte("qux")}, batches[0])
+		assert.Equal(t, []string{"foo", "bar", "baz", "qux"}, items[0])
 	}
 	{
 		// Non-empty slice + all items exactly fit into just under one batch:
-		batches, err := testBySize([]string{"foo", "bar", "baz", "qux"}, 13, true, goodEncoder)
+		batches, items, err := testBySize([]string{"foo", "bar", "baz", "qux"}, 13, true, goodEncoder)
 		assert.NoError(t, err)
 		assert.Len(t, batches, 1)
+		assert.Len(t, items, 1)
 		assert.Equal(t, [][]byte{[]byte("foo"), []byte("bar"), []byte("baz"), []byte("qux")}, batches[0])
+		assert.Equal(t, []string{"foo", "bar", "baz", "qux"}, items[0])
 	}
 }


### PR DESCRIPTION
This way, we can choose to take either the encoded bytes and/or the rows that have been validated against the payload size.

This will be helpful for Reader to reduce a layer of marshal. We are currently encoding in `BySize` and then running an unmarshal to get the parent object to convert into a Kafka message.