### PR TITLE
[BigQuery] Update StorageWriter to be exactly once

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -115,26 +115,6 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 		return fmt.Errorf("failed to put table: %w", err)
 	}
 
-	if s.auditRows {
-		return s.auditStagingTable(ctx, bqTempTableID, tableData)
-	}
-
-	return nil
-}
-
-func (s *Store) auditStagingTable(ctx context.Context, bqTempTableID dialect.TableIdentifier, tableData *optimization.TableData) error {
-	expectedRowCount := uint64(tableData.NumberOfRows())
-
-	// With committed stream, we can get the count immediately
-	resp, err := s.bqClient.Dataset(bqTempTableID.Dataset()).Table(bqTempTableID.Table()).Metadata(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get %q metadata: %w", bqTempTableID.FullyQualifiedName(), err)
-	}
-
-	if resp.NumRows != expectedRowCount {
-		return fmt.Errorf("temporary table row count mismatch, expected: %d, got: %d", expectedRowCount, resp.NumRows)
-	}
-
 	return nil
 }
 

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -36,8 +36,6 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (b
 		ColumnSettings:            s.config.SharedDestinationSettings.ColumnSettings,
 		// BigQuery has DDL quotas.
 		RetryColBackfill: true,
-		// We are using BigQuery's streaming API which doesn't guarantee exactly once semantics
-		SubQueryDedupe: true,
 	})
 	if err != nil {
 		return false, fmt.Errorf("failed to merge: %w", err)


### PR DESCRIPTION
We were previously using the default stream for BigQuery which provides at-least-once semantics and we would then dedupe the rows prior to merging.

However, this hinders our ability to truly audit the number of rows in the staging table and whether they fully made it to the staging table or not.

![image](https://github.com/user-attachments/assets/f4770cac-288d-4f39-a20f-71b059f50dba)

This PR is moving us to the committed stream which will allow us to get exactly-once semantics and an exact rows written count to the staging table, thus providing more reliability and assurances around data consistency.

![image](https://github.com/user-attachments/assets/a9e088bc-853a-404b-9e71-79e4d1c202c6)
