### PR TITLE
Refactor `SanitizePayload` to be `ParsePayload`

### DIFF
--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -259,6 +259,9 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 // MongoDB will return the native objects back such as `map[string]any{"hello": "world"}`
 // Relational will return a string representation of the struct such as `{"hello": "world"}`
 func encodeStructToJSONString(value any) (string, error) {
+
+	fmt.Println("before value", value)
+
 	if stringValue, isOk := value.(string); isOk {
 		if strings.Contains(stringValue, constants.ToastUnavailableValuePlaceholder) {
 			return fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder), nil
@@ -270,6 +273,8 @@ func encodeStructToJSONString(value any) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal value: %w", err)
 	}
+
+	fmt.Println("after value", string(bytes))
 
 	return string(bytes), nil
 }

--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -259,9 +259,6 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 // MongoDB will return the native objects back such as `map[string]any{"hello": "world"}`
 // Relational will return a string representation of the struct such as `{"hello": "world"}`
 func encodeStructToJSONString(value any) (string, error) {
-
-	fmt.Println("before value", value)
-
 	if stringValue, isOk := value.(string); isOk {
 		if strings.Contains(stringValue, constants.ToastUnavailableValuePlaceholder) {
 			return fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder), nil
@@ -273,8 +270,6 @@ func encodeStructToJSONString(value any) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal value: %w", err)
 	}
-
-	fmt.Println("after value", string(bytes))
 
 	return string(bytes), nil
 }

--- a/lib/debezium/converters/basic.go
+++ b/lib/debezium/converters/basic.go
@@ -124,8 +124,6 @@ func (a Array) Convert(value any) (any, error) {
 			return nil, err
 		}
 
-		fmt.Println("element", element, "convertedElement", convertedElement)
-
 		convertedElements[i] = convertedElement
 	}
 

--- a/lib/debezium/converters/basic.go
+++ b/lib/debezium/converters/basic.go
@@ -21,7 +21,7 @@ func (JSON) Convert(value any) (any, error) {
 		return value, nil
 	}
 
-	return jsonutil.ParsePayload(valueString)
+	return jsonutil.UnmarshalPayload(valueString)
 }
 
 func (JSON) ToKindDetails() typing.KindDetails {

--- a/lib/debezium/converters/basic.go
+++ b/lib/debezium/converters/basic.go
@@ -124,6 +124,8 @@ func (a Array) Convert(value any) (any, error) {
 			return nil, err
 		}
 
+		fmt.Println("element", element, "convertedElement", convertedElement)
+
 		convertedElements[i] = convertedElement
 	}
 

--- a/lib/debezium/converters/basic.go
+++ b/lib/debezium/converters/basic.go
@@ -21,7 +21,7 @@ func (JSON) Convert(value any) (any, error) {
 		return value, nil
 	}
 
-	return jsonutil.SanitizePayload(valueString)
+	return jsonutil.ParsePayload(valueString)
 }
 
 func (JSON) ToKindDetails() typing.KindDetails {

--- a/lib/debezium/converters/basic_test.go
+++ b/lib/debezium/converters/basic_test.go
@@ -1,7 +1,6 @@
 package converters
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,7 @@ func TestJSON_Convert(t *testing.T) {
 		// JSON with duplicate values
 		value, err := JSON{}.Convert(`{"a": 1, "a": 2}`)
 		assert.Nil(t, err)
-		assert.Equal(t, `{"a":2}`, value)
+		assert.Equal(t, map[string]any{"a": float64(2)}, value)
 	}
 }
 
@@ -128,8 +127,7 @@ func TestArray_Convert(t *testing.T) {
 			value, err := NewArray(JSON{}.Convert).Convert([]any{`{"body": "they are on to us", "sender": "pablo"}`})
 			assert.NoError(t, err)
 			assert.Len(t, value.([]any), 1)
-			fmt.Println("value", value)
-			assert.ElementsMatch(t, []any{`{"body":"they are on to us","sender":"pablo"}`}, value.([]any))
+			assert.ElementsMatch(t, []any{map[string]any{"body": "they are on to us", "sender": "pablo"}}, value.([]any))
 		}
 	}
 }

