### PR TITLE
[Livy] Adding throttling

### DIFF
--- a/lib/apachelivy/client.go
+++ b/lib/apachelivy/client.go
@@ -18,9 +18,6 @@ const (
 	sleepBaseMs                     = 1_000
 	sleepMaxMs                      = 3_000
 	defaultHeartbeatTimeoutInSecond = 300
-
-	defaultDriverMemory = "512M"
-	defaultCores        = 0.5
 )
 
 type Client struct {
@@ -30,10 +27,6 @@ type Client struct {
 	sessionConf                     map[string]any
 	sessionJars                     []string
 	sessionHeartbeatTimeoutInSecond int
-	driverMemory                    string
-	driverCores                     int
-	executorMemory                  string
-	executorCores                   int
 
 	lastChecked time.Time
 }

--- a/lib/apachelivy/client.go
+++ b/lib/apachelivy/client.go
@@ -18,6 +18,9 @@ const (
 	sleepBaseMs                     = 1_000
 	sleepMaxMs                      = 3_000
 	defaultHeartbeatTimeoutInSecond = 300
+
+	defaultDriverMemory = "512M"
+	defaultCores        = 0.5
 )
 
 type Client struct {
@@ -27,6 +30,10 @@ type Client struct {
 	sessionConf                     map[string]any
 	sessionJars                     []string
 	sessionHeartbeatTimeoutInSecond int
+	driverMemory                    string
+	driverCores                     int
+	executorMemory                  string
+	executorCores                   int
 
 	lastChecked time.Time
 }
@@ -184,6 +191,18 @@ func (c *Client) newSession(ctx context.Context, kind SessionKind, blockUntilRea
 
 	resp, err := c.doRequest(ctx, "POST", "/sessions", body)
 	if err != nil {
+		var errorResponse ErrorResponse
+		if err = json.Unmarshal(resp.body, &errorResponse); err != nil {
+			return fmt.Errorf("failed to unmarshal error response: %w", err)
+		}
+
+		if errorResponse.Message == ErrTooManySessionsCreated {
+			sleepTime := jitter.Jitter(sleepBaseMs, sleepMaxMs, 0)
+			slog.Info("Too many sessions created, throttling", slog.String("message", errorResponse.Message), slog.Duration("sleepTime", sleepTime))
+			time.Sleep(sleepTime)
+			return c.newSession(ctx, kind, blockUntilReady)
+		}
+
 		slog.Warn("Failed to create session", slog.Any("err", err), slog.String("response", string(resp.body)))
 		return err
 	}

--- a/lib/apachelivy/types.go
+++ b/lib/apachelivy/types.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+const ErrTooManySessionsCreated = "Rejected, too many sessions are being created!"
+
 // SessionKind - https://livy.incubator.apache.org/docs/latest/rest-api.html#session-kind
 type SessionKind string
 
@@ -135,4 +137,8 @@ type GetSchemaFieldResponse struct {
 	Type     string         `json:"type"`
 	Nullable bool           `json:"nullable"`
 	Metadata map[string]any `json:"metadata"`
+}
+
+type ErrorResponse struct {
+	Message string `json:"msg"`
 }


### PR DESCRIPTION
If there are too many sessions being created at the same time, let's handle the error, throttle sleep and then retry.