### PR TITLE
Addressing Snowflake TODO

### DIFF
--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -110,7 +110,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 	s.mockDB.ExpectExec(createTableRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for PUT - use regex pattern to match the actual table name with suffix
-	putQueryRegex := regexp.QuoteMeta(`PUT 'file://`) + `.*` + regexp.QuoteMeta(`' @"CUSTOMER"."PUBLIC"."%`) + `.*` + regexp.QuoteMeta(`" AUTO_COMPRESS=TRUE`)
+	putQueryRegex := regexp.QuoteMeta(`PUT 'file://`) + `.*` + regexp.QuoteMeta(`' @"CUSTOMER"."PUBLIC"."%`) + `.*"`
 	s.mockDB.ExpectExec(putQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for COPY INTO - use regex pattern to match the actual table name with suffix
@@ -176,7 +176,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 	s.mockDB.ExpectExec(createTableRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for PUT - use regex pattern to match the actual table name with suffix
-	putQueryRegex := regexp.QuoteMeta(`PUT 'file://`) + `.*` + regexp.QuoteMeta(`' @"CUSTOMER"."PUBLIC"."%`) + `.*` + regexp.QuoteMeta(`" AUTO_COMPRESS=TRUE`)
+	putQueryRegex := regexp.QuoteMeta(`PUT 'file://`) + `.*` + regexp.QuoteMeta(`' @"CUSTOMER"."PUBLIC"."%`) + `.*"`
 	s.mockDB.ExpectExec(putQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for COPY INTO - use regex pattern to match the actual table name with suffix
@@ -239,7 +239,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 	s.mockDB.ExpectExec(createTableRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for PUT - use regex pattern to match the actual table name with suffix
-	putQueryRegex := regexp.QuoteMeta(`PUT 'file://`) + `.*` + regexp.QuoteMeta(`' @"CUSTOMER"."PUBLIC"."%`) + `.*` + regexp.QuoteMeta(`" AUTO_COMPRESS=TRUE`)
+	putQueryRegex := regexp.QuoteMeta(`PUT 'file://`) + `.*` + regexp.QuoteMeta(`' @"CUSTOMER"."PUBLIC"."%`) + `.*` + regexp.QuoteMeta(`"`)
 	s.mockDB.ExpectExec(putQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for COPY INTO - use regex pattern to match the actual table name with suffix
@@ -319,7 +319,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	s.mockDB.ExpectExec(createTableRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for PUT - use regex pattern to match the actual table name with suffix
-	putQueryRegex := regexp.QuoteMeta(`PUT 'file://`) + `.*` + regexp.QuoteMeta(`' @"CUSTOMER"."PUBLIC"."%`) + `.*` + regexp.QuoteMeta(`" AUTO_COMPRESS=TRUE`)
+	putQueryRegex := regexp.QuoteMeta(`PUT 'file://`) + `.*` + regexp.QuoteMeta(`' @"CUSTOMER"."PUBLIC"."%`) + `.*"`
 	s.mockDB.ExpectExec(putQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for COPY INTO - use regex pattern to match the actual table name with suffix

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -239,7 +239,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 	s.mockDB.ExpectExec(createTableRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for PUT - use regex pattern to match the actual table name with suffix
-	putQueryRegex := regexp.QuoteMeta(`PUT 'file://`) + `.*` + regexp.QuoteMeta(`' @"CUSTOMER"."PUBLIC"."%`) + `.*` + regexp.QuoteMeta(`"`)
+	putQueryRegex := regexp.QuoteMeta(`PUT 'file://`) + `.*` + regexp.QuoteMeta(`' @"CUSTOMER"."PUBLIC"."%`) + `.*"`
 	s.mockDB.ExpectExec(putQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for COPY INTO - use regex pattern to match the actual table name with suffix

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -169,7 +169,7 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 		s.mockDB.ExpectExec(createTableRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 		stagingTableID := tempTableID.WithTable("%" + tempTableID.Table())
-		putQueryRegex := regexp.QuoteMeta(fmt.Sprintf(`PUT 'file://%s' @"DATABASE"."SCHEMA".%s AUTO_COMPRESS=TRUE`,
+		putQueryRegex := regexp.QuoteMeta(fmt.Sprintf(`PUT 'file://%s' @"DATABASE"."SCHEMA".%s`,
 			filepath.Join(os.TempDir(), fmt.Sprintf("%s.csv", strings.ReplaceAll(tempTableName, `"`, ""))),
 			stagingTableID.EscapedTable()))
 		s.mockDB.ExpectExec(putQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
@@ -185,7 +185,7 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 	{
 		// Set up expectations for the second test case (don't create temporary table)
 		stagingTableID := tempTableID.WithTable("%" + tempTableID.Table())
-		putQueryRegex := regexp.QuoteMeta(fmt.Sprintf(`PUT 'file://%s' @"DATABASE"."SCHEMA".%s AUTO_COMPRESS=TRUE`,
+		putQueryRegex := regexp.QuoteMeta(fmt.Sprintf(`PUT 'file://%s' @"DATABASE"."SCHEMA".%s`,
 			filepath.Join(os.TempDir(), fmt.Sprintf("%s.csv", strings.ReplaceAll(tempTableName, `"`, ""))),
 			stagingTableID.EscapedTable()))
 		s.mockDB.ExpectExec(putQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
@@ -203,7 +203,7 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 func (s *SnowflakeTestSuite) TestLoadTemporaryTable() {
 	tempTableID, tableData := generateTableData(100)
 	file, err := s.stageStore.writeTemporaryTableFile(tableData, tempTableID)
-	assert.Equal(s.T(), fmt.Sprintf("%s.csv", strings.ReplaceAll(tempTableID.FullyQualifiedName(), `"`, "")), file.FileName)
+	assert.Equal(s.T(), fmt.Sprintf("%s.csv.gz", strings.ReplaceAll(tempTableID.FullyQualifiedName(), `"`, "")), file.FileName)
 	assert.NoError(s.T(), err)
 	// Read the CSV and confirm.
 	csvfile, err := os.Open(file.FilePath)

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -206,11 +206,12 @@ func (s *SnowflakeTestSuite) TestLoadTemporaryTable() {
 	file, err := s.stageStore.writeTemporaryTableFile(tableData, tempTableID)
 	assert.Equal(s.T(), fmt.Sprintf("%s.csv.gz", strings.ReplaceAll(tempTableID.FullyQualifiedName(), `"`, "")), file.FileName)
 	assert.NoError(s.T(), err)
+
 	// Read the CSV and confirm.
 	csvfile, err := os.Open(file.FilePath)
 	assert.NoError(s.T(), err)
-	// Parse the file
 
+	// Parse the file
 	gzipReader, err := gzip.NewReader(csvfile)
 	assert.NoError(s.T(), err)
 


### PR DESCRIPTION
This PR is standardizing the usage of `writeTemporaryTableFileGZIP`, while this is enabled - we can remove the `AUTO_COMPRESS` flag in `PUT`
