### PR TITLE
[BigQuery] Fix nested JSON arrays

### DIFF
--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -28,7 +28,6 @@ func InterfaceToArrayString(val any, recastAsArray bool) ([]string, error) {
 	for i := 0; i < list.Len(); i++ {
 		kind := list.Index(i).Kind()
 		value := list.Index(i).Interface()
-
 		if stringValue, ok := value.(string); ok {
 			vals = append(vals, stringValue)
 			continue

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -51,6 +51,7 @@ func InterfaceToArrayString(val any, recastAsArray bool) ([]string, error) {
 
 			vals = append(vals, string(bytes))
 		} else {
+			// TODO: Do we need to escape backslashes?
 			vals = append(vals, stringutil.EscapeBackslashes(fmt.Sprint(value)))
 		}
 	}

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -29,6 +29,11 @@ func InterfaceToArrayString(val any, recastAsArray bool) ([]string, error) {
 		kind := list.Index(i).Kind()
 		value := list.Index(i).Interface()
 		var shouldParse bool
+		if stringValue, ok := value.(string); ok {
+			vals = append(vals, stringValue)
+			continue
+		}
+
 		if kind == reflect.Interface {
 			valMap, isOk := value.(map[string]any)
 			if isOk {

--- a/lib/array/strings.go
+++ b/lib/array/strings.go
@@ -28,12 +28,13 @@ func InterfaceToArrayString(val any, recastAsArray bool) ([]string, error) {
 	for i := 0; i < list.Len(); i++ {
 		kind := list.Index(i).Kind()
 		value := list.Index(i).Interface()
-		var shouldParse bool
+
 		if stringValue, ok := value.(string); ok {
 			vals = append(vals, stringValue)
 			continue
 		}
 
+		var shouldParse bool
 		if kind == reflect.Interface {
 			valMap, isOk := value.(map[string]any)
 			if isOk {

--- a/lib/array/strings_test.go
+++ b/lib/array/strings_test.go
@@ -57,6 +57,11 @@ func TestToArrayString(t *testing.T) {
 		assert.Equal(t, []string{"[foo bar]", "[abc def]"}, value)
 	}
 	{
+		value, err := InterfaceToArrayString([]any{`{"foo":"bar"}`}, true)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{`{"foo":"bar"}`}, value)
+	}
+	{
 		// Test boolean recast as array
 		value, err := InterfaceToArrayString(true, true)
 		assert.NoError(t, err)


### PR DESCRIPTION
If the value is already a string, we don't need to run this through JSON parse again. 

By going through the parsing function again, we're double escaping the value