### PR TITLE
[Snowflake] Improving PUT & COPY INTO

### DIFF
--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -234,7 +234,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 
 	// COPY INTO customer.public.orders___artie_Mwv9YADmRy (id,name,__artie_delete,created_at) FROM (SELECT $1,$2,$3,$4 FROM @customer.public.%orders___artie_Mwv9YADmRy
 	_, copyQuery, _ := s.fakeStageStore.ExecContextArgsForCall(2)
-	assert.Equal(s.T(), fmt.Sprintf(`COPY INTO "CUSTOMER"."PUBLIC"."%s" ("ID","NAME","__ARTIE_DELETE","__ARTIE_ONLY_SET_DELETE","CREATED_AT") FROM (SELECT $1,$2,$3,$4,$5 FROM @"CUSTOMER"."PUBLIC"."%%%s")`, tableName, tableName), copyQuery)
+	assert.Equal(s.T(), fmt.Sprintf(`COPY INTO "CUSTOMER"."PUBLIC"."%s" ("ID","NAME","__ARTIE_DELETE","__ARTIE_ONLY_SET_DELETE","CREATED_AT") FROM (SELECT $1,$2,$3,$4,$5 FROM @"CUSTOMER"."PUBLIC"."%%%s" FILES = ('CUSTOMER.PUBLIC.%s.csv'))`, tableName, tableName, tableName), copyQuery)
 
 	mergeQuery, _ := s.fakeStageStore.ExecArgsForCall(0)
 	assert.Contains(s.T(), mergeQuery, fmt.Sprintf("MERGE INTO %s", fqName), fmt.Sprintf("query: %v, destKind: %v", mergeQuery, constants.Snowflake))

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -236,7 +236,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 
 	// COPY INTO customer.public.orders___artie_Mwv9YADmRy (id,name,__artie_delete,created_at) FROM (SELECT $1,$2,$3,$4 FROM @customer.public.%orders___artie_Mwv9YADmRy
 	_, copyQuery, _ := s.fakeStageStore.ExecContextArgsForCall(2)
-	assert.Equal(s.T(), fmt.Sprintf(`COPY INTO "CUSTOMER"."PUBLIC"."%s" ("ID","NAME","__ARTIE_DELETE","__ARTIE_ONLY_SET_DELETE","CREATED_AT") FROM (SELECT $1,$2,$3,$4,$5 FROM @"CUSTOMER"."PUBLIC"."%%%s" FILES = ('CUSTOMER.PUBLIC.%s.csv'))`, tableName, tableName, tableName), copyQuery)
+	assert.Equal(s.T(), fmt.Sprintf(`COPY INTO "CUSTOMER"."PUBLIC"."%s" ("ID","NAME","__ARTIE_DELETE","__ARTIE_ONLY_SET_DELETE","CREATED_AT") FROM (SELECT $1,$2,$3,$4,$5 FROM @"CUSTOMER"."PUBLIC"."%%%s") FILES = ('CUSTOMER.PUBLIC.%s.csv.gz')`, tableName, tableName, tableName), copyQuery)
 
 	mergeQuery, _ := s.fakeStageStore.ExecArgsForCall(0)
 	assert.Contains(s.T(), mergeQuery, fmt.Sprintf("MERGE INTO %s", fqName), fmt.Sprintf("query: %v, destKind: %v", mergeQuery, constants.Snowflake))

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -2,6 +2,8 @@ package snowflake
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -228,9 +230,9 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 	tableName := retrieveTableNameFromCreateTable(s.T(), createQuery)
 	assert.Equal(s.T(), fmt.Sprintf(`CREATE TABLE IF NOT EXISTS "CUSTOMER"."PUBLIC"."%s" ("ID" int,"NAME" string,"__ARTIE_DELETE" boolean,"__ARTIE_ONLY_SET_DELETE" boolean,"CREATED_AT" string) DATA_RETENTION_TIME_IN_DAYS = 0 STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='__artie_null_value' EMPTY_FIELD_AS_NULL=FALSE)`, tableName), createQuery)
 
-	// PUT file:///tmp/customer.public.orders___artie_Mwv9YADmRy.csv @customer.public.%orders___artie_Mwv9YADmRy AUTO_COMPRESS=TRUE
+	// PUT file:///tmp/CUSTOMER.PUBLIC.orders.csv @"CUSTOMER"."PUBLIC"."%%orders" AUTO_COMPRESS=TRUE
 	_, putQuery, _ := s.fakeStageStore.ExecContextArgsForCall(1)
-	assert.Contains(s.T(), putQuery, "PUT 'file://")
+	assert.Equal(s.T(), fmt.Sprintf(`PUT 'file://%s' @"CUSTOMER"."PUBLIC"."%%%s" AUTO_COMPRESS=TRUE`, filepath.Join(os.TempDir(), fmt.Sprintf("CUSTOMER.PUBLIC.%s.csv", tableName)), tableName), putQuery)
 
 	// COPY INTO customer.public.orders___artie_Mwv9YADmRy (id,name,__artie_delete,created_at) FROM (SELECT $1,$2,$3,$4 FROM @customer.public.%orders___artie_Mwv9YADmRy
 	_, copyQuery, _ := s.fakeStageStore.ExecContextArgsForCall(2)

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -230,7 +230,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 
 	// PUT file:///tmp/customer.public.orders___artie_Mwv9YADmRy.csv @customer.public.%orders___artie_Mwv9YADmRy AUTO_COMPRESS=TRUE
 	_, putQuery, _ := s.fakeStageStore.ExecContextArgsForCall(1)
