### PR TITLE
Adding the ability to Include Artie Operation column

### DIFF
--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -53,6 +53,7 @@ type TopicConfig struct {
 	SoftDelete               bool   `yaml:"softDelete"`
 	SkippedOperations        string `yaml:"skippedOperations,omitempty"`
 	IncludeArtieUpdatedAt    bool   `yaml:"includeArtieUpdatedAt"`
+	IncludeArtieOperation    bool   `yaml:"includeArtieOperation"`
 	IncludeDatabaseUpdatedAt bool   `yaml:"includeDatabaseUpdatedAt"`
 	// TODO: Deprecate BigQueryPartitionSettings and use AdditionalMergePredicates instead.
 	BigQueryPartitionSettings *partition.BigQuerySettings `yaml:"bigQueryPartitionSettings,omitempty"`

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -275,6 +275,10 @@ func (t *TableData) BuildColumnsToKeep() []string {
 		colsMap.Add(constants.OperationColumnMarker, true)
 	}
 
+	if t.TopicConfig().IncludeArtieOperation {
+		colsMap.Add(constants.OperationColumnMarker, true)
+	}
+
 	if t.TopicConfig().SoftDelete {
 		colsMap.Add(constants.DeleteColumnMarker, true)
 	}

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -304,6 +304,11 @@ func TestTableData_BuildColumnsToKeep(t *testing.T) {
 		assert.ElementsMatch(t, []string{constants.OperationColumnMarker}, td.BuildColumnsToKeep())
 	}
 	{
+		// If history mode and include artie operation are both true, we should only get the operation column once
+		td := TableData{mode: config.History, topicConfig: kafkalib.TopicConfig{IncludeArtieOperation: true}}
+		assert.ElementsMatch(t, []string{constants.OperationColumnMarker}, td.BuildColumnsToKeep())
+	}
+	{
 		// Soft delete is enabled
 		td := TableData{mode: config.Replication, topicConfig: kafkalib.TopicConfig{SoftDelete: true}}
 		assert.ElementsMatch(t, []string{constants.DeleteColumnMarker}, td.BuildColumnsToKeep())
@@ -312,5 +317,10 @@ func TestTableData_BuildColumnsToKeep(t *testing.T) {
 		// Artie + DB updated at are both true
 		td := TableData{mode: config.Replication, topicConfig: kafkalib.TopicConfig{IncludeArtieUpdatedAt: true, IncludeDatabaseUpdatedAt: true}}
 		assert.ElementsMatch(t, []string{constants.UpdateColumnMarker, constants.DatabaseUpdatedColumnMarker}, td.BuildColumnsToKeep())
+	}
+	{
+		// Include artie operation is true
+		td := TableData{mode: config.Replication, topicConfig: kafkalib.TopicConfig{IncludeArtieOperation: true}}
+		assert.ElementsMatch(t, []string{constants.OperationColumnMarker}, td.BuildColumnsToKeep())
 	}
 }

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -137,6 +137,11 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc kafkalib.TopicConfi
 	if err != nil {
 		return Event{}, err
 	}
+
+	if tc.IncludeArtieOperation {
+		evtData[constants.OperationColumnMarker] = event.Operation()
+	}
+
 	tblName := cmp.Or(tc.TableName, event.GetTableName())
 	if cfgMode == config.History {
 		if !strings.HasSuffix(tblName, constants.HistoryModeSuffix) {
@@ -145,6 +150,7 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc kafkalib.TopicConfi
 			slog.Warn(fmt.Sprintf("History mode is enabled, but table name does not have a %s suffix, so we're adding it...", constants.HistoryModeSuffix), slog.String("tblName", tblName))
 		}
 
+		// If this is already set, it's a no-op.
 		evtData[constants.OperationColumnMarker] = event.Operation()
 
 		// We don't need the deletion markers either.


### PR DESCRIPTION
With https://github.com/artie-labs/transfer/pull/1332, we now have an extensible way to filter Artie columns by configs.

This PR adds the ability to specify whether you want Artie to include the Artie operation column in your destination.