### PR TITLE
Removing `ext.PostgresDateFormat`

### DIFF
--- a/clients/bigquery/partition.go
+++ b/clients/bigquery/partition.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/ext"
 )
@@ -21,7 +22,7 @@ func buildDistinctDates(colName string, rows []map[string]any) ([]string, error)
 			return nil, fmt.Errorf("column %q is not a time column, value: %v, err: %w", colName, val, err)
 		}
 
-		dateMap[_time.Format(ext.PostgresDateFormat)] = true
+		dateMap[_time.Format(time.DateOnly)] = true
 	}
 
 	return slices.Collect(maps.Keys(dateMap)), nil

--- a/clients/mssql/values_test.go
+++ b/clients/mssql/values_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
-	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
 func TestParseValue(t *testing.T) {
@@ -24,13 +23,13 @@ func TestParseValue(t *testing.T) {
 			// String
 			val, err := parseValue("2021-01-01", columns.NewColumn("date", typing.Date))
 			assert.NoError(t, err)
-			assert.Equal(t, "2021-01-01", val.(time.Time).Format(ext.PostgresDateFormat))
+			assert.Equal(t, "2021-01-01", val.(time.Time).Format(time.DateOnly))
 		}
 		{
 			// time.Time
 			val, err := parseValue(time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC), columns.NewColumn("date", typing.Date))
 			assert.NoError(t, err)
-			assert.Equal(t, "2021-01-01", val.(time.Time).Format(ext.PostgresDateFormat))
+			assert.Equal(t, "2021-01-01", val.(time.Time).Format(time.DateOnly))
 		}
 	}
 	{

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -19,7 +19,6 @@ import (
 	"github.com/artie-labs/transfer/lib/parquetutil"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/stringutil"
-	"github.com/artie-labs/transfer/lib/typing/ext"
 )
 
 type Store struct {
@@ -49,7 +48,7 @@ func (s *Store) ObjectPrefix(tableData *optimization.TableData) string {
 	tableID := s.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
 	fqTableName := tableID.FullyQualifiedName()
 	// Adding date= prefix so that it adheres to the partitioning format for Hive.
-	yyyyMMDDFormat := fmt.Sprintf("date=%s", time.Now().Format(ext.PostgresDateFormat))
+	yyyyMMDDFormat := fmt.Sprintf("date=%s", time.Now().Format(time.DateOnly))
 	if len(s.config.S3.FolderName) > 0 {
 		return strings.Join([]string{s.config.S3.FolderName, fqTableName, yyyyMMDDFormat}, "/")
 	}

--- a/clients/s3/s3_test.go
+++ b/clients/s3/s3_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/typing/ext"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/lib/config"
@@ -51,7 +49,7 @@ func TestObjectPrefix(t *testing.T) {
 				AwsAccessKeyID:     "bar",
 				OutputFormat:       constants.ParquetFormat,
 			},
-			expectedFormat: fmt.Sprintf("db.public.table/date=%s", time.Now().Format(ext.PostgresDateFormat)),
+			expectedFormat: fmt.Sprintf("db.public.table/date=%s", time.Now().Format(time.DateOnly)),
 		},
 		{
 			name:      "valid #2 w/ folder",
@@ -63,7 +61,7 @@ func TestObjectPrefix(t *testing.T) {
 				OutputFormat:       constants.ParquetFormat,
 				FolderName:         "foo",
 			},
-			expectedFormat: fmt.Sprintf("foo/db.public.table/date=%s", time.Now().Format(ext.PostgresDateFormat)),
+			expectedFormat: fmt.Sprintf("foo/db.public.table/date=%s", time.Now().Format(time.DateOnly)),
 		},
 	}
 

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -30,7 +30,7 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 			return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)
 		}
 
-		return sql.QuoteLiteral(_time.Format(ext.PostgresDateFormat)), nil
+		return sql.QuoteLiteral(_time.Format(time.DateOnly)), nil
 	case typing.Time.Kind:
 		_time, err := ext.ParseTimeFromAny(column.DefaultValue())
 		if err != nil {

--- a/lib/debezium/converters/date_test.go
+++ b/lib/debezium/converters/date_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/typing/ext"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +19,7 @@ func TestDate_Convert(t *testing.T) {
 
 		date, isOk := val.(time.Time)
 		assert.True(t, isOk)
-		assert.Equal(t, "2023-02-13", date.Format(ext.PostgresDateFormat))
+		assert.Equal(t, "2023-02-13", date.Format(time.DateOnly))
 	}
 	{
 		val, err := Date{}.Convert(int64(19429))
@@ -29,6 +27,6 @@ func TestDate_Convert(t *testing.T) {
 
 		date, isOk := val.(time.Time)
 		assert.True(t, isOk)
-		assert.Equal(t, "2023-03-13", date.Format(ext.PostgresDateFormat))
+		assert.Equal(t, "2023-03-13", date.Format(time.DateOnly))
 	}
 }

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/artie-labs/transfer/lib/array"
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -27,7 +28,7 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
-		return _time.Format(ext.PostgresDateFormat), nil
+		return _time.Format(time.DateOnly), nil
 	case typing.Time.Kind:
 		_time, err := ext.ParseTimeFromAny(colVal)
 		if err != nil {

--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -105,7 +105,7 @@ func (DateConverter) Convert(value any) (string, error) {
 		return "", fmt.Errorf("failed to cast colVal as date, colVal: '%v', err: %w", value, err)
 	}
 
-	return _time.Format(ext.PostgresDateFormat), nil
+	return _time.Format(time.DateOnly), nil
 }
 
 type TimeConverter struct{}

--- a/lib/typing/ext/variables.go
+++ b/lib/typing/ext/variables.go
@@ -3,7 +3,6 @@ package ext
 import "time"
 
 const (
-	PostgresDateFormat     = "2006-01-02"
 	PostgresTimeFormat     = PostgresTimeFormatNoTZ + TimezoneOffsetFormat
 	PostgresTimeFormatNoTZ = "15:04:05.999999" // microsecond precision, used because certain destinations do not like `Time` types to specify tz locale
 )
@@ -29,7 +28,7 @@ var supportedDateTimeLayouts = []string{
 }
 
 var supportedDateFormats = []string{
-	PostgresDateFormat,
+	time.DateOnly,
 }
 
 var SupportedTimeFormats = []string{


### PR DESCRIPTION
time.DateOnly is the same format: https://cs.opensource.google/go/go/+/refs/tags/go1.24.2:src/time/format.go;l=128, so let's standardize on stdlib