### PR TITLE
Moving `DropTable` to the `Baseline` interface

### DIFF
--- a/clients/iceberg/table.go
+++ b/clients/iceberg/table.go
@@ -99,7 +99,7 @@ func (s Store) AlterTableDropColumns(ctx context.Context, tableID sql.TableIdent
 	return nil
 }
 
-func (s Store) DeleteTable(ctx context.Context, tableID sql.TableIdentifier) error {
+func (s Store) DropTable(ctx context.Context, tableID sql.TableIdentifier) error {
 	castedTableID, ok := tableID.(dialect.TableIdentifier)
 	if !ok {
 		return fmt.Errorf("failed to cast table ID to dialect.TableIdentifier")

--- a/clients/s3/s3.go
+++ b/clients/s3/s3.go
@@ -149,6 +149,10 @@ func (s *Store) IsRetryableError(_ error) bool {
 	return false // not supported for S3
 }
 
+func (s *Store) DropTable(ctx context.Context, tableID sql.TableIdentifier) error {
+	return fmt.Errorf("not supported for S3")
+}
+
 func LoadStore(ctx context.Context, cfg config.Config) (*Store, error) {
 	creds := credentials.NewStaticCredentialsProvider(cfg.S3.AwsAccessKeyID, cfg.S3.AwsSecretAccessKey, "")
 	awsConfig, err := awsCfg.LoadDefaultConfig(ctx, awsCfg.WithCredentialsProvider(creds), awsCfg.WithRegion(cfg.S3.AwsRegion))

--- a/integration_tests/shared/framework.go
+++ b/integration_tests/shared/framework.go
@@ -154,7 +154,7 @@ func (tf *TestFramework) VerifyDataContent(rowCount int) error {
 func (tf *TestFramework) Cleanup(tableID sql.TableIdentifier) error {
 	dropTableID := tableID.WithDisableDropProtection(true)
 	if tf.iceberg != nil {
-		return tf.iceberg.DeleteTable(tf.ctx, dropTableID)
+		return tf.iceberg.DropTable(tf.ctx, dropTableID)
 	}
 
 	return tf.dest.DropTable(tf.ctx, dropTableID)

--- a/lib/destination/destination.go
+++ b/lib/destination/destination.go
@@ -27,10 +27,6 @@ type Destination interface {
 	// Helper functions for merge
 	GetTableConfig(tableID sqllib.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error)
 	PrepareTemporaryTable(ctx context.Context, tableData *optimization.TableData, tableConfig *types.DestinationTableConfig, tempTableID sqllib.TableIdentifier, parentTableID sqllib.TableIdentifier, additionalSettings types.AdditionalSettings, createTempTable bool) error
-
-	// Helper function for multi-step merge
-	// This is only available to Snowflake for now.
-	DropTable(ctx context.Context, tableID sqllib.TableIdentifier) error
 }
 
 type Baseline interface {
@@ -38,6 +34,7 @@ type Baseline interface {
 	Append(ctx context.Context, tableData *optimization.TableData, useTempTable bool) error
 	IsRetryableError(err error) bool
 	IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchemaPair, table string) sqllib.TableIdentifier
+	DropTable(ctx context.Context, tableID sqllib.TableIdentifier) error
 }
 
 // ExecContextStatements executes one or more statements against a [Destination].


### PR DESCRIPTION
## Changes

Moving this from the `Destination` interface to the `Baseline` interface

To make this possible, I've also done the following:

* Stub out the S3 implementation
* Rename Iceberg's `DeleteTable` to `DropTable`