### PR TITLE
[Snowflake] Moving the Escape function

### DIFF
--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -186,3 +186,25 @@ func (SnowflakeDialect) BuildRemoveFilesFromStage(stageName string, path string)
 	// https://docs.snowflake.com/en/sql-reference/sql/remove
 	return fmt.Sprintf("REMOVE @%s", filepath.Join(stageName, path))
 }
+
+// EscapeColumns will take columns, escape and return them in ordered received.
+// It'll return like this: $1, $2, $3
+func (SnowflakeDialect) EscapeColumns(columns []columns.Column, delimiter string) string {
+	var escapedCols []string
+	var index int
+	for _, col := range columns {
+		escapedCol := fmt.Sprintf("$%d", index+1)
+		switch col.KindDetails {
+		case typing.Struct:
+			// https://community.snowflake.com/s/article/how-to-load-json-values-in-a-csv-file
+			escapedCol = fmt.Sprintf("PARSE_JSON(%s)", escapedCol)
+		case typing.Array:
+			escapedCol = fmt.Sprintf("CAST(PARSE_JSON(%s) AS ARRAY) AS %s", escapedCol, escapedCol)
+		}
+
+		escapedCols = append(escapedCols, escapedCol)
+		index += 1
+	}
+
+	return strings.Join(escapedCols, delimiter)
+}

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -299,3 +299,39 @@ func TestSnowflakeDialect_BuildRemoveAllFilesFromStage(t *testing.T) {
 		)
 	}
 }
+
+func TestSnowflakeDialect_EscapeColumns(t *testing.T) {
+	{
+		// Test basic string columns
+		var cols columns.Columns
+		cols.AddColumn(columns.NewColumn("foo", typing.String))
+		cols.AddColumn(columns.NewColumn("bar", typing.String))
+		assert.Equal(t, "$1,$2", SnowflakeDialect{}.EscapeColumns(cols.GetColumns(), ","))
+	}
+	{
+		// Test string columns with struct
+		var cols columns.Columns
+		cols.AddColumn(columns.NewColumn("foo", typing.String))
+		cols.AddColumn(columns.NewColumn("bar", typing.String))
+		cols.AddColumn(columns.NewColumn("struct", typing.Struct))
+		assert.Equal(t, "$1,$2,PARSE_JSON($3)", SnowflakeDialect{}.EscapeColumns(cols.GetColumns(), ","))
+	}
+	{
+		// Test string columns with struct and array
+		var cols columns.Columns
+		cols.AddColumn(columns.NewColumn("foo", typing.String))
+		cols.AddColumn(columns.NewColumn("bar", typing.String))
+		cols.AddColumn(columns.NewColumn("struct", typing.Struct))
+		cols.AddColumn(columns.NewColumn("array", typing.Array))
+		assert.Equal(t, "$1,$2,PARSE_JSON($3),CAST(PARSE_JSON($4) AS ARRAY) AS $4", SnowflakeDialect{}.EscapeColumns(cols.GetColumns(), ","))
+	}
+	{
+		// Test with invalid columns mixed in
+		var cols columns.Columns
+		cols.AddColumn(columns.NewColumn("foo", typing.String))
+		cols.AddColumn(columns.NewColumn("bar", typing.String))
+		cols.AddColumn(columns.NewColumn("struct", typing.Struct))
+		cols.AddColumn(columns.NewColumn("array", typing.Array))
+		assert.Equal(t, "$1,$2,PARSE_JSON($3),CAST(PARSE_JSON($4) AS ARRAY) AS $4", SnowflakeDialect{}.EscapeColumns(cols.GetColumns(), ","))
+	}
+}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -80,7 +80,7 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 		// COPY INTO <table> (<columns>)
 		tempTableID.FullyQualifiedName(), strings.Join(sql.QuoteColumns(tableData.ReadOnlyInMemoryCols().ValidColumns(), s.Dialect()), ","),
 		// FROM (SELECT <columns> FROM @<stage> FILES = ('<file_name>'))
-		escapeColumns(tableData.ReadOnlyInMemoryCols(), ","), tableStageName,
+		s.dialect().EscapeColumns(tableData.ReadOnlyInMemoryCols().ValidColumns(), ","), tableStageName,
 		// We're appending gz to the file name since it was compressed by the PUT command.
 		fmt.Sprintf("%s.gz", file.FileName),
 	)

