### PR TITLE
New String Converter

### DIFF
--- a/clients/iceberg/staging.go
+++ b/clients/iceberg/staging.go
@@ -15,15 +15,16 @@ import (
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/artie-labs/transfer/lib/typing/converters"
 	"github.com/artie-labs/transfer/lib/typing/values"
 )
 
-func castColValStaging(colVal any, colKind typing.KindDetails, _ config.SharedDestinationSettings) (shared.ValueConvertResponse, error) {
+func castColValStaging(colVal any, colKind typing.KindDetails, cfg config.SharedDestinationSettings) (shared.ValueConvertResponse, error) {
 	if colVal == nil {
 		return shared.ValueConvertResponse{Value: constants.NullValuePlaceholder}, nil
 	}
 
-	value, err := values.ToString(colVal, colKind)
+	value, err := values.ToStringOpts(colVal, colKind, converters.GetStringConverterOpts{UseNewStringMethod: cfg.UseNewStringMethod})
 	if err != nil {
 		return shared.ValueConvertResponse{}, err
 	}

--- a/lib/config/types.go
+++ b/lib/config/types.go
@@ -35,8 +35,7 @@ type SharedDestinationColumnSettings struct {
 	// TODO: Deprecate BigQueryNumericForVariableNumeric in favor of UseBigNumericForVariableNumeric
 	// BigQueryNumericForVariableNumeric - If enabled, we will use BigQuery's NUMERIC type for variable numeric types.
 	BigQueryNumericForVariableNumeric bool `yaml:"bigQueryNumericForVariableNumeric"`
-
-	UseBigNumericForVariableNumeric bool `yaml:"useBigNumericForVariableNumeric"`
+	UseBigNumericForVariableNumeric   bool `yaml:"useBigNumericForVariableNumeric"`
 }
 
 func (s SharedDestinationColumnSettings) BigNumericForVariableNumeric() bool {
@@ -50,6 +49,8 @@ type SharedDestinationSettings struct {
 	// This is only supported by Redshift at the moment.
 	ExpandStringPrecision bool                            `yaml:"expandStringPrecision"`
 	ColumnSettings        SharedDestinationColumnSettings `yaml:"columnSettings"`
+	// TODO: Standardize on this method.
+	UseNewStringMethod bool `yaml:"useNewStringMethod"`
 }
 
 type Reporting struct {

--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -109,6 +109,10 @@ func (StringConverter) ConvertNew(value any) (string, error) {
 	case *decimal.Decimal:
 		return DecimalConverter{}.Convert(castedValue)
 	default:
+		if reflect.ValueOf(value).Kind() == reflect.Slice {
+			return ArrayConverter{}.Convert(value)
+		}
+
 		return "", fmt.Errorf("unsupported value: %v, type: %T", value, value)
 	}
 }

--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -104,6 +104,10 @@ func (StringConverter) ConvertNew(value any) (string, error) {
 		return castedValue, nil
 	case map[string]any:
 		return StructConverter{}.Convert(castedValue)
+	case time.Time:
+		return TimestampTZConverter{}.Convert(castedValue)
+	case *decimal.Decimal:
+		return DecimalConverter{}.Convert(castedValue)
 	default:
 		return "", fmt.Errorf("unsupported value: %v, type: %T", value, value)
 	}

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -305,4 +305,10 @@ func TestStringConverter_Convert(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, `{"foo":"bar"}`, val)
 	}
+	{
+		// Array
+		val, err := conv.Convert([]string{"foo", "bar"})
+		assert.NoError(t, err)
+		assert.Equal(t, `["foo","bar"]`, val)
+	}
 }

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -3,6 +3,7 @@ package converters
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/artie-labs/transfer/lib/typing"
 
@@ -277,6 +278,12 @@ func TestStringConverter_Convert(t *testing.T) {
 		val, err := conv.Convert(true)
 		assert.NoError(t, err)
 		assert.Equal(t, "true", val)
+	}
+	{
+		// time.Time
+		val, err := conv.Convert(time.Date(2021, 1, 1, 2, 3, 4, 5678910, time.UTC))
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01T02:03:04.00567891Z", val)
 	}
 	{
 		// Integers

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -305,6 +305,10 @@ func TestStringConverter_Convert(t *testing.T) {
 		val, err := conv.Convert(map[string]any{"foo": "bar"})
 		assert.NoError(t, err)
 		assert.Equal(t, `{"foo":"bar"}`, val)
+
+		var obj any
+		assert.NoError(t, json.Unmarshal([]byte(val), &obj))
+		assert.Equal(t, map[string]any{"foo": "bar"}, obj)
 	}
 	{
 		// Array
@@ -312,8 +316,8 @@ func TestStringConverter_Convert(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, `["foo","bar"]`, val)
 
-		var arr []any
+		var arr any
 		assert.NoError(t, json.Unmarshal([]byte(val), &arr))
-		assert.Equal(t, []any{"foo", "bar"}, arr)
+		assert.Equal(t, []any{"foo", "bar"}, arr.([]any))
 	}
 }

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -1,6 +1,7 @@
 package converters
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/artie-labs/transfer/lib/typing"
@@ -310,5 +311,9 @@ func TestStringConverter_Convert(t *testing.T) {
 		val, err := conv.Convert([]string{"foo", "bar"})
 		assert.NoError(t, err)
 		assert.Equal(t, `["foo","bar"]`, val)
+
+		var arr []any
+		assert.NoError(t, json.Unmarshal([]byte(val), &arr))
+		assert.Equal(t, []any{"foo", "bar"}, arr)
 	}
 }

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -262,3 +262,47 @@ func TestStructConverter_Convert(t *testing.T) {
 		assert.Equal(t, "123", val)
 	}
 }
