### PR TITLE
[Redshift] Tweaking Redshift SUPER.

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -80,6 +80,7 @@ func castColValStaging(colVal any, colKind typing.KindDetails, sharedDestination
 	colValString, err := values.ToStringOpts(colVal, colKind, converters.GetStringConverterOpts{
 		TimestampTZLayoutOverride:  ext.RFC3339MicroTZ,
 		TimestampNTZLayoutOverride: ext.RFC3339MicroTZNoTZ,
+		Redshift:                   true,
 	})
 
 	if err != nil {

--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -41,7 +41,7 @@ func replaceExceededValues(colVal string, colKind typing.KindDetails, truncateEx
 		// Try again, but use [typing.String] instead.
 		result := replaceExceededValues(colVal, typing.String, truncateExceededValue, expandStringPrecision)
 		if result.Exceeded {
-			result.Value = fmt.Sprintf(`"%s"`, result.Value)
+			result.Value = fmt.Sprintf("%q", result.Value)
 		}
 
 		return result

--- a/clients/shared/temp_table.go
+++ b/clients/shared/temp_table.go
@@ -85,8 +85,6 @@ func (t TemporaryDataFile) WriteTemporaryTableFile(tableData *optimization.Table
 				return File{}, AdditionalOutput{}, castErr
 			}
 
-			fmt.Println("colName", col.Name(), "value", result.Value, fmt.Sprintf("type: %T", value[col.Name()]))
-
 			if result.NewLength > 0 {
 				_newLength, ok := columnToNewLengthMap[col.Name()]
 				if result.NewLength > _newLength || !ok {

--- a/clients/shared/temp_table.go
+++ b/clients/shared/temp_table.go
@@ -85,6 +85,8 @@ func (t TemporaryDataFile) WriteTemporaryTableFile(tableData *optimization.Table
 				return File{}, AdditionalOutput{}, castErr
 			}
 
+			fmt.Println("colName", col.Name(), "value", result.Value, fmt.Sprintf("type: %T", value[col.Name()]))
+
 			if result.NewLength > 0 {
 				_newLength, ok := columnToNewLengthMap[col.Name()]
 				if result.NewLength > _newLength || !ok {

--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -46,7 +46,7 @@ func GetStringConverter(kd typing.KindDetails, opts GetStringConverterOpts) (Con
 	case typing.Array.Kind:
 		return ArrayConverter{}, nil
 	case typing.Struct.Kind:
-		return StructConverter{}, nil
+		return NewStructConverter(opts.Redshift), nil
 	// Numbers types
 	case typing.EDecimal.Kind:
 		return DecimalConverter{}, nil
@@ -231,6 +231,10 @@ func (DecimalConverter) Convert(value any) (string, error) {
 	default:
 		return "", fmt.Errorf("unexpected value: '%v' type: %T", value, value)
 	}
+}
+
+func NewStructConverter(redshift bool) StructConverter {
+	return StructConverter{redshift: redshift}
 }
 
 type StructConverter struct {

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -221,32 +221,57 @@ func TestDecimalConverter_Convert(t *testing.T) {
 func TestStructConverter_Convert(t *testing.T) {
 	{
 		// Toast
-		val, err := StructConverter{}.Convert(constants.ToastUnavailableValuePlaceholder)
-		assert.NoError(t, err)
-		assert.Equal(t, `{"key":"__debezium_unavailable_value"}`, val)
+		for _, rs := range []bool{true, false} {
+			val, err := NewStructConverter(rs).Convert(constants.ToastUnavailableValuePlaceholder)
+			assert.NoError(t, err)
+			assert.Equal(t, `{"key":"__debezium_unavailable_value"}`, val)
+		}
 	}
 	{
 		// Toast object
-		val, err := StructConverter{}.Convert(`{"__debezium_unavailable_value":"__debezium_unavailable_value"}`)
-		assert.NoError(t, err)
-		assert.Equal(t, `{"key":"__debezium_unavailable_value"}`, val)
+		for _, rs := range []bool{true, false} {
+			val, err := NewStructConverter(rs).Convert(`{"__debezium_unavailable_value":"__debezium_unavailable_value"}`)
+			assert.NoError(t, err)
+			assert.Equal(t, `{"key":"__debezium_unavailable_value"}`, val)
+		}
 	}
 	{
-		// Normal string
-		val, err := StructConverter{}.Convert(`{"foo":"bar"}`)
-		assert.NoError(t, err)
-		assert.Equal(t, `{"foo":"bar"}`, val)
+		value := `{"foo":"bar"}`
+		{
+			// Redsshift = false
+			val, err := NewStructConverter(false).Convert(value)
+			assert.NoError(t, err)
+			assert.Equal(t, value, val)
+		}
+		{
+			// Redshift = true
+			val, err := NewStructConverter(true).Convert(value)
+			assert.NoError(t, err)
+			assert.Equal(t, `"{\"foo\":\"bar\"}"`, val)
+		}
 	}
 	{
 		// Boolean
-		val, err := StructConverter{}.Convert(true)
-		assert.NoError(t, err)
-		assert.Equal(t, "true", val)
+		for _, rs := range []bool{true, false} {
+			val, err := NewStructConverter(rs).Convert(true)
+			assert.NoError(t, err)
+			assert.Equal(t, "true", val)
+		}
 	}
 	{
 		// Map
-		val, err := StructConverter{}.Convert(map[string]any{"foo": "bar"})
-		assert.NoError(t, err)
-		assert.Equal(t, `{"foo":"bar"}`, val)
+		for _, rs := range []bool{true, false} {
+			val, err := NewStructConverter(rs).Convert(map[string]any{"foo": "bar"})
+			assert.NoError(t, err)
+			assert.Equal(t, `{"foo":"bar"}`, val)
+		}
+	}
+	{
+		// Number
+		for _, rs := range []bool{true, false} {
+			val, err := NewStructConverter(rs).Convert(123)
+			assert.NoError(t, err)
+			assert.Equal(t, "123", val)
+		}
 	}
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7652dcf1-136e-4c3b-9d4b-6a61f743db64)

[Source](https://docs.aws.amazon.com/redshift/latest/dg/ingest-super.html#:~:text=Copying%20data%20from%20text%20and%20CSV)

We need to be wrapping literal strings in double quotes when the Redshift data type is SUPER