### PR TITLE
Update Struct

### DIFF
--- a/clients/redshift/cast.go
+++ b/clients/redshift/cast.go
@@ -80,7 +80,6 @@ func castColValStaging(colVal any, colKind typing.KindDetails, sharedDestination
 	colValString, err := values.ToStringOpts(colVal, colKind, converters.GetStringConverterOpts{
 		TimestampTZLayoutOverride:  ext.RFC3339MicroTZ,
 		TimestampNTZLayoutOverride: ext.RFC3339MicroTZNoTZ,
-		Redshift:                   true,
 	})
 
 	if err != nil {

--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -22,8 +22,6 @@ type Converter interface {
 type GetStringConverterOpts struct {
 	TimestampTZLayoutOverride  string
 	TimestampNTZLayoutOverride string
-	// Redshift - This is to communicate with the typing.StructConverter so that we can handle double quoting literal string values
-	Redshift bool
 }
 
 func GetStringConverter(kd typing.KindDetails, opts GetStringConverterOpts) (Converter, error) {
@@ -46,7 +44,7 @@ func GetStringConverter(kd typing.KindDetails, opts GetStringConverterOpts) (Con
 	case typing.Array.Kind:
 		return ArrayConverter{}, nil
 	case typing.Struct.Kind:
-		return NewStructConverter(), nil
+		return StructConverter{}, nil
 	// Numbers types
 	case typing.EDecimal.Kind:
 		return DecimalConverter{}, nil
@@ -233,13 +231,9 @@ func (DecimalConverter) Convert(value any) (string, error) {
 	}
 }
 
-func NewStructConverter() StructConverter {
-	return StructConverter{}
-}
-
 type StructConverter struct{}
 
-func (s StructConverter) Convert(value any) (string, error) {
+func (StructConverter) Convert(value any) (string, error) {
 	if strings.Contains(fmt.Sprint(value), constants.ToastUnavailableValuePlaceholder) {
 		return fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder), nil
 	}

--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -46,7 +46,7 @@ func GetStringConverter(kd typing.KindDetails, opts GetStringConverterOpts) (Con
 	case typing.Array.Kind:
 		return ArrayConverter{}, nil
 	case typing.Struct.Kind:
-		return NewStructConverter(opts.Redshift), nil
+		return NewStructConverter(), nil
 	// Numbers types
 	case typing.EDecimal.Kind:
 		return DecimalConverter{}, nil
@@ -233,13 +233,11 @@ func (DecimalConverter) Convert(value any) (string, error) {
 	}
 }
 
-func NewStructConverter(redshift bool) StructConverter {
-	return StructConverter{redshift: redshift}
+func NewStructConverter() StructConverter {
+	return StructConverter{}
 }
 
-type StructConverter struct {
-	redshift bool
-}
+type StructConverter struct{}
 
 func (s StructConverter) Convert(value any) (string, error) {
 	if strings.Contains(fmt.Sprint(value), constants.ToastUnavailableValuePlaceholder) {
@@ -248,11 +246,7 @@ func (s StructConverter) Convert(value any) (string, error) {
 
 	switch castedValue := (value).(type) {
 	case string:
-		if s.redshift {
-			return fmt.Sprintf("%q", castedValue), nil
-		}
-
-		return castedValue, nil
+		return fmt.Sprintf("%q", castedValue), nil
 	default:
 		colValBytes, err := json.Marshal(value)
 		if err != nil {

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -221,37 +221,37 @@ func TestDecimalConverter_Convert(t *testing.T) {
 func TestStructConverter_Convert(t *testing.T) {
 	{
 		// Toast
-		val, err := NewStructConverter().Convert(constants.ToastUnavailableValuePlaceholder)
+		val, err := StructConverter{}.Convert(constants.ToastUnavailableValuePlaceholder)
 		assert.NoError(t, err)
 		assert.Equal(t, `{"key":"__debezium_unavailable_value"}`, val)
 	}
 	{
 		// Toast object
-		val, err := NewStructConverter().Convert(`{"__debezium_unavailable_value":"__debezium_unavailable_value"}`)
+		val, err := StructConverter{}.Convert(`{"__debezium_unavailable_value":"__debezium_unavailable_value"}`)
 		assert.NoError(t, err)
 		assert.Equal(t, `{"key":"__debezium_unavailable_value"}`, val)
 	}
 	{
 		// Struct
-		val, err := NewStructConverter().Convert(`{"foo":"bar"}`)
+		val, err := StructConverter{}.Convert(`{"foo":"bar"}`)
 		assert.NoError(t, err)
 		assert.Equal(t, `"{\"foo\":\"bar\"}"`, val)
 	}
 	{
 		// Boolean
-		val, err := NewStructConverter().Convert(true)
+		val, err := StructConverter{}.Convert(true)
 		assert.NoError(t, err)
 		assert.Equal(t, "true", val)
 	}
 	{
 		// Map
-		val, err := NewStructConverter().Convert(map[string]any{"foo": "bar"})
+		val, err := StructConverter{}.Convert(map[string]any{"foo": "bar"})
 		assert.NoError(t, err)
 		assert.Equal(t, `{"foo":"bar"}`, val)
 	}
 	{
 		// Number
-		val, err := NewStructConverter().Convert(123)
+		val, err := StructConverter{}.Convert(123)
 		assert.NoError(t, err)
 		assert.Equal(t, "123", val)
 	}

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -221,57 +221,38 @@ func TestDecimalConverter_Convert(t *testing.T) {
 func TestStructConverter_Convert(t *testing.T) {
 	{
 		// Toast
-		for _, rs := range []bool{true, false} {
-			val, err := NewStructConverter(rs).Convert(constants.ToastUnavailableValuePlaceholder)
-			assert.NoError(t, err)
-			assert.Equal(t, `{"key":"__debezium_unavailable_value"}`, val)
-		}
+		val, err := NewStructConverter().Convert(constants.ToastUnavailableValuePlaceholder)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"key":"__debezium_unavailable_value"}`, val)
 	}
 	{
 		// Toast object
-		for _, rs := range []bool{true, false} {
-			val, err := NewStructConverter(rs).Convert(`{"__debezium_unavailable_value":"__debezium_unavailable_value"}`)
-			assert.NoError(t, err)
-			assert.Equal(t, `{"key":"__debezium_unavailable_value"}`, val)
-		}
+		val, err := NewStructConverter().Convert(`{"__debezium_unavailable_value":"__debezium_unavailable_value"}`)
+		assert.NoError(t, err)
+		assert.Equal(t, `{"key":"__debezium_unavailable_value"}`, val)
 	}
 	{
-		value := `{"foo":"bar"}`
-		{
-			// Redsshift = false
-			val, err := NewStructConverter(false).Convert(value)
-			assert.NoError(t, err)
-			assert.Equal(t, value, val)
-		}
-		{
-			// Redshift = true
-			val, err := NewStructConverter(true).Convert(value)
-			assert.NoError(t, err)
-			assert.Equal(t, `"{\"foo\":\"bar\"}"`, val)
-		}
+		// Struct
+		val, err := NewStructConverter().Convert(`{"foo":"bar"}`)
+		assert.NoError(t, err)
+		assert.Equal(t, `"{\"foo\":\"bar\"}"`, val)
 	}
 	{
 		// Boolean
-		for _, rs := range []bool{true, false} {
-			val, err := NewStructConverter(rs).Convert(true)
-			assert.NoError(t, err)
-			assert.Equal(t, "true", val)
-		}
+		val, err := NewStructConverter().Convert(true)
+		assert.NoError(t, err)
+		assert.Equal(t, "true", val)
 	}
 	{
 		// Map
-		for _, rs := range []bool{true, false} {
-			val, err := NewStructConverter(rs).Convert(map[string]any{"foo": "bar"})
-			assert.NoError(t, err)
-			assert.Equal(t, `{"foo":"bar"}`, val)
-		}
+		val, err := NewStructConverter().Convert(map[string]any{"foo": "bar"})
+		assert.NoError(t, err)
+		assert.Equal(t, `{"foo":"bar"}`, val)
 	}
 	{
 		// Number
-		for _, rs := range []bool{true, false} {
-			val, err := NewStructConverter(rs).Convert(123)
-			assert.NoError(t, err)
-			assert.Equal(t, "123", val)
-		}
+		val, err := NewStructConverter().Convert(123)
+		assert.NoError(t, err)
+		assert.Equal(t, "123", val)
 	}
 }


### PR DESCRIPTION
## Checks

- [x] Iceberg
- [x] Databricks
- [x] Snowflake

Our previous PR: https://github.com/artie-labs/transfer/pull/1276 caused some regression as it was escaping JSON values more upstream. By removing that, we are now putting literal string values into our string converter. 

We had this code originally fix our issue with Redshift, but now starting to see it as well for Snowflake.