### PR TITLE
[BigQuery] Updating NUMERIC and BIGNUMERIC defaults

### DIFF
--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -7,6 +7,7 @@ import (
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/decimal"
 )
 
 func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, settings config.SharedDestinationColumnSettings) string {
@@ -63,11 +64,17 @@ func (BigQueryDialect) KindForDataType(rawBqType string, _ string) (typing.KindD
 
 	// Geography, geometry date, time, varbinary, binary are currently not supported.
 	switch strings.TrimSpace(bqType[:idxStop]) {
-	case "numeric", "bignumeric":
+	// https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
+	case "numeric":
 		if len(parameters) == 0 {
 			// This is a specific thing to BigQuery
 			// A `NUMERIC` type without precision or scale specified is NUMERIC(38, 9)
-			return typing.EDecimal, nil
+			return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(38, 9)), nil
+		}
+		return typing.ParseNumeric(parameters)
+	case "bignumeric":
+		if len(parameters) == 0 {
+			return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(76, 38)), nil
 		}
 		return typing.ParseNumeric(parameters)
 	case "decimal", "float", "float64", "bigdecimal":

--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -67,13 +67,13 @@ func (BigQueryDialect) KindForDataType(rawBqType string, _ string) (typing.KindD
 	// https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
 	case "numeric":
 		if len(parameters) == 0 {
-			// This is a specific thing to BigQuery
-			// A `NUMERIC` type without precision or scale specified is NUMERIC(38, 9)
+			// BigQuery [NUMERIC] type will default to NUMERIC(38, 9)
 			return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(38, 9)), nil
 		}
 		return typing.ParseNumeric(parameters)
 	case "bignumeric":
 		if len(parameters) == 0 {
+			// BigQuery [BIGNUMERIC] type will default to BIGNUMERIC(76, 38)
 			return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(76, 38)), nil
 		}
 		return typing.ParseNumeric(parameters)

--- a/clients/bigquery/dialect/typing_test.go
+++ b/clients/bigquery/dialect/typing_test.go
@@ -72,6 +72,14 @@ func TestBigQueryDialect_KindForDataType(t *testing.T) {
 			}
 		}
 		{
+			// NUMERIC (no precision or scale)
+			kd, err := dialect.KindForDataType("numeric", "")
+			assert.NoError(t, err)
+			assert.Equal(t, typing.EDecimal.Kind, kd.Kind)
+			assert.Equal(t, int32(38), kd.ExtendedDecimalDetails.Precision())
+			assert.Equal(t, int32(9), kd.ExtendedDecimalDetails.Scale())
+		}
+		{
 			// Numeric(5)
 			kd, err := dialect.KindForDataType("NUMERIC(5)", "")
 			assert.NoError(t, err)
@@ -107,6 +115,14 @@ func TestBigQueryDialect_KindForDataType(t *testing.T) {
 			assert.Equal(t, typing.EDecimal.Kind, kd.Kind)
 			assert.Equal(t, int32(5), kd.ExtendedDecimalDetails.Precision())
 			assert.Equal(t, int32(2), kd.ExtendedDecimalDetails.Scale())
+		}
+		{
+			// BIGNUMERIC (no precision or scale)
+			kd, err := dialect.KindForDataType("bignumeric", "")
+			assert.NoError(t, err)
+			assert.Equal(t, typing.EDecimal.Kind, kd.Kind)
+			assert.Equal(t, int32(76), kd.ExtendedDecimalDetails.Precision())
+			assert.Equal(t, int32(38), kd.ExtendedDecimalDetails.Scale())
 		}
 	}
 	{

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -319,12 +319,16 @@ func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Col
 	}
 
 	// Copy over the decimal details
+
+	fmt.Println("inMemoryCol", inMemoryCol.Name(), "destCol", destCol.Name())
 	if destCol.KindDetails.ExtendedDecimalDetails != nil && inMemoryCol.KindDetails.ExtendedDecimalDetails == nil {
+		fmt.Println("setting inMemoryCol", inMemoryCol.Name(), "destCol", destCol.Name(), "extendedDecimalDetails", destCol.KindDetails.ExtendedDecimalDetails.Precision(), destCol.KindDetails.ExtendedDecimalDetails.Scale())
 		inMemoryCol.KindDetails.ExtendedDecimalDetails = destCol.KindDetails.ExtendedDecimalDetails
 	}
 
 	// If the destination column does not have extended decimal details, we should remove it from the in-memory column as well
 	if destCol.KindDetails.ExtendedDecimalDetails == nil && inMemoryCol.KindDetails.ExtendedDecimalDetails != nil {
+		fmt.Println("removing inMemoryCol", inMemoryCol.Name(), "destCol", destCol.Name(), "extendedDecimalDetails", inMemoryCol.KindDetails.ExtendedDecimalDetails.Precision(), inMemoryCol.KindDetails.ExtendedDecimalDetails.Scale())
 		inMemoryCol.KindDetails.ExtendedDecimalDetails = nil
 	}
 

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -319,16 +319,12 @@ func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Col
 	}
 
 	// Copy over the decimal details
-
-	fmt.Println("inMemoryCol", inMemoryCol.Name(), "destCol", destCol.Name())
 	if destCol.KindDetails.ExtendedDecimalDetails != nil && inMemoryCol.KindDetails.ExtendedDecimalDetails == nil {
-		fmt.Println("setting inMemoryCol", inMemoryCol.Name(), "destCol", destCol.Name(), "extendedDecimalDetails", destCol.KindDetails.ExtendedDecimalDetails.Precision(), destCol.KindDetails.ExtendedDecimalDetails.Scale())
 		inMemoryCol.KindDetails.ExtendedDecimalDetails = destCol.KindDetails.ExtendedDecimalDetails
 	}
 
 	// If the destination column does not have extended decimal details, we should remove it from the in-memory column as well
 	if destCol.KindDetails.ExtendedDecimalDetails == nil && inMemoryCol.KindDetails.ExtendedDecimalDetails != nil {
-		fmt.Println("removing inMemoryCol", inMemoryCol.Name(), "destCol", destCol.Name(), "extendedDecimalDetails", inMemoryCol.KindDetails.ExtendedDecimalDetails.Precision(), inMemoryCol.KindDetails.ExtendedDecimalDetails.Scale())
 		inMemoryCol.KindDetails.ExtendedDecimalDetails = nil
 	}
 


### PR DESCRIPTION
If they aren't passed in, we should be setting to what the true precision and scale values should be. This way, we don't overwrite the decimal kind details when we merge the columns.
