### PR TITLE
[Redshift] Implement `IsTableDoesNotExistErr`

### DIFF
--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -26,7 +26,16 @@ func (RedshiftDialect) IsColumnAlreadyExistsErr(err error) bool {
 	return strings.Contains(err.Error(), "already exists")
 }
 
-func (RedshiftDialect) IsTableDoesNotExistErr(_ error) bool {
+func (RedshiftDialect) IsTableDoesNotExistErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// 42P01 is the SQLSTATE code for table does not exist.
+	if strings.Contains(err.Error(), "does not exist (SQLSTATE 42P01)") {
+		return true
+	}
+
 	return false
 }
 

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -422,3 +422,14 @@ func TestRedshiftDialect_BuildCopyStatement(t *testing.T) {
 		RedshiftDialect{}.BuildCopyStatement(fakeTableID, cols, s3URI, credentialsClause),
 	)
 }
+
+func TestRedshiftDialect_IsTableDoesNotExistErr(t *testing.T) {
+	// nil
+	assert.False(t, RedshiftDialect{}.IsTableDoesNotExistErr(nil))
+
+	// Random error
+	assert.False(t, RedshiftDialect{}.IsTableDoesNotExistErr(fmt.Errorf("random error")))
+
+	// Table does not exist error
+	assert.True(t, RedshiftDialect{}.IsTableDoesNotExistErr(fmt.Errorf(`ERROR: relation "artie.alloy_journeyactionversions_v1" does not exist (SQLSTATE 42P01)`)))
+}


### PR DESCRIPTION
Redshift's `TRUNCATE TABLE` does not support `TRUNCATE TABLE IF EXISTS`, so we'll need to swallow the table does not exist error.