### PR TITLE
Add handling for `map[string]any`

### DIFF
--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -114,6 +114,8 @@ func (f Field) ShouldSetDefaultValue(defaultValue any) bool {
 		return true
 	case bool, int, int16, int32, int64, float32, float64, *decimal.Decimal:
 		return true
+	case map[string]any:
+		return true
 	default:
 		slog.Warn("Default value that we did not add a case for yet, we're returning true",
 			slog.String("type", fmt.Sprintf("%T", defaultValue)),

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -54,6 +54,11 @@ func TestField_ShouldSetDefaultValue(t *testing.T) {
 		assert.False(t, field.ShouldSetDefaultValue(time.Time{}))
 		assert.False(t, field.ShouldSetDefaultValue(time.Unix(0, 0)))
 	}
+	{
+		// Empty map
+		field := Field{}
+		assert.True(t, field.ShouldSetDefaultValue(map[string]any{}))
+	}
 }
 
 func TestToInt64(t *testing.T) {


### PR DESCRIPTION
Seeing this type pop up in our warning logs, so we're adding explicit handling for this type. There should be no functional difference with this PR other than less warnings.