### PR TITLE
Moving `WriteTemporaryTableFile` to be shared

### DIFF
--- a/clients/shared/temp_table.go
+++ b/clients/shared/temp_table.go
@@ -2,12 +2,17 @@ package shared
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/csvwriter"
+	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/stringutil"
+	"github.com/artie-labs/transfer/lib/typing"
 )
 
 func TempTableID(tableID sql.TableIdentifier) sql.TableIdentifier {
@@ -23,4 +28,44 @@ func TempTableIDWithSuffix(tableID sql.TableIdentifier, suffix string) sql.Table
 		time.Now().Add(constants.TemporaryTableTTL).Unix(),
 	)
 	return tableID.WithTable(tempTable)
+}
+
+type File struct {
+	FilePath string
+	FileName string
+}
+
+type ValueConverterFunc func(colValue any, colKind typing.KindDetails) (string, error)
+
+func WriteTemporaryTableFile(tableData *optimization.TableData, newTableID sql.TableIdentifier, valueConverter ValueConverterFunc) (File, error) {
+	fp := filepath.Join(os.TempDir(), fmt.Sprintf("%s.csv.gz", strings.ReplaceAll(newTableID.FullyQualifiedName(), `"`, "")))
+	gzipWriter, err := csvwriter.NewGzipWriter(fp)
+	if err != nil {
+		return File{}, fmt.Errorf("failed to create gzip writer: %w", err)
+	}
+
+	defer gzipWriter.Close()
+
+	columns := tableData.ReadOnlyInMemoryCols().ValidColumns()
+	for _, value := range tableData.Rows() {
+		var row []string
+		for _, col := range columns {
+			castedValue, castErr := valueConverter(value[col.Name()], col.KindDetails)
+			if castErr != nil {
+				return File{}, castErr
+			}
+
+			row = append(row, castedValue)
+		}
+
+		if err = gzipWriter.Write(row); err != nil {
+			return File{}, fmt.Errorf("failed to write to csv: %w", err)
+		}
+	}
+
+	if err = gzipWriter.Flush(); err != nil {
+		return File{}, fmt.Errorf("failed to flush gzip writer: %w", err)
+	}
+
+	return File{FilePath: fp, FileName: gzipWriter.FileName()}, nil
 }

--- a/clients/shared/temp_table_test.go
+++ b/clients/shared/temp_table_test.go
@@ -1,0 +1,92 @@
+package shared
+
+import (
+	"compress/gzip"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/artie-labs/transfer/clients/snowflake/dialect"
+	"github.com/artie-labs/transfer/lib/config"
+	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/optimization"
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteTemporaryTableFile(t *testing.T) {
+	// Create test data
+	cols := &columns.Columns{}
+	for _, col := range []string{"user_id", "first_name", "last_name", "description"} {
+		cols.AddColumn(columns.NewColumn(col, typing.String))
+	}
+
+	tableData := optimization.NewTableData(cols, config.Replication, []string{"user_id"}, kafkalib.TopicConfig{}, "test_table")
+
+	// Add test rows
+	for i := 0; i < 100; i++ {
+		key := fmt.Sprint(i)
+		rowData := map[string]any{
+			"user_id":     key,
+			"first_name":  fmt.Sprintf("First%d", i),
+			"last_name":   fmt.Sprintf("Last%d", i),
+			"description": "the mini aussie",
+		}
+		tableData.InsertRow(key, rowData, false)
+	}
+
+	// Create a table identifier using Snowflake dialect
+	tableID := dialect.NewTableIdentifier("test_db", "test_schema", "test_table")
+
+	// Define a simple value converter
+	valueConverter := func(colValue any, colKind typing.KindDetails) (string, error) {
+		return fmt.Sprintf("%v", colValue), nil
+	}
+
+	// Write the temporary table file
+	file, err := WriteTemporaryTableFile(tableData, tableID, valueConverter)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, file.FilePath)
+	assert.NotEmpty(t, file.FileName)
+
+	// Read and verify the CSV file
+	csvfile, err := os.Open(file.FilePath)
+	assert.NoError(t, err)
+	defer csvfile.Close()
+
+	gzipReader, err := gzip.NewReader(csvfile)
+	assert.NoError(t, err)
+	defer gzipReader.Close()
+
+	r := csv.NewReader(gzipReader)
+	r.Comma = '\t'
+
+	seenUserID := make(map[string]bool)
+	seenFirstName := make(map[string]bool)
+	seenLastName := make(map[string]bool)
+
+	for {
+		record, readErr := r.Read()
+		if readErr == io.EOF {
+			break
+		}
+
+		assert.NoError(t, readErr)
+		assert.Equal(t, 4, len(record))
+
+		seenUserID[record[0]] = true
+		seenFirstName[record[1]] = true
+		seenLastName[record[2]] = true
+		assert.Equal(t, "the mini aussie", record[3])
+	}
+
+	assert.Len(t, seenUserID, 100)
+	assert.Len(t, seenFirstName, 100)
+	assert.Len(t, seenLastName, 100)
+
+	// Clean up
+	assert.NoError(t, os.RemoveAll(file.FilePath))
+}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -63,7 +63,7 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 	}
 
 	// Write data into CSV
-	file, err := s.writeTemporaryTableFile(tableData, tempTableID)
+	file, err := shared.WriteTemporaryTableFile(tableData, tempTableID, castColValStaging)
 	if err != nil {
 		return fmt.Errorf("failed to load temporary table: %w", err)
 	}
@@ -153,8 +153,4 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 	}
 
 	return nil
-}
-
-func (s *Store) writeTemporaryTableFile(tableData *optimization.TableData, newTableID sql.TableIdentifier) (shared.File, error) {
-	return shared.WriteTemporaryTableFile(tableData, newTableID, castColValStaging)
 }


### PR DESCRIPTION
We are doing a lot of the same boilerplate code for all destinations. This PR starts a shared function that we can extend and reuse for other destinations, starting with Snowflake.

Once this is all linked in here, we can then play around with adding randomness to the file name so that we don't run into a race condition when trying to parallelize our table loading (as the file names may collide with eachother)

