### PR TITLE
[Livy] Session resiliency

### DIFF
--- a/lib/apachelivy/client.go
+++ b/lib/apachelivy/client.go
@@ -37,7 +37,6 @@ type Client struct {
 const sessionBufferSeconds = 30
 
 func shouldCreateNewSession(resp GetSessionResponse, statusCode int, err error) (bool, error) {
-	// Now, if the session is dead, then we should also create a new one.
 	if statusCode == http.StatusNotFound {
 		return true, nil
 	}

--- a/lib/apachelivy/client.go
+++ b/lib/apachelivy/client.go
@@ -56,6 +56,15 @@ func (c *Client) ensureSession(ctx context.Context) error {
 	return nil
 }
 
+func (c *Client) buildRetryConfig() (retry.RetryConfig, error) {
+	cfg, err := retry.NewJitterRetryConfig(sleepBaseMs, sleepMaxMs, maxSessionRetries, retry.AlwaysRetry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create retry config: %w", err)
+	}
+
+	return cfg, nil
+}
+
 func (c *Client) queryContext(ctx context.Context, query string) (GetStatementResponse, error) {
 	if err := c.ensureSession(ctx); err != nil {
 		return GetStatementResponse{}, err
@@ -75,9 +84,8 @@ func (c *Client) queryContext(ctx context.Context, query string) (GetStatementRe
 }
 
 func (c *Client) QueryContext(ctx context.Context, query string) (GetStatementResponse, error) {
-	retryCfg, err := retry.NewJitterRetryConfig(sleepBaseMs, sleepMaxMs, maxSessionRetries, retry.AlwaysRetry)
+	retryCfg, err := c.buildRetryConfig()
 	if err != nil {
-		slog.Error("Failed to create retry config", slog.Any("err", err))
 		return GetStatementResponse{}, err
 	}
 
@@ -105,9 +113,8 @@ func (c *Client) execContext(ctx context.Context, query string) error {
 }
 
 func (c *Client) ExecContext(ctx context.Context, query string) error {
-	retryCfg, err := retry.NewJitterRetryConfig(sleepBaseMs, sleepMaxMs, maxSessionRetries, retry.AlwaysRetry)
+	retryCfg, err := c.buildRetryConfig()
 	if err != nil {
-		slog.Error("Failed to create retry config", slog.Any("err", err))
 		return err
 	}
 

--- a/lib/apachelivy/client.go
+++ b/lib/apachelivy/client.go
@@ -72,7 +72,7 @@ func (c *Client) ensureSession(ctx context.Context) error {
 }
 
 func (c *Client) buildRetryConfig() (retry.RetryConfig, error) {
-	// TODO: Move this from `[retry.AlwaysRetry]` to be more targeted
+	// TODO: Move this from [retry.AlwaysRetry] to be more targeted
 	cfg, err := retry.NewJitterRetryConfig(sleepBaseMs, sleepMaxMs, maxSessionRetries, retry.AlwaysRetry)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create retry config: %w", err)

--- a/lib/apachelivy/types.go
+++ b/lib/apachelivy/types.go
@@ -33,6 +33,13 @@ const (
 	StateError        SessionState = "error"
 )
 
+var TerminalSessionStates = []SessionState{
+	StateError,
+	StateKilled,
+	StateShuttingDown,
+	StateDead,
+}
+
 func (s SessionState) IsReady() bool {
 	return s == StateIdle
 }


### PR DESCRIPTION
## Context

We should have more resiliency around sessions. Right now, we are coupling all statements to a particular session. If the session dies,  we will immediately fail the entire call stack. 

That doesn't need to happen as sessions do not need to be treated as atomic. If statements in a session succeeded prior to the session dying, then we don't need to retry the statements again.

## Changes

* Adding retries around ExecContext and QueryContext by reusing our Retry framework
* Consolidating the way we retrieve sessions back from Livy