### PR TITLE
Parquet to allow location 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,4 +90,4 @@ test-parquet: parquet-venv
 	@echo "Running parquet integration test (Go)..."
 	@cd integration_tests/parquet && go run main.go --location=America/New_York
 	@echo "Running parquet verification (Python)..."
-	@cd integration_tests/parquet && venv/bin/python verify_parquet.py output/test.parquet
+	@cd integration_tests/parquet && venv/bin/python verify_parquet.py --file-path output/test.parquet --location America/New_York

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,12 @@ parquet-venv:
 
 .PHONY: test-parquet
 test-parquet: parquet-venv
-	@echo "Running parquet integration test (Go)..."
+	@echo "Running parquet integration test (Go) with location America/New_York"
 	@cd integration_tests/parquet && go run main.go --location=America/New_York
 	@echo "Running parquet verification (Python)..."
 	@cd integration_tests/parquet && venv/bin/python verify_parquet.py --file-path output/test.parquet --location America/New_York
+	
+	@echo "Running parquet integration test (Go) with no location set"
+	@cd integration_tests/parquet && go run main.go
+	@echo "Running parquet verification (Python)..."
+	@cd integration_tests/parquet && venv/bin/python verify_parquet.py --file-path output/test.parquet

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,6 @@ parquet-venv:
 .PHONY: test-parquet
 test-parquet: parquet-venv
 	@echo "Running parquet integration test (Go)..."
