### PR TITLE
Minor refactors

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -71,7 +71,7 @@ func (s *Store) Append(ctx context.Context, tableData *optimization.TableData, u
 	// We can simplify this once Google has fully rolled out the ability to execute DML on recently streamed data
 	// See: https://cloud.google.com/bigquery/docs/write-api#use_data_manipulation_language_dml_with_recently_streamed_data
 	// For now, we'll need to append this to a temporary table and then append temporary table onto the target table
-	tableID := s.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	tableID := s.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	temporaryTableID := shared.TempTableID(tableID)
 
 	defer func() { _ = ddl.DropTemporaryTable(ctx, s, temporaryTableID, false) }()
@@ -151,7 +151,7 @@ func (s *Store) auditStagingTable(ctx context.Context, bqTempTableID dialect.Tab
 	return fmt.Errorf("temporary table row count mismatch, expected: %d, got: %d", expectedRowCount, stagingTableRowsCount)
 }
 
-func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchemaPair, table string) sql.TableIdentifier {
 	return dialect.NewTableIdentifier(s.config.BigQuery.ProjectID, databaseAndSchema.Database, table)
 }
 

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -71,7 +71,7 @@ func (s *Store) Append(ctx context.Context, tableData *optimization.TableData, u
 	// We can simplify this once Google has fully rolled out the ability to execute DML on recently streamed data
 	// See: https://cloud.google.com/bigquery/docs/write-api#use_data_manipulation_language_dml_with_recently_streamed_data
 	// For now, we'll need to append this to a temporary table and then append temporary table onto the target table
-	tableID := s.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	tableID := s.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 	temporaryTableID := shared.TempTableID(tableID)
 
 	defer func() { _ = ddl.DropTemporaryTable(ctx, s, temporaryTableID, false) }()
@@ -151,8 +151,8 @@ func (s *Store) auditStagingTable(ctx context.Context, bqTempTableID dialect.Tab
 	return fmt.Errorf("temporary table row count mismatch, expected: %d, got: %d", expectedRowCount, stagingTableRowsCount)
 }
 
-func (s *Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sql.TableIdentifier {
-	return dialect.NewTableIdentifier(s.config.BigQuery.ProjectID, topicConfig.Database, table)
+func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+	return dialect.NewTableIdentifier(s.config.BigQuery.ProjectID, databaseAndSchema.Database, table)
 }
 
 func (s *Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {

--- a/clients/bigquery/bigquery_test.go
+++ b/clients/bigquery/bigquery_test.go
@@ -25,7 +25,7 @@ func TestTempTableIDWithSuffix(t *testing.T) {
 
 	store := &Store{config: config.Config{BigQuery: &config.BigQuery{ProjectID: "123454321"}}}
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
-	tableID := store.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	tableID := store.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	tempTableName := shared.TempTableIDWithSuffix(tableID, "sUfFiX").FullyQualifiedName()
 	assert.Equal(t, "`123454321`.`db`.`table___artie_sUfFiX`", trimTTL(tempTableName))
 }

--- a/clients/bigquery/bigquery_test.go
+++ b/clients/bigquery/bigquery_test.go
@@ -25,7 +25,7 @@ func TestTempTableIDWithSuffix(t *testing.T) {
 
 	store := &Store{config: config.Config{BigQuery: &config.BigQuery{ProjectID: "123454321"}}}
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
-	tableID := store.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	tableID := store.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 	tempTableName := shared.TempTableIDWithSuffix(tableID, "sUfFiX").FullyQualifiedName()
 	assert.Equal(t, "`123454321`.`db`.`table___artie_sUfFiX`", trimTTL(tempTableName))
 }

--- a/clients/databricks/store.go
+++ b/clients/databricks/store.go
@@ -58,7 +58,7 @@ func (s Store) Append(ctx context.Context, tableData *optimization.TableData, _ 
 	return shared.Append(ctx, s, tableData, types.AdditionalSettings{})
 }
 
-func (s Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+func (s Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchemaPair, table string) sql.TableIdentifier {
 	return dialect.NewTableIdentifier(databaseAndSchema.Database, databaseAndSchema.Schema, table)
 }
 

--- a/clients/databricks/store.go
+++ b/clients/databricks/store.go
@@ -58,8 +58,8 @@ func (s Store) Append(ctx context.Context, tableData *optimization.TableData, _ 
 	return shared.Append(ctx, s, tableData, types.AdditionalSettings{})
 }
 
-func (s Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sql.TableIdentifier {
-	return dialect.NewTableIdentifier(topicConfig.Database, topicConfig.Schema, table)
+func (s Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+	return dialect.NewTableIdentifier(databaseAndSchema.Database, databaseAndSchema.Schema, table)
 }
 
 func (s Store) Dialect() sql.Dialect {

--- a/clients/iceberg/store.go
+++ b/clients/iceberg/store.go
@@ -36,7 +36,7 @@ func (s Store) Append(ctx context.Context, tableData *optimization.TableData, us
 		return nil
 	}
 
-	tableID := s.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	tableID := s.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	tempTableID := shared.TempTableIDWithSuffix(tableID, tableData.TempTableSuffix())
 	tableConfig, err := s.GetTableConfig(ctx, tableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
@@ -118,7 +118,7 @@ func (s Store) Merge(ctx context.Context, tableData *optimization.TableData) (bo
 		return false, nil
 	}
 
-	tableID := s.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	tableID := s.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	temporaryTableID := shared.TempTableIDWithSuffix(tableID, tableData.TempTableSuffix())
 	tableConfig, err := s.GetTableConfig(ctx, tableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
@@ -206,7 +206,7 @@ func (s Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, primaryK
 	return nil
 }
 
-func (s Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+func (s Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchemaPair, table string) sql.TableIdentifier {
 	return dialect.NewTableIdentifier(databaseAndSchema.Database, databaseAndSchema.Schema, table)
 }
 

--- a/clients/iceberg/store.go
+++ b/clients/iceberg/store.go
@@ -36,7 +36,7 @@ func (s Store) Append(ctx context.Context, tableData *optimization.TableData, us
 		return nil
 	}
 
-	tableID := s.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	tableID := s.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 	tempTableID := shared.TempTableIDWithSuffix(tableID, tableData.TempTableSuffix())
 	tableConfig, err := s.GetTableConfig(ctx, tableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
@@ -118,7 +118,7 @@ func (s Store) Merge(ctx context.Context, tableData *optimization.TableData) (bo
 		return false, nil
 	}
 
-	tableID := s.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	tableID := s.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 	temporaryTableID := shared.TempTableIDWithSuffix(tableID, tableData.TempTableSuffix())
 	tableConfig, err := s.GetTableConfig(ctx, tableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
@@ -206,8 +206,8 @@ func (s Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, primaryK
 	return nil
 }
 
-func (s Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sql.TableIdentifier {
-	return dialect.NewTableIdentifier(s.catalogName, topicConfig.Schema, table)
+func (s Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+	return dialect.NewTableIdentifier(databaseAndSchema.Database, databaseAndSchema.Schema, table)
 }
 
 func LoadStore(ctx context.Context, cfg config.Config) (Store, error) {

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -67,13 +67,13 @@ func (s *Store) Append(ctx context.Context, tableData *optimization.TableData, _
 }
 
 // specificIdentifierFor returns a MS SQL [TableIdentifier] for a [TopicConfig] + table name.
-func (s *Store) specificIdentifierFor(topicConfig kafkalib.TopicConfig, table string) dialect.TableIdentifier {
-	return dialect.NewTableIdentifier(getSchema(topicConfig.Schema), table)
+func (s *Store) specificIdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) dialect.TableIdentifier {
+	return dialect.NewTableIdentifier(getSchema(databaseAndSchema.Schema), table)
 }
 
 // IdentifierFor returns a generic [sql.TableIdentifier] interface for a [TopicConfig] + table name.
-func (s *Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sql.TableIdentifier {
-	return s.specificIdentifierFor(topicConfig, table)
+func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+	return s.specificIdentifierFor(databaseAndSchema, table)
 }
 
 func (s *Store) SweepTemporaryTables(ctx context.Context) error {

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -67,12 +67,12 @@ func (s *Store) Append(ctx context.Context, tableData *optimization.TableData, _
 }
 
 // specificIdentifierFor returns a MS SQL [TableIdentifier] for a [TopicConfig] + table name.
-func (s *Store) specificIdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) dialect.TableIdentifier {
+func (s *Store) specificIdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchemaPair, table string) dialect.TableIdentifier {
 	return dialect.NewTableIdentifier(getSchema(databaseAndSchema.Schema), table)
 }
 
 // IdentifierFor returns a generic [sql.TableIdentifier] interface for a [TopicConfig] + table name.
-func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchemaPair, table string) sql.TableIdentifier {
 	return s.specificIdentifierFor(databaseAndSchema, table)
 }
 

--- a/clients/mssql/store_test.go
+++ b/clients/mssql/store_test.go
@@ -27,14 +27,14 @@ func TestTempTableIDWithSuffix(t *testing.T) {
 	{
 		// Schema is "schema":
 		tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
-		tableID := store.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+		tableID := store.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 		tempTableName := shared.TempTableIDWithSuffix(tableID, "sUfFiX").FullyQualifiedName()
 		assert.Equal(t, `"schema"."table___artie_sUfFiX"`, trimTTL(tempTableName))
 	}
 	{
 		// Schema is "public" -> "dbo":
 		tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "public"}, "table")
-		tableID := store.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+		tableID := store.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 		tempTableName := shared.TempTableIDWithSuffix(tableID, "sUfFiX").FullyQualifiedName()
 		assert.Equal(t, `"dbo"."table___artie_sUfFiX"`, trimTTL(tempTableName))
 	}

--- a/clients/mssql/store_test.go
+++ b/clients/mssql/store_test.go
@@ -27,14 +27,14 @@ func TestTempTableIDWithSuffix(t *testing.T) {
 	{
 		// Schema is "schema":
 		tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
-		tableID := store.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+		tableID := store.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 		tempTableName := shared.TempTableIDWithSuffix(tableID, "sUfFiX").FullyQualifiedName()
 		assert.Equal(t, `"schema"."table___artie_sUfFiX"`, trimTTL(tempTableName))
 	}
 	{
 		// Schema is "public" -> "dbo":
 		tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "public"}, "table")
-		tableID := store.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+		tableID := store.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 		tempTableName := shared.TempTableIDWithSuffix(tableID, "sUfFiX").FullyQualifiedName()
 		assert.Equal(t, `"dbo"."table___artie_sUfFiX"`, trimTTL(tempTableName))
 	}

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -75,8 +75,8 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (b
 	return true, nil
 }
 
-func (s *Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sql.TableIdentifier {
-	return dialect.NewTableIdentifier(topicConfig.Schema, table)
+func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+	return dialect.NewTableIdentifier(databaseAndSchema.Schema, table)
 }
 
 func (s *Store) GetConfigMap() *types.DestinationTableConfigMap {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -75,7 +75,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (b
 	return true, nil
 }
 
-func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchemaPair, table string) sql.TableIdentifier {
 	return dialect.NewTableIdentifier(databaseAndSchema.Schema, table)
 }
 

--- a/clients/redshift/redshift_test.go
+++ b/clients/redshift/redshift_test.go
@@ -24,7 +24,7 @@ func TestTempTableIDWithSuffix(t *testing.T) {
 	}
 
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
-	tableID := (&Store{}).IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	tableID := (&Store{}).IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	tempTableName := shared.TempTableIDWithSuffix(tableID, "sUfFiX").FullyQualifiedName()
 	assert.Equal(t, `schema."table___artie_suffix"`, trimTTL(tempTableName))
 }

--- a/clients/redshift/redshift_test.go
+++ b/clients/redshift/redshift_test.go
@@ -24,7 +24,7 @@ func TestTempTableIDWithSuffix(t *testing.T) {
 	}
 
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
-	tableID := (&Store{}).IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	tableID := (&Store{}).IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 	tempTableName := shared.TempTableIDWithSuffix(tableID, "sUfFiX").FullyQualifiedName()
 	assert.Equal(t, `schema."table___artie_suffix"`, trimTTL(tempTableName))
 }

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -38,7 +38,7 @@ func (s *Store) Validate() error {
 	return nil
 }
 
-func (s *Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sql.TableIdentifier {
+func (s *Store) IdentifierFor(topicConfig kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
 	return NewTableIdentifier(topicConfig.Database, topicConfig.Schema, table, s.config.S3.TableNameSeparator)
 }
 
@@ -46,7 +46,7 @@ func (s *Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sq
 // It will look like something like this:
 // > folderName/fullyQualifiedTableName/YYYY-MM-DD
 func (s *Store) ObjectPrefix(tableData *optimization.TableData) string {
-	tableID := s.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	tableID := s.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 	fqTableName := tableID.FullyQualifiedName()
 	// Adding date= prefix so that it adheres to the partitioning format for Hive.
 	yyyyMMDDFormat := fmt.Sprintf("date=%s", time.Now().Format(ext.PostgresDateFormat))

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -38,7 +38,7 @@ func (s *Store) Validate() error {
 	return nil
 }
 
-func (s *Store) IdentifierFor(topicConfig kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+func (s *Store) IdentifierFor(topicConfig kafkalib.DatabaseAndSchemaPair, table string) sql.TableIdentifier {
 	return NewTableIdentifier(topicConfig.Database, topicConfig.Schema, table, s.config.S3.TableNameSeparator)
 }
 
@@ -46,7 +46,7 @@ func (s *Store) IdentifierFor(topicConfig kafkalib.DatabaseAndSchema, table stri
 // It will look like something like this:
 // > folderName/fullyQualifiedTableName/YYYY-MM-DD
 func (s *Store) ObjectPrefix(tableData *optimization.TableData) string {
-	tableID := s.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	tableID := s.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	fqTableName := tableID.FullyQualifiedName()
 	// Adding date= prefix so that it adheres to the partitioning format for Hive.
 	yyyyMMDDFormat := fmt.Sprintf("date=%s", time.Now().Format(ext.PostgresDateFormat))

--- a/clients/shared/append.go
+++ b/clients/shared/append.go
@@ -15,7 +15,7 @@ func Append(ctx context.Context, dest destination.Destination, tableData *optimi
 		return nil
 	}
 
-	tableID := dest.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	tableID := dest.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	tableConfig, err := dest.GetTableConfig(tableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
 		return fmt.Errorf("failed to get table config: %w", err)

--- a/clients/shared/append.go
+++ b/clients/shared/append.go
@@ -15,7 +15,7 @@ func Append(ctx context.Context, dest destination.Destination, tableData *optimi
 		return nil
 	}
 
-	tableID := dest.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	tableID := dest.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 	tableConfig, err := dest.GetTableConfig(tableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
 		return fmt.Errorf("failed to get table config: %w", err)

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -22,7 +22,7 @@ func Merge(ctx context.Context, dest destination.Destination, tableData *optimiz
 		return nil
 	}
 
-	tableID := dest.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	tableID := dest.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 	tableConfig, err := dest.GetTableConfig(tableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
 		return fmt.Errorf("failed to get table config: %w", err)
@@ -57,7 +57,7 @@ func Merge(ctx context.Context, dest destination.Destination, tableData *optimiz
 		return fmt.Errorf("failed to merge columns from destination: %w for table %q", err, tableData.Name())
 	}
 
-	temporaryTableID := TempTableIDWithSuffix(dest.IdentifierFor(tableData.TopicConfig(), tableData.Name()), tableData.TempTableSuffix())
+	temporaryTableID := TempTableIDWithSuffix(dest.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name()), tableData.TempTableSuffix())
 	defer func() {
 		if dropErr := ddl.DropTemporaryTable(ctx, dest, temporaryTableID, false); dropErr != nil {
 			slog.Warn("Failed to drop temporary table", slog.Any("err", dropErr), slog.String("tableName", temporaryTableID.FullyQualifiedName()))

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -22,7 +22,7 @@ func Merge(ctx context.Context, dest destination.Destination, tableData *optimiz
 		return nil
 	}
 
-	tableID := dest.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	tableID := dest.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	tableConfig, err := dest.GetTableConfig(tableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
 		return fmt.Errorf("failed to get table config: %w", err)
@@ -57,7 +57,7 @@ func Merge(ctx context.Context, dest destination.Destination, tableData *optimiz
 		return fmt.Errorf("failed to merge columns from destination: %w for table %q", err, tableData.Name())
 	}
 
-	temporaryTableID := TempTableIDWithSuffix(dest.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name()), tableData.TempTableSuffix())
+	temporaryTableID := TempTableIDWithSuffix(dest.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name()), tableData.TempTableSuffix())
 	defer func() {
 		if dropErr := ddl.DropTemporaryTable(ctx, dest, temporaryTableID, false); dropErr != nil {
 			slog.Warn("Failed to drop temporary table", slog.Any("err", dropErr), slog.String("tableName", temporaryTableID.FullyQualifiedName()))

--- a/clients/shared/multi_step_merge.go
+++ b/clients/shared/multi_step_merge.go
@@ -31,8 +31,8 @@ func MultiStepMerge(ctx context.Context, dest destination.Destination, tableData
 		return false, nil
 	}
 
-	msmTableID := dest.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), fmt.Sprintf("%s_%s_msm", constants.ArtiePrefix, tableData.Name()))
-	targetTableID := dest.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	msmTableID := dest.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), fmt.Sprintf("%s_%s_msm", constants.ArtiePrefix, tableData.Name()))
+	targetTableID := dest.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	targetTableConfig, err := dest.GetTableConfig(targetTableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
 		return false, fmt.Errorf("failed to get table config: %w", err)

--- a/clients/shared/multi_step_merge.go
+++ b/clients/shared/multi_step_merge.go
@@ -31,8 +31,8 @@ func MultiStepMerge(ctx context.Context, dest destination.Destination, tableData
 		return false, nil
 	}
 
-	msmTableID := dest.IdentifierFor(tableData.TopicConfig(), fmt.Sprintf("%s_%s_msm", constants.ArtiePrefix, tableData.Name()))
-	targetTableID := dest.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	msmTableID := dest.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), fmt.Sprintf("%s_%s_msm", constants.ArtiePrefix, tableData.Name()))
+	targetTableID := dest.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 	targetTableConfig, err := dest.GetTableConfig(targetTableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
 		return false, fmt.Errorf("failed to get table config: %w", err)

--- a/clients/shared/sweep.go
+++ b/clients/shared/sweep.go
@@ -13,7 +13,7 @@ type GetQueryFunc func(dbName string, schemaName string) (string, []any)
 
 func Sweep(ctx context.Context, dest destination.Destination, topicConfigs []*kafkalib.TopicConfig, getQueryFunc GetQueryFunc) error {
 	slog.Info("Looking to see if there are any dangling artie temporary tables to delete...")
-	for _, topicConfig := range kafkalib.GetUniqueTopicConfigs(topicConfigs) {
+	for _, topicConfig := range kafkalib.GetUniqueDatabaseAndSchemaPairs(topicConfigs) {
 		query, args := getQueryFunc(topicConfig.Database, topicConfig.Schema)
 		rows, err := dest.QueryContext(ctx, query, args...)
 		if err != nil {

--- a/clients/shared/sweep.go
+++ b/clients/shared/sweep.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/artie-labs/transfer/lib/destination"
@@ -20,7 +21,7 @@ func Sweep(ctx context.Context, dest destination.Destination, topicConfigs []*ka
 			return err
 		}
 
-		for rows != nil && rows.Next() {
+		for rows.Next() {
 			var tableSchema, tableName string
 			if err = rows.Scan(&tableSchema, &tableName); err != nil {
 				return err
@@ -31,6 +32,10 @@ func Sweep(ctx context.Context, dest destination.Destination, topicConfigs []*ka
 					return err
 				}
 			}
+		}
+
+		if err = rows.Err(); err != nil {
+			return fmt.Errorf("failed to iterate over rows: %w", err)
 		}
 	}
 

--- a/clients/shared/sweep.go
+++ b/clients/shared/sweep.go
@@ -13,8 +13,8 @@ type GetQueryFunc func(dbName string, schemaName string) (string, []any)
 
 func Sweep(ctx context.Context, dest destination.Destination, topicConfigs []*kafkalib.TopicConfig, getQueryFunc GetQueryFunc) error {
 	slog.Info("Looking to see if there are any dangling artie temporary tables to delete...")
-	for _, topicConfig := range kafkalib.GetUniqueDatabaseAndSchemaPairs(topicConfigs) {
-		query, args := getQueryFunc(topicConfig.Database, topicConfig.Schema)
+	for _, dbAndSchemaPair := range kafkalib.GetUniqueDatabaseAndSchemaPairs(topicConfigs) {
+		query, args := getQueryFunc(dbAndSchemaPair.Database, dbAndSchemaPair.Schema)
 		rows, err := dest.QueryContext(ctx, query, args...)
 		if err != nil {
 			return err
@@ -22,14 +22,12 @@ func Sweep(ctx context.Context, dest destination.Destination, topicConfigs []*ka
 
 		for rows != nil && rows.Next() {
 			var tableSchema, tableName string
-			err = rows.Scan(&tableSchema, &tableName)
-			if err != nil {
+			if err = rows.Scan(&tableSchema, &tableName); err != nil {
 				return err
 			}
 
 			if ddl.ShouldDeleteFromName(tableName) {
-				err = ddl.DropTemporaryTable(ctx, dest, dest.IdentifierFor(topicConfig, tableName), true)
-				if err != nil {
+				if err = ddl.DropTemporaryTable(ctx, dest, dest.IdentifierFor(dbAndSchemaPair, tableName), true); err != nil {
 					return err
 				}
 			}

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -22,8 +22,8 @@ type Store struct {
 	config    config.Config
 }
 
-func (s *Store) IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sql.TableIdentifier {
-	return dialect.NewTableIdentifier(topicConfig.Database, topicConfig.Schema, table)
+func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+	return dialect.NewTableIdentifier(databaseAndSchema.Database, databaseAndSchema.Schema, table)
 }
 
 func (s *Store) DropTable(ctx context.Context, tableID sql.TableIdentifier) error {

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -22,7 +22,7 @@ type Store struct {
 	config    config.Config
 }
 
-func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sql.TableIdentifier {
+func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchemaPair, table string) sql.TableIdentifier {
 	return dialect.NewTableIdentifier(databaseAndSchema.Database, databaseAndSchema.Schema, table)
 }
 

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (s *SnowflakeTestSuite) identifierFor(tableData *optimization.TableData) sql.TableIdentifier {
-	return s.stageStore.IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	return s.stageStore.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 }
 
 func (s *SnowflakeTestSuite) TestDropTable() {
@@ -423,7 +423,7 @@ func TestTempTableIDWithSuffix(t *testing.T) {
 	}
 
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
-	tableID := (&Store{}).IdentifierFor(tableData.TopicConfig(), tableData.Name())
+	tableID := (&Store{}).IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
 	tempTableName := shared.TempTableIDWithSuffix(tableID, "sUfFiX").FullyQualifiedName()
 	assert.Equal(t, `"DB"."SCHEMA"."TABLE___ARTIE_SUFFIX"`, trimTTL(tempTableName))
 }

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (s *SnowflakeTestSuite) identifierFor(tableData *optimization.TableData) sql.TableIdentifier {
-	return s.stageStore.IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	return s.stageStore.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 }
 
 func (s *SnowflakeTestSuite) TestDropTable() {
@@ -423,7 +423,7 @@ func TestTempTableIDWithSuffix(t *testing.T) {
 	}
 
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", Schema: "schema"}, "table")
-	tableID := (&Store{}).IdentifierFor(tableData.TopicConfig().DatabaseAndSchema(), tableData.Name())
+	tableID := (&Store{}).IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	tempTableName := shared.TempTableIDWithSuffix(tableID, "sUfFiX").FullyQualifiedName()
 	assert.Equal(t, `"DB"."SCHEMA"."TABLE___ARTIE_SUFFIX"`, trimTTL(tempTableName))
 }

--- a/integration_tests/shared/framework.go
+++ b/integration_tests/shared/framework.go
@@ -27,7 +27,7 @@ func NewTestFramework(ctx context.Context, dest destination.Destination, topicCo
 	return &TestFramework{
 		ctx:         ctx,
 		dest:        dest,
-		tableID:     dest.IdentifierFor(topicConfig, topicConfig.TableName),
+		tableID:     dest.IdentifierFor(topicConfig.DatabaseAndSchema(), topicConfig.TableName),
 		topicConfig: topicConfig,
 	}
 }

--- a/integration_tests/shared/framework.go
+++ b/integration_tests/shared/framework.go
@@ -27,7 +27,7 @@ func NewTestFramework(ctx context.Context, dest destination.Destination, topicCo
 	return &TestFramework{
 		ctx:         ctx,
 		dest:        dest,
-		tableID:     dest.IdentifierFor(topicConfig.DatabaseAndSchema(), topicConfig.TableName),
+		tableID:     dest.IdentifierFor(topicConfig.BuildDatabaseAndSchemaPair(), topicConfig.TableName),
 		topicConfig: topicConfig,
 	}
 }

--- a/lib/destination/ddl/ddl_alter_delete_test.go
+++ b/lib/destination/ddl/ddl_alter_delete_test.go
@@ -33,13 +33,13 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 
 	originalColumnLength := len(cols.GetColumns())
 
-	bqTableID := d.bigQueryStore.IdentifierFor(td.TopicConfig(), td.Name())
+	bqTableID := d.bigQueryStore.IdentifierFor(td.TopicConfig().DatabaseAndSchema(), td.Name())
 	bqName := bqTableID.FullyQualifiedName()
 
-	redshiftTableID := d.redshiftStore.IdentifierFor(td.TopicConfig(), td.Name())
+	redshiftTableID := d.redshiftStore.IdentifierFor(td.TopicConfig().DatabaseAndSchema(), td.Name())
 	redshiftName := redshiftTableID.FullyQualifiedName()
 
-	snowflakeTableID := d.snowflakeStagesStore.IdentifierFor(td.TopicConfig(), td.Name())
+	snowflakeTableID := d.snowflakeStagesStore.IdentifierFor(td.TopicConfig().DatabaseAndSchema(), td.Name())
 	snowflakeName := snowflakeTableID.FullyQualifiedName()
 
 	// Testing 3 scenarios here

--- a/lib/destination/ddl/ddl_alter_delete_test.go
+++ b/lib/destination/ddl/ddl_alter_delete_test.go
@@ -33,13 +33,13 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 
 	originalColumnLength := len(cols.GetColumns())
 
-	bqTableID := d.bigQueryStore.IdentifierFor(td.TopicConfig().DatabaseAndSchema(), td.Name())
+	bqTableID := d.bigQueryStore.IdentifierFor(td.TopicConfig().BuildDatabaseAndSchemaPair(), td.Name())
 	bqName := bqTableID.FullyQualifiedName()
 
-	redshiftTableID := d.redshiftStore.IdentifierFor(td.TopicConfig().DatabaseAndSchema(), td.Name())
+	redshiftTableID := d.redshiftStore.IdentifierFor(td.TopicConfig().BuildDatabaseAndSchemaPair(), td.Name())
 	redshiftName := redshiftTableID.FullyQualifiedName()
 
-	snowflakeTableID := d.snowflakeStagesStore.IdentifierFor(td.TopicConfig().DatabaseAndSchema(), td.Name())
+	snowflakeTableID := d.snowflakeStagesStore.IdentifierFor(td.TopicConfig().BuildDatabaseAndSchemaPair(), td.Name())
 	snowflakeName := snowflakeTableID.FullyQualifiedName()
 
 	// Testing 3 scenarios here

--- a/lib/destination/ddl/ddl_bq_test.go
+++ b/lib/destination/ddl/ddl_bq_test.go
@@ -40,7 +40,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	tableID := d.bigQueryStore.IdentifierFor(td.TopicConfig(), td.Name())
+	tableID := d.bigQueryStore.IdentifierFor(td.TopicConfig().DatabaseAndSchema(), td.Name())
 	fqName := tableID.FullyQualifiedName()
 	originalColumnLength := len(cols.GetColumns())
 	d.bigQueryStore.GetConfigMap().AddTable(tableID, types.NewDestinationTableConfig(cols.GetColumns(), true))
@@ -190,7 +190,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	tableID := d.bigQueryStore.IdentifierFor(td.TopicConfig(), td.Name())
+	tableID := d.bigQueryStore.IdentifierFor(td.TopicConfig().DatabaseAndSchema(), td.Name())
 	d.bigQueryStore.GetConfigMap().AddTable(tableID, types.NewDestinationTableConfig(cols.GetColumns(), false))
 	tc := d.bigQueryStore.GetConfigMap().GetTableConfig(tableID)
 

--- a/lib/destination/ddl/ddl_bq_test.go
+++ b/lib/destination/ddl/ddl_bq_test.go
@@ -40,7 +40,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	tableID := d.bigQueryStore.IdentifierFor(td.TopicConfig().DatabaseAndSchema(), td.Name())
+	tableID := d.bigQueryStore.IdentifierFor(td.TopicConfig().BuildDatabaseAndSchemaPair(), td.Name())
 	fqName := tableID.FullyQualifiedName()
 	originalColumnLength := len(cols.GetColumns())
 	d.bigQueryStore.GetConfigMap().AddTable(tableID, types.NewDestinationTableConfig(cols.GetColumns(), true))
@@ -190,7 +190,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 		cols.AddColumn(columns.NewColumn(colName, kindDetails))
 	}
 
-	tableID := d.bigQueryStore.IdentifierFor(td.TopicConfig().DatabaseAndSchema(), td.Name())
+	tableID := d.bigQueryStore.IdentifierFor(td.TopicConfig().BuildDatabaseAndSchemaPair(), td.Name())
 	d.bigQueryStore.GetConfigMap().AddTable(tableID, types.NewDestinationTableConfig(cols.GetColumns(), false))
 	tc := d.bigQueryStore.GetConfigMap().GetTableConfig(tableID)
 

--- a/lib/destination/ddl/ddl_temp_test.go
+++ b/lib/destination/ddl/ddl_temp_test.go
@@ -51,7 +51,7 @@ func (d *DDLTestSuite) Test_DropTemporaryTableCaseSensitive() {
 		}
 
 		for tableIndex, table := range tablesToDrop {
-			tableIdentifier := dest.IdentifierFor(kafkalib.DatabaseAndSchema{Database: "db", Schema: "schema"}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
+			tableIdentifier := dest.IdentifierFor(kafkalib.DatabaseAndSchemaPair{Database: "db", Schema: "schema"}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
 			_ = ddl.DropTemporaryTable(d.T().Context(), dest, tableIdentifier, false)
 
 			// There should be the same number of DROP table calls as the number of tables to drop.
@@ -72,7 +72,7 @@ func (d *DDLTestSuite) Test_DropTemporaryTable() {
 
 	// Should not drop since these do not have Artie prefix in the name.
 	for _, table := range doNotDropTables {
-		tableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchema{Database: "db", Schema: "schema"}, table)
+		tableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchemaPair{Database: "db", Schema: "schema"}, table)
 		_ = ddl.DropTemporaryTable(d.T().Context(), d.snowflakeStagesStore, tableID, false)
 		assert.Equal(d.T(), 0, d.fakeSnowflakeStagesStore.ExecContextCallCount())
 	}
@@ -87,14 +87,14 @@ func (d *DDLTestSuite) Test_DropTemporaryTable() {
 		}
 
 		for _, doNotDropTable := range doNotDropTables {
-			doNotDropTableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchema{Database: "db", Schema: "schema"}, doNotDropTable)
+			doNotDropTableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchemaPair{Database: "db", Schema: "schema"}, doNotDropTable)
 			_ = ddl.DropTemporaryTable(d.T().Context(), _dwh, doNotDropTableID, false)
 
 			assert.Equal(d.T(), 0, fakeStore.ExecContextCallCount())
 		}
 
 		for index, table := range doNotDropTables {
-			fullTableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchema{Database: "db", Schema: "schema"}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
+			fullTableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchemaPair{Database: "db", Schema: "schema"}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
 			_ = ddl.DropTemporaryTable(d.T().Context(), _dwh, fullTableID, false)
 
 			count := index + 1
@@ -128,7 +128,7 @@ func (d *DDLTestSuite) Test_DropTemporaryTable_Errors() {
 		var count int
 		for _, shouldReturnErr := range []bool{true, false} {
 			for _, table := range tablesToDrop {
-				tableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchema{Database: "db", Schema: "schema"}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
+				tableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchemaPair{Database: "db", Schema: "schema"}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
 				err := ddl.DropTemporaryTable(d.T().Context(), _dwh, tableID, shouldReturnErr)
 				if shouldReturnErr {
 					assert.ErrorContains(d.T(), err, randomErr.Error())

--- a/lib/destination/ddl/ddl_temp_test.go
+++ b/lib/destination/ddl/ddl_temp_test.go
@@ -51,7 +51,7 @@ func (d *DDLTestSuite) Test_DropTemporaryTableCaseSensitive() {
 		}
 
 		for tableIndex, table := range tablesToDrop {
-			tableIdentifier := dest.IdentifierFor(kafkalib.TopicConfig{}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
+			tableIdentifier := dest.IdentifierFor(kafkalib.DatabaseAndSchema{Database: "db", Schema: "schema"}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
 			_ = ddl.DropTemporaryTable(d.T().Context(), dest, tableIdentifier, false)
 
 			// There should be the same number of DROP table calls as the number of tables to drop.
@@ -72,7 +72,7 @@ func (d *DDLTestSuite) Test_DropTemporaryTable() {
 
 	// Should not drop since these do not have Artie prefix in the name.
 	for _, table := range doNotDropTables {
-		tableID := d.bigQueryStore.IdentifierFor(kafkalib.TopicConfig{}, table)
+		tableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchema{Database: "db", Schema: "schema"}, table)
 		_ = ddl.DropTemporaryTable(d.T().Context(), d.snowflakeStagesStore, tableID, false)
 		assert.Equal(d.T(), 0, d.fakeSnowflakeStagesStore.ExecContextCallCount())
 	}
@@ -87,14 +87,14 @@ func (d *DDLTestSuite) Test_DropTemporaryTable() {
 		}
 
 		for _, doNotDropTable := range doNotDropTables {
-			doNotDropTableID := d.bigQueryStore.IdentifierFor(kafkalib.TopicConfig{}, doNotDropTable)
+			doNotDropTableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchema{Database: "db", Schema: "schema"}, doNotDropTable)
 			_ = ddl.DropTemporaryTable(d.T().Context(), _dwh, doNotDropTableID, false)
 
 			assert.Equal(d.T(), 0, fakeStore.ExecContextCallCount())
 		}
 
 		for index, table := range doNotDropTables {
-			fullTableID := d.bigQueryStore.IdentifierFor(kafkalib.TopicConfig{}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
+			fullTableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchema{Database: "db", Schema: "schema"}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
 			_ = ddl.DropTemporaryTable(d.T().Context(), _dwh, fullTableID, false)
 
 			count := index + 1
@@ -128,7 +128,7 @@ func (d *DDLTestSuite) Test_DropTemporaryTable_Errors() {
 		var count int
 		for _, shouldReturnErr := range []bool{true, false} {
 			for _, table := range tablesToDrop {
-				tableID := d.bigQueryStore.IdentifierFor(kafkalib.TopicConfig{}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
+				tableID := d.bigQueryStore.IdentifierFor(kafkalib.DatabaseAndSchema{Database: "db", Schema: "schema"}, fmt.Sprintf("%s_%s", table, constants.ArtiePrefix))
 				err := ddl.DropTemporaryTable(d.T().Context(), _dwh, tableID, shouldReturnErr)
 				if shouldReturnErr {
 					assert.ErrorContains(d.T(), err, randomErr.Error())

--- a/lib/destination/destination.go
+++ b/lib/destination/destination.go
@@ -37,7 +37,7 @@ type Baseline interface {
 	Merge(ctx context.Context, tableData *optimization.TableData) (commitTransaction bool, err error)
 	Append(ctx context.Context, tableData *optimization.TableData, useTempTable bool) error
 	IsRetryableError(err error) bool
-	IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sqllib.TableIdentifier
+	IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchemaPair, table string) sqllib.TableIdentifier
 }
 
 // ExecContextStatements executes one or more statements against a [Destination].

--- a/lib/destination/destination.go
+++ b/lib/destination/destination.go
@@ -37,7 +37,7 @@ type Baseline interface {
 	Merge(ctx context.Context, tableData *optimization.TableData) (commitTransaction bool, err error)
 	Append(ctx context.Context, tableData *optimization.TableData, useTempTable bool) error
 	IsRetryableError(err error) bool
-	IdentifierFor(topicConfig kafkalib.TopicConfig, table string) sqllib.TableIdentifier
+	IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchema, table string) sqllib.TableIdentifier
 }
 
 // ExecContextStatements executes one or more statements against a [Destination].

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -9,15 +9,19 @@ import (
 	"github.com/artie-labs/transfer/lib/stringutil"
 )
 
-// GetUniqueTopicConfigs - will return a list of unique TopicConfigs based on the database and schema in O(n) time.
-func GetUniqueTopicConfigs(tcs []*TopicConfig) []TopicConfig {
-	var uniqueTopicConfigs []TopicConfig
-	seenMap := make(map[string]bool)
+type DatabaseAndSchema struct {
+	Database string
+	Schema   string
+}
+
+func GetUniqueDatabaseAndSchemaPairs(tcs []*TopicConfig) []DatabaseAndSchema {
+	var uniqueTopicConfigs []DatabaseAndSchema
+	seenMap := make(map[DatabaseAndSchema]bool)
 	for _, tc := range tcs {
-		key := fmt.Sprintf("%s###%s", tc.Database, tc.Schema)
+		key := tc.DatabaseAndSchema()
 		if _, isOk := seenMap[key]; !isOk {
-			seenMap[key] = true                                  // Mark this as seen
-			uniqueTopicConfigs = append(uniqueTopicConfigs, *tc) // Now add this to the list
+			seenMap[key] = true
+			uniqueTopicConfigs = append(uniqueTopicConfigs, key)
 		}
 	}
 
@@ -65,6 +69,10 @@ type TopicConfig struct {
 
 	// Internal metadata
 	opsToSkipMap map[string]bool `yaml:"-"`
+}
+
+func (t TopicConfig) DatabaseAndSchema() DatabaseAndSchema {
+	return DatabaseAndSchema{Database: t.Database, Schema: t.Schema}
 }
 
 const (

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -9,16 +9,16 @@ import (
 	"github.com/artie-labs/transfer/lib/stringutil"
 )
 
-type DatabaseAndSchema struct {
+type DatabaseAndSchemaPair struct {
 	Database string
 	Schema   string
 }
 
-func GetUniqueDatabaseAndSchemaPairs(tcs []*TopicConfig) []DatabaseAndSchema {
-	var uniqueTopicConfigs []DatabaseAndSchema
-	seenMap := make(map[DatabaseAndSchema]bool)
+func GetUniqueDatabaseAndSchemaPairs(tcs []*TopicConfig) []DatabaseAndSchemaPair {
+	var uniqueTopicConfigs []DatabaseAndSchemaPair
+	seenMap := make(map[DatabaseAndSchemaPair]bool)
 	for _, tc := range tcs {
-		key := tc.DatabaseAndSchema()
+		key := tc.BuildDatabaseAndSchemaPair()
 		if _, isOk := seenMap[key]; !isOk {
 			seenMap[key] = true
 			uniqueTopicConfigs = append(uniqueTopicConfigs, key)
@@ -71,8 +71,8 @@ type TopicConfig struct {
 	opsToSkipMap map[string]bool `yaml:"-"`
 }
 
-func (t TopicConfig) DatabaseAndSchema() DatabaseAndSchema {
-	return DatabaseAndSchema{Database: t.Database, Schema: t.Schema}
+func (t TopicConfig) BuildDatabaseAndSchemaPair() DatabaseAndSchemaPair {
+	return DatabaseAndSchemaPair{Database: t.Database, Schema: t.Schema}
 }
 
 const (

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -2,6 +2,7 @@ package kafkalib
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -15,17 +16,12 @@ type DatabaseAndSchemaPair struct {
 }
 
 func GetUniqueDatabaseAndSchemaPairs(tcs []*TopicConfig) []DatabaseAndSchemaPair {
-	var uniqueTopicConfigs []DatabaseAndSchemaPair
 	seenMap := make(map[DatabaseAndSchemaPair]bool)
 	for _, tc := range tcs {
-		key := tc.BuildDatabaseAndSchemaPair()
-		if _, isOk := seenMap[key]; !isOk {
-			seenMap[key] = true
-			uniqueTopicConfigs = append(uniqueTopicConfigs, key)
-		}
+		seenMap[tc.BuildDatabaseAndSchemaPair()] = true
 	}
 
-	return uniqueTopicConfigs
+	return slices.Collect(maps.Keys(seenMap))
 }
 
 type MultiStepMergeSettings struct {

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -23,7 +23,7 @@ func TestGetUniqueDatabaseAndSchemaPairs(t *testing.T) {
 
 		actual := GetUniqueDatabaseAndSchemaPairs(tcs)
 		assert.Len(t, actual, 1)
-		assert.Equal(t, tcs[0].DatabaseAndSchema(), actual[0])
+		assert.Equal(t, tcs[0].BuildDatabaseAndSchemaPair(), actual[0])
 	}
 	{
 		// 2 topic configs (both the same)
@@ -40,7 +40,7 @@ func TestGetUniqueDatabaseAndSchemaPairs(t *testing.T) {
 
 		actual := GetUniqueDatabaseAndSchemaPairs(tcs)
 		assert.Len(t, actual, 1)
-		assert.Equal(t, tcs[0].DatabaseAndSchema(), actual[0])
+		assert.Equal(t, tcs[0].BuildDatabaseAndSchemaPair(), actual[0])
 	}
 	{
 		// 3 topic configs (2 the same)
@@ -61,8 +61,8 @@ func TestGetUniqueDatabaseAndSchemaPairs(t *testing.T) {
 
 		actual := GetUniqueDatabaseAndSchemaPairs(tcs)
 		assert.Len(t, actual, 2)
-		assert.Equal(t, tcs[0].DatabaseAndSchema(), actual[0])
-		assert.Equal(t, tcs[2].DatabaseAndSchema(), actual[1])
+		assert.Equal(t, tcs[0].BuildDatabaseAndSchemaPair(), actual[0])
+		assert.Equal(t, tcs[2].BuildDatabaseAndSchemaPair(), actual[1])
 	}
 }
 

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetUniqueTopicConfigs(t *testing.T) {
+func TestGetUniqueDatabaseAndSchemaPairs(t *testing.T) {
 	{
 		// No topic configs
-		assert.Empty(t, GetUniqueTopicConfigs(nil))
+		assert.Empty(t, GetUniqueDatabaseAndSchemaPairs(nil))
 	}
 	{
 		// 1 topic config
@@ -21,9 +21,9 @@ func TestGetUniqueTopicConfigs(t *testing.T) {
 			},
 		}
 
-		actual := GetUniqueTopicConfigs(tcs)
+		actual := GetUniqueDatabaseAndSchemaPairs(tcs)
 		assert.Len(t, actual, 1)
-		assert.Equal(t, *tcs[0], actual[0])
+		assert.Equal(t, tcs[0].DatabaseAndSchema(), actual[0])
 	}
 	{
 		// 2 topic configs (both the same)
@@ -38,9 +38,9 @@ func TestGetUniqueTopicConfigs(t *testing.T) {
 			},
 		}
 
-		actual := GetUniqueTopicConfigs(tcs)
+		actual := GetUniqueDatabaseAndSchemaPairs(tcs)
 		assert.Len(t, actual, 1)
-		assert.Equal(t, *tcs[0], actual[0])
+		assert.Equal(t, tcs[0].DatabaseAndSchema(), actual[0])
 	}
 	{
 		// 3 topic configs (2 the same)
@@ -59,10 +59,10 @@ func TestGetUniqueTopicConfigs(t *testing.T) {
 			},
 		}
 
-		actual := GetUniqueTopicConfigs(tcs)
+		actual := GetUniqueDatabaseAndSchemaPairs(tcs)
 		assert.Len(t, actual, 2)
-		assert.Equal(t, *tcs[0], actual[0])
-		assert.Equal(t, *tcs[2], actual[1])
+		assert.Equal(t, tcs[0].DatabaseAndSchema(), actual[0])
+		assert.Equal(t, tcs[2].DatabaseAndSchema(), actual[1])
 	}
 }
 


### PR DESCRIPTION
There are 3 changes here.

1. Introducing a slim data structure called `DatabaseAndSchemaPair` which is similar to `TableID` and using this instead of `kafkalib.TopicConfig`

2. Refactoring `GetUniqueDatabaseAndSchemaPairs` to be more clear

3. Refactoring `Sweep`