--- a/lib/debezium/converters/basic_test.go
+++ b/lib/debezium/converters/basic_test.go
@@ -127,7 +127,7 @@ func TestArray_Convert(t *testing.T) {
 			value, err := NewArray(JSON{}.Convert).Convert([]any{`{"body": "they are on to us", "sender": "pablo"}`})
 			assert.NoError(t, err)
 			assert.Len(t, value.([]any), 1)
-			assert.ElementsMatch(t, []any{`{"body":"they are on to us","sender":"pablo"}`}, value.([]any))
+			assert.ElementsMatch(t, []any{map[string]any{"body": "they are on to us", "sender": "pablo"}}, value.([]any))
 		}
 	}
 }

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -146,7 +146,7 @@ func TestField_ParseValue(t *testing.T) {
 			// Valid
 			value, err := field.ParseValue(`{"foo": "bar", "foo": "bar"}`)
 			assert.NoError(t, err)
-			assert.Equal(t, `{"foo":"bar"}`, value)
+			assert.Equal(t, map[string]any{"foo": "bar"}, value)
 		}
 		{
 			// Malformed
@@ -163,13 +163,13 @@ func TestField_ParseValue(t *testing.T) {
 			// Array
 			val, err := field.ParseValue(`[{"foo":"bar", "foo": "bar"}, {"hello":"world"}, {"dusty":"the mini aussie"}]`)
 			assert.NoError(t, err)
-			assert.Equal(t, `[{"foo":"bar"},{"hello":"world"},{"dusty":"the mini aussie"}]`, val)
+			assert.Equal(t, []any{map[string]any{"foo": "bar"}, map[string]any{"hello": "world"}, map[string]any{"dusty": "the mini aussie"}}, val)
 		}
 		{
 			// Array of objects
 			val, err := field.ParseValue(`[[{"foo":"bar", "foo": "bar"}], [{"hello":"world"}, {"dusty":"the mini aussie"}]]`)
 			assert.NoError(t, err)
-			assert.Equal(t, `[[{"foo":"bar"}],[{"hello":"world"},{"dusty":"the mini aussie"}]]`, val)
+			assert.Equal(t, []any{[]any{map[string]any{"foo": "bar"}}, []any{map[string]any{"hello": "world"}, map[string]any{"dusty": "the mini aussie"}}}, val)
 		}
 	}
 	{
@@ -178,7 +178,7 @@ func TestField_ParseValue(t *testing.T) {
 		value, err := field.ParseValue([]any{`{"foo": "bar", "foo": "bar"}`, `{"hello": "world"}`})
 		assert.NoError(t, err)
 		assert.Len(t, value.([]any), 2)
-		assert.ElementsMatch(t, []string{`{"foo":"bar"}`, `{"hello":"world"}`}, value)
+		assert.ElementsMatch(t, []any{map[string]any{"foo": "bar"}, map[string]any{"hello": "world"}}, value)
 	}
 	{
 		// Int32

--- a/lib/jsonutil/jsonutil.go
+++ b/lib/jsonutil/jsonutil.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 )
 
-// ParsePayload will take in a JSON string, and return a JSON string that has been sanitized (removed duplicate keys)
 func ParsePayload(val string) (any, error) {
 	// There are edge cases for when this may happen
 	// Example: JSONB column in a table in Postgres where the table replica identity is set to `default` and it was a delete event.

--- a/lib/jsonutil/jsonutil.go
+++ b/lib/jsonutil/jsonutil.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 )
 
-// SanitizePayload will take in a JSON string, and return a JSON string that has been sanitized (removed duplicate keys)
-func SanitizePayload(val string) (any, error) {
+// ParsePayload will take in a JSON string, and return a JSON string that has been sanitized (removed duplicate keys)
+func ParsePayload(val string) (any, error) {
 	// There are edge cases for when this may happen
 	// Example: JSONB column in a table in Postgres where the table replica identity is set to `default` and it was a delete event.
 	if val == "" {

--- a/lib/jsonutil/jsonutil.go
+++ b/lib/jsonutil/jsonutil.go
@@ -17,10 +17,5 @@ func SanitizePayload(val string) (any, error) {
 		return nil, err
 	}
 
-	valBytes, err := json.Marshal(obj)
-	if err != nil {
-		return nil, err
-	}
-
-	return string(valBytes), nil
+	return obj, nil
 }

--- a/lib/jsonutil/jsonutil.go
+++ b/lib/jsonutil/jsonutil.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 )
 
-func ParsePayload(val string) (any, error) {
+func UnmarshalPayload(val string) (any, error) {
 	// There are edge cases for when this may happen
 	// Example: JSONB column in a table in Postgres where the table replica identity is set to `default` and it was a delete event.
 	if val == "" {

--- a/lib/jsonutil/jsonutil_test.go
+++ b/lib/jsonutil/jsonutil_test.go
@@ -1,47 +1,39 @@
 package jsonutil
 
 import (
-	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSanitizePayload(t *testing.T) {
+func TestParsePayload(t *testing.T) {
 	{
 		// Invalid JSON string
-		_, err := SanitizePayload("hello")
+		_, err := ParsePayload("hello")
 		assert.ErrorContains(t, err, "invalid character 'h' looking for beginning of value")
 	}
 	{
 		// Empty JSON string edge case
-		val, err := SanitizePayload("")
+		val, err := ParsePayload("")
 		assert.NoError(t, err)
 		assert.Equal(t, "", val)
 	}
 	{
 		// Valid JSON string, nothing changed.
-		val, err := SanitizePayload(`{"hello":"world"}`)
+		val, err := ParsePayload(`{"hello":"world"}`)
 		assert.NoError(t, err)
-		assert.Equal(t, `{"hello":"world"}`, val)
+		assert.Equal(t, map[string]any{"hello": "world"}, val)
 	}
 	{
 		// Fake JSON - appears to be in JSON format, but has duplicate keys
-		val, err := SanitizePayload(`{"hello":"11world","hello":"world"}`)
+		val, err := ParsePayload(`{"hello":"11world","hello":"world"}`)
 		assert.NoError(t, err)
-		assert.Equal(t, `{"hello":"world"}`, val)
+		assert.Equal(t, map[string]any{"hello": "world"}, val)
 	}
 	{
 		// Make sure all the keys are good and only duplicate keys got stripped
-		val, err := SanitizePayload(`{"hello":"world","foo":"bar","hello":"world"}`)
+		val, err := ParsePayload(`{"hello":"world","foo":"bar","hello":"world"}`)
 		assert.NoError(t, err)
-
-		var jsonMap map[string]any
-		err = json.Unmarshal([]byte(fmt.Sprint(val)), &jsonMap)
-		assert.NoError(t, err)
-
-		assert.Contains(t, jsonMap, "hello")
-		assert.Contains(t, jsonMap, "foo")
+		assert.Equal(t, map[string]any{"hello": "world", "foo": "bar"}, val)
 	}
 }

--- a/lib/jsonutil/jsonutil_test.go
+++ b/lib/jsonutil/jsonutil_test.go
@@ -6,33 +6,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParsePayload(t *testing.T) {
+func TestUnmarshalPayload(t *testing.T) {
 	{
 		// Invalid JSON string
-		_, err := ParsePayload("hello")
+		_, err := UnmarshalPayload("hello")
 		assert.ErrorContains(t, err, "invalid character 'h' looking for beginning of value")
 	}
 	{
 		// Empty JSON string edge case
-		val, err := ParsePayload("")
+		val, err := UnmarshalPayload("")
 		assert.NoError(t, err)
 		assert.Equal(t, "", val)
 	}
 	{
 		// Valid JSON string, nothing changed.
-		val, err := ParsePayload(`{"hello":"world"}`)
+		val, err := UnmarshalPayload(`{"hello":"world"}`)
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]any{"hello": "world"}, val)
 	}
 	{
 		// Fake JSON - appears to be in JSON format, but has duplicate keys
-		val, err := ParsePayload(`{"hello":"11world","hello":"world"}`)
+		val, err := UnmarshalPayload(`{"hello":"11world","hello":"world"}`)
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]any{"hello": "world"}, val)
 	}
 	{
 		// Make sure all the keys are good and only duplicate keys got stripped
-		val, err := ParsePayload(`{"hello":"world","foo":"bar","hello":"world"}`)
+		val, err := UnmarshalPayload(`{"hello":"world","foo":"bar","hello":"world"}`)
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]any{"hello": "world", "foo": "bar"}, val)
 	}


### PR DESCRIPTION
We were previously sanitizing incoming JSON values by running this through a JSON parser and then stringifying the results to get rid of duplicate keys.

Given that the value is escaped, if we run `JSON.Marshal()` again, it will try to escape the results again. This is then further exacerbated if the column type is an array and inner fields are JSON. This then leaves us with a Frankenstein value where it's an array of JSON strings (instead of JSON objects).

If we then try to marshal the array, it will lead inner values getting double escaped.

