### PR TITLE
Kafka Randomize

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -25,9 +25,9 @@ const (
 	FlushIntervalSecondsMax = 6 * 60 * 60
 )
 
-func (k *Kafka) BootstrapServers(randomize bool) []string {
+func (k *Kafka) BootstrapServers(shuffle bool) []string {
 	parts := strings.Split(k.BootstrapServer, ",")
-	if randomize {
+	if shuffle {
 		rand.Shuffle(len(parts), func(i, j int) {
 			parts[i], parts[j] = parts[j], parts[i]
 		})

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"os"
 	"strings"
 
@@ -24,8 +25,15 @@ const (
 	FlushIntervalSecondsMax = 6 * 60 * 60
 )
 
-func (k *Kafka) BootstrapServers() []string {
-	return strings.Split(k.BootstrapServer, ",")
+func (k *Kafka) BootstrapServers(randomize bool) []string {
+	parts := strings.Split(k.BootstrapServer, ",")
+	if randomize {
+		rand.Shuffle(len(parts), func(i, j int) {
+			parts[i], parts[j] = parts[j], parts[i]
+		})
+	}
+
+	return parts
 }
 
 func (s *S3Settings) Validate() error {

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -523,6 +523,11 @@ func TestCfg_KafkaBootstrapServers(t *testing.T) {
 	{
 		// Multiple brokers
 		kafkaWithMultipleBrokers := Kafka{BootstrapServer: "a:9092,b:9093,c:9094"}
-		assert.Equal(t, []string{"a:9092", "b:9093", "c:9094"}, kafkaWithMultipleBrokers.BootstrapServers())
+		assert.Equal(t, []string{"a:9092", "b:9093", "c:9094"}, kafkaWithMultipleBrokers.BootstrapServers(false))
+	}
+	{
+		// Randomize
+		kafkaWithMultipleBrokers := Kafka{BootstrapServer: "a:9092,b:9093,c:9094"}
+		assert.ElementsMatch(t, []string{"a:9092", "b:9093", "c:9094"}, kafkaWithMultipleBrokers.BootstrapServers(true))
 	}
 }

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -518,7 +518,7 @@ func TestCfg_KafkaBootstrapServers(t *testing.T) {
 	{
 		// Single broker
 		kafka := Kafka{BootstrapServer: "localhost:9092"}
-		assert.Equal(t, []string{"localhost:9092"}, kafka.BootstrapServers())
+		assert.Equal(t, []string{"localhost:9092"}, kafka.BootstrapServers(false))
 	}
 	{
 		// Multiple brokers

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -78,7 +78,7 @@ func StartConsumer(ctx context.Context, cfg config.Config, inMemDB *models.Datab
 				GroupID: cfg.Kafka.GroupID,
 				Dialer:  dialer,
 				Topic:   topic,
-				Brokers: cfg.Kafka.BootstrapServers(),
+				Brokers: cfg.Kafka.BootstrapServers(true),
 			}
 
 			kafkaConsumer := kafka.NewReader(kafkaCfg)


### PR DESCRIPTION
We should randomize the bootstrap server addresses before we send it to our Kafka SDK as it's not deterministically shuffling (https://github.com/segmentio/kafka-go/blob/755cac09a1e2d850da573c72f7ccdeeefbb3bbf5/transport.go#L1152-L1160)

Our Kafka library (kafka-segment-io) only randomizes bootstrap server as part of the transport protocol. By randomizing here, we'll have a better client connection distribution and avoid hot brokers.

* https://github.com/segmentio/kafka-go/blob/755cac09a1e2d850da573c72f7ccdeeefbb3bbf5/consumergroup.go#L878
* https://github.com/segmentio/kafka-go/blob/755cac09a1e2d850da573c72f7ccdeeefbb3bbf5/consumergroup.go#L898-L921
* ☝️ is iterating over to find the first successful broker, instead of first shuffling.

