### PR TITLE
Update copying decimal details over

### DIFF
--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -76,7 +76,6 @@ func (BigQueryDialect) KindForDataType(rawBqType string, _ string) (typing.KindD
 			// BigQuery [BIGNUMERIC] type will default to BIGNUMERIC(76, 38)
 			return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(76, 38)), nil
 		}
-
 		return typing.ParseNumeric(parameters)
 	case "decimal", "float", "float64", "bigdecimal":
 		return typing.Float, nil

--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -73,12 +73,10 @@ func (BigQueryDialect) KindForDataType(rawBqType string, _ string) (typing.KindD
 		return typing.ParseNumeric(parameters)
 	case "bignumeric":
 		if len(parameters) == 0 {
-			fmt.Println("bignumeric default")
 			// BigQuery [BIGNUMERIC] type will default to BIGNUMERIC(76, 38)
 			return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(76, 38)), nil
 		}
 
-		fmt.Println("bignumeric", parameters)
 		return typing.ParseNumeric(parameters)
 	case "decimal", "float", "float64", "bigdecimal":
 		return typing.Float, nil

--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -73,9 +73,12 @@ func (BigQueryDialect) KindForDataType(rawBqType string, _ string) (typing.KindD
 		return typing.ParseNumeric(parameters)
 	case "bignumeric":
 		if len(parameters) == 0 {
+			fmt.Println("bignumeric default")
 			// BigQuery [BIGNUMERIC] type will default to BIGNUMERIC(76, 38)
 			return typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(76, 38)), nil
 		}
+
+		fmt.Println("bignumeric", parameters)
 		return typing.ParseNumeric(parameters)
 	case "decimal", "float", "float64", "bigdecimal":
 		return typing.Float, nil

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -318,6 +318,14 @@ func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Col
 		inMemoryCol.KindDetails.OptionalIntegerKind = destCol.KindDetails.OptionalIntegerKind
 	}
 
+	fmt.Println("colName", inMemoryCol.Name(), "destColName", destCol.Name())
+	if inMemoryCol.KindDetails.ExtendedDecimalDetails != nil {
+		fmt.Println("inMemoryCol.KindDetails.ExtendedDecimalDetails", inMemoryCol.KindDetails.ExtendedDecimalDetails.Precision, inMemoryCol.KindDetails.ExtendedDecimalDetails.Scale)
+	}
+	if destCol.KindDetails.ExtendedDecimalDetails != nil {
+		fmt.Println("destCol.KindDetails.ExtendedDecimalDetails", destCol.KindDetails.ExtendedDecimalDetails.Precision, destCol.KindDetails.ExtendedDecimalDetails.Scale)
+	}
+
 	// Copy over the decimal details
 	if destCol.KindDetails.ExtendedDecimalDetails != nil && inMemoryCol.KindDetails.ExtendedDecimalDetails == nil {
 		inMemoryCol.KindDetails.ExtendedDecimalDetails = destCol.KindDetails.ExtendedDecimalDetails

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -320,10 +320,10 @@ func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Col
 
 	fmt.Println("colName", inMemoryCol.Name(), "destColName", destCol.Name())
 	if inMemoryCol.KindDetails.ExtendedDecimalDetails != nil {
-		fmt.Println("inMemoryCol.KindDetails.ExtendedDecimalDetails", fmt.Sprintf("%d, %d", inMemoryCol.KindDetails.ExtendedDecimalDetails.Precision, inMemoryCol.KindDetails.ExtendedDecimalDetails.Scale))
+		fmt.Println("inMemoryCol.KindDetails.ExtendedDecimalDetails", fmt.Sprintf("%d, %d", inMemoryCol.KindDetails.ExtendedDecimalDetails.Precision(), inMemoryCol.KindDetails.ExtendedDecimalDetails.Scale()))
 	}
 	if destCol.KindDetails.ExtendedDecimalDetails != nil {
-		fmt.Println("destCol.KindDetails.ExtendedDecimalDetails", fmt.Sprintf("%d, %d", destCol.KindDetails.ExtendedDecimalDetails.Precision, destCol.KindDetails.ExtendedDecimalDetails.Scale))
+		fmt.Println("destCol.KindDetails.ExtendedDecimalDetails", fmt.Sprintf("%d, %d", destCol.KindDetails.ExtendedDecimalDetails.Precision(), destCol.KindDetails.ExtendedDecimalDetails.Scale()))
 	}
 
 	// Copy over the decimal details

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -318,16 +318,8 @@ func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Col
 		inMemoryCol.KindDetails.OptionalIntegerKind = destCol.KindDetails.OptionalIntegerKind
 	}
 
-	fmt.Println("colName", inMemoryCol.Name(), "destColName", destCol.Name())
-	if inMemoryCol.KindDetails.ExtendedDecimalDetails != nil {
-		fmt.Println("inMemoryCol.KindDetails.ExtendedDecimalDetails", fmt.Sprintf("%d, %d", inMemoryCol.KindDetails.ExtendedDecimalDetails.Precision(), inMemoryCol.KindDetails.ExtendedDecimalDetails.Scale()))
-	}
-	if destCol.KindDetails.ExtendedDecimalDetails != nil {
-		fmt.Println("destCol.KindDetails.ExtendedDecimalDetails", fmt.Sprintf("%d, %d", destCol.KindDetails.ExtendedDecimalDetails.Precision(), destCol.KindDetails.ExtendedDecimalDetails.Scale()))
-	}
-
 	// Copy over the decimal details
