### PR TITLE
Standing up `TemporaryDataFile`

### DIFF
--- a/clients/redshift/staging.go
+++ b/clients/redshift/staging.go
@@ -98,7 +98,8 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 }
 
 func (s *Store) loadTemporaryTable(tableData *optimization.TableData, newTableID sql.TableIdentifier) (string, map[string]int32, error) {
-	file, additionalOutput, err := shared.WriteTemporaryTableFile(tableData, newTableID, castColValStaging, s.config.SharedDestinationSettings)
+	tempTableDataFile := shared.NewTemporaryDataFile(newTableID)
+	file, additionalOutput, err := tempTableDataFile.WriteTemporaryTableFile(tableData, castColValStaging, s.config.SharedDestinationSettings)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to write temporary table file: %w", err)
 	}

--- a/clients/shared/temp_table.go
+++ b/clients/shared/temp_table.go
@@ -50,8 +50,18 @@ type ValueConvertResponse struct {
 
 type ValueConverterFunc func(colValue any, colKind typing.KindDetails, sharedDestinationSettings config.SharedDestinationSettings) (ValueConvertResponse, error)
 
-func WriteTemporaryTableFile(tableData *optimization.TableData, newTableID sql.TableIdentifier, valueConverter ValueConverterFunc, sharedDestinationSettings config.SharedDestinationSettings) (File, AdditionalOutput, error) {
-	fp := filepath.Join(os.TempDir(), fmt.Sprintf("%s.csv.gz", strings.ReplaceAll(newTableID.FullyQualifiedName(), `"`, "")))
+type TemporaryDataFile struct {
+	fileName string
+}
+
+func NewTemporaryDataFile(newTableID sql.TableIdentifier) TemporaryDataFile {
+	return TemporaryDataFile{
+		fileName: fmt.Sprintf("%s.csv.gz", strings.ReplaceAll(newTableID.FullyQualifiedName(), `"`, "")),
+	}
+}
+
+func (t TemporaryDataFile) WriteTemporaryTableFile(tableData *optimization.TableData, valueConverter ValueConverterFunc, sharedDestinationSettings config.SharedDestinationSettings) (File, AdditionalOutput, error) {
+	fp := filepath.Join(os.TempDir(), t.fileName)
 	gzipWriter, err := csvwriter.NewGzipWriter(fp)
 	if err != nil {
 		return File{}, AdditionalOutput{}, fmt.Errorf("failed to create gzip writer: %w", err)

--- a/clients/shared/temp_table.go
+++ b/clients/shared/temp_table.go
@@ -60,6 +60,12 @@ func NewTemporaryDataFile(newTableID sql.TableIdentifier) TemporaryDataFile {
 	}
 }
 
+func NewTemporaryDataFileWithFileName(fileName string) TemporaryDataFile {
+	return TemporaryDataFile{
+		fileName: fileName,
+	}
+}
+
 func (t TemporaryDataFile) WriteTemporaryTableFile(tableData *optimization.TableData, valueConverter ValueConverterFunc, sharedDestinationSettings config.SharedDestinationSettings) (File, AdditionalOutput, error) {
 	fp := filepath.Join(os.TempDir(), t.fileName)
 	gzipWriter, err := csvwriter.NewGzipWriter(fp)

--- a/clients/shared/temp_table_test.go
+++ b/clients/shared/temp_table_test.go
@@ -47,7 +47,8 @@ func TestWriteTemporaryTableFile(t *testing.T) {
 	}
 
 	// Write the temporary table file
-	file, _, err := WriteTemporaryTableFile(tableData, tableID, valueConverter, config.SharedDestinationSettings{})
+	tempTableDataFile := NewTemporaryDataFile(tableID)
+	file, _, err := tempTableDataFile.WriteTemporaryTableFile(tableData, valueConverter, config.SharedDestinationSettings{})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, file.FilePath)
 	assert.NotEmpty(t, file.FileName)

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -64,7 +64,8 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 	}
 
 	// Write data into CSV
-	file, _, err := shared.WriteTemporaryTableFile(tableData, tempTableID, castColValStaging, s.config.SharedDestinationSettings)
+	tempTableDataFile := shared.NewTemporaryDataFile(tempTableID)
+	file, _, err := tempTableDataFile.WriteTemporaryTableFile(tableData, castColValStaging, s.config.SharedDestinationSettings)
 	if err != nil {
 		return fmt.Errorf("failed to load temporary table: %w", err)
 	}


### PR DESCRIPTION
Standing this up and decoupling how file names get generated. I did this so that we have Databricks share the same implementation (`WriteTemporaryDataFile`)