### PR TITLE
Adding S3 Filename separator

### DIFF
--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -39,7 +39,7 @@ func (s *Store) Validate() error {
 }
 
 func (s *Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sql.TableIdentifier {
-	return NewTableIdentifier(topicConfig.Database, topicConfig.Schema, table)
+	return NewTableIdentifier(topicConfig.Database, topicConfig.Schema, table, s.config.S3.TableNameSeparator)
 }
 
 // ObjectPrefix - this will generate the exact right prefix that we need to write into S3.

--- a/clients/s3/tableid.go
+++ b/clients/s3/tableid.go
@@ -1,19 +1,21 @@
 package s3
 
 import (
-	"fmt"
+	"cmp"
+	"strings"
 
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
 type TableIdentifier struct {
-	database string
-	schema   string
-	table    string
+	database      string
+	schema        string
+	table         string
+	nameSeparator string
 }
 
-func NewTableIdentifier(database, schema, table string) TableIdentifier {
-	return TableIdentifier{database: database, schema: schema, table: table}
+func NewTableIdentifier(database, schema, table string, nameSeparator string) TableIdentifier {
+	return TableIdentifier{database: database, schema: schema, table: table, nameSeparator: cmp.Or(nameSeparator, ".")}
 }
 
 func (ti TableIdentifier) Database() string {
@@ -34,9 +36,9 @@ func (ti TableIdentifier) Table() string {
 }
 
 func (ti TableIdentifier) WithTable(table string) sql.TableIdentifier {
-	return NewTableIdentifier(ti.database, ti.schema, table)
+	return NewTableIdentifier(ti.database, ti.schema, table, ti.nameSeparator)
 }
 
 func (ti TableIdentifier) FullyQualifiedName() string {
-	return fmt.Sprintf("%s.%s.%s", ti.database, ti.schema, ti.EscapedTable())
+	return strings.Join([]string{ti.database, ti.schema, ti.EscapedTable()}, ti.nameSeparator)
 }

--- a/clients/s3/tableid_test.go
+++ b/clients/s3/tableid_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTableIdentifier_WithTable(t *testing.T) {
-	tableID := NewTableIdentifier("database", "schema", "foo")
+	tableID := NewTableIdentifier("database", "schema", "foo", "")
 	tableID2 := tableID.WithTable("bar")
 	typedTableID2, ok := tableID2.(TableIdentifier)
 	assert.True(t, ok)
@@ -17,13 +17,20 @@ func TestTableIdentifier_WithTable(t *testing.T) {
 }
 
 func TestTableIdentifier_FullyQualifiedName(t *testing.T) {
-	// S3 doesn't escape the table name.
-	tableID := NewTableIdentifier("database", "schema", "table")
-	assert.Equal(t, "database.schema.table", tableID.FullyQualifiedName())
+	{
+		// S3 doesn't escape the table name.
+		tableID := NewTableIdentifier("database", "schema", "table", "")
+		assert.Equal(t, "database.schema.table", tableID.FullyQualifiedName())
+	}
+	{
+		// Separator via `/`
+		tableID := NewTableIdentifier("database", "schema", "table", "/")
+		assert.Equal(t, "database/schema/table", tableID.FullyQualifiedName())
+	}
 }
 
 func TestTableIdentifier_EscapedTable(t *testing.T) {
 	// S3 doesn't escape the table name.
-	tableID := NewTableIdentifier("database", "schema", "table")
+	tableID := NewTableIdentifier("database", "schema", "table", "")
 	assert.Equal(t, "table", tableID.EscapedTable())
 }

--- a/lib/config/destination_types.go
+++ b/lib/config/destination_types.go
@@ -53,6 +53,7 @@ type S3Settings struct {
 	AwsSecretAccessKey string                   `yaml:"awsSecretAccessKey"`
 	AwsRegion          string                   `yaml:"awsRegion"`
 	OutputFormat       constants.S3OutputFormat `yaml:"outputFormat"`
+	TableNameSeparator string                   `yaml:"tableNameSeparator"`
 }
 
 type Snowflake struct {


### PR DESCRIPTION
By default, we'll use `.`

But you can now pass in a custom separator string and we'll use that instead.


Using `/` delimiter allows us organize data better:
![image](https://github.com/user-attachments/assets/26961b34-debb-4e1f-acad-2edc91abdb21)
