### PR TITLE
Improving Livy

### DIFF
--- a/clients/iceberg/store.go
+++ b/clients/iceberg/store.go
@@ -254,6 +254,8 @@ func LoadStore(ctx context.Context, cfg config.Config) (Store, error) {
 		cfg.Iceberg.S3Tables.ApacheLivyConfig(),
 		cfg.Iceberg.S3Tables.SessionJars,
 		cfg.Iceberg.SessionHeartbeatTimeoutInSecond,
+		cfg.Iceberg.SessionDriverMemory,
+		cfg.Iceberg.SessionExecutorMemory,
 	)
 	if err != nil {
 		return Store{}, err

--- a/clients/iceberg/store.go
+++ b/clients/iceberg/store.go
@@ -267,7 +267,7 @@ func LoadStore(ctx context.Context, cfg config.Config) (Store, error) {
 	store := Store{
 		catalogName:      cfg.Iceberg.S3Tables.CatalogName(),
 		config:           cfg,
-		apacheLivyClient: &apacheLivyClient,
+		apacheLivyClient: apacheLivyClient,
 		cm:               &types.DestinationTableConfigMap{},
 		s3TablesAPI:      awslib.NewS3TablesAPI(awsCfg, cfg.Iceberg.S3Tables.BucketARN),
 	}

--- a/lib/apachelivy/client.go
+++ b/lib/apachelivy/client.go
@@ -32,6 +32,8 @@ type Client struct {
 	sessionConf                     map[string]any
 	sessionJars                     []string
 	sessionHeartbeatTimeoutInSecond int
+	sessionDriverMemory             string
+	sessionExecutorMemory           string
 
 	lastChecked time.Time
 }
@@ -228,6 +230,8 @@ func (c *Client) newSession(ctx context.Context, kind SessionKind, blockUntilRea
 		Jars:                     c.sessionJars,
 		Conf:                     c.sessionConf,
 		HeartbeatTimeoutInSecond: c.sessionHeartbeatTimeoutInSecond,
+		DriverMemory:             c.sessionDriverMemory,
+		ExecutorMemory:           c.sessionExecutorMemory,
 	}
 
 	body, err := json.Marshal(request)
@@ -327,13 +331,15 @@ func (c *Client) DeleteSession(ctx context.Context, sessionID int) error {
 	return nil
 }
 
-func NewClient(ctx context.Context, url string, config map[string]any, jars []string, heartbeatTimeoutInSecond int) (*Client, error) {
+func NewClient(ctx context.Context, url string, config map[string]any, jars []string, heartbeatTimeoutInSecond int, driverMemory, executorMemory string) (*Client, error) {
 	client := &Client{
 		url:                             url,
 		httpClient:                      &http.Client{},
 		sessionConf:                     config,
 		sessionJars:                     jars,
 		sessionHeartbeatTimeoutInSecond: cmp.Or(heartbeatTimeoutInSecond, defaultHeartbeatTimeoutInSecond),
+		sessionDriverMemory:             driverMemory,
+		sessionExecutorMemory:           executorMemory,
 	}
 
 	return client, nil

--- a/lib/apachelivy/types.go
+++ b/lib/apachelivy/types.go
@@ -64,6 +64,8 @@ type CreateSessionRequest struct {
 	Jars                     []string       `json:"jars,omitempty"`
 	Conf                     map[string]any `json:"conf"`
 	HeartbeatTimeoutInSecond int            `json:"heartbeatTimeoutInSecond,omitempty"`
+	DriverMemory             string         `json:"driverMemory,omitempty"`
+	ExecutorMemory           string         `json:"executorMemory"`
 }
 
 type CreateSessionResponse struct {

--- a/lib/config/destination_types.go
+++ b/lib/config/destination_types.go
@@ -91,6 +91,8 @@ type ExternalStage struct {
 type Iceberg struct {
 	ApacheLivyURL                   string `yaml:"apacheLivyURL"`
 	SessionHeartbeatTimeoutInSecond int    `yaml:"sessionHeartbeatTimeoutInSecond"`
+	SessionDriverMemory             string `yaml:"sessionDriverMemory"`
+	SessionExecutorMemory           string `yaml:"sessionExecutorMemory"`
 
 	// Current implementation of Iceberg uses S3Tables:
 	S3Tables *S3Tables `yaml:"s3Tables,omitempty"`


### PR DESCRIPTION
## Changes

* Adding a mutex lock on Livy client

There's a race condition where if multiple codepaths are calling Livy client at the same time, ensure session will be invoked. As such, Livy will try to create a bunch of clients and leaving the previous orphaned and taking up compute resources.

This code makes it so that there will only be one session shared per Transfer pod.

* Adding the ability to specify K8 request for memory for driver and executor

Once this is in, we'll also want to add this to our dashboard so we can specify how much memory we want to give each Livy client for a particular deployment.
