### PR TITLE
Standing up a S3 Client

### DIFF
--- a/clients/iceberg/staging.go
+++ b/clients/iceberg/staging.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/artie-labs/transfer/clients/shared"
-	"github.com/artie-labs/transfer/lib/awslib"
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/destination/types"
@@ -47,14 +46,7 @@ func (s Store) buildColumnParts(columns []columns.Column) []string {
 }
 
 func (s Store) uploadToS3(ctx context.Context, fp string) (string, error) {
-	s3URI, err := awslib.UploadLocalFileToS3(ctx, awslib.UploadArgs{
-		Bucket:                     s.config.Iceberg.S3Tables.Bucket,
-		FilePath:                   fp,
-		OverrideAWSAccessKeyID:     s.config.Iceberg.S3Tables.AwsAccessKeyID,
-		OverrideAWSAccessKeySecret: s.config.Iceberg.S3Tables.AwsSecretAccessKey,
-		Region:                     s.config.Iceberg.S3Tables.Region,
-	})
-
+	s3URI, err := s.s3Client.UploadLocalFileToS3(ctx, s.config.Iceberg.S3Tables.Bucket, "", fp)
 	if err != nil {
 		return "", fmt.Errorf("failed to upload to s3: %w", err)
 	}

--- a/clients/iceberg/store.go
+++ b/clients/iceberg/store.go
@@ -25,6 +25,7 @@ import (
 type Store struct {
 	catalogName      string
 	s3TablesAPI      awslib.S3TablesAPIWrapper
+	s3Client         awslib.S3Client
 	apacheLivyClient *apachelivy.Client
 	config           config.Config
 	cm               *types.DestinationTableConfigMap
@@ -270,6 +271,7 @@ func LoadStore(ctx context.Context, cfg config.Config) (Store, error) {
 		apacheLivyClient: &apacheLivyClient,
 		cm:               &types.DestinationTableConfigMap{},
 		s3TablesAPI:      awslib.NewS3TablesAPI(awsCfg, cfg.Iceberg.S3Tables.BucketARN),
+		s3Client:         awslib.NewS3Client(awsCfg),
 	}
 
 	namespaces := make(map[string]bool)

--- a/clients/s3/s3_test.go
+++ b/clients/s3/s3_test.go
@@ -66,7 +66,7 @@ func TestObjectPrefix(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		store, err := LoadStore(config.Config{S3: tc.config})
+		store, err := LoadStore(t.Context(), config.Config{S3: tc.config})
 		if tc.expectedErr != "" {
 			assert.ErrorContains(t, err, tc.expectedErr, tc.name)
 		} else {

--- a/clients/s3/s3_test.go
+++ b/clients/s3/s3_test.go
@@ -22,12 +22,7 @@ func TestBuildTemporaryFilePath(t *testing.T) {
 }
 
 func TestObjectPrefix(t *testing.T) {
-	td := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{
-		Database:  "db",
-		TableName: "table",
-		Schema:    "public",
-	}, "table")
-
+	td := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "db", TableName: "table", Schema: "public"}, "table")
 	{
 		// Valid - No Folder
 		store, err := LoadStore(t.Context(), config.Config{S3: &config.S3Settings{

--- a/clients/s3/s3_test.go
+++ b/clients/s3/s3_test.go
@@ -37,16 +37,13 @@ func TestObjectPrefix(t *testing.T) {
 		expectedFormat string
 	}{
 		{
-			name:        "nil",
-			expectedErr: "failed to validate settings: s3 settings are nil",
-		},
-		{
 			name:      "valid #1 (no folder)",
 			tableData: td,
 			config: &config.S3Settings{
 				Bucket:             "bucket",
 				AwsSecretAccessKey: "foo",
 				AwsAccessKeyID:     "bar",
+				AwsRegion:          "us-east-1",
 				OutputFormat:       constants.ParquetFormat,
 			},
 			expectedFormat: fmt.Sprintf("db.public.table/date=%s", time.Now().Format(time.DateOnly)),
@@ -58,6 +55,7 @@ func TestObjectPrefix(t *testing.T) {
 				Bucket:             "bucket",
 				AwsSecretAccessKey: "foo",
 				AwsAccessKeyID:     "bar",
+				AwsRegion:          "us-east-1",
 				OutputFormat:       constants.ParquetFormat,
 				FolderName:         "foo",
 			},

--- a/lib/awslib/s3.go
+++ b/lib/awslib/s3.go
@@ -13,6 +13,49 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
+type S3Client struct {
+	cfg    aws.Config
+	client *s3.Client
+}
+
+func NewS3Client(cfg aws.Config) S3Client {
+	return S3Client{
+		cfg:    cfg,
+		client: s3.NewFromConfig(cfg),
+	}
+}
+
+func (s S3Client) UploadLocalFileToS3(ctx context.Context, bucket, prefix, filepath string) (string, error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+
+	defer file.Close()
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	objectKey := fileInfo.Name()
+	if prefix != "" {
+		objectKey = fmt.Sprintf("%s/%s", prefix, objectKey)
+	}
+
+	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(objectKey),
+		Body:   file,
+	})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to upload file to s3: %w", err)
+	}
+
+	return fmt.Sprintf("s3://%s/%s", bucket, objectKey), nil
+}
+
 type UploadArgs struct {
 	Bucket                     string
 	OptionalS3Prefix           string

--- a/lib/awslib/s3.go
+++ b/lib/awslib/s3.go
@@ -66,6 +66,7 @@ type UploadArgs struct {
 	Region                     string
 }
 
+// TODO: Remove this function
 // UploadLocalFileToS3 - takes a filepath with the file and bucket and optional expiry
 // It will then upload it and then return the S3 URI and any error(s).
 func UploadLocalFileToS3(ctx context.Context, args UploadArgs) (string, error) {

--- a/lib/destination/utils/load.go
+++ b/lib/destination/utils/load.go
@@ -24,7 +24,7 @@ func IsOutputBaseline(cfg config.Config) bool {
 func LoadBaseline(ctx context.Context, cfg config.Config) (destination.Baseline, error) {
 	switch cfg.Output {
 	case constants.S3:
-		store, err := s3.LoadStore(cfg)
+		store, err := s3.LoadStore(ctx, cfg)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load S3: %w", err)
 		}


### PR DESCRIPTION
## Changes

Standing up a S3 Client so that we can use this to upload files to S3 instead of calling `UploadLocalFileToS3`. This will make it easier for us to support more functionality with S3.

With this PR, I started to move Iceberg and S3 to start using this function.