### PR TITLE
[Parquet] Better handling around logical types

### DIFF
--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -28,8 +28,8 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
-		// Days since EPOCH
-		return _time.UnixMilli() / (24 * time.Hour.Milliseconds()), nil
+		// Days since epoch
+		return int32(_time.UnixMilli() / (24 * time.Hour.Milliseconds())), nil
 	case typing.Time.Kind:
 		_time, err := ext.ParseTimeFromAny(colVal)
 		if err != nil {

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -28,7 +28,8 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
-		return _time.Format(time.DateOnly), nil
+		// Days since EPOCH
+		return _time.UnixMilli() / (24 * time.Hour.Milliseconds()), nil
 	case typing.Time.Kind:
 		_time, err := ext.ParseTimeFromAny(colVal)
 		if err != nil {

--- a/lib/parquetutil/parse_values_test.go
+++ b/lib/parquetutil/parse_values_test.go
@@ -64,7 +64,7 @@ func TestParseValue(t *testing.T) {
 		// Date
 		value, err := ParseValue("2022-12-25", typing.Date)
 		assert.NoError(t, err)
-		assert.Equal(t, "2022-12-25", value)
+		assert.Equal(t, int32(19351), value)
 	}
 	{
 		// Timestamp TZ

--- a/lib/parquetutil/parse_values_test.go
+++ b/lib/parquetutil/parse_values_test.go
@@ -2,7 +2,9 @@ package parquetutil
 
 import (
 	"testing"
+	"time"
 
+	"github.com/artie-labs/transfer/lib/debezium/converters"
 	"github.com/artie-labs/transfer/lib/numbers"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/decimal"
@@ -58,7 +60,11 @@ func TestParseValue(t *testing.T) {
 		// Time
 		value, err := ParseValue("03:15:00", typing.Time)
 		assert.NoError(t, err)
-		assert.Equal(t, "03:15:00Z", value)
+		assert.Equal(t, int32(11700000), value)
+
+		converted, err := converters.Time{}.Convert(int64(value.(int32)))
+		assert.NoError(t, err)
+		assert.Equal(t, "03:15:00", converted.(time.Time).Format(time.TimeOnly))
 	}
 	{
 		// Date

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -65,7 +65,7 @@ type Field struct {
 
 func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 	switch k.Kind {
-	case String.Kind, Struct.Kind, Time.Kind:
+	case String.Kind, Struct.Kind:
 		return &Field{
 			Tag: FieldTag{
 				Name:          colName,
@@ -86,6 +86,14 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 				Name:          colName,
 				Type:          ToPtr(parquet.Type_INT32.String()),
 				ConvertedType: ToPtr(parquet.ConvertedType_DATE.String()),
+			}.String(),
+		}, nil
+	case Time.Kind:
+		return &Field{
+			Tag: FieldTag{
+				Name:          colName,
+				Type:          ToPtr(parquet.Type_INT32.String()),
+				ConvertedType: ToPtr(parquet.ConvertedType_TIME_MILLIS.String()),
 			}.String(),
 		}, nil
 	case TimestampNTZ.Kind, TimestampTZ.Kind:

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -65,7 +65,7 @@ type Field struct {
 
 func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 	switch k.Kind {
-	case String.Kind, Struct.Kind, Date.Kind, Time.Kind:
+	case String.Kind, Struct.Kind, Time.Kind:
 		return &Field{
 			Tag: FieldTag{
 				Name:          colName,
@@ -78,6 +78,14 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 			Tag: FieldTag{
 				Name: colName,
 				Type: ToPtr(parquet.Type_FLOAT.String()),
+			}.String(),
+		}, nil
+	case Date.Kind:
+		return &Field{
+			Tag: FieldTag{
+				Name:          colName,
+				Type:          ToPtr(parquet.Type_INT32.String()),
+				ConvertedType: ToPtr(parquet.ConvertedType_DATE.String()),
 			}.String(),
 		}, nil
 	case TimestampNTZ.Kind, TimestampTZ.Kind:

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -69,22 +69,30 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 		return &Field{
 			Tag: FieldTag{
 				Name:          colName,
-				Type:          ToPtr("BYTE_ARRAY"),
-				ConvertedType: ToPtr("UTF8"),
+				Type:          ToPtr(parquet.Type_BYTE_ARRAY.String()),
+				ConvertedType: ToPtr(parquet.ConvertedType_UTF8.String()),
 			}.String(),
 		}, nil
 	case Float.Kind:
 		return &Field{
 			Tag: FieldTag{
 				Name: colName,
-				Type: ToPtr("FLOAT"),
+				Type: ToPtr(parquet.Type_FLOAT.String()),
 			}.String(),
 		}, nil
-	case Integer.Kind, TimestampNTZ.Kind, TimestampTZ.Kind:
+	case TimestampNTZ.Kind, TimestampTZ.Kind:
+		return &Field{
+			Tag: FieldTag{
+				Name:          colName,
+				Type:          ToPtr(parquet.Type_INT64.String()),
+				ConvertedType: ToPtr(parquet.ConvertedType_TIMESTAMP_MILLIS.String()),
+			}.String(),
+		}, nil
+	case Integer.Kind:
 		return &Field{
 			Tag: FieldTag{
 				Name: colName,
-				Type: ToPtr("INT64"),
+				Type: ToPtr(parquet.Type_INT64.String()),
 			}.String(),
 		}, nil
 	case EDecimal.Kind:
@@ -94,8 +102,8 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 			return &Field{
 				Tag: FieldTag{
 					Name:          colName,
-					Type:          ToPtr("BYTE_ARRAY"),
-					ConvertedType: ToPtr("UTF8"),
+					Type:          ToPtr(parquet.Type_BYTE_ARRAY.String()),
+					ConvertedType: ToPtr(parquet.ConvertedType_UTF8.String()),
 				}.String(),
 			}, nil
 		}
@@ -119,7 +127,7 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 		return &Field{
 			Tag: FieldTag{
 				Name: colName,
-				Type: ToPtr("BOOLEAN"),
+				Type: ToPtr(parquet.Type_BOOLEAN.String()),
 			}.String(),
 		}, nil
 	case Array.Kind:
@@ -133,8 +141,8 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 				{
 					Tag: FieldTag{
 						Name:           "element",
-						Type:           ToPtr("BYTE_ARRAY"),
-						ConvertedType:  ToPtr("UTF8"),
+						Type:           ToPtr(parquet.Type_BYTE_ARRAY.String()),
+						ConvertedType:  ToPtr(parquet.ConvertedType_UTF8.String()),
 						RepetitionType: ToPtr("REQUIRED"),
 					}.String(),
 				},

--- a/lib/typing/parquet_test.go
+++ b/lib/typing/parquet_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xitongsys/parquet-go/parquet"
 )
 
 func TestKindDetails_ParquetAnnotation(t *testing.T) {
@@ -26,14 +27,31 @@ func TestKindDetails_ParquetAnnotation(t *testing.T) {
 	}
 	{
 		// Integers
-		for _, kd := range []KindDetails{Integer, TimestampTZ, TimestampNTZ} {
+		for _, kd := range []KindDetails{Integer} {
 			field, err := kd.ParquetAnnotation("foo")
 			assert.NoError(t, err)
 			assert.Equal(t,
 				Field{
 					Tag: FieldTag{
 						Name: "foo",
-						Type: ToPtr("INT64"),
+						Type: ToPtr(parquet.Type_INT64.String()),
+					}.String(),
+				},
+				*field,
+			)
+		}
+	}
+	{
+		// Timestamps
+		for _, kd := range []KindDetails{TimestampTZ, TimestampNTZ} {
+			field, err := kd.ParquetAnnotation("foo")
+			assert.NoError(t, err)
+			assert.Equal(t,
+				Field{
+					Tag: FieldTag{
+						Name:          "foo",
+						Type:          ToPtr(parquet.Type_INT64.String()),
+						ConvertedType: ToPtr(parquet.ConvertedType_TIMESTAMP_MILLIS.String()),
 					}.String(),
 				},
 				*field,

--- a/lib/typing/parquet_test.go
+++ b/lib/typing/parquet_test.go
@@ -10,7 +10,7 @@ import (
 func TestKindDetails_ParquetAnnotation(t *testing.T) {
 	{
 		// String field
-		for _, kd := range []KindDetails{String, Struct, Time} {
+		for _, kd := range []KindDetails{String, Struct} {
 			field, err := kd.ParquetAnnotation("foo")
 			assert.NoError(t, err)
 			assert.Equal(t,
@@ -40,6 +40,21 @@ func TestKindDetails_ParquetAnnotation(t *testing.T) {
 				*field,
 			)
 		}
+	}
+	{
+		// Time
+		field, err := Time.ParquetAnnotation("foo")
+		assert.NoError(t, err)
+		assert.Equal(t,
+			Field{
+				Tag: FieldTag{
+					Name:          "foo",
+					Type:          ToPtr(parquet.Type_INT32.String()),
+					ConvertedType: ToPtr(parquet.ConvertedType_TIME_MILLIS.String()),
+				}.String(),
+			},
+			*field,
+		)
 	}
 	{
 		// Date

--- a/lib/typing/parquet_test.go
+++ b/lib/typing/parquet_test.go
@@ -10,7 +10,7 @@ import (
 func TestKindDetails_ParquetAnnotation(t *testing.T) {
 	{
 		// String field
-		for _, kd := range []KindDetails{String, Struct, Date, Time} {
+		for _, kd := range []KindDetails{String, Struct, Time} {
 			field, err := kd.ParquetAnnotation("foo")
 			assert.NoError(t, err)
 			assert.Equal(t,
@@ -40,6 +40,21 @@ func TestKindDetails_ParquetAnnotation(t *testing.T) {
 				*field,
 			)
 		}
+	}
+	{
+		// Date
+		field, err := Date.ParquetAnnotation("foo")
+		assert.NoError(t, err)
+		assert.Equal(t,
+			Field{
+				Tag: FieldTag{
+					Name:          "foo",
+					Type:          ToPtr(parquet.Type_INT32.String()),
+					ConvertedType: ToPtr(parquet.ConvertedType_DATE.String()),
+				}.String(),
+			},
+			*field,
+		)
 	}
 	{
 		// Timestamps

--- a/lib/typing/parquet_test.go
+++ b/lib/typing/parquet_test.go
@@ -27,19 +27,17 @@ func TestKindDetails_ParquetAnnotation(t *testing.T) {
 	}
 	{
 		// Integers
-		for _, kd := range []KindDetails{Integer} {
-			field, err := kd.ParquetAnnotation("foo")
-			assert.NoError(t, err)
-			assert.Equal(t,
-				Field{
-					Tag: FieldTag{
-						Name: "foo",
-						Type: ToPtr(parquet.Type_INT64.String()),
-					}.String(),
-				},
-				*field,
-			)
-		}
+		field, err := Integer.ParquetAnnotation("foo")
+		assert.NoError(t, err)
+		assert.Equal(t,
+			Field{
+				Tag: FieldTag{
+					Name: "foo",
+					Type: ToPtr(parquet.Type_INT64.String()),
+				}.String(),
+			},
+			*field,
+		)
 	}
 	{
 		// Time


### PR DESCRIPTION
This PR adds additional handling around Parquet logical types such as:

1. DATE
2. TIME
3. TIMESTAMP

This will make it easier for Parquet consumers to be able to read and interpret our delta files.