### PR TITLE
[BigQuery] Handle extended decimals

### DIFF
--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -34,8 +34,8 @@ func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, s
 		// We should be using TIMESTAMP since it's an absolute point in time.
 		return "timestamp"
 	case typing.EDecimal.Kind:
+		// [kindDetails.ExtendedDecimalDetails] may be nil if the target data type is a variable numeric or bignumeric.
 		if kindDetails.ExtendedDecimalDetails == nil {
-			// We should be using NUMERIC if extended decimal details are not provided.
 			return "numeric"
 		}
 

--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -34,6 +34,11 @@ func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, s
 		// We should be using TIMESTAMP since it's an absolute point in time.
 		return "timestamp"
 	case typing.EDecimal.Kind:
+		if kindDetails.ExtendedDecimalDetails == nil {
+			// We should be using NUMERIC if extended decimal details are not provided.
+			return "numeric"
+		}
+
 		return kindDetails.ExtendedDecimalDetails.BigQueryKind(settings.BigQueryNumericForVariableNumeric)
 	}
 

--- a/clients/bigquery/dialect/typing_test.go
+++ b/clients/bigquery/dialect/typing_test.go
@@ -12,12 +12,13 @@ import (
 func TestBigQueryDialect_DataTypeForKind(t *testing.T) {
 	{
 		// String
-		{
-			assert.Equal(t, "string", BigQueryDialect{}.DataTypeForKind(typing.String, false, config.SharedDestinationColumnSettings{}))
-		}
-		{
-			assert.Equal(t, "string", BigQueryDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.String.Kind, OptionalStringPrecision: typing.ToPtr(int32(12345))}, true, config.SharedDestinationColumnSettings{}))
-		}
+		assert.Equal(t, "string", BigQueryDialect{}.DataTypeForKind(typing.String, false, config.SharedDestinationColumnSettings{}))
+		assert.Equal(t, "string", BigQueryDialect{}.DataTypeForKind(typing.KindDetails{Kind: typing.String.Kind, OptionalStringPrecision: typing.ToPtr(int32(12345))}, true, config.SharedDestinationColumnSettings{}))
+	}
+	{
+		// NUMERIC
+		// Precision and scale are not specified
+		assert.Equal(t, "numeric", BigQueryDialect{}.DataTypeForKind(typing.EDecimal, false, config.SharedDestinationColumnSettings{}))
 	}
 }
 

--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -17,7 +17,7 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
-	"github.com/artie-labs/transfer/lib/typing/decimal"
+	libconverters "github.com/artie-labs/transfer/lib/typing/converters"
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
@@ -178,12 +178,12 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 
 			message.Set(field, protoreflect.ValueOfFloat64(castedVal))
 		case typing.EDecimal.Kind:
-			decimalValue, err := typing.AssertType[*decimal.Decimal](value)
+			out, err := libconverters.DecimalConverter{}.Convert(value)
 			if err != nil {
-				return nil, fmt.Errorf("failed to cast value for column: %q, err: %w", column.Name(), err)
+				return nil, fmt.Errorf("failed to convert value for column: %q, err: %w", column.Name(), err)
 			}
 
-			message.Set(field, protoreflect.ValueOfString(decimalValue.String()))
+			message.Set(field, protoreflect.ValueOfString(out))
 		case typing.String.Kind:
 			val, err := converters.NewStringConverter(column.KindDetails).Convert(value)
 			if err != nil {

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -52,7 +52,7 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 
 		return sql.QuoteLiteral(_time.Format(time.RFC3339Nano)), nil
 	case typing.EDecimal.Kind:
-		if column.KindDetails.ExtendedDecimalDetails.Scale() == 0 {
+		if column.KindDetails.ExtendedDecimalDetails == nil || column.KindDetails.ExtendedDecimalDetails.Scale() == 0 {
 			switch column.DefaultValue().(type) {
 			case int, int8, int16, int32, int64:
 				return fmt.Sprint(column.DefaultValue()), nil

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -323,5 +323,10 @@ func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Col
 		inMemoryCol.KindDetails.ExtendedDecimalDetails = destCol.KindDetails.ExtendedDecimalDetails
 	}
 
+	// If the destination column does not have extended decimal details, we should remove it from the in-memory column as well
+	if destCol.KindDetails.ExtendedDecimalDetails == nil && inMemoryCol.KindDetails.ExtendedDecimalDetails != nil {
+		inMemoryCol.KindDetails.ExtendedDecimalDetails = nil
+	}
+
 	return inMemoryCol
 }

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -259,6 +259,16 @@ func TestMergeColumn(t *testing.T) {
 		assert.Equal(t, details, *col.KindDetails.ExtendedDecimalDetails)
 	}
 	{
+		// Decimal details should be removed when destination column doesn't have them
+		inMemoryCol := columns.NewColumn("foo", typing.EDecimal)
+		details := decimal.NewDetails(5, 2)
+		inMemoryCol.KindDetails.ExtendedDecimalDetails = &details
+
+		destCol := columns.NewColumn("foo", typing.EDecimal)
+		col := mergeColumn(inMemoryCol, destCol)
+		assert.Nil(t, col.KindDetails.ExtendedDecimalDetails)
+	}
+	{
 		// Time details get copied over
 		{
 			// Testing for backwards compatibility

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -16,6 +16,7 @@ const (
 	BigIntegerKind
 )
 
+// TODO: KindDetails should store the raw data type from the target table (if exists).
 type KindDetails struct {
 	Kind                   string
 	ExtendedDecimalDetails *decimal.Details


### PR DESCRIPTION
If the target data type is a variable numeric or big numeric, we are returning it as a `EDecimal` without any precision or scale defined. As such, we should be handling the NPE that may arise when `ExtendedDecimalDetails` is nil.

This also fixes https://github.com/artie-labs/transfer/issues/1054