-	if destCol.KindDetails.ExtendedDecimalDetails != nil && inMemoryCol.KindDetails.ExtendedDecimalDetails == nil {
+	if destCol.KindDetails.ExtendedDecimalDetails != nil && (inMemoryCol.KindDetails.ExtendedDecimalDetails == nil || inMemoryCol.KindDetails.ExtendedDecimalDetails.Unset()) {
 		inMemoryCol.KindDetails.ExtendedDecimalDetails = destCol.KindDetails.ExtendedDecimalDetails
 	}
 

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -320,10 +320,10 @@ func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Col
 
 	fmt.Println("colName", inMemoryCol.Name(), "destColName", destCol.Name())
 	if inMemoryCol.KindDetails.ExtendedDecimalDetails != nil {
-		fmt.Println("inMemoryCol.KindDetails.ExtendedDecimalDetails", inMemoryCol.KindDetails.ExtendedDecimalDetails.Precision, inMemoryCol.KindDetails.ExtendedDecimalDetails.Scale)
+		fmt.Println("inMemoryCol.KindDetails.ExtendedDecimalDetails", fmt.Sprintf("%d, %d", inMemoryCol.KindDetails.ExtendedDecimalDetails.Precision, inMemoryCol.KindDetails.ExtendedDecimalDetails.Scale))
 	}
 	if destCol.KindDetails.ExtendedDecimalDetails != nil {
-		fmt.Println("destCol.KindDetails.ExtendedDecimalDetails", destCol.KindDetails.ExtendedDecimalDetails.Precision, destCol.KindDetails.ExtendedDecimalDetails.Scale)
+		fmt.Println("destCol.KindDetails.ExtendedDecimalDetails", fmt.Sprintf("%d, %d", destCol.KindDetails.ExtendedDecimalDetails.Precision, destCol.KindDetails.ExtendedDecimalDetails.Scale))
 	}
 
 	// Copy over the decimal details

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -318,13 +318,13 @@ func mergeColumn(inMemoryCol columns.Column, destCol columns.Column) columns.Col
 		inMemoryCol.KindDetails.OptionalIntegerKind = destCol.KindDetails.OptionalIntegerKind
 	}
 
-	// Copy over the decimal details
-	if destCol.KindDetails.ExtendedDecimalDetails != nil && (inMemoryCol.KindDetails.ExtendedDecimalDetails == nil || inMemoryCol.KindDetails.ExtendedDecimalDetails.Unset()) {
+	// If destination column details does have decimal details set and in-memory is not, then we should copy it over.
+	if !destCol.KindDetails.DecimalDetailsNotSet() && inMemoryCol.KindDetails.DecimalDetailsNotSet() {
 		inMemoryCol.KindDetails.ExtendedDecimalDetails = destCol.KindDetails.ExtendedDecimalDetails
 	}
 
 	// If the destination column does not have extended decimal details, we should remove it from the in-memory column as well
-	if destCol.KindDetails.ExtendedDecimalDetails == nil && inMemoryCol.KindDetails.ExtendedDecimalDetails != nil {
+	if destCol.KindDetails.DecimalDetailsNotSet() && !inMemoryCol.KindDetails.DecimalDetailsNotSet() {
 		inMemoryCol.KindDetails.ExtendedDecimalDetails = nil
 	}
 

--- a/lib/typing/decimal/details.go
+++ b/lib/typing/decimal/details.go
@@ -23,6 +23,10 @@ func (d Details) TwosComplementByteArrLength() int32 {
 	return (d.precision + 1) / 2
 }
 
+func (d Details) Unset() bool {
+	return d.precision == PrecisionNotSpecified && d.scale == DefaultScale
+}
+
 func NewDetails(precision int32, scale int32) Details {
 	if precision == 0 {
 		// MySQL, PostgreSQL, and SQLServer do not allow a zero precision, so this should never happen.

--- a/lib/typing/decimal/details.go
+++ b/lib/typing/decimal/details.go
@@ -23,7 +23,7 @@ func (d Details) TwosComplementByteArrLength() int32 {
 	return (d.precision + 1) / 2
 }
 
-func (d Details) Unset() bool {
+func (d Details) NotSet() bool {
 	return d.precision == PrecisionNotSpecified && d.scale == DefaultScale
 }
 

--- a/lib/typing/decimal/details_test.go
+++ b/lib/typing/decimal/details_test.go
@@ -19,6 +19,11 @@ func TestDetails_BigQueryKind(t *testing.T) {
 	}
 }
 
+func TestDetails_NotSet(t *testing.T) {
+	details := NewDetails(PrecisionNotSpecified, DefaultScale)
+	assert.True(t, details.NotSet())
+}
+
 func TestDecimalDetailsKind(t *testing.T) {
 	type _testCase struct {
 		Name      string
@@ -85,5 +90,6 @@ func TestDecimalDetailsKind(t *testing.T) {
 		assert.Equal(t, testCase.ExpectedSnowflakeKind, d.SnowflakeKind(), testCase.Name)
 		assert.Equal(t, testCase.ExpectedRedshiftKind, d.RedshiftKind(), testCase.Name)
 		assert.Equal(t, testCase.ExpectedBigQueryKind, d.BigQueryKind(false), testCase.Name)
+		assert.False(t, d.NotSet(), testCase.Name)
 	}
 }

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -26,6 +26,10 @@ type KindDetails struct {
 	OptionalIntegerKind     *OptionalIntegerKind
 }
 
+func (k KindDetails) DecimalDetailsNotSet() bool {
+	return k.ExtendedDecimalDetails == nil || k.ExtendedDecimalDetails.NotSet()
+}
+
 var (
 	Invalid = KindDetails{
 		Kind: "invalid",


### PR DESCRIPTION
When we create a variable numeric column, we're creating it with the decimal details set such that precision is not specified and default scale.

Our merge columns logic did not have this understanding and as such, there was no merge column of taking the higher precision from the destination to update the in-memory column.