### PR TITLE
Misc Improvements

### DIFF
--- a/clients/databricks/dialect/dialect.go
+++ b/clients/databricks/dialect/dialect.go
@@ -176,7 +176,8 @@ FORMAT_OPTIONS (
     'header' = 'false',
     'nullValue' = '%s',
     'multiLine' = 'true',
-    'compression' = 'gzip'
+    'compression' = 'gzip',
+    'lineSep' = '\n'
 );`,
 		// COPY INTO
 		tempTableID.FullyQualifiedName(),

--- a/clients/databricks/dialect/dialect_test.go
+++ b/clients/databricks/dialect/dialect_test.go
@@ -342,6 +342,7 @@ FORMAT_OPTIONS (
     'header' = 'false',
     'nullValue' = '%s',
     'multiLine' = 'true',
-    'compression' = 'gzip'
+    'compression' = 'gzip',
+    'lineSep' = '\n'
 );`, constants.NullValuePlaceholder), dialect.BuildCopyIntoQuery(tempTableID, []string{"_c0", "_c1"}, "dbfs:/path/to/file.csv.gz"))
 }

--- a/clients/iceberg/dialect/dialect.go
+++ b/clients/iceberg/dialect/dialect.go
@@ -207,7 +207,7 @@ func (IcebergDialect) BuildTruncateTableQuery(tableID sql.TableIdentifier) strin
 
 func getCSVOptions(fp string) string {
 	// Options are sourced from: https://spark.apache.org/docs/3.5.3/sql-data-sources-csv.html
-	return fmt.Sprintf(`OPTIONS (path '%s', sep '\t', header 'false', compression 'gzip', nullValue '%s', escape '"', inferSchema 'false', multiLine 'true')`, fp, constants.NullValuePlaceholder)
+	return fmt.Sprintf(`OPTIONS (path '%s', sep '\t', header 'false', compression 'gzip', nullValue '%s', escape '"', inferSchema 'false', multiLine 'true', lineSep '\n')`, fp, constants.NullValuePlaceholder)
 }
 
 func (IcebergDialect) BuildCreateTemporaryView(viewName string, colParts []string, s3Path string) string {

--- a/clients/iceberg/dialect/dialect_test.go
+++ b/clients/iceberg/dialect/dialect_test.go
@@ -41,5 +41,5 @@ func TestIcebergDialect_BuildDedupeQueries(t *testing.T) {
 
 func TestIcebergDialect_BuildCreateTemporaryView(t *testing.T) {
 	query := IcebergDialect{}.BuildCreateTemporaryView("{{VIEW_NAME}}", []string{"{{ID}}", "{{NAME}}"}, "{{S3_PATH}}")
-	assert.Equal(t, `CREATE OR REPLACE TEMPORARY VIEW {{VIEW_NAME}} ( {{ID}}, {{NAME}} ) USING csv OPTIONS (path '{{S3_PATH}}', sep '\t', header 'false', compression 'gzip', nullValue '__artie_null_value', escape '"', inferSchema 'false', multiLine 'true');`, query)
+	assert.Equal(t, `CREATE OR REPLACE TEMPORARY VIEW {{VIEW_NAME}} ( {{ID}}, {{NAME}} ) USING csv OPTIONS (path '{{S3_PATH}}', sep '\t', header 'false', compression 'gzip', nullValue '__artie_null_value', escape '"', inferSchema 'false', multiLine 'true', lineSep '\n');`, query)
 }

--- a/clients/shared/temp_table.go
+++ b/clients/shared/temp_table.go
@@ -92,7 +92,6 @@ func (t TemporaryDataFile) WriteTemporaryTableFile(tableData *optimization.Table
 				}
 			}
 
-			fmt.Println("colName", col.Name(), "result", result.Value)
 			row = append(row, result.Value)
 		}
 

--- a/clients/shared/temp_table.go
+++ b/clients/shared/temp_table.go
@@ -92,6 +92,7 @@ func (t TemporaryDataFile) WriteTemporaryTableFile(tableData *optimization.Table
 				}
 			}
 
+			fmt.Println("colName", col.Name(), "result", result.Value)
 			row = append(row, result.Value)
 		}
 

--- a/lib/config/destination_types.go
+++ b/lib/config/destination_types.go
@@ -62,11 +62,11 @@ type Snowflake struct {
 	// If pathToPrivateKey is specified, the password field will be ignored
 	PathToPrivateKey string `yaml:"pathToPrivateKey,omitempty"`
 	Password         string `yaml:"password,omitempty"`
-
-	Warehouse   string `yaml:"warehouse"`
-	Region      string `yaml:"region"`
-	Host        string `yaml:"host"`
-	Application string `yaml:"application"`
+	Role             string `yaml:"role"`
+	Warehouse        string `yaml:"warehouse"`
+	Region           string `yaml:"region"`
+	Host             string `yaml:"host"`
+	Application      string `yaml:"application"`
 
 	// ExternalStage configuration
 	ExternalStage *ExternalStage `yaml:"externalStage,omitempty"`

--- a/lib/config/destinations.go
+++ b/lib/config/destinations.go
@@ -43,6 +43,7 @@ func (s Snowflake) ToConfig() (*gosnowflake.Config, error) {
 		Account:     s.AccountID,
 		User:        s.Username,
 		Warehouse:   s.Warehouse,
+		Role:        s.Role,
 		Region:      s.Region,
 		Application: s.Application,
 		Params: map[string]*string{


### PR DESCRIPTION
* Spark's CSV defaults are not RFC 4180 compliant, which is why we need to specify escape and multi-line. We also need to specify the line separator as the defaults are `\r`, `\r\n` and `\n`. When it really should just be `\n`.

Further sleuthing last night also revealed this: https://issues.apache.org/jira/browse/SPARK-22236

![image](https://github.com/user-attachments/assets/cdd4e51c-c9af-483e-933b-52c74b908287)

^ This is why we were getting the column out of bound error yesterday. Further, we would want to specify `\r\n`. If we enabled `UseCRLF` (carriage return, line feed) on our CSV writer, which we are not.

![image](https://github.com/user-attachments/assets/e874bff1-e6b8-4da6-9ab0-064f97e5abc2)

https://pkg.go.dev/encoding/csv#Writer


This is a bug with Databricks and iceberg, which both use Spark plugins.

---

I've also added a role to our Snowflake config for when we want to support Snowflake roles in the future!

