### PR TITLE
[BigQuery] Returning `row_errors` if present + numeric refactor

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -209,6 +209,12 @@ func (s *Store) putTable(ctx context.Context, bqTableID dialect.TableIdentifier,
 
 		resp, err := result.FullResponse(ctx)
 		if err != nil {
+			if rowErrs := resp.GetRowErrors(); len(rowErrs) > 0 {
+				for _, rowErr := range rowErrs {
+					fmt.Println("rowErr", rowErr)
+				}
+			}
+
 			return fmt.Errorf("failed to get response: %w", err)
 		}
 

--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -209,10 +209,21 @@ func (s *Store) putTable(ctx context.Context, bqTableID dialect.TableIdentifier,
 
 		resp, err := result.FullResponse(ctx)
 		if err != nil {
-			if rowErrs := resp.GetRowErrors(); len(rowErrs) > 0 {
-				for _, rowErr := range rowErrs {
-					fmt.Println("rowErr", rowErr)
+			if resp != nil {
+				if rowErrs := resp.GetRowErrors(); len(rowErrs) > 0 {
+					// Just log the first few errors
+					var errors []any
+					for i, rowErr := range rowErrs {
+						if i > 5 {
+							break
+						}
+
+						errors = append(errors, rowErr)
+					}
+
+					return fmt.Errorf("failed to append rows, encountered %d errors: %v", len(rowErrs), errors)
 				}
+
 			}
 
 			return fmt.Errorf("failed to get response: %w", err)

--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -36,7 +36,11 @@ func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, s
 	case typing.EDecimal.Kind:
 		// [kindDetails.ExtendedDecimalDetails] may be nil if the target data type is a variable numeric or bignumeric.
 		if kindDetails.ExtendedDecimalDetails == nil {
-			return "numeric"
+			if settings.BigQueryNumericForVariableNumeric {
+				return "bignumeric"
+			} else {
+				return "numeric"
+			}
 		}
 
 		return kindDetails.ExtendedDecimalDetails.BigQueryKind(settings.BigQueryNumericForVariableNumeric)


### PR DESCRIPTION
If we don't have precision or scale, we are returning NUMERIC. However, we should take into account if BIGNUMERIC is enabled.

We should also log some row errors out so we can action on the actual error.