### PR TITLE
More usage of `WriteTemporaryTableFile`

### DIFF
--- a/clients/redshift/cast_test.go
+++ b/clients/redshift/cast_test.go
@@ -3,6 +3,7 @@ package redshift
 import (
 	"fmt"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -194,17 +195,19 @@ func (r *RedshiftTestSuite) TestReplaceExceededValues() {
 }
 
 func (r *RedshiftTestSuite) TestCastColValStaging() {
+	settings := config.SharedDestinationSettings{}
 	{
 		// nil
 		{
 			// Struct
-			result, err := castColValStaging(nil, typing.Struct, false, false)
+
+			result, err := castColValStaging(nil, typing.Struct, settings)
 			assert.NoError(r.T(), err)
 			assert.Empty(r.T(), result.Value)
 		}
 		{
 			// Not struct
-			result, err := castColValStaging(nil, typing.String, false, false)
+			result, err := castColValStaging(nil, typing.String, settings)
 			assert.NoError(r.T(), err)
 			assert.Equal(r.T(), constants.NullValuePlaceholder, result.Value)
 		}

--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -115,8 +115,7 @@ func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableID
 			result, err := castColValStaging(
 				value[col.Name()],
 				col.KindDetails,
-				s.config.SharedDestinationSettings.TruncateExceededValues,
-				s.config.SharedDestinationSettings.ExpandStringPrecision,
+				s.config.SharedDestinationSettings,
 			)
 
 			if err != nil {

--- a/clients/shared/temp_table.go
+++ b/clients/shared/temp_table.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/csvwriter"
 	"github.com/artie-labs/transfer/lib/optimization"
@@ -35,9 +36,9 @@ type File struct {
 	FileName string
 }
 
-type ValueConverterFunc func(colValue any, colKind typing.KindDetails) (string, error)
+type ValueConverterFunc func(colValue any, colKind typing.KindDetails, sharedDestinationSettings config.SharedDestinationSettings) (string, error)
 
-func WriteTemporaryTableFile(tableData *optimization.TableData, newTableID sql.TableIdentifier, valueConverter ValueConverterFunc) (File, error) {
+func WriteTemporaryTableFile(tableData *optimization.TableData, newTableID sql.TableIdentifier, sharedDestinationSettings config.SharedDestinationSettings, valueConverter ValueConverterFunc) (File, error) {
 	fp := filepath.Join(os.TempDir(), fmt.Sprintf("%s.csv.gz", strings.ReplaceAll(newTableID.FullyQualifiedName(), `"`, "")))
 	gzipWriter, err := csvwriter.NewGzipWriter(fp)
 	if err != nil {
@@ -50,7 +51,7 @@ func WriteTemporaryTableFile(tableData *optimization.TableData, newTableID sql.T
 	for _, value := range tableData.Rows() {
 		var row []string
 		for _, col := range columns {
-			castedValue, castErr := valueConverter(value[col.Name()], col.KindDetails)
+			castedValue, castErr := valueConverter(value[col.Name()], col.KindDetails, sharedDestinationSettings)
 			if castErr != nil {
 				return File{}, castErr
 			}

--- a/clients/shared/temp_table.go
+++ b/clients/shared/temp_table.go
@@ -2,12 +2,17 @@ package shared
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/csvwriter"
+	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/stringutil"
+	"github.com/artie-labs/transfer/lib/typing"
 )
 
 func TempTableID(tableID sql.TableIdentifier) sql.TableIdentifier {
@@ -23,4 +28,44 @@ func TempTableIDWithSuffix(tableID sql.TableIdentifier, suffix string) sql.Table
 		time.Now().Add(constants.TemporaryTableTTL).Unix(),
 	)
 	return tableID.WithTable(tempTable)
+}
+
+type File struct {
+	FilePath string
+	FileName string
+}
+
+type ValueConverterFunc func(colValue any, colKind typing.KindDetails) (string, error)
+
+func WriteTemporaryTableFile(tableData *optimization.TableData, newTableID sql.TableIdentifier, valueConverter ValueConverterFunc) (File, error) {
+	fp := filepath.Join(os.TempDir(), fmt.Sprintf("%s.csv.gz", strings.ReplaceAll(newTableID.FullyQualifiedName(), `"`, "")))
+	gzipWriter, err := csvwriter.NewGzipWriter(fp)
+	if err != nil {
+		return File{}, fmt.Errorf("failed to create gzip writer: %w", err)
+	}
+
+	defer gzipWriter.Close()
+
+	columns := tableData.ReadOnlyInMemoryCols().ValidColumns()
+	for _, value := range tableData.Rows() {
+		var row []string
+		for _, col := range columns {
+			castedValue, castErr := valueConverter(value[col.Name()], col.KindDetails)
+			if castErr != nil {
+				return File{}, castErr
+			}
+
+			row = append(row, castedValue)
+		}
+
+		if err = gzipWriter.Write(row); err != nil {
+			return File{}, fmt.Errorf("failed to write to csv: %w", err)
+		}
+	}
+
+	if err = gzipWriter.Flush(); err != nil {
+		return File{}, fmt.Errorf("failed to flush gzip writer: %w", err)
+	}
+
+	return File{FilePath: fp, FileName: gzipWriter.FileName()}, nil
 }

--- a/clients/shared/temp_table_test.go
+++ b/clients/shared/temp_table_test.go
@@ -42,12 +42,12 @@ func TestWriteTemporaryTableFile(t *testing.T) {
 	tableID := dialect.NewTableIdentifier("test_db", "test_schema", "test_table")
 
 	// Define a simple value converter
-	valueConverter := func(colValue any, colKind typing.KindDetails) (string, error) {
+	valueConverter := func(colValue any, colKind typing.KindDetails, _ config.SharedDestinationSettings) (string, error) {
 		return fmt.Sprintf("%v", colValue), nil
 	}
 
 	// Write the temporary table file
-	file, err := WriteTemporaryTableFile(tableData, tableID, valueConverter)
+	file, err := WriteTemporaryTableFile(tableData, tableID, config.SharedDestinationSettings{}, valueConverter)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, file.FilePath)
 	assert.NotEmpty(t, file.FileName)

--- a/clients/shared/temp_table_test.go
+++ b/clients/shared/temp_table_test.go
@@ -1,0 +1,92 @@
+package shared
+
+import (
+	"compress/gzip"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/artie-labs/transfer/clients/snowflake/dialect"
+	"github.com/artie-labs/transfer/lib/config"
+	"github.com/artie-labs/transfer/lib/kafkalib"
+	"github.com/artie-labs/transfer/lib/optimization"
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteTemporaryTableFile(t *testing.T) {
+	// Create test data
+	cols := &columns.Columns{}
+	for _, col := range []string{"user_id", "first_name", "last_name", "description"} {
+		cols.AddColumn(columns.NewColumn(col, typing.String))
+	}
+
+	tableData := optimization.NewTableData(cols, config.Replication, []string{"user_id"}, kafkalib.TopicConfig{}, "test_table")
+
+	// Add test rows
+	for i := 0; i < 100; i++ {
+		key := fmt.Sprint(i)
+		rowData := map[string]any{
+			"user_id":     key,
+			"first_name":  fmt.Sprintf("First%d", i),
+			"last_name":   fmt.Sprintf("Last%d", i),
+			"description": "the mini aussie",
+		}
+		tableData.InsertRow(key, rowData, false)
+	}
+
+	// Create a table identifier using Snowflake dialect
+	tableID := dialect.NewTableIdentifier("test_db", "test_schema", "test_table")
+
+	// Define a simple value converter
+	valueConverter := func(colValue any, colKind typing.KindDetails) (string, error) {
+		return fmt.Sprintf("%v", colValue), nil
+	}
+
+	// Write the temporary table file
+	file, err := WriteTemporaryTableFile(tableData, tableID, valueConverter)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, file.FilePath)
+	assert.NotEmpty(t, file.FileName)
+
+	// Read and verify the CSV file
+	csvfile, err := os.Open(file.FilePath)
+	assert.NoError(t, err)
+	defer csvfile.Close()
+
+	gzipReader, err := gzip.NewReader(csvfile)
+	assert.NoError(t, err)
+	defer gzipReader.Close()
+
+	r := csv.NewReader(gzipReader)
+	r.Comma = '\t'
+
+	seenUserID := make(map[string]bool)
+	seenFirstName := make(map[string]bool)
+	seenLastName := make(map[string]bool)
+
+	for {
+		record, readErr := r.Read()
+		if readErr == io.EOF {
+			break
+		}
+
+		assert.NoError(t, readErr)
+		assert.Equal(t, 4, len(record))
+
+		seenUserID[record[0]] = true
+		seenFirstName[record[1]] = true
+		seenLastName[record[2]] = true
+		assert.Equal(t, "the mini aussie", record[3])
+	}
+
+	assert.Len(t, seenUserID, 100)
+	assert.Len(t, seenFirstName, 100)
+	assert.Len(t, seenLastName, 100)
+
+	// Clean up
+	assert.NoError(t, os.RemoveAll(file.FilePath))
+}

--- a/clients/shared/temp_table_test.go
+++ b/clients/shared/temp_table_test.go
@@ -47,7 +47,7 @@ func TestWriteTemporaryTableFile(t *testing.T) {
 	}
 
 	// Write the temporary table file
-	file, err := WriteTemporaryTableFile(tableData, tableID, valueConverter, config.SharedDestinationSettings{})
+	file, _, err := WriteTemporaryTableFile(tableData, tableID, valueConverter, config.SharedDestinationSettings{})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, file.FilePath)
 	assert.NotEmpty(t, file.FileName)

--- a/clients/shared/temp_table_test.go
+++ b/clients/shared/temp_table_test.go
@@ -42,12 +42,12 @@ func TestWriteTemporaryTableFile(t *testing.T) {
 	tableID := dialect.NewTableIdentifier("test_db", "test_schema", "test_table")
 
 	// Define a simple value converter
-	valueConverter := func(colValue any, colKind typing.KindDetails, _ config.SharedDestinationSettings) (string, error) {
-		return fmt.Sprintf("%v", colValue), nil
+	valueConverter := func(colValue any, colKind typing.KindDetails, _ config.SharedDestinationSettings) (ValueConvertResponse, error) {
+		return ValueConvertResponse{Value: fmt.Sprintf("%v", colValue)}, nil
 	}
 
 	// Write the temporary table file
-	file, err := WriteTemporaryTableFile(tableData, tableID, config.SharedDestinationSettings{}, valueConverter)
+	file, err := WriteTemporaryTableFile(tableData, tableID, valueConverter, config.SharedDestinationSettings{})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, file.FilePath)
 	assert.NotEmpty(t, file.FileName)

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -11,6 +11,7 @@ import (
 	"github.com/artie-labs/transfer/clients/shared"
 	"github.com/artie-labs/transfer/clients/snowflake/dialect"
 	"github.com/artie-labs/transfer/lib/awslib"
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/maputil"
@@ -38,7 +39,7 @@ func replaceExceededValues(colVal string, kindDetails typing.KindDetails) string
 	return colVal
 }
 
-func castColValStaging(colVal any, colKind typing.KindDetails) (string, error) {
+func castColValStaging(colVal any, colKind typing.KindDetails, _ config.SharedDestinationSettings) (string, error) {
 	if colVal == nil {
 		return constants.NullValuePlaceholder, nil
 	}
@@ -63,7 +64,7 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 	}
 
 	// Write data into CSV
-	file, err := shared.WriteTemporaryTableFile(tableData, tempTableID, castColValStaging)
+	file, err := shared.WriteTemporaryTableFile(tableData, tempTableID, s.config.SharedDestinationSettings, castColValStaging)
 	if err != nil {
 		return fmt.Errorf("failed to load temporary table: %w", err)
 	}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -39,17 +39,17 @@ func replaceExceededValues(colVal string, kindDetails typing.KindDetails) string
 	return colVal
 }
 
-func castColValStaging(colVal any, colKind typing.KindDetails, _ config.SharedDestinationSettings) (string, error) {
+func castColValStaging(colVal any, colKind typing.KindDetails, _ config.SharedDestinationSettings) (shared.ValueConvertResponse, error) {
 	if colVal == nil {
-		return constants.NullValuePlaceholder, nil
+		return shared.ValueConvertResponse{Value: constants.NullValuePlaceholder}, nil
 	}
 
 	value, err := values.ToString(colVal, colKind)
 	if err != nil {
-		return "", err
+		return shared.ValueConvertResponse{}, err
 	}
 
-	return replaceExceededValues(value, colKind), nil
+	return shared.ValueConvertResponse{Value: replaceExceededValues(value, colKind)}, nil
 }
 
 func (s Store) useExternalStage() bool {
@@ -64,7 +64,7 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 	}
 
 	// Write data into CSV
-	file, err := shared.WriteTemporaryTableFile(tableData, tempTableID, s.config.SharedDestinationSettings, castColValStaging)
+	file, err := shared.WriteTemporaryTableFile(tableData, tempTableID, castColValStaging, s.config.SharedDestinationSettings)
 	if err != nil {
 		return fmt.Errorf("failed to load temporary table: %w", err)
 	}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -63,7 +63,7 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 	}
 
 	// Write data into CSV
-	file, err := s.writeTemporaryTableFile(tableData, tempTableID)
+	file, err := shared.WriteTemporaryTableFile(tableData, tempTableID, castColValStaging)
 	if err != nil {
 		return fmt.Errorf("failed to load temporary table: %w", err)
 	}
@@ -153,8 +153,4 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 	}
 
 	return nil
-}
-
-func (s *Store) writeTemporaryTableFile(tableData *optimization.TableData, newTableID sql.TableIdentifier) (shared.File, error) {
-	return shared.WriteTemporaryTableFile(tableData, newTableID, castColValStaging)
 }

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -64,7 +64,7 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 	}
 
 	// Write data into CSV
-	file, err := shared.WriteTemporaryTableFile(tableData, tempTableID, castColValStaging, s.config.SharedDestinationSettings)
+	file, _, err := shared.WriteTemporaryTableFile(tableData, tempTableID, castColValStaging, s.config.SharedDestinationSettings)
 	if err != nil {
 		return fmt.Errorf("failed to load temporary table: %w", err)
 	}

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -47,30 +47,31 @@ func (s *SnowflakeTestSuite) TestReplaceExceededValues() {
 }
 
 func (s *SnowflakeTestSuite) TestCastColValStaging() {
+	settings := config.SharedDestinationSettings{}
 	{
 		// Null
-		value, err := castColValStaging(nil, typing.String)
+		result, err := castColValStaging(nil, typing.String, settings)
 		assert.NoError(s.T(), err)
-		assert.Equal(s.T(), constants.NullValuePlaceholder, value)
+		assert.Equal(s.T(), constants.NullValuePlaceholder, result.Value)
 	}
 	{
 		// Struct field
 
 		// Did not exceed lob size
-		value, err := castColValStaging(map[string]any{"key": "value"}, typing.Struct)
+		result, err := castColValStaging(map[string]any{"key": "value"}, typing.Struct, settings)
 		assert.NoError(s.T(), err)
-		assert.Equal(s.T(), `{"key":"value"}`, value)
+		assert.Equal(s.T(), `{"key":"value"}`, result.Value)
 
 		// Did exceed lob size
-		value, err = castColValStaging(map[string]any{"key": strings.Repeat("a", 16777216)}, typing.Struct)
+		result, err = castColValStaging(map[string]any{"key": strings.Repeat("a", 16777216)}, typing.Struct, settings)
 		assert.NoError(s.T(), err)
-		assert.Equal(s.T(), `{"key":"__artie_exceeded_value"}`, value)
+		assert.Equal(s.T(), `{"key":"__artie_exceeded_value"}`, result.Value)
 	}
 	{
 		// String field
-		value, err := castColValStaging("foo", typing.String)
+		result, err := castColValStaging("foo", typing.String, settings)
 		assert.NoError(s.T(), err)
-		assert.Equal(s.T(), "foo", value)
+		assert.Equal(s.T(), "foo", result.Value)
 	}
 }
 


### PR DESCRIPTION
Pre-requisite: https://github.com/artie-labs/transfer/pull/1279


This PR moves Redshift to be using the same shared utility. 
