### PR TITLE
Improved Parquet handling for DECIMAL

### DIFF
--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/debezium/converters"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
+	"github.com/xitongsys/parquet-go/types"
 )
 
 func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
@@ -91,8 +91,8 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return decimalValue.String(), nil
 		}
 
-		bytes, _ := converters.EncodeDecimal(decimalValue.Value())
-		return string(bytes), nil
+		scale := colKind.ExtendedDecimalDetails.Scale()
+		return types.StrIntToBinary(decimalValue.String(), "BigEndian", int(scale+precision), true), nil
 	case typing.Integer.Kind:
 		return asInt64(colVal)
 	}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/debezium/converters"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
@@ -86,18 +85,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 		}
 
 		// If the precision is not specified, we should return a string
-		if colKind.ExtendedDecimalDetails.Precision() == decimal.PrecisionNotSpecified {
-			return decimalValue.String(), nil
-		}
-
-		// Else, we should return the unscaled number must be encoded as two's complement using big-endian byte order
-		encodedBytes, scale := converters.EncodeDecimal(decimalValue.Value())
-		if scale != colKind.ExtendedDecimalDetails.Scale() {
-			return nil, fmt.Errorf("scale mismatch, expected: %d, got: %d", colKind.ExtendedDecimalDetails.Scale(), scale)
-		}
-
-		fmt.Println("Encoded bytes", string(encodedBytes))
-		return string(encodedBytes), nil
+		return decimalValue.String(), nil
 	case typing.Integer.Kind:
 		fmt.Println("Incoming data", colVal, fmt.Sprintf("%T", colVal))
 		asInt64, err := asInt64(colVal)

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -12,6 +12,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
+	"github.com/xitongsys/parquet-go/parquet"
 	"github.com/xitongsys/parquet-go/types"
 )
 
@@ -92,7 +93,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 		}
 
 		scale := colKind.ExtendedDecimalDetails.Scale()
-		return types.StrIntToBinary(decimalValue.String(), "BigEndian", int(scale+precision), true), nil
+		return types.StrToParquetType(decimalValue.String(), typing.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), typing.ToPtr(parquet.ConvertedType_DECIMAL), int(scale+precision), int(scale))
 	case typing.Integer.Kind:
 		return asInt64(colVal)
 	}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -100,6 +100,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 	return colVal, nil
 }
 
+// TODO: Move this into a Primative converter package.
 func asInt64(value any) (int64, error) {
 	switch castValue := value.(type) {
 	case string:

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -85,7 +85,16 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return nil, err
 		}
 
-		return types.DECIMAL_BYTE_ARRAY_ToString([]byte(decimalValue.String()), int(decimalValue.Details().Precision()), int(decimalValue.Details().Scale())), nil
+		precision := colKind.ExtendedDecimalDetails.Precision()
+		scale := colKind.ExtendedDecimalDetails.Scale()
+		if precision == decimal.PrecisionNotSpecified {
+			// If precision is not provided, just default to a string.
+			return decimalValue.String(), nil
+		}
+
+		fmt.Println("precision", precision, "scale", scale)
+
+		return types.DECIMAL_BYTE_ARRAY_ToString([]byte(decimalValue.String()), int(precision), int(scale)), nil
 	case typing.Integer.Kind:
 		return asInt64(colVal)
 	}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -92,7 +92,13 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return decimalValue.String(), nil
 		}
 
-		return types.StrToParquetType(decimalValue.String(), typing.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), typing.ToPtr(parquet.ConvertedType_DECIMAL), int(colKind.ExtendedDecimalDetails.TwosComplementByteArrLength()), int(colKind.ExtendedDecimalDetails.Scale()))
+		return types.StrToParquetType(
+			decimalValue.String(),
+			typing.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY),
+			typing.ToPtr(parquet.ConvertedType_DECIMAL),
+			int(colKind.ExtendedDecimalDetails.TwosComplementByteArrLength()),
+			int(colKind.ExtendedDecimalDetails.Scale()),
+		)
 	case typing.Integer.Kind:
 		return asInt64(colVal)
 	}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/debezium/converters"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
-	"github.com/xitongsys/parquet-go/types"
 )
 
 func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
@@ -86,14 +86,13 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 		}
 
 		precision := colKind.ExtendedDecimalDetails.Precision()
