### PR TITLE
[Databricks] Include multiLine option

### DIFF
--- a/clients/databricks/dialect/dialect.go
+++ b/clients/databricks/dialect/dialect.go
@@ -175,6 +175,7 @@ FORMAT_OPTIONS (
     'delimiter' = '\t',
     'header' = 'false',
     'nullValue' = '%s',
+    'multiLine' = 'true',
     'compression' = 'gzip'
 );`,
 		// COPY INTO

--- a/clients/databricks/dialect/dialect_test.go
+++ b/clients/databricks/dialect/dialect_test.go
@@ -341,6 +341,7 @@ FORMAT_OPTIONS (
     'delimiter' = '\t',
     'header' = 'false',
     'nullValue' = '%s',
+    'multiLine' = 'true',
     'compression' = 'gzip'
 );`, constants.NullValuePlaceholder), dialect.BuildCopyIntoQuery(tempTableID, []string{"_c0", "_c1"}, "dbfs:/path/to/file.csv.gz"))
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c02e6c8d-4ede-4c1b-b49d-1ef8a8f8c987)

I'm a bit surprised this is default to false. But this will tell Databricks that a row may be multiple lines and to follow the escape rune and delimiter.