### PR TITLE
Adding `RowsAffected` check for `PrepareTemporaryTable`

### DIFF
--- a/clients/mssql/staging.go
+++ b/clients/mssql/staging.go
@@ -56,8 +56,18 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 		}
 	}
 
-	if _, err = stmt.ExecContext(ctx); err != nil {
+	result, err := stmt.ExecContext(ctx)
+	if err != nil {
 		return fmt.Errorf("failed to finalize bulk insert: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rows != int64(len(tableData.Rows())) {
+		return fmt.Errorf("expected %d rows to be inserted, but got %d", len(tableData.Rows()), rows)
 	}
 
 	if err = tx.Commit(); err != nil {

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -100,8 +100,9 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
 
-	if rows != int64(len(tableData.Rows())) {
-		return fmt.Errorf("expected %d rows to be inserted, but got %d", len(tableData.Rows()), rows)
+	expectedRows := int64(len(tableData.Rows()))
+	if rows != expectedRows {
+		return fmt.Errorf("expected %d rows to be inserted, but got %d", expectedRows, rows)
 	}
 
 	return nil

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -95,6 +95,8 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 		return fmt.Errorf("failed to run copy into temporary table: %w", err)
 	}
 
+	fmt.Println("result", result)
+
 	rows, err := result.RowsAffected()
 	if err != nil {
 		return fmt.Errorf("failed to get rows affected: %w", err)

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -95,8 +95,6 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 		return fmt.Errorf("failed to run copy into temporary table: %w", err)
 	}
 
-	fmt.Println("result", result)
-
 	rows, err := result.RowsAffected()
 	if err != nil {
 		return fmt.Errorf("failed to get rows affected: %w", err)

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/mocks"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -163,6 +164,10 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 	sflkTc := s.stageStore.GetConfigMap().GetTableConfig(tempTableID)
 
 	{
+		fakeCopyResult := &mocks.FakeResult{}
+		fakeCopyResult.RowsAffectedReturns(int64(len(tableData.Rows())), nil)
+		s.fakeStageStore.ExecContextReturnsOnCall(2, fakeCopyResult, nil)
+
 		assert.NoError(s.T(), s.stageStore.PrepareTemporaryTable(s.T().Context(), tableData, sflkTc, tempTableID, tempTableID, types.AdditionalSettings{}, true))
 		assert.Equal(s.T(), 0, s.fakeStageStore.ExecCallCount())
 		assert.Equal(s.T(), 3, s.fakeStageStore.ExecContextCallCount())
@@ -191,6 +196,10 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 	}
 	{
 		// Don't create the temporary table.
+		fakeCopyResult := &mocks.FakeResult{}
+		fakeCopyResult.RowsAffectedReturns(int64(len(tableData.Rows())), nil)
+		s.fakeStageStore.ExecContextReturnsOnCall(4, fakeCopyResult, nil)
+
 		assert.NoError(s.T(), s.stageStore.PrepareTemporaryTable(s.T().Context(), tableData, sflkTc, tempTableID, tempTableID, types.AdditionalSettings{}, false))
 		assert.Equal(s.T(), 0, s.fakeStageStore.ExecCallCount())
 		assert.Equal(s.T(), 5, s.fakeStageStore.ExecContextCallCount())

--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -19,6 +19,8 @@ type Store interface {
 	Exec(query string, args ...any) (sql.Result, error)
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	Query(query string, args ...any) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 	Begin() (*sql.Tx, error)
 	IsRetryableError(err error) bool
 }
@@ -73,6 +75,14 @@ func (s *storeWrapper) Exec(query string, args ...any) (sql.Result, error) {
 
 func (s *storeWrapper) Query(query string, args ...any) (*sql.Rows, error) {
 	return s.DB.Query(query, args...)
+}
+
+func (s *storeWrapper) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return s.DB.QueryContext(ctx, query, args...)
+}
+
+func (s *storeWrapper) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	return s.DB.QueryRowContext(ctx, query, args...)
 }
 
 func (s *storeWrapper) Begin() (*sql.Tx, error) {

--- a/lib/mocks/generate.go
+++ b/lib/mocks/generate.go
@@ -9,3 +9,4 @@ package mocks
 //counterfeiter:generate -o=tableid.mock.go ../sql TableIdentifier
 
 //counterfeiter:generate -o=event.mock.go ../cdc Event
+//counterfeiter:generate -o=sql.result.mock.go database/sql.Result

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -128,7 +128,6 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 
 	assert.NoError(f.T(), Flush(f.T().Context(), f.db, f.dest, metrics.NullMetricsProvider{}, Args{}))
 	assert.Equal(f.T(), f.fakeConsumer.CommitMessagesCallCount(), len(tableNames)) // Commit 3 times because 3 topics.
-
 	for i := range len(tableNames) {
 		_, kafkaMessages := f.fakeConsumer.CommitMessagesArgsForCall(i)
 		assert.Equal(f.T(), len(kafkaMessages), 1) // There's only 1 partition right now

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -120,6 +120,10 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 	for idx := range tableNames {
 		td := f.db.GetOrCreateTableData(tableNames[idx])
 		assert.Len(f.T(), td.Rows(), 5)
+
+		fakeCopyIntoResult := &mocks.FakeResult{}
+		fakeCopyIntoResult.RowsAffectedReturns(int64(5), nil)
+		f.fakeStore.ExecContextReturns(fakeCopyIntoResult, nil)
 	}
 
 	assert.NoError(f.T(), Flush(f.T().Context(), f.db, f.dest, metrics.NullMetricsProvider{}, Args{}))


### PR DESCRIPTION
We'll now have checks for both appending to an existing table and loading a staging table.