### PR TITLE
Improve converter errors

### DIFF
--- a/lib/typing/values/string.go
+++ b/lib/typing/values/string.go
@@ -17,7 +17,12 @@ func ToStringOpts(colVal any, colKind typing.KindDetails, opts converters.GetStr
 		return "", fmt.Errorf("failed to get string converter: %w", err)
 	}
 
-	return sv.Convert(colVal)
+	value, err := sv.Convert(colVal)
+	if err != nil {
+		return "", fmt.Errorf("converter %T failed to convert value: %w", sv, err)
+	}
+
+	return value, nil
 }
 
 func ToString(colVal any, colKind typing.KindDetails) (string, error) {

--- a/lib/typing/values/string_test.go
+++ b/lib/typing/values/string_test.go
@@ -166,6 +166,11 @@ func TestToString(t *testing.T) {
 	{
 		// Integer column
 		{
+			// Invalid (string value)
+			_, err := ToString("foo", typing.Integer)
+			assert.ErrorContains(t, err, `converter converters.IntegerConverter failed to convert value: unexpected value: 'foo', type: string`)
+		}
+		{
 			// Float32 value
 			val, err := ToString(float32(45452.999991), typing.Integer)
 			assert.NoError(t, err)


### PR DESCRIPTION
We will now include the converter type if the conversion failed. This will help us with debugging by quickly narrowing in on the problematic converter.