### PR TITLE
[Databricks] Fixes around COPY INTO

### DIFF
--- a/clients/databricks/file.go
+++ b/clients/databricks/file.go
@@ -8,6 +8,7 @@ import (
 	"github.com/artie-labs/transfer/clients/databricks/dialect"
 	"github.com/artie-labs/transfer/lib/destination/ddl"
 	"github.com/artie-labs/transfer/lib/maputil"
+	"github.com/artie-labs/transfer/lib/stringutil"
 )
 
 type File struct {
@@ -30,7 +31,7 @@ func NewFile(fileRow map[string]any) (File, error) {
 }
 
 func NewFileFromTableID(tableID dialect.TableIdentifier, volume string) File {
-	name := fmt.Sprintf("%s.csv.gz", tableID.Table())
+	name := fmt.Sprintf("%s_%s.csv.gz", tableID.Table(), stringutil.Random(10))
 	return File{
 		name: name,
 		fp:   fmt.Sprintf("/Volumes/%s/%s/%s/%s", tableID.Database(), tableID.Schema(), volume, name),

--- a/clients/databricks/file_test.go
+++ b/clients/databricks/file_test.go
@@ -70,5 +70,17 @@ func TestFile_ShouldDelete(t *testing.T) {
 
 func TestFile_DBFSFilePath(t *testing.T) {
 	file := NewFileFromTableID(dialect.NewTableIdentifier("{DB}", "{SCHEMA}", "{TABLE}"), "{VOLUME}")
-	assert.Equal(t, "dbfs:/Volumes/{DB}/{SCHEMA}/{VOLUME}/{TABLE}.csv.gz", file.DBFSFilePath())
+
+	parts := strings.Split(file.DBFSFilePath(), "/")
+	assert.Len(t, parts, 6)
+
+	assert.Equal(t, "dbfs:", parts[0])
+	assert.Equal(t, "Volumes", parts[1])
+	assert.Equal(t, "{DB}", parts[2])
+	assert.Equal(t, "{SCHEMA}", parts[3])
+	assert.Equal(t, "{VOLUME}", parts[4])
+
+	// Last one has a random suffix
+	assert.Contains(t, parts[5], "{TABLE}")
+	assert.Contains(t, parts[5], ".csv.gz")
 }

--- a/clients/databricks/store.go
+++ b/clients/databricks/store.go
@@ -101,13 +101,7 @@ func (s Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizatio
 		return fmt.Errorf("failed to cast temp table ID to TableIdentifier")
 	}
 
-	anotherTempTableID := shared.TempTableID(castedTempTableID)
-	castedAnotherTempTableID, isOk := anotherTempTableID.(dialect.TableIdentifier)
-	if !isOk {
-		return fmt.Errorf("failed to cast another temp table ID to TableIdentifier")
-	}
-
-	file := NewFileFromTableID(castedAnotherTempTableID, s.volume)
+	file := NewFileFromTableID(castedTempTableID, s.volume)
 	fp, err := s.writeTemporaryTableFile(tableData, file.Name())
 	if err != nil {
 		return fmt.Errorf("failed to load temporary table: %w", err)


### PR DESCRIPTION
After running the Databricks integration tests, I've observed that by using the same delta file for COPY INTO in Databricks, it will result in subsequent COPY INTOs having no-ops.

My guess is that there's heavy caching on Databricks end to not process that particular COPY INTO. By using a different name, we're able to bypass this problem.