### PR TITLE
[Snowflake] `writeTemporaryTableFile` to output file path and name

### DIFF
--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -195,10 +195,11 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 
 func (s *SnowflakeTestSuite) TestLoadTemporaryTable() {
 	tempTableID, tableData := generateTableData(100)
-	fp, err := s.stageStore.writeTemporaryTableFile(tableData, tempTableID)
+	file, err := s.stageStore.writeTemporaryTableFile(tableData, tempTableID)
+	assert.Equal(s.T(), fmt.Sprintf("%s.csv", tempTableID.FullyQualifiedName()), file.FileName)
 	assert.NoError(s.T(), err)
 	// Read the CSV and confirm.
-	csvfile, err := os.Open(fp)
+	csvfile, err := os.Open(file.FilePath)
 	assert.NoError(s.T(), err)
 	// Parse the file
 	r := csv.NewReader(csvfile)
@@ -230,5 +231,5 @@ func (s *SnowflakeTestSuite) TestLoadTemporaryTable() {
 	assert.Len(s.T(), seenLastName, int(tableData.NumberOfRows()))
 
 	// Delete the file.
-	assert.NoError(s.T(), os.RemoveAll(fp))
+	assert.NoError(s.T(), os.RemoveAll(file.FilePath))
 }


### PR DESCRIPTION
Having `writeTemporaryTableFile` output a File object which contains both the file path and name values. 

We will be using the file name as part of the COPY INTO command to ensure that the file we just uploaded is being processed.