-		scale := colKind.ExtendedDecimalDetails.Scale()
 		if precision == decimal.PrecisionNotSpecified {
 			// If precision is not provided, just default to a string.
 			return decimalValue.String(), nil
 		}
 
-		fmt.Println("precision", precision, "scale", scale, "value", decimalValue.String())
-		return types.DECIMAL_BYTE_ARRAY_ToString([]byte(decimalValue.String()), int(precision), int(scale)), nil
+		bytes, _ := converters.EncodeDecimal(decimalValue.Value())
+		return string(bytes), nil
 	case typing.Integer.Kind:
 		return asInt64(colVal)
 	}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -92,9 +92,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return decimalValue.String(), nil
 		}
 
-		scale := colKind.ExtendedDecimalDetails.Scale()
-		length := (precision + 1) / 2
-		return types.StrToParquetType(decimalValue.String(), typing.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), typing.ToPtr(parquet.ConvertedType_DECIMAL), int(length), int(scale))
+		return types.StrToParquetType(decimalValue.String(), typing.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), typing.ToPtr(parquet.ConvertedType_DECIMAL), int(colKind.ExtendedDecimalDetails.TwosComplementByteArrLength()), int(colKind.ExtendedDecimalDetails.Scale()))
 	case typing.Integer.Kind:
 		return asInt64(colVal)
 	}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -92,9 +92,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 		}
 
 		bytes, _ := converters.EncodeDecimal(decimalValue.Value())
-
-		bytes = padBytesLeft(bytes, int(colKind.ExtendedDecimalDetails.TwosComplementByteArrLength()))
-		return string(bytes), nil
+		return string(padBytesLeft(bytes, int(colKind.ExtendedDecimalDetails.TwosComplementByteArrLength()))), nil
 	case typing.Integer.Kind:
 		return asInt64(colVal)
 	}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -96,6 +96,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return nil, fmt.Errorf("scale mismatch, expected: %d, got: %d", colKind.ExtendedDecimalDetails.Scale(), scale)
 		}
 
+		fmt.Println("Encoded bytes", string(encodedBytes))
 		return string(encodedBytes), nil
 	case typing.Integer.Kind:
 		fmt.Println("Incoming data", colVal, fmt.Sprintf("%T", colVal))

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -92,8 +92,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return decimalValue.String(), nil
 		}
 
-		fmt.Println("precision", precision, "scale", scale)
-
+		fmt.Println("precision", precision, "scale", scale, "value", decimalValue.String())
 		return types.DECIMAL_BYTE_ARRAY_ToString([]byte(decimalValue.String()), int(precision), int(scale)), nil
 	case typing.Integer.Kind:
 		return asInt64(colVal)

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -93,7 +93,8 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 		}
 
 		scale := colKind.ExtendedDecimalDetails.Scale()
-		return types.StrToParquetType(decimalValue.String(), typing.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), typing.ToPtr(parquet.ConvertedType_DECIMAL), int(scale+precision), int(scale))
+		length := (precision + 1) / 2
+		return types.StrToParquetType(decimalValue.String(), typing.ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY), typing.ToPtr(parquet.ConvertedType_DECIMAL), int(length), int(scale))
 	case typing.Integer.Kind:
 		return asInt64(colVal)
 	}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -87,7 +87,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 		// If the precision is not specified, we should return a string
 		return decimalValue.String(), nil
 	case typing.Integer.Kind:
-		return asInt64, nil
+		return asInt64(colVal)
 	}
 
 	return colVal, nil

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -92,7 +92,12 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 		}
 
 		bytes, _ := converters.EncodeDecimal(decimalValue.Value())
-		return string(padBytesLeft(bytes, int(colKind.ExtendedDecimalDetails.TwosComplementByteArrLength()))), nil
+		bytes, err = padBytesLeft(bytes, int(colKind.ExtendedDecimalDetails.TwosComplementByteArrLength()))
+		if err != nil {
+			return nil, err
+		}
+
+		return string(bytes), nil
 	case typing.Integer.Kind:
 		return asInt64(colVal)
 	}
@@ -122,12 +127,16 @@ func asInt64(value any) (int64, error) {
 }
 
 // padBytesLeft pads the left side of the bytes with zeros.
