### PR TITLE
Rename goreleaser `format` to formats

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,7 +50,7 @@ dockers:
 
 
 archives:
-  - format: tar.gz
+  - formats: tar.gz
     # this name template makes the OS and Arch compatible with the results of uname.
     name_template: >-
       {{ .ProjectName }}_


### PR DESCRIPTION
https://goreleaser.com/deprecations/#archivesformat