### PR TITLE
[BigQuery] Refactor BIGNUMERIC and NUMERIC

### DIFF
--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -37,14 +37,14 @@ func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, s
 	case typing.EDecimal.Kind:
 		// [kindDetails.ExtendedDecimalDetails] may be nil if the target data type is a variable numeric or bignumeric.
 		if kindDetails.ExtendedDecimalDetails == nil {
-			if settings.BigQueryNumericForVariableNumeric {
+			if settings.BigNumericForVariableNumeric() {
 				return "bignumeric"
 			} else {
 				return "numeric"
 			}
 		}
 
-		return kindDetails.ExtendedDecimalDetails.BigQueryKind(settings.BigQueryNumericForVariableNumeric)
+		return kindDetails.ExtendedDecimalDetails.BigQueryKind(settings.BigNumericForVariableNumeric())
 	}
 
 	return kindDetails.Kind

--- a/lib/config/types.go
+++ b/lib/config/types.go
@@ -32,8 +32,15 @@ type Kafka struct {
 }
 
 type SharedDestinationColumnSettings struct {
+	// TODO: Deprecate BigQueryNumericForVariableNumeric in favor of UseBigNumericForVariableNumeric
 	// BigQueryNumericForVariableNumeric - If enabled, we will use BigQuery's NUMERIC type for variable numeric types.
 	BigQueryNumericForVariableNumeric bool `yaml:"bigQueryNumericForVariableNumeric"`
+
+	UseBigNumericForVariableNumeric bool `yaml:"useBigNumericForVariableNumeric"`
+}
+
+func (s SharedDestinationColumnSettings) BigNumericForVariableNumeric() bool {
+	return s.UseBigNumericForVariableNumeric || s.BigQueryNumericForVariableNumeric
 }
 
 type SharedDestinationSettings struct {

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -36,7 +36,11 @@ func BuildCreateTableSQL(settings config.SharedDestinationColumnSettings, dialec
 			primaryKeys = append(primaryKeys, colName)
 		}
 
-		parts = append(parts, fmt.Sprintf("%s %s", colName, dialect.DataTypeForKind(col.KindDetails, col.PrimaryKey(), settings)))
+		kd := dialect.DataTypeForKind(col.KindDetails, col.PrimaryKey(), settings)
+
+		fmt.Println("col", col.Name(), "kd", kd)
+
+		parts = append(parts, fmt.Sprintf("%s %s", colName, kd))
 	}
 
 	if len(primaryKeys) > 0 {

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -37,9 +37,6 @@ func BuildCreateTableSQL(settings config.SharedDestinationColumnSettings, dialec
 		}
 
 		kd := dialect.DataTypeForKind(col.KindDetails, col.PrimaryKey(), settings)
-
-		fmt.Println("col", col.Name(), "kd", kd)
-
 		parts = append(parts, fmt.Sprintf("%s %s", colName, kd))
 	}
 

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -36,8 +36,7 @@ func BuildCreateTableSQL(settings config.SharedDestinationColumnSettings, dialec
 			primaryKeys = append(primaryKeys, colName)
 		}
 