-func padBytesLeft(bytes []byte, length int) []byte {
-	if len(bytes) >= length {
-		return bytes
+func padBytesLeft(bytes []byte, length int) ([]byte, error) {
+	if len(bytes) == length {
+		return bytes, nil
+	}
+
+	if len(bytes) > length {
+		return nil, fmt.Errorf("bytes (%d) are longer than the length: %d", len(bytes), length)
 	}
 
 	padded := make([]byte, length)
 	copy(padded[length-len(bytes):], bytes)
-	return padded
+	return padded, nil
 }

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -96,7 +96,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return nil, fmt.Errorf("scale mismatch, expected: %d, got: %d", colKind.ExtendedDecimalDetails.Scale(), scale)
 		}
 
-		return encodedBytes, nil
+		return string(encodedBytes), nil
 	case typing.Integer.Kind:
 		fmt.Println("Incoming data", colVal, fmt.Sprintf("%T", colVal))
 		asInt64, err := asInt64(colVal)

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -87,12 +87,6 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 		// If the precision is not specified, we should return a string
 		return decimalValue.String(), nil
 	case typing.Integer.Kind:
-		fmt.Println("Incoming data", colVal, fmt.Sprintf("%T", colVal))
-		asInt64, err := asInt64(colVal)
-		if err != nil {
-			return nil, err
-		}
-
 		return asInt64, nil
 	}
 

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/artie-labs/transfer/lib/array"
@@ -84,7 +85,35 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 		}
 
 		return decimalValue.String(), nil
+	case typing.Integer.Kind:
+		fmt.Println("Incoming data", colVal, fmt.Sprintf("%T", colVal))
+		asInt64, err := asInt64(colVal)
+		if err != nil {
+			return nil, err
+		}
+
+		return asInt64, nil
 	}
 
 	return colVal, nil
+}
+
+func asInt64(value any) (int64, error) {
+	switch castValue := value.(type) {
+	case string:
+		parsed, err := strconv.ParseInt(castValue, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse string to int64: %w", err)
+		}
+		return parsed, nil
+	case int16:
+		return int64(castValue), nil
+	case int32:
+		return int64(castValue), nil
+	case int:
+		return int64(castValue), nil
+	case int64:
+		return castValue, nil
+	}
+	return 0, fmt.Errorf("expected string/int/int16/int32/int64 got %T with value: %v", value, value)
 }

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -12,6 +12,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/artie-labs/transfer/lib/typing/ext"
+	"github.com/xitongsys/parquet-go/types"
 )
 
 func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
@@ -84,8 +85,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return nil, err
 		}
 
-		// If the precision is not specified, we should return a string
-		return decimalValue.String(), nil
+		return types.DECIMAL_BYTE_ARRAY_ToString([]byte(decimalValue.String()), int(decimalValue.Details().Precision()), int(decimalValue.Details().Scale())), nil
 	case typing.Integer.Kind:
 		return asInt64(colVal)
 	}

