### PR TITLE
More refactor around S3 Client

### DIFF
--- a/clients/iceberg/store.go
+++ b/clients/iceberg/store.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"slices"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 
 	"github.com/artie-labs/transfer/clients/iceberg/dialect"
@@ -262,10 +261,11 @@ func LoadStore(ctx context.Context, cfg config.Config) (Store, error) {
 		return Store{}, err
 	}
 
-	awsCfg := aws.Config{
-		Region:      cfg.Iceberg.S3Tables.Region,
-		Credentials: credentials.NewStaticCredentialsProvider(cfg.Iceberg.S3Tables.AwsAccessKeyID, cfg.Iceberg.S3Tables.AwsSecretAccessKey, ""),
-	}
+	awsCfg := awslib.NewConfigWithCredentialsAndRegion(
+		ctx,
+		credentials.NewStaticCredentialsProvider(cfg.Iceberg.S3Tables.AwsAccessKeyID, cfg.Iceberg.S3Tables.AwsSecretAccessKey, ""),
+		cfg.Iceberg.S3Tables.Region,
+	)
 
 	store := Store{
 		catalogName:      cfg.Iceberg.S3Tables.CatalogName(),

--- a/clients/iceberg/store.go
+++ b/clients/iceberg/store.go
@@ -262,7 +262,6 @@ func LoadStore(ctx context.Context, cfg config.Config) (Store, error) {
 	}
 
 	awsCfg := awslib.NewConfigWithCredentialsAndRegion(
-		ctx,
 		credentials.NewStaticCredentialsProvider(cfg.Iceberg.S3Tables.AwsAccessKeyID, cfg.Iceberg.S3Tables.AwsSecretAccessKey, ""),
 		cfg.Iceberg.S3Tables.Region,
 	)

--- a/lib/awslib/config.go
+++ b/lib/awslib/config.go
@@ -1,0 +1,15 @@
+package awslib
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+)
+
+func NewConfigWithCredentialsAndRegion(ctx context.Context, credentials credentials.StaticCredentialsProvider, region string) aws.Config {
+	return aws.Config{
+		Region:      region,
+		Credentials: credentials,
+	}
+}

--- a/lib/awslib/config.go
+++ b/lib/awslib/config.go
@@ -4,12 +4,17 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 )
 
-func NewConfigWithCredentialsAndRegion(ctx context.Context, credentials credentials.StaticCredentialsProvider, region string) aws.Config {
+func NewConfigWithCredentialsAndRegion(credentials credentials.StaticCredentialsProvider, region string) aws.Config {
 	return aws.Config{
 		Region:      region,
 		Credentials: credentials,
 	}
+}
+
+func NewDefaultConfig(ctx context.Context, region string) (aws.Config, error) {
+	return config.LoadDefaultConfig(ctx, config.WithRegion(region))
 }


### PR DESCRIPTION
Adding helper functions into our awslib to make it easier for our codepaths to migrate to the new S3 client object.

This PR then moves Redshift to start using it.