-		kd := dialect.DataTypeForKind(col.KindDetails, col.PrimaryKey(), settings)
-		parts = append(parts, fmt.Sprintf("%s %s", colName, kd))
+		parts = append(parts, fmt.Sprintf("%s %s", colName, dialect.DataTypeForKind(col.KindDetails, col.PrimaryKey(), settings)))
 	}
 
 	if len(primaryKeys) > 0 {

--- a/lib/typing/decimal/base_test.go
+++ b/lib/typing/decimal/base_test.go
@@ -1,0 +1,73 @@
+package decimal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecimal_IsNumeric(t *testing.T) {
+	{
+		// Valid numeric with small scale
+		assert.True(t, NewDetails(10, 2).isNumeric(), "should be valid numeric with small scale")
+	}
+	{
+		// Valid numeric with max scale
+		assert.True(t, NewDetails(38, 9).isNumeric(), "should be valid numeric with max scale")
+	}
+	{
+		// Invalid - precision not specified
+		assert.False(t, NewDetails(PrecisionNotSpecified, 2).isNumeric(), "should be invalid when precision is not specified")
+	}
+	{
+		// Invalid - scale too large
+		assert.False(t, NewDetails(10, 10).isNumeric(), "should be invalid when scale is too large")
+	}
+	{
+		// Invalid - precision too small
+		assert.False(t, NewDetails(1, 2).isNumeric(), "should be invalid when precision is too small")
+	}
+	{
+		// Invalid - precision too large
+		assert.False(t, NewDetails(40, 2).isNumeric(), "should be invalid when precision is too large")
+	}
+	{
+		// Valid - minimum valid case
+		assert.True(t, NewDetails(1, 0).isNumeric(), "should be valid with minimum precision and scale")
+	}
+	{
+		// Valid - scale equals precision
+		assert.True(t, NewDetails(5, 5).isNumeric(), "should be valid when scale equals precision")
+	}
+}
+
+func TestDecimal_IsBigNumeric(t *testing.T) {
+	{
+		// Valid bignumeric with small scale
+		assert.True(t, NewDetails(39, 2).isBigNumeric(), "should be valid bignumeric with small scale")
+	}
+	{
+		// Valid bignumeric with max scale
+		assert.True(t, NewDetails(77, 38).isBigNumeric(), "should be valid bignumeric with max scale")
+	}
+	{
+		// Invalid - precision not specified
+		assert.False(t, NewDetails(PrecisionNotSpecified, 2).isBigNumeric(), "should be invalid when precision is not specified")
+	}
+	{
+		// Invalid - scale too large
+		assert.False(t, NewDetails(39, 39).isBigNumeric(), "should be invalid when scale is too large")
+	}
+	{
+		// Invalid - precision too small
+		assert.False(t, NewDetails(38, 2).isBigNumeric(), "should be invalid when precision is too small")
+	}
+	{
+		// Valid - minimum valid case
+		assert.True(t, NewDetails(39, 0).isBigNumeric(), "should be valid with minimum precision and scale")
+	}
+	{
+		// Valid - scale equals precision
+		assert.True(t, NewDetails(39, 39).isBigNumeric(), "should be valid when scale equals precision")
+	}
+}

--- a/lib/typing/decimal/base_test.go
+++ b/lib/typing/decimal/base_test.go
@@ -24,8 +24,8 @@ func TestDecimal_IsNumeric(t *testing.T) {
 		assert.False(t, NewDetails(10, 10).isNumeric(), "should be invalid when scale is too large")
 	}
 	{
-		// Invalid - precision too small
-		assert.False(t, NewDetails(1, 2).isNumeric(), "should be invalid when precision is too small")
+		// Valid - precision equals scale
+		assert.True(t, NewDetails(2, 2).isNumeric(), "should be valid when precision equals scale")
 	}
 	{
 		// Invalid - precision too large
@@ -44,11 +44,11 @@ func TestDecimal_IsNumeric(t *testing.T) {
 func TestDecimal_IsBigNumeric(t *testing.T) {
 	{
 		// Valid bignumeric with small scale
-		assert.True(t, NewDetails(39, 2).isBigNumeric(), "should be valid bignumeric with small scale")
+		assert.True(t, NewDetails(40, 2).isBigNumeric(), "should be valid bignumeric with small scale")
 	}
 	{
 		// Valid bignumeric with max scale
-		assert.True(t, NewDetails(77, 38).isBigNumeric(), "should be valid bignumeric with max scale")
+		assert.True(t, NewDetails(76, 38).isBigNumeric(), "should be valid bignumeric with max scale")
 	}
 	{
 		// Invalid - precision not specified
@@ -56,18 +56,18 @@ func TestDecimal_IsBigNumeric(t *testing.T) {
 	}
 	{
 		// Invalid - scale too large
-		assert.False(t, NewDetails(39, 39).isBigNumeric(), "should be invalid when scale is too large")
+		assert.False(t, NewDetails(77, 39).isBigNumeric(), "should be invalid when scale is too large")
 	}
 	{
-		// Invalid - precision too small
-		assert.False(t, NewDetails(38, 2).isBigNumeric(), "should be invalid when precision is too small")
+		// Valid - numeric precision
+		assert.True(t, NewDetails(38, 2).isBigNumeric(), "should be valid with numeric precision")
 	}
 	{
-		// Valid - minimum valid case
-		assert.True(t, NewDetails(39, 0).isBigNumeric(), "should be valid with minimum precision and scale")
+		// Valid - precision equals scale
+		assert.True(t, NewDetails(40, 2).isBigNumeric(), "should be valid when precision equals scale")
 	}
 	{
-		// Valid - scale equals precision
-		assert.True(t, NewDetails(39, 39).isBigNumeric(), "should be valid when scale equals precision")
+		// Valid - scale equals max
+		assert.True(t, NewDetails(40, 38).isBigNumeric(), "should be valid when scale equals max allowed")
 	}
 }

--- a/lib/typing/decimal/details.go
+++ b/lib/typing/decimal/details.go
@@ -80,10 +80,16 @@ func (d Details) RedshiftKind() string {
 }
 
 // BigQueryKind - is inferring logic from: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
-func (d Details) BigQueryKind(numericTypeForVariableNumeric bool) string {
-	if numericTypeForVariableNumeric && d.precision == PrecisionNotSpecified {
-		return "BIGNUMERIC"
+func (d Details) BigQueryKind(bigQueryNumericForVariableNumeric bool) string {
+	if d.precision == PrecisionNotSpecified {
+		if bigQueryNumericForVariableNumeric {
+			return "BIGNUMERIC"
+		} else {
+			return "NUMERIC"
+		}
 	}
+
+	fmt.Println("d.precision", d.precision, "d.scale", d.scale, "d.isNumeric()", d.isNumeric(), "d.isBigNumeric()", d.isBigNumeric())
 
 	if d.isNumeric() {
 		return fmt.Sprintf("NUMERIC(%v, %v)", d.precision, d.scale)

--- a/lib/typing/decimal/details.go
+++ b/lib/typing/decimal/details.go
@@ -80,16 +80,14 @@ func (d Details) RedshiftKind() string {
 }
 
 // BigQueryKind - is inferring logic from: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types
-func (d Details) BigQueryKind(bigQueryNumericForVariableNumeric bool) string {
+func (d Details) BigQueryKind(useBigNumericForVariableNumeric bool) string {
 	if d.precision == PrecisionNotSpecified {
-		if bigQueryNumericForVariableNumeric {
+		if useBigNumericForVariableNumeric {
 			return "BIGNUMERIC"
 		} else {
 			return "NUMERIC"
 		}
 	}
-
-	fmt.Println("d.precision", d.precision, "d.scale", d.scale, "d.isNumeric()", d.isNumeric(), "d.isBigNumeric()", d.isBigNumeric())
 
 	if d.isNumeric() {
 		return fmt.Sprintf("NUMERIC(%v, %v)", d.precision, d.scale)

--- a/lib/typing/decimal/details_test.go
+++ b/lib/typing/decimal/details_test.go
@@ -11,7 +11,7 @@ func TestDetails_BigQueryKind(t *testing.T) {
 	details := NewDetails(PrecisionNotSpecified, DefaultScale)
 	{
 		// numericTypeForVariableNumeric = false
-		assert.Equal(t, "STRING", details.BigQueryKind(false))
+		assert.Equal(t, "NUMERIC", details.BigQueryKind(false))
 	}
 	{
 		// numericTypeForVariableNumeric = true
@@ -36,7 +36,7 @@ func TestDecimalDetailsKind(t *testing.T) {
 			Precision:             -1,
 			ExpectedSnowflakeKind: "STRING",
 			ExpectedRedshiftKind:  "TEXT",
-			ExpectedBigQueryKind:  "STRING",
+			ExpectedBigQueryKind:  "NUMERIC",
 		},
 		{
 			Name:                  "numeric(39, 0)",


### PR DESCRIPTION
## Changes

We previously would create a TEXT (or equivalent) column for a variable numeric data type. However, we have found that most users want it to be an actual numeric or big numeric column in BigQuery so they can query it easier.

As such, I've renamed this variable to be `UseBigNumericForVariableNumeric` and we are now defaulting to create a `NUMERIC` data type for a variable numeric data type. And if ☝️ is enabled, we'll create the data type as `BIGNUMERIC`.