--- a/lib/parquetutil/parse_values_test.go
+++ b/lib/parquetutil/parse_values_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/xitongsys/parquet-go/types"
 )
 
 func TestParseValue(t *testing.T) {
@@ -51,7 +52,7 @@ func TestParseValue(t *testing.T) {
 		)
 
 		assert.NoError(t, err)
-		assert.Equal(t, "5000.22320", value)
+		assert.Equal(t, "5000.22320", types.DECIMAL_BYTE_ARRAY_ToString([]byte(value.(string)), 30, 5))
 	}
 	{
 		// Time

--- a/lib/typing/decimal/details.go
+++ b/lib/typing/decimal/details.go
@@ -17,6 +17,12 @@ type Details struct {
 	precision int32
 }
 
+// TwosComplementByteArrLength - returns the length of the twos complement byte array for the decimal.
+// This is used to determine the length of the byte array for the decimal.
+func (d Details) TwosComplementByteArrLength() int32 {
+	return (d.precision + 1) / 2
+}
+
 func NewDetails(precision int32, scale int32) Details {
 	if precision == 0 {
 		// MySQL, PostgreSQL, and SQLServer do not allow a zero precision, so this should never happen.

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -90,6 +90,7 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 	case EDecimal.Kind:
 		precision := k.ExtendedDecimalDetails.Precision()
 		if precision == decimal.PrecisionNotSpecified {
+			fmt.Println("colName", colName, "precision was not specified")
 			// Precision is required for a parquet DECIMAL type, as such, we should fall back on a STRING type.
 			return &Field{
 				Tag: FieldTag{

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -114,7 +114,7 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL.String()),
 				Precision:     ToPtr(int(precision)),
 				Scale:         ToPtr(int(scale)),
-				Length:        ToPtr(int((precision + 1) / 2)),
+				Length:        ToPtr(int(scale + precision)),
 			}.String(),
 		}, nil
 	case Boolean.Kind:

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -90,7 +90,6 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 	case EDecimal.Kind:
 		precision := k.ExtendedDecimalDetails.Precision()
 		if precision == decimal.PrecisionNotSpecified {
-			fmt.Println("colName", colName, "precision was not specified")
 			// Precision is required for a parquet DECIMAL type, as such, we should fall back on a STRING type.
 			return &Field{
 				Tag: FieldTag{
@@ -106,8 +105,6 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 			return nil, fmt.Errorf("scale (%d) must be less than or equal to precision (%d)", scale, precision)
 		}
 
-		length := (precision + 1) / 2
-
 		return &Field{
 			Tag: FieldTag{
 				Name:          colName,
@@ -115,7 +112,7 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL.String()),
 				Precision:     ToPtr(int(precision)),
 				Scale:         ToPtr(int(scale)),
-				Length:        ToPtr(int(length)),
+				Length:        ToPtr(int(k.ExtendedDecimalDetails.TwosComplementByteArrLength())),
 			}.String(),
 		}, nil
 	case Boolean.Kind:

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/artie-labs/transfer/lib/typing/decimal"
+	"github.com/xitongsys/parquet-go/parquet"
 )
 
 type FieldTag struct {
@@ -104,11 +105,12 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 			return nil, fmt.Errorf("scale (%d) must be less than or equal to precision (%d)", scale, precision)
 		}
 
+		fmt.Println("colName", colName, "byte array", "decimal", "precision", precision, "scale", scale)
 		return &Field{
 			Tag: FieldTag{
 				Name:          colName,
 				Type:          ToPtr("BYTE_ARRAY"),
-				ConvertedType: ToPtr("DECIMAL"),
+				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL.String()),
 				Precision:     ToPtr(int(precision)),
 				Scale:         ToPtr(int(scale)),
 			}.String(),

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -106,7 +106,8 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 			return nil, fmt.Errorf("scale (%d) must be less than or equal to precision (%d)", scale, precision)
 		}
 
-		fmt.Println("colName", colName, "byte array", "decimal", "precision", precision, "scale", scale)
+		length := (precision + 1) / 2
+
 		return &Field{
 			Tag: FieldTag{
 				Name:          colName,
@@ -114,7 +115,7 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL.String()),
 				Precision:     ToPtr(int(precision)),
 				Scale:         ToPtr(int(scale)),
-				Length:        ToPtr(int(scale + precision)),
+				Length:        ToPtr(int(length)),
 			}.String(),
 		}, nil
 	case Boolean.Kind:

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -114,6 +114,7 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL.String()),
 				Precision:     ToPtr(int(precision)),
 				Scale:         ToPtr(int(scale)),
+				Length:        ToPtr(int(precision + scale)),
 			}.String(),
 		}, nil
 	case Boolean.Kind:

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -114,7 +114,7 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL.String()),
 				Precision:     ToPtr(int(precision)),
 				Scale:         ToPtr(int(scale)),
-				Length:        ToPtr(int(precision + scale)),
+				Length:        ToPtr(int((precision + 1) / 2)),
 			}.String(),
 		}, nil
 	case Boolean.Kind:

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -110,7 +110,7 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 		return &Field{
 			Tag: FieldTag{
 				Name:          colName,
-				Type:          ToPtr("BYTE_ARRAY"),
+				Type:          ToPtr(parquet.Type_FIXED_LEN_BYTE_ARRAY.String()),
 				ConvertedType: ToPtr(parquet.ConvertedType_DECIMAL.String()),
 				Precision:     ToPtr(int(precision)),
 				Scale:         ToPtr(int(scale)),


### PR DESCRIPTION
# Problem

1. Our previous way of handling decimal was brittle and required special parsing from our customers. Instead of storing the string value, we should be storing the two's complement value (which the library we are using supports).

2. We were using `BYTE_ARRAY` instead of `FIXED_LEN_BYTE_ARRAY`, which clients like `pyarrow` expects decimals to be stored either in Parquet floats, INT32/INT64 or `FIXED_LEN_BYTE_ARRAY`