--- a/clients/snowflake/util.go
+++ b/clients/snowflake/util.go
@@ -1,40 +1,11 @@
 package snowflake
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/artie-labs/transfer/lib/sql"
-	"github.com/artie-labs/transfer/lib/typing"
-	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
 // addPrefixToTableName will take a [sql.TableIdentifier] and add a prefix in front of the table.
 // This is necessary for `PUT` commands.
 func addPrefixToTableName(tableID sql.TableIdentifier, prefix string) string {
 	return tableID.WithTable(prefix + tableID.Table()).FullyQualifiedName()
-}
-
-// escapeColumns will take columns, filter out invalid, escape and return them in ordered received.
-// It'll return like this: $1, $2, $3
-func escapeColumns(columns *columns.Columns, delimiter string) string {
-	var escapedCols []string
-	var index int
-	for _, col := range columns.GetColumns() {
-		escapedCol := fmt.Sprintf("$%d", index+1)
-		switch col.KindDetails {
-		case typing.Invalid:
-			continue
-		case typing.Struct:
-			// https://community.snowflake.com/s/article/how-to-load-json-values-in-a-csv-file
-			escapedCol = fmt.Sprintf("PARSE_JSON(%s)", escapedCol)
-		case typing.Array:
-			escapedCol = fmt.Sprintf("CAST(PARSE_JSON(%s) AS ARRAY) AS %s", escapedCol, escapedCol)
-		}
-
-		escapedCols = append(escapedCols, escapedCol)
-		index += 1
-	}
-
-	return strings.Join(escapedCols, delimiter)
 }

--- a/clients/snowflake/util_test.go
+++ b/clients/snowflake/util_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/clients/snowflake/dialect"
-	"github.com/artie-labs/transfer/lib/typing"
-	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
 func TestAddPrefixToTableName(t *testing.T) {
@@ -27,43 +25,5 @@ func TestAddPrefixToTableName(t *testing.T) {
 	{
 		// Database and table name
 		assert.Equal(t, `"DB".""."%TABLENAME"`, addPrefixToTableName(dialect.NewTableIdentifier("db", "", "tableName"), prefix))
-	}
-}
-
-func (s *SnowflakeTestSuite) TestEscapeColumns() {
-	{
-		// Test basic string columns
-		var cols columns.Columns
-		cols.AddColumn(columns.NewColumn("foo", typing.String))
-		cols.AddColumn(columns.NewColumn("bar", typing.String))
-		assert.Equal(s.T(), "$1,$2", escapeColumns(&cols, ","))
-	}
-	{
-		// Test string columns with struct
-		var cols columns.Columns
-		cols.AddColumn(columns.NewColumn("foo", typing.String))
-		cols.AddColumn(columns.NewColumn("bar", typing.String))
-		cols.AddColumn(columns.NewColumn("struct", typing.Struct))
-		assert.Equal(s.T(), "$1,$2,PARSE_JSON($3)", escapeColumns(&cols, ","))
-	}
-	{
-		// Test string columns with struct and array
-		var cols columns.Columns
-		cols.AddColumn(columns.NewColumn("foo", typing.String))
-		cols.AddColumn(columns.NewColumn("bar", typing.String))
-		cols.AddColumn(columns.NewColumn("struct", typing.Struct))
-		cols.AddColumn(columns.NewColumn("array", typing.Array))
-		assert.Equal(s.T(), "$1,$2,PARSE_JSON($3),CAST(PARSE_JSON($4) AS ARRAY) AS $4", escapeColumns(&cols, ","))
-	}
-	{
-		// Test with invalid columns mixed in
-		var cols columns.Columns
-		cols.AddColumn(columns.NewColumn("invalid1", typing.Invalid))
-		cols.AddColumn(columns.NewColumn("foo", typing.String))
-		cols.AddColumn(columns.NewColumn("bar", typing.String))
-		cols.AddColumn(columns.NewColumn("struct", typing.Struct))
-		cols.AddColumn(columns.NewColumn("array", typing.Array))
-		cols.AddColumn(columns.NewColumn("invalid2", typing.Invalid))
-		assert.Equal(s.T(), "$1,$2,PARSE_JSON($3),CAST(PARSE_JSON($4) AS ARRAY) AS $4", escapeColumns(&cols, ","))
 	}
 }


### PR DESCRIPTION
## Changes

1. Moving the escape function into the Snowflake dialect pkg
2. Passing around columns instead of `*columns.Columns`
3. Filtering of invalid columns is done upstream via `.ValidColumns()`

## Motivation

By doing this, we are one step closer to moving the COPY command into the dialect pkg and having robust tests around it.