+
+func TestStringConverter_Convert(t *testing.T) {
+	conv := StringConverter{useNewMethod: true}
+	{
+		// String
+		val, err := conv.Convert("foo")
+		assert.NoError(t, err)
+		assert.Equal(t, "foo", val)
+	}
+	{
+		// Boolean
+		val, err := conv.Convert(true)
+		assert.NoError(t, err)
+		assert.Equal(t, "true", val)
+	}
+	{
+		// Integers
+		for _, value := range []any{42, int8(42), int16(42), int32(42), int64(42), float32(42), float64(42)} {
+			val, err := conv.Convert(value)
+			assert.NoError(t, err)
+			assert.Equal(t, "42", val)
+		}
+	}
+	{
+		// Floats
+		for _, value := range []any{123.45, float32(123.45), float64(123.45)} {
+			val, err := conv.Convert(value)
+			assert.NoError(t, err)
+			assert.Equal(t, "123.45", val)
+		}
+	}
+	{
+		// Decimal
+		val, err := conv.Convert(decimal.NewDecimal(numbers.MustParseDecimal("123.45")))
+		assert.NoError(t, err)
+		assert.Equal(t, "123.45", val)
+	}
+	{
+		// JSON
+		val, err := conv.Convert(map[string]any{"foo": "bar"})
+		assert.NoError(t, err)
+		assert.Equal(t, `{"foo":"bar"}`, val)
+	}
+}


### PR DESCRIPTION
## Context

We are writing TSV GZIPPED delta files while loading into the destination. As such, we already have logic that will take the destination data type and build converters that will convert incoming data to match the destination data type in string (since we're loading through TSV).

The problem is that in our string data type converter, the incoming value could be boolean, integers, floats, etc and we should try to convert them into string without sacrificing readability or precision. Our current method which has been renamed to be `convertOld` does some of that, however the string escape is non-optimal and the way we inspect data type is not great either.

## Changes

This PR is coming up with a different approach, one where we're doing a switch case on the actual data type and in the String converter, we are then leveraging the appropriate converters instead of relying on `fmt.Sprint(...)`.

I've added a flag so that we can control the flow of opt-in for customers. We will then default to using the new converter behavior in the newer versions.

<img width="922" alt="image" src="https://github.com/user-attachments/assets/8cf7ce1b-936f-40e7-a17c-55bc2176fe50" />
