### PR TITLE
Better handling of `msm` tables

### DIFF
--- a/lib/destination/ddl/expiry.go
+++ b/lib/destination/ddl/expiry.go
@@ -20,17 +20,14 @@ func ShouldDeleteFromName(name string) bool {
 		return false
 	}
 
-	if strings.EqualFold(suffixParts[len(suffixParts)-1], "msm") {
+	part := suffixParts[2]
+	if strings.EqualFold(part, "msm") {
 		return false
 	}
 
-	unix, err := strconv.Atoi(suffixParts[2])
+	unix, err := strconv.Atoi(part)
 	if err != nil {
-		slog.Error("Failed to parse unix string",
-			slog.Any("err", err),
-			slog.String("tableName", name),
-			slog.String("tsString", suffixParts[2]),
-		)
+		slog.Error("Failed to parse unix string", slog.Any("err", err), slog.String("tableName", name), slog.String("part", part))
 		return false
 	}
 

--- a/lib/destination/ddl/expiry.go
+++ b/lib/destination/ddl/expiry.go
@@ -20,12 +20,11 @@ func ShouldDeleteFromName(name string) bool {
 		return false
 	}
 
-	part := suffixParts[2]
-	if part == "msm" {
+	if strings.EqualFold(suffixParts[len(suffixParts)-1], "msm") {
 		return false
 	}
 
-	unix, err := strconv.Atoi(part)
+	unix, err := strconv.Atoi(suffixParts[2])
 	if err != nil {
 		slog.Error("Failed to parse unix string",
 			slog.Any("err", err),

--- a/lib/destination/ddl/expiry_test.go
+++ b/lib/destination/ddl/expiry_test.go
@@ -20,6 +20,8 @@ func TestShouldDeleteFromName(t *testing.T) {
 			fmt.Sprintf("future_tbl___artie_suffix_%d", time.Now().Add(constants.TemporaryTableTTL).Unix()),
 			fmt.Sprintf("future_tbl___notartie_%d", time.Now().Add(-1*time.Hour).Unix()),
 			fmt.Sprintf("%s_foo_msm", constants.ArtiePrefix),
+			fmt.Sprintf("%s_foo_MSM", constants.ArtiePrefix),
+			fmt.Sprintf("%s_foo_foo_MSM", constants.ArtiePrefix),
 		}
 
 		for _, tblToNotDelete := range tablesToNotDrop {


### PR DESCRIPTION
Should be using `strings.EqualFold` since identifiers are uppercased in Snowflake.