-	@cd integration_tests/parquet && go run main.go
+	@cd integration_tests/parquet && go run main.go --location=America/New_York
 	@echo "Running parquet verification (Python)..."
 	@cd integration_tests/parquet && venv/bin/python verify_parquet.py output/test.parquet

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -26,6 +26,7 @@ import (
 type Store struct {
 	config   config.Config
 	s3Client awslib.S3Client
+	location *time.Location
 }
 
 func (s Store) Validate() error {
@@ -70,7 +71,7 @@ func buildTemporaryFilePath(tableData *optimization.TableData) string {
 
 // WriteParquetFiles writes the table data to a parquet file at the specified path.
 // Returns an error if any step of the writing process fails.
-func WriteParquetFiles(tableData *optimization.TableData, filePath string) error {
+func WriteParquetFiles(tableData *optimization.TableData, filePath string, location *time.Location) error {
 	cols := tableData.ReadOnlyInMemoryCols().ValidColumns()
 	schema, err := parquetutil.BuildCSVSchema(cols)
 	if err != nil {
@@ -91,7 +92,7 @@ func WriteParquetFiles(tableData *optimization.TableData, filePath string) error
 	for _, val := range tableData.Rows() {
 		var row []any
 		for _, col := range cols {
-			value, err := parquetutil.ParseValue(val[col.Name()], col.KindDetails)
+			value, err := parquetutil.ParseValue(val[col.Name()], col.KindDetails, location)
 			if err != nil {
 				return fmt.Errorf("failed to parse value, err: %w, value: %v, column: %q", err, val[col.Name()], col.Name())
 			}
@@ -126,7 +127,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (b
 	}
 
 	fp := buildTemporaryFilePath(tableData)
-	if err := WriteParquetFiles(tableData, fp); err != nil {
+	if err := WriteParquetFiles(tableData, fp, s.location); err != nil {
 		return false, err
 	}
 
@@ -155,9 +156,18 @@ func LoadStore(ctx context.Context, cfg config.Config) (*Store, error) {
 		return nil, fmt.Errorf("failed to load aws config: %w", err)
 	}
 
+	var location *time.Location
+	if cfg.SharedDestinationSettings.SharedTimestampSettings.Location != "" {
+		location, err = time.LoadLocation(cfg.SharedDestinationSettings.SharedTimestampSettings.Location)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load location: %w", err)
+		}
+	}
+
 	store := Store{
 		config:   cfg,
 		s3Client: awslib.NewS3Client(awsConfig),
+		location: location,
 	}
 
 	if err := store.Validate(); err != nil {

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -73,7 +73,7 @@ func buildTemporaryFilePath(tableData *optimization.TableData) string {
 // Returns an error if any step of the writing process fails.
 func WriteParquetFiles(tableData *optimization.TableData, filePath string, location *time.Location) error {
 	cols := tableData.ReadOnlyInMemoryCols().ValidColumns()
-	schema, err := parquetutil.BuildCSVSchema(cols)
+	schema, err := parquetutil.BuildCSVSchema(cols, location)
 	if err != nil {
 		return fmt.Errorf("failed to generate parquet schema: %w", err)
 	}

--- a/integration_tests/parquet/main.go
+++ b/integration_tests/parquet/main.go
@@ -22,24 +22,27 @@ func main() {
 	cols.AddColumn(columns.NewColumn("name", typing.String))
 	cols.AddColumn(columns.NewColumn("age", typing.Integer))
 	cols.AddColumn(columns.NewColumn("created_at", typing.TimestampTZ))
+	cols.AddColumn(columns.NewColumn("created_at_ntz", typing.TimestampNTZ))
 	cols.AddColumn(columns.NewColumn("score", typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(10, 7))))
 
 	tableData := optimization.NewTableData(&cols, config.Replication, []string{"id"}, kafkalib.TopicConfig{}, "test_table")
 
 	// Add test rows
 	tableData.InsertRow("1", map[string]any{
-		"id":         1,
-		"name":       "John Doe",
-		"age":        30,
-		"created_at": "2024-03-20T10:00:00Z",
-		"score":      decimal.NewDecimalWithPrecision(numbers.MustParseDecimal("-97.410511"), 10),
+		"id":             1,
+		"name":           "John Doe",
+		"age":            30,
+		"created_at":     "2024-03-20T10:00:00.111Z",
+		"created_at_ntz": "2024-03-20T10:00:00.111",
+		"score":          decimal.NewDecimalWithPrecision(numbers.MustParseDecimal("-97.410511"), 10),
 	}, false)
 	tableData.InsertRow("2", map[string]any{
-		"id":         2,
-		"name":       "Jane Smith",
-		"age":        25,
-		"created_at": "2024-03-20T11:00:00Z",
-		"score":      decimal.NewDecimalWithPrecision(numbers.MustParseDecimal("99.410511"), 10),
+		"id":             2,
+		"name":           "Jane Smith",
+		"age":            25,
+		"created_at":     "2024-03-20T11:00:00.555Z",
+		"created_at_ntz": "2024-03-20T11:00:00.444",
+		"score":          decimal.NewDecimalWithPrecision(numbers.MustParseDecimal("99.410511"), 10),
 	}, false)
 
 	// Create output directory if it doesn't exist

--- a/integration_tests/parquet/main.go
+++ b/integration_tests/parquet/main.go
@@ -25,6 +25,7 @@ func main() {
 
 	var loc *time.Location
 	if locationString != "" {
+		slog.Info("Loading location", slog.String("location", locationString))
 		var err error
 		loc, err = time.LoadLocation(locationString)
 		if err != nil {

--- a/integration_tests/parquet/main.go
+++ b/integration_tests/parquet/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// Write the parquet file
 	parquetPath := filepath.Join(outputDir, "test.parquet")
-	if err := s3.WriteParquetFiles(tableData, parquetPath); err != nil {
+	if err := s3.WriteParquetFiles(tableData, parquetPath, nil); err != nil {
 		logger.Fatal("Failed to write parquet file", slog.Any("error", err))
 	}
 

--- a/integration_tests/parquet/verify_parquet.py
+++ b/integration_tests/parquet/verify_parquet.py
@@ -24,20 +24,22 @@ def verify_parquet_file(file_path):
     print(df.dtypes)
     
     # Define expected data
-    expected_columns = ['id', 'name', 'age', 'created_at', 'score']
+    expected_columns = ['id', 'name', 'age', 'created_at', 'created_at_ntz', 'score']
     expected_rows = [
         {
             'id': 1,
             'name': 'John Doe',
             'age': 30,
-            'created_at': datetime.fromisoformat("2024-03-20 10:00:00").replace(tzinfo=timezone.utc),
+            'created_at': datetime.fromisoformat("2024-03-20 10:00:00.111").replace(tzinfo=timezone.utc),
+            'created_at_ntz': datetime.fromisoformat("2024-03-20 10:00:00.111").replace(tzinfo=timezone.utc),
             'score': Decimal('-97.410511')
         },
         {
             'id': 2,
             'name': 'Jane Smith',
             'age': 25,
-            'created_at': datetime.fromisoformat("2024-03-20 11:00:00").replace(tzinfo=timezone.utc),
+            'created_at': datetime.fromisoformat("2024-03-20 11:00:00.555").replace(tzinfo=timezone.utc),
+            'created_at_ntz': datetime.fromisoformat("2024-03-20 11:00:00.444").replace(tzinfo=timezone.utc),
             'score': Decimal('99.410511')
         }
     ]

--- a/integration_tests/parquet/verify_parquet.py
+++ b/integration_tests/parquet/verify_parquet.py
@@ -20,7 +20,7 @@ def verify_parquet_file(file_path):
     # Print the data
     print("DataFrame contents:")
     print(df)
-    print("\nColumn data types:")
+    print("Column data types:")
     print(df.dtypes)
     
     # Define expected data

--- a/integration_tests/parquet/verify_parquet.py
+++ b/integration_tests/parquet/verify_parquet.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import sys
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 
 def verify_parquet_file(file_path):
@@ -30,14 +30,14 @@ def verify_parquet_file(file_path):
             'id': 1,
             'name': 'John Doe',
             'age': 30,
-            'created_at': datetime.fromisoformat("2024-03-20 10:00:00"),
+            'created_at': datetime.fromisoformat("2024-03-20 10:00:00").replace(tzinfo=timezone.utc),
             'score': Decimal('-97.410511')
         },
         {
             'id': 2,
             'name': 'Jane Smith',
             'age': 25,
-            'created_at': datetime.fromisoformat("2024-03-20 11:00:00"),
+            'created_at': datetime.fromisoformat("2024-03-20 11:00:00").replace(tzinfo=timezone.utc),
             'score': Decimal('99.410511')
         }
     ]
@@ -52,12 +52,7 @@ def verify_parquet_file(file_path):
     for i, expected_row in enumerate(expected_rows):
         for col, expected_value in expected_row.items():
             actual_value = df.iloc[i][col]
-            if isinstance(expected_value, Decimal):
-                # Convert actual value to Decimal for comparison
-                actual_decimal = Decimal(str(actual_value))
-                assert actual_decimal == expected_value, f"Row {i}, Column {col}: Expected {expected_value}, got {actual_decimal}"
-            else:
-                assert actual_value == expected_value, f"Row {i}, Column {col}: Expected {expected_value}, got {actual_value}"
+            assert actual_value == expected_value, f"Row {i}, Column {col}: Expected {expected_value}, got {actual_value}"
     
     print("All assertions passed!")
     return True

--- a/integration_tests/parquet/verify_parquet.py
+++ b/integration_tests/parquet/verify_parquet.py
@@ -6,7 +6,7 @@ import argparse
 from datetime import datetime, timezone
 from decimal import Decimal
 
-def verify_parquet_file(file_path):
+def verify_parquet_file(file_path, location):
     """
     Read and verify the contents of a parquet file.
     Returns True if all verifications pass, False otherwise.
@@ -30,16 +30,16 @@ def verify_parquet_file(file_path):
             'id': 1,
             'name': 'John Doe',
             'age': 30,
-            'created_at': datetime.fromisoformat("2024-03-20 10:00:00.111").replace(tzinfo=timezone.utc),
-            'created_at_ntz': datetime.fromisoformat("2024-03-20 10:00:00.111").replace(tzinfo=timezone.utc),
+            'created_at': datetime.fromisoformat("2024-03-20 06:00:00.111") if location else datetime.fromisoformat("2024-03-20 10:00:00.111").replace(tzinfo=timezone.utc),
+            'created_at_ntz': datetime.fromisoformat("2024-03-20 06:00:00.111") if location else datetime.fromisoformat("2024-03-20 10:00:00.111").replace(tzinfo=timezone.utc),
             'score': Decimal('-97.410511')
         },
         {
             'id': 2,
             'name': 'Jane Smith',
             'age': 25,
-            'created_at': datetime.fromisoformat("2024-03-20 11:00:00.555").replace(tzinfo=timezone.utc),
-            'created_at_ntz': datetime.fromisoformat("2024-03-20 11:00:00.444").replace(tzinfo=timezone.utc),
+            'created_at': datetime.fromisoformat("2024-03-20 07:00:00.555") if location else datetime.fromisoformat("2024-03-20 11:00:00.555").replace(tzinfo=timezone.utc),
+            'created_at_ntz': datetime.fromisoformat("2024-03-20 07:00:00.444") if location else datetime.fromisoformat("2024-03-20 11:00:00.444").replace(tzinfo=timezone.utc),
             'score': Decimal('99.410511')
         }
     ]
@@ -61,10 +61,11 @@ def verify_parquet_file(file_path):
 
 def main():
     parser = argparse.ArgumentParser(description='Verify parquet file contents')
-    parser.add_argument('file_path', help='Path to the parquet file to verify')
+    parser.add_argument('--file-path', help='Path to the parquet file to verify')
+    parser.add_argument('--location', help='Location to use for the parquet file')
     args = parser.parse_args()
-    
-    success = verify_parquet_file(args.file_path)
+
+    success = verify_parquet_file(args.file_path, args.location)
     sys.exit(0 if success else 1)
 
 if __name__ == "__main__":

--- a/integration_tests/parquet/verify_parquet.py
+++ b/integration_tests/parquet/verify_parquet.py
@@ -20,8 +20,8 @@ def verify_parquet_file(file_path):
     # Print the data
     print("DataFrame contents:")
     print(df)
-    for i, row in df.iterrows():
-        print(f"Row {i} score value: {row['score']} (type: {type(row['score'])})")
+    print("\nColumn data types:")
+    print(df.dtypes)
     
     # Define expected data
     expected_columns = ['id', 'name', 'age', 'created_at', 'score']

--- a/lib/config/types.go
+++ b/lib/config/types.go
@@ -59,6 +59,7 @@ type SharedDestinationSettings struct {
 type SharedTimestampSettings struct {
 	// If [location] is specified, we'll be using that location for all timestamp (without timezone) columns.
 	// The only exception is to Parquet where there's no explicit timestamp with timezone column, so both will use the location.
+	// Note: This only works for Parquet at the moment.
 	Location string `yaml:"location"`
 }
 

--- a/lib/config/types.go
+++ b/lib/config/types.go
@@ -51,6 +51,15 @@ type SharedDestinationSettings struct {
 	ColumnSettings        SharedDestinationColumnSettings `yaml:"columnSettings"`
 	// TODO: Standardize on this method.
 	UseNewStringMethod bool `yaml:"useNewStringMethod"`
+
+	// Timestamp Settings
+	SharedTimestampSettings SharedTimestampSettings `yaml:"sharedTimestampSettings"`
+}
+
+type SharedTimestampSettings struct {
+	// If [location] is specified, we'll be using that location for all timestamp (without timezone) columns.
+	// The only exception is to Parquet where there's no explicit timestamp with timezone column, so both will use the location.
+	Location string `yaml:"location"`
 }
 
 type Reporting struct {

--- a/lib/parquetutil/generate_schema.go
+++ b/lib/parquetutil/generate_schema.go
@@ -1,14 +1,16 @@
 package parquetutil
 
 import (
+	"time"
+
 	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
-func BuildCSVSchema(columns []columns.Column) ([]string, error) {
+func BuildCSVSchema(columns []columns.Column, location *time.Location) ([]string, error) {
 	var fields []string
 	for _, column := range columns {
 		// We don't need to escape the column name here.
-		field, err := column.KindDetails.ParquetAnnotation(column.Name())
+		field, err := column.KindDetails.ParquetAnnotation(column.Name(), location)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -51,22 +51,26 @@ func ParseValue(colVal any, colKind typing.KindDetails, location *time.Location)
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
+		var offsetMS int64
 		if location != nil {
-			_time = _time.In(location)
+			_, offset := _time.In(location).Zone()
+			offsetMS = int64(offset * 1000)
 		}
 
-		return _time.UnixMilli(), nil
+		return _time.UnixMilli() + offsetMS, nil
 	case typing.TimestampTZ.Kind:
 		_time, err := ext.ParseTimestampTZFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
+		var offsetMS int64
 		if location != nil {
-			_time = _time.In(location)
+			_, offset := _time.In(location).Zone()
+			offsetMS = int64(offset * 1000)
 		}
 
-		return _time.UnixMilli(), nil
+		return _time.UnixMilli() + offsetMS, nil
 	case typing.String.Kind:
 		return colVal, nil
 	case typing.Struct.Kind:

--- a/lib/parquetutil/parse_values.go
+++ b/lib/parquetutil/parse_values.go
@@ -22,7 +22,7 @@ func millisecondsAfterMidnight(t time.Time) int32 {
 	return int32(t.Sub(midnight).Milliseconds())
 }
 
-func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
+func ParseValue(colVal any, colKind typing.KindDetails, location *time.Location) (any, error) {
 	if colVal == nil {
 		return nil, nil
 	}
@@ -51,11 +51,19 @@ func ParseValue(colVal any, colKind typing.KindDetails) (any, error) {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
 		}
 
+		if location != nil {
+			_time = _time.In(location)
+		}
+
 		return _time.UnixMilli(), nil
 	case typing.TimestampTZ.Kind:
 		_time, err := ext.ParseTimestampTZFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: %v, err: %w", colVal, err)
+		}
+
+		if location != nil {
+			_time = _time.In(location)
 		}
 
 		return _time.UnixMilli(), nil

--- a/lib/parquetutil/parse_values_test.go
+++ b/lib/parquetutil/parse_values_test.go
@@ -15,19 +15,19 @@ import (
 func TestParseValue(t *testing.T) {
 	{
 		// Nil
-		value, err := ParseValue(nil, typing.KindDetails{})
+		value, err := ParseValue(nil, typing.KindDetails{}, nil)
 		assert.NoError(t, err)
 		assert.Nil(t, value)
 	}
 	{
 		// String
-		value, err := ParseValue("test", typing.String)
+		value, err := ParseValue("test", typing.String, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "test", value)
 	}
 	{
 		// Struct
-		value, err := ParseValue(map[string]any{"foo": "bar"}, typing.Struct)
+		value, err := ParseValue(map[string]any{"foo": "bar"}, typing.Struct, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, `{"foo":"bar"}`, value)
 	}
@@ -35,13 +35,13 @@ func TestParseValue(t *testing.T) {
 		// Arrays
 		{
 			// Arrays (numbers - converted to string)
-			value, err := ParseValue([]any{123, 456}, typing.Array)
+			value, err := ParseValue([]any{123, 456}, typing.Array, nil)
 			assert.NoError(t, err)
 			assert.Equal(t, []string{"123", "456"}, value)
 		}
 		{
 			// Arrays (booleans - converted to string)
-			value, err := ParseValue([]any{false, true, false}, typing.Array)
+			value, err := ParseValue([]any{false, true, false}, typing.Array, nil)
 			assert.NoError(t, err)
 			assert.Equal(t, []string{"false", "true", "false"}, value)
 		}
@@ -51,6 +51,7 @@ func TestParseValue(t *testing.T) {
 		value, err := ParseValue(decimal.NewDecimalWithPrecision(
 			numbers.MustParseDecimal("5000.22320"), 30),
 			typing.NewDecimalDetailsFromTemplate(typing.EDecimal, decimal.NewDetails(30, 5)),
+			nil,
 		)
 
 		assert.NoError(t, err)
@@ -58,7 +59,7 @@ func TestParseValue(t *testing.T) {
 	}
 	{
 		// Time
-		value, err := ParseValue("03:15:00", typing.Time)
+		value, err := ParseValue("03:15:00", typing.Time, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, int32(11700000), value)
 
@@ -68,14 +69,44 @@ func TestParseValue(t *testing.T) {
 	}
 	{
 		// Date
-		value, err := ParseValue("2022-12-25", typing.Date)
+		value, err := ParseValue("2022-12-25", typing.Date, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, int32(19351), value)
 	}
 	{
+		// TIMESTAMP NTZ
+		{
+			// No location
+			value, err := ParseValue("2023-04-24T17:29:05.69944Z", typing.TimestampNTZ, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, int64(1682357345699), value)
+		}
+		{
+			// With location
+			est, err := time.LoadLocation("America/New_York")
+			assert.NoError(t, err)
+
+			value, err := ParseValue("2023-04-24T17:29:05.69944Z", typing.TimestampNTZ, est)
+			assert.NoError(t, err)
+			assert.Equal(t, int64(1682357345699), value)
+		}
+	}
+	{
 		// Timestamp TZ
-		value, err := ParseValue("2023-04-24T17:29:05.69944Z", typing.TimestampTZ)
-		assert.NoError(t, err)
-		assert.Equal(t, int64(1682357345699), value)
+		{
+			// No location
+			value, err := ParseValue("2023-04-24T17:29:05.69944Z", typing.TimestampTZ, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, int64(1682357345699), value)
+		}
+		{
+			// With location
+			est, err := time.LoadLocation("America/New_York")
+			assert.NoError(t, err)
+
+			value, err := ParseValue("2023-04-24T17:29:05.69944Z", typing.TimestampTZ, est)
+			assert.NoError(t, err)
+			assert.Equal(t, int64(1682357345699), value)
+		}
 	}
 }

--- a/lib/parquetutil/parse_values_test.go
+++ b/lib/parquetutil/parse_values_test.go
@@ -75,9 +75,10 @@ func TestParseValue(t *testing.T) {
 	}
 	{
 		// TIMESTAMP NTZ
+		_time := time.Date(2023, 4, 24, 17, 29, 5, 699440000, time.UTC)
 		{
 			// No location
-			value, err := ParseValue("2023-04-24T17:29:05.69944Z", typing.TimestampNTZ, nil)
+			value, err := ParseValue(_time, typing.TimestampNTZ, nil)
 			assert.NoError(t, err)
 			assert.Equal(t, int64(1682357345699), value)
 		}
@@ -86,16 +87,17 @@ func TestParseValue(t *testing.T) {
 			est, err := time.LoadLocation("America/New_York")
 			assert.NoError(t, err)
 
-			value, err := ParseValue("2023-04-24T17:29:05.69944Z", typing.TimestampNTZ, est)
+			value, err := ParseValue(_time, typing.TimestampNTZ, est)
 			assert.NoError(t, err)
 			assert.Equal(t, int64(1682357345699), value)
 		}
 	}
 	{
 		// Timestamp TZ
+		_time := time.Date(2023, 4, 24, 17, 29, 5, 699440000, time.UTC)
 		{
 			// No location
-			value, err := ParseValue("2023-04-24T17:29:05.69944Z", typing.TimestampTZ, nil)
+			value, err := ParseValue(_time, typing.TimestampTZ, nil)
 			assert.NoError(t, err)
 			assert.Equal(t, int64(1682357345699), value)
 		}
@@ -104,7 +106,7 @@ func TestParseValue(t *testing.T) {
 			est, err := time.LoadLocation("America/New_York")
 			assert.NoError(t, err)
 
-			value, err := ParseValue("2023-04-24T17:29:05.69944Z", typing.TimestampTZ, est)
+			value, err := ParseValue(_time, typing.TimestampTZ, est)
 			assert.NoError(t, err)
 			assert.Equal(t, int64(1682357345699), value)
 		}

--- a/lib/parquetutil/parse_values_test.go
+++ b/lib/parquetutil/parse_values_test.go
@@ -75,12 +75,12 @@ func TestParseValue(t *testing.T) {
 	}
 	{
 		// TIMESTAMP NTZ
-		_time := time.Date(2023, 4, 24, 17, 29, 5, 699440000, time.UTC)
+		_time := time.Date(2023, 4, 24, 17, 29, 5, 699_000_000, time.UTC)
 		{
 			// No location
 			value, err := ParseValue(_time, typing.TimestampNTZ, nil)
 			assert.NoError(t, err)
-			assert.Equal(t, int64(1682357345699), value)
+			assert.Equal(t, int64(1_682_357_345_699), value)
 		}
 		{
 			// With location
@@ -89,17 +89,22 @@ func TestParseValue(t *testing.T) {
 
 			value, err := ParseValue(_time, typing.TimestampNTZ, est)
 			assert.NoError(t, err)
-			assert.Equal(t, int64(1682357345699), value)
+			assert.Equal(t, int64(1_682_342_945_699), value)
+
+			_, offset := _time.In(est).Zone()
+			// This needs to be subtract since we need to do the opposite of what we're doing in [ParseValue] to unravel the value back to UTC.
+			estTime := time.UnixMilli(value.(int64) - int64(offset*1000)).In(time.UTC)
+			assert.Equal(t, _time, estTime)
 		}
 	}
 	{
 		// Timestamp TZ
-		_time := time.Date(2023, 4, 24, 17, 29, 5, 699440000, time.UTC)
+		_time := time.Date(2023, 4, 24, 17, 29, 5, 699_000_000, time.UTC)
 		{
 			// No location
 			value, err := ParseValue(_time, typing.TimestampTZ, nil)
 			assert.NoError(t, err)
-			assert.Equal(t, int64(1682357345699), value)
+			assert.Equal(t, int64(1_682_357_345_699), value)
 		}
 		{
 			// With location
@@ -108,7 +113,11 @@ func TestParseValue(t *testing.T) {
 
 			value, err := ParseValue(_time, typing.TimestampTZ, est)
 			assert.NoError(t, err)
-			assert.Equal(t, int64(1682357345699), value)
+			assert.Equal(t, int64(1_682_342_945_699), value)
+
+			_, offset := _time.In(est).Zone()
+			estTime := time.UnixMilli(value.(int64) - int64(offset*1000)).In(time.UTC)
+			assert.Equal(t, _time, estTime)
 		}
 	}
 }

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -19,6 +19,7 @@ type FieldTag struct {
 	Precision      *int
 	Length         *int
 	// This is used for timestamps only:
+	LogicalType      *string
 	IsAdjustedForUTC *bool
 	Unit             *string
 }
@@ -58,12 +59,17 @@ func (f FieldTag) String() string {
 		parts = append(parts, fmt.Sprintf("length=%v", *f.Length))
 	}
 
+	// Timestamps:
+	if f.LogicalType != nil {
+		parts = append(parts, fmt.Sprintf("logicaltype=%s", *f.LogicalType))
+	}
+
 	if f.IsAdjustedForUTC != nil {
-		parts = append(parts, fmt.Sprintf("isAdjustedToUTC=%t", *f.IsAdjustedForUTC))
+		parts = append(parts, fmt.Sprintf("logicaltype.isadjustedtoutc=%t", *f.IsAdjustedForUTC))
 	}
 
 	if f.Unit != nil {
-		parts = append(parts, fmt.Sprintf("unit=%s", *f.Unit))
+		parts = append(parts, fmt.Sprintf("logicaltype.unit=%s", *f.Unit))
 	}
 
 	return strings.Join(parts, ", ")
@@ -112,6 +118,7 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 			Tag: FieldTag{
 				Name:             colName,
 				Type:             ToPtr(parquet.Type_INT64.String()),
+				LogicalType:      ToPtr("TIMESTAMP"),
 				IsAdjustedForUTC: ToPtr(true),
 				Unit:             ToPtr("MILLIS"),
 			}.String(),

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -59,7 +59,7 @@ func (f FieldTag) String() string {
 	}
 
 	if f.IsAdjustedForUTC != nil {
-		parts = append(parts, fmt.Sprintf("isadjustedforutc=%t", *f.IsAdjustedForUTC))
+		parts = append(parts, fmt.Sprintf("isAdjustedToUTC=%t", *f.IsAdjustedForUTC))
 	}
 
 	if f.Unit != nil {

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -18,6 +18,9 @@ type FieldTag struct {
 	Scale          *int
 	Precision      *int
 	Length         *int
+	// This is used for timestamps only:
+	IsAdjustedForUTC *bool
+	Unit             *string
 }
 
 func (f FieldTag) String() string {
@@ -53,6 +56,14 @@ func (f FieldTag) String() string {
 
 	if f.Length != nil {
 		parts = append(parts, fmt.Sprintf("length=%v", *f.Length))
+	}
+
+	if f.IsAdjustedForUTC != nil {
+		parts = append(parts, fmt.Sprintf("isadjustedforutc=%t", *f.IsAdjustedForUTC))
+	}
+
+	if f.Unit != nil {
+		parts = append(parts, fmt.Sprintf("unit=%s", *f.Unit))
 	}
 
 	return strings.Join(parts, ", ")
@@ -99,9 +110,10 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 	case TimestampNTZ.Kind, TimestampTZ.Kind:
 		return &Field{
 			Tag: FieldTag{
-				Name:          colName,
-				Type:          ToPtr(parquet.Type_INT64.String()),
-				ConvertedType: ToPtr(parquet.ConvertedType_TIMESTAMP_MILLIS.String()),
+				Name:             colName,
+				Type:             ToPtr(parquet.Type_INT64.String()),
+				IsAdjustedForUTC: ToPtr(true),
+				Unit:             ToPtr("MILLIS"),
 			}.String(),
 		}, nil
 	case Integer.Kind:

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -3,6 +3,7 @@ package typing
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 	"github.com/xitongsys/parquet-go/parquet"
@@ -80,7 +81,7 @@ type Field struct {
 	Fields []Field `json:"Fields,omitempty"`
 }
 
-func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
+func (k *KindDetails) ParquetAnnotation(colName string, location *time.Location) (*Field, error) {
 	switch k.Kind {
 	case String.Kind, Struct.Kind:
 		return &Field{
@@ -114,12 +115,17 @@ func (k *KindDetails) ParquetAnnotation(colName string) (*Field, error) {
 			}.String(),
 		}, nil
 	case TimestampNTZ.Kind, TimestampTZ.Kind:
+		adjustedForUTC := true
+		if location != nil {
+			adjustedForUTC = false
+		}
+
 		return &Field{
 			Tag: FieldTag{
 				Name:             colName,
 				Type:             ToPtr(parquet.Type_INT64.String()),
 				LogicalType:      ToPtr("TIMESTAMP"),
-				IsAdjustedForUTC: ToPtr(true),
+				IsAdjustedForUTC: ToPtr(adjustedForUTC),
 				Unit:             ToPtr("MILLIS"),
 			}.String(),
 		}, nil


### PR DESCRIPTION
This PR adds the ability to specify a location in Parquet.

By doing this, we'll convert the incoming data to be in the specified location.