-	assert.Contains(s.T(), putQuery, "PUT file://")
+	assert.Contains(s.T(), putQuery, "PUT 'file://")
 
 	// COPY INTO customer.public.orders___artie_Mwv9YADmRy (id,name,__artie_delete,created_at) FROM (SELECT $1,$2,$3,$4 FROM @customer.public.%orders___artie_Mwv9YADmRy
 	_, copyQuery, _ := s.fakeStageStore.ExecContextArgsForCall(2)

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -140,3 +140,8 @@ func (s *Store) writeTemporaryTableFile(tableData *optimization.TableData, newTa
 	writer.Flush()
 	return File{FilePath: fp, FileName: fileName}, writer.Error()
 }
+
+// BuildPutQuery builds a PUT query to upload a file to Snowflake's staging area
+func (s *Store) BuildPutQuery(filePath string, stageName string) string {
+	return fmt.Sprintf("PUT 'file://%s' @%s AUTO_COMPRESS=TRUE", filePath, stageName)
+}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -142,8 +142,3 @@ func (s *Store) writeTemporaryTableFile(tableData *optimization.TableData, newTa
 	writer.Flush()
 	return File{FilePath: fp, FileName: fileName}, writer.Error()
 }
-
-// BuildPutQuery builds a PUT query to upload a file to Snowflake's staging area
-func (s *Store) BuildPutQuery(filePath string, stageName string) string {
-	return fmt.Sprintf("PUT 'file://%s' @%s AUTO_COMPRESS=TRUE", filePath, stageName)
-}

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -188,7 +188,7 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 			), putQuery)
 		// Third call is a COPY INTO
 		_, copyQuery, _ := s.fakeStageStore.ExecContextArgsForCall(2)
-		assert.Equal(s.T(), fmt.Sprintf(`COPY INTO %s ("USER_ID","FIRST_NAME","LAST_NAME","DUSTY") FROM (SELECT $1,$2,$3,$4 FROM @%s FILES = ('%s.csv'))`,
+		assert.Equal(s.T(), fmt.Sprintf(`COPY INTO %s ("USER_ID","FIRST_NAME","LAST_NAME","DUSTY") FROM (SELECT $1,$2,$3,$4 FROM @%s) FILES = ('%s.csv.gz')`,
 			tempTableName, resourceName, strings.ReplaceAll(tempTableName, `"`, "")), copyQuery)
 	}
 	{

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -178,7 +178,7 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 		resourceName := addPrefixToTableName(tempTableID, "%")
 		// Second call is a PUT
 		_, putQuery, _ := s.fakeStageStore.ExecContextArgsForCall(1)
-		assert.Contains(s.T(), putQuery, "PUT file://", putQuery)
+		assert.Contains(s.T(), putQuery, "PUT 'file://", putQuery)
 		assert.Contains(s.T(), putQuery, fmt.Sprintf("@%s AUTO_COMPRESS=TRUE", resourceName))
 		// Third call is a COPY INTO
 		_, copyQuery, _ := s.fakeStageStore.ExecContextArgsForCall(2)
@@ -196,7 +196,7 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 func (s *SnowflakeTestSuite) TestLoadTemporaryTable() {
 	tempTableID, tableData := generateTableData(100)
 	file, err := s.stageStore.writeTemporaryTableFile(tableData, tempTableID)
-	assert.Equal(s.T(), fmt.Sprintf("%s.csv", tempTableID.FullyQualifiedName()), file.FileName)
+	assert.Equal(s.T(), fmt.Sprintf("%s.csv", strings.ReplaceAll(tempTableID.FullyQualifiedName(), `"`, "")), file.FileName)
 	assert.NoError(s.T(), err)
 	// Read the CSV and confirm.
 	csvfile, err := os.Open(file.FilePath)

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -182,8 +182,8 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 		assert.Contains(s.T(), putQuery, fmt.Sprintf("@%s AUTO_COMPRESS=TRUE", resourceName))
 		// Third call is a COPY INTO
 		_, copyQuery, _ := s.fakeStageStore.ExecContextArgsForCall(2)
-		assert.Equal(s.T(), fmt.Sprintf(`COPY INTO %s ("USER_ID","FIRST_NAME","LAST_NAME","DUSTY") FROM (SELECT $1,$2,$3,$4 FROM @%s)`,
-			tempTableName, resourceName), copyQuery)
+		assert.Equal(s.T(), fmt.Sprintf(`COPY INTO %s ("USER_ID","FIRST_NAME","LAST_NAME","DUSTY") FROM (SELECT $1,$2,$3,$4 FROM @%s FILES = ('%s.csv'))`,
+			tempTableName, resourceName, strings.ReplaceAll(tempTableName, `"`, "")), copyQuery)
 	}
 	{
 		// Don't create the temporary table.


### PR DESCRIPTION
## Improvements

Adding improvements around Snowflake PUT & COPY INTO commands:

1. Adding single quotes around the filename for PUT
2. Specifying the file to copy for Snowflake. [1]


## Problem 

[1] - This process was susceptible to silent failures. We noticed that the older versions of Snowflake's SDK could have PUT silently fail but still return a success. We would then issue a COPY INTO from a stage to a table and given that there are no files in the stage, the COPY INTO would then also succeed. This could then lead to us to have inconsistent or missing data if PUT failed.

By specifying the file name as part of COPY INTO, Snowflake will throw an error if the remote file does not exist.
![image](https://github.com/user-attachments/assets/61e0126d-a5db-43d6-9d06-187d5a49fa58)
