### PR TITLE
Fixing Redshift Edge Case

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -29,6 +29,7 @@ func replaceExceededValues(colVal string, colKind typing.KindDetails, truncateEx
 		// Ref: https://docs.aws.amazon.com/redshift/latest/dg/limitations-super.html
 		if typing.IsJSON(colVal) {
 			if len(colVal) > maxSuperLength {
+				fmt.Println("colVal", colVal)
 				return Result{Value: fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker)}
 			}
 
@@ -46,6 +47,7 @@ func replaceExceededValues(colVal string, colKind typing.KindDetails, truncateEx
 		}
 
 		if shouldReplace := colValLength > maxLength; shouldReplace {
+			fmt.Println("colValLength", colValLength, "maxLength", maxLength, "colVal", colVal)
 			if truncateExceededValue {
 				return Result{Value: colVal[:maxLength]}
 			} else {

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -15,6 +15,7 @@ type Result struct {
 	// NewLength - If the value exceeded the maximum length, this will be the new length of the value.
 	// This is only applicable if [expandStringPrecision] is enabled.
 	NewLength int32
+	Exceeded  bool
 }
 
 const (
@@ -29,7 +30,6 @@ func replaceExceededValues(colVal string, colKind typing.KindDetails, truncateEx
 		// Ref: https://docs.aws.amazon.com/redshift/latest/dg/limitations-super.html
 		if typing.IsJSON(colVal) {
 			if len(colVal) > maxSuperLength {
-				fmt.Println("colVal", colVal)
 				return Result{Value: fmt.Sprintf(`{"key":"%s"}`, constants.ExceededValueMarker)}
 			}
 
@@ -37,7 +37,12 @@ func replaceExceededValues(colVal string, colKind typing.KindDetails, truncateEx
 		}
 
 		// Try again, but use [typing.String] instead.
-		return replaceExceededValues(colVal, typing.String, truncateExceededValue, expandStringPrecision)
+		result := replaceExceededValues(colVal, typing.String, truncateExceededValue, expandStringPrecision)
+		if result.Exceeded {
+			result.Value = fmt.Sprintf(`"%s"`, result.Value)
+		}
+
+		return result
 	case typing.String.Kind:
 		maxLength := typing.DefaultValueFromPtr[int32](colKind.OptionalStringPrecision, maxStringLength)
 		colValLength := int32(len(colVal))
@@ -47,11 +52,10 @@ func replaceExceededValues(colVal string, colKind typing.KindDetails, truncateEx
 		}
 
 		if shouldReplace := colValLength > maxLength; shouldReplace {
-			fmt.Println("colValLength", colValLength, "maxLength", maxLength, "colVal", colVal)
 			if truncateExceededValue {
-				return Result{Value: colVal[:maxLength]}
+				return Result{Value: colVal[:maxLength], Exceeded: true}
 			} else {
-				return Result{Value: constants.ExceededValueMarker}
+				return Result{Value: constants.ExceededValueMarker, Exceeded: true}
 			}
 		}
 	}

--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -85,8 +85,8 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 				}
 				{
 					// Masked (data type is a string)
-					result := replaceExceededValues(stringutil.Random(int(maxStringLength)+1), typing.String, false, false)
-					assert.Equal(r.T(), constants.ExceededValueMarker, result.Value)
+					result := replaceExceededValues(stringutil.Random(int(maxStringLength)+1), typing.Struct, false, false)
+					assert.Equal(r.T(), fmt.Sprintf(`"%s"`, constants.ExceededValueMarker), result.Value)
 					assert.Zero(r.T(), result.NewLength)
 				}
 			}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f2d275d6-4363-4ab3-8b50-82dff5fa86b3)

Postgres allows storage of strings in JSONB columns, for which we are creating SUPER in Redshift.

However, Redshift SUPER has a DDL limit of 2^16 if the actual value is a string. We needed to escape the string with quotes for it to be valid