### PR TITLE
[Decimal] Refactor Default Value + Add Test

### DIFF
--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -52,7 +52,7 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 
 		return sql.QuoteLiteral(_time.Format(time.RFC3339Nano)), nil
 	case typing.EDecimal.Kind:
-		if column.KindDetails.ExtendedDecimalDetails.Scale() == 0 {
+		if column.KindDetails.ExtendedDecimalDetails == nil || column.KindDetails.ExtendedDecimalDetails.Scale() == 0 {
 			switch column.DefaultValue().(type) {
 			case int, int8, int16, int32, int64:
 				return fmt.Sprint(column.DefaultValue()), nil

--- a/clients/shared/default_value_test.go
+++ b/clients/shared/default_value_test.go
@@ -125,6 +125,13 @@ func TestColumn_DefaultValue(t *testing.T) {
 		assert.Equal(t, "3.14159", value)
 	}
 	{
+		// Column is a decimal, however the incoming data is an integer.
+		col := columns.NewColumnWithDefaultValue("", typing.EDecimal, int64(123))
+		value, err := DefaultValue(col, redshiftDialect.RedshiftDialect{})
+		assert.NoError(t, err)
+		assert.Equal(t, "123", value)
+	}
+	{
 		// Int64
 		col := columns.NewColumnWithDefaultValue("", typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(5, 0)), int64(123))
 		value, err := DefaultValue(col, redshiftDialect.RedshiftDialect{})


### PR DESCRIPTION
This PR is widening our default value parser to be more resilient around decimal types.

The following scenario may happen if the target table has a NUMERIC column (without precision and scale specified) and incoming data is an integer.