### PR TITLE
Support `int8`

### DIFF
--- a/lib/debezium/types.go
+++ b/lib/debezium/types.go
@@ -77,6 +77,8 @@ func toInt64(value any) (int64, error) {
 	switch typedValue := value.(type) {
 	case int:
 		return int64(typedValue), nil
+	case int8:
+		return int64(typedValue), nil
 	case int16:
 		return int64(typedValue), nil
 	case int32:

--- a/lib/debezium/types_test.go
+++ b/lib/debezium/types_test.go
@@ -69,6 +69,12 @@ func TestToInt64(t *testing.T) {
 		assert.Equal(t, int64(12321), actual)
 	}
 	{
+		// int8
+		actual, err := toInt64(int8(12))
+		assert.NoError(t, err)
+		assert.Equal(t, int64(12), actual)
+	}
+	{
 		// int16
 		actual, err := toInt64(int16(12321))
 		assert.NoError(t, err)


### PR DESCRIPTION
Updating this function to support `int8` which will unblock Reader's snapshot process