### PR TITLE
[AWS STS] Adding mutex

### DIFF
--- a/lib/awslib/sts.go
+++ b/lib/awslib/sts.go
@@ -70,7 +70,7 @@ func (c *Credentials) refresh(ctx context.Context) error {
 	return nil
 }
 
-func (c Credentials) isExpired() bool {
+func (c *Credentials) isExpired() bool {
 	// 10 minute buffer
 	return c.expiresAt.Before(time.Now().Add(expirationBuffer))
 }

--- a/lib/awslib/sts.go
+++ b/lib/awslib/sts.go
@@ -70,7 +70,7 @@ func (c *Credentials) refresh(ctx context.Context) error {
 	return nil
 }
 
-func (c *Credentials) isExpired() bool {
+func (c Credentials) isExpired() bool {
 	// 10 minute buffer
 	return c.expiresAt.Before(time.Now().Add(expirationBuffer))
 }

--- a/lib/awslib/sts.go
+++ b/lib/awslib/sts.go
@@ -2,6 +2,7 @@ package awslib
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -17,6 +18,7 @@ type Credentials struct {
 	awsSecretAccessKey string
 	awsSessionToken    string
 	expiresAt          time.Time
+	mu                 sync.Mutex
 
 	// Arguments to generate the credentials:
 	_awsAccessKeyID     string
@@ -68,13 +70,16 @@ func (c *Credentials) refresh(ctx context.Context) error {
 	return nil
 }
 
-func (c Credentials) IsExpired() bool {
+func (c *Credentials) isExpired() bool {
 	// 10 minute buffer
 	return c.expiresAt.Before(time.Now().Add(expirationBuffer))
 }
 
 func (c *Credentials) BuildCredentials(ctx context.Context) (credentials.StaticCredentialsProvider, error) {
-	if c.IsExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.isExpired() {
 		// If expired, then refresh the creds and then run this function again.
 		if err := c.refresh(ctx); err != nil {
 			return credentials.StaticCredentialsProvider{}, err

--- a/lib/awslib/sts_test.go
+++ b/lib/awslib/sts_test.go
@@ -16,21 +16,21 @@ func TestCredentials_IsExpired(t *testing.T) {
 
 	{
 		// Expiration = true, because there's no expiration set
-		assert.True(t, creds.IsExpired())
+		assert.True(t, creds.isExpired())
 	}
 	{
 		// Expiration = true, because is in the past, so it has expired
 		creds.expiresAt = time.Now().Add(-1 * time.Minute)
-		assert.True(t, creds.IsExpired())
+		assert.True(t, creds.isExpired())
 	}
 	{
 		// Expiration = true, because is in the future (but less than the buffer)
 		creds.expiresAt = time.Now().Add(1 * time.Minute)
-		assert.True(t, creds.IsExpired())
+		assert.True(t, creds.isExpired())
 	}
 	{
 		// Expiration = false, because is in the future (but more than the buffer)
 		creds.expiresAt = time.Now().Add(100 * time.Minute)
-		assert.False(t, creds.IsExpired())
+		assert.False(t, creds.isExpired())
 	}
 }


### PR DESCRIPTION
Adding a mutex here so we don't run into a scenario where simultaneous call paths are trying to call `BuildCredentials`, realizing that it expired and overriding one another.