### PR TITLE
Better typing support around describe table

### DIFF
--- a/lib/apachelivy/schema.go
+++ b/lib/apachelivy/schema.go
@@ -35,17 +35,17 @@ func (g GetSchemaResponse) BuildColumns() ([]Column, error) {
 	for _, row := range g.Data {
 		name, ok := row[colNameIndex].(string)
 		if !ok {
-			return nil, fmt.Errorf("col_name is not a string")
+			return nil, fmt.Errorf("col_name is not a string, type: %T", row[colNameIndex])
 		}
 
 		dataType, ok := row[colTypeIndex].(string)
 		if !ok {
-			return nil, fmt.Errorf("data_type is not a string")
+			return nil, fmt.Errorf("data_type is not a string, type: %T", row[colTypeIndex])
 		}
 
 		comment, ok := row[colCommentIndex].(string)
 		if !ok {
-			return nil, fmt.Errorf("comment is not a string")
+			return nil, fmt.Errorf("comment is not a string, type: %T", row[colCommentIndex])
 		}
 
 		cols = append(cols, Column{

--- a/lib/apachelivy/schema.go
+++ b/lib/apachelivy/schema.go
@@ -2,6 +2,8 @@ package apachelivy
 
 import (
 	"fmt"
+
+	"github.com/artie-labs/transfer/lib/typing"
 )
 
 // SparkSQL does not support primary keys.
@@ -33,18 +35,18 @@ func (g GetSchemaResponse) BuildColumns() ([]Column, error) {
 
 	var cols []Column
 	for _, row := range g.Data {
-		name, ok := row[colNameIndex].(string)
-		if !ok {
+		name, err := typing.AssertTypeOrNil[string](row[colNameIndex])
+		if err != nil {
 			return nil, fmt.Errorf("col_name is not a string, type: %T", row[colNameIndex])
 		}
 
-		dataType, ok := row[colTypeIndex].(string)
-		if !ok {
+		dataType, err := typing.AssertTypeOrNil[string](row[colTypeIndex])
+		if err != nil {
 			return nil, fmt.Errorf("data_type is not a string, type: %T", row[colTypeIndex])
 		}
 
-		comment, ok := row[colCommentIndex].(string)
-		if !ok {
+		comment, err := typing.AssertTypeOrNil[string](row[colCommentIndex])
+		if err != nil {
 			return nil, fmt.Errorf("comment is not a string, type: %T", row[colCommentIndex])
 		}
 

--- a/lib/apachelivy/schema.go
+++ b/lib/apachelivy/schema.go
@@ -35,17 +35,17 @@ func (g GetSchemaResponse) BuildColumns() ([]Column, error) {
 
 	var cols []Column
 	for _, row := range g.Data {
-		name, err := typing.AssertTypeOrNil[string](row[colNameIndex])
+		name, err := typing.AssertTypeOptional[string](row[colNameIndex])
 		if err != nil {
 			return nil, fmt.Errorf("col_name is not a string, type: %T", row[colNameIndex])
 		}
 
-		dataType, err := typing.AssertTypeOrNil[string](row[colTypeIndex])
+		dataType, err := typing.AssertTypeOptional[string](row[colTypeIndex])
 		if err != nil {
 			return nil, fmt.Errorf("data_type is not a string, type: %T", row[colTypeIndex])
 		}
 
-		comment, err := typing.AssertTypeOrNil[string](row[colCommentIndex])
+		comment, err := typing.AssertTypeOptional[string](row[colCommentIndex])
 		if err != nil {
 			return nil, fmt.Errorf("comment is not a string, type: %T", row[colCommentIndex])
 		}

--- a/lib/typing/assert.go
+++ b/lib/typing/assert.go
@@ -10,3 +10,17 @@ func AssertType[T any](val any) (T, error) {
 	}
 	return castedVal, nil
 }
+
+func AssertTypeOrNil[T any](val any) (T, error) {
+	var zero T
+	if val == nil {
+		return zero, nil
+	}
+
+	castedVal, isOk := val.(T)
+	if !isOk {
+		return zero, fmt.Errorf("expected type %T, got %T", zero, val)
+	}
+
+	return castedVal, nil
+}

--- a/lib/typing/assert.go
+++ b/lib/typing/assert.go
@@ -11,16 +11,12 @@ func AssertType[T any](val any) (T, error) {
 	return castedVal, nil
 }
 
-func AssertTypeOrNil[T any](val any) (T, error) {
+// AssertTypeOptional - will return zero if the value is nil, otherwise it will assert the type
+func AssertTypeOptional[T any](val any) (T, error) {
 	var zero T
 	if val == nil {
 		return zero, nil
 	}
 
-	castedVal, isOk := val.(T)
-	if !isOk {
-		return zero, fmt.Errorf("expected type %T, got %T", zero, val)
-	}
-
-	return castedVal, nil
+	return AssertType[T](val)
 }

--- a/lib/typing/assert_test.go
+++ b/lib/typing/assert_test.go
@@ -30,3 +30,18 @@ func TestAssertType(t *testing.T) {
 		assert.ErrorContains(t, err, "expected type bool, got string")
 	}
 }
+
+func TestAssertTypeOptional(t *testing.T) {
+	{
+		// String to string
+		val, err := AssertTypeOptional[string]("hello")
+		assert.NoError(t, err)
+		assert.Equal(t, "hello", val)
+	}
+	{
+		// Nil to string
+		val, err := AssertTypeOptional[string](nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "", val)
+	}
+}


### PR DESCRIPTION
Some values may be optional, which will return `nil`.

I added a helper function in our typing library to return the zero value of that type if the value is nil.