### PR TITLE
Include string precision into Redshift typing

### DIFF
--- a/clients/redshift/dialect/ddl.go
+++ b/clients/redshift/dialect/ddl.go
@@ -22,8 +22,8 @@ SELECT
     CASE
         WHEN c.data_type = 'numeric' THEN
             'numeric(' || COALESCE(CAST(c.numeric_precision AS VARCHAR), '') || ',' || COALESCE(CAST(c.numeric_scale AS VARCHAR), '') || ')'
-		WHEN c.data_type = 'character varying' THEN
-			'character varying(' || COALESCE(CAST(c.character_maximum_length AS VARCHAR), '') || ')'
+        WHEN c.data_type = 'character varying' THEN
+            'character varying(' || COALESCE(CAST(c.character_maximum_length AS VARCHAR), '') || ')'
         ELSE
             c.data_type
     END AS data_type,

--- a/clients/redshift/dialect/ddl.go
+++ b/clients/redshift/dialect/ddl.go
@@ -22,6 +22,8 @@ SELECT
     CASE
         WHEN c.data_type = 'numeric' THEN
             'numeric(' || COALESCE(CAST(c.numeric_precision AS VARCHAR), '') || ',' || COALESCE(CAST(c.numeric_scale AS VARCHAR), '') || ')'
+		WHEN c.data_type = 'character varying' THEN
+			'character varying(' || COALESCE(CAST(c.character_maximum_length AS VARCHAR), '') || ')'
         ELSE
             c.data_type
     END AS data_type,

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -60,7 +60,7 @@ func (RedshiftDialect) DataTypeForKind(kd typing.KindDetails, _ bool, _ config.S
 	return kd.Kind
 }
 
-func (RedshiftDialect) KindForDataType(rawType string, stringPrecision string) (typing.KindDetails, error) {
+func (RedshiftDialect) KindForDataType(rawType string, _ string) (typing.KindDetails, error) {
 	rawType = strings.ToLower(rawType)
 	if strings.HasPrefix(rawType, "numeric") {
 		_, parameters, err := sql.ParseDataTypeDefinition(rawType)
@@ -71,9 +71,14 @@ func (RedshiftDialect) KindForDataType(rawType string, stringPrecision string) (
 	}
 
 	if strings.Contains(rawType, "character varying") {
-		precision, err := strconv.ParseInt(stringPrecision, 10, 32)
+		_, parameters, err := sql.ParseDataTypeDefinition(rawType)
 		if err != nil {
-			return typing.Invalid, fmt.Errorf("failed to parse string precision: %q, err: %w", stringPrecision, err)
+			return typing.Invalid, err
+		}
+
+		precision, err := strconv.ParseInt(parameters[0], 10, 32)
+		if err != nil {
+			return typing.Invalid, fmt.Errorf("failed to parse string precision: %q, err: %w", parameters[0], err)
 		}
 
 		return typing.KindDetails{

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -76,6 +76,10 @@ func (RedshiftDialect) KindForDataType(rawType string, _ string) (typing.KindDet
 			return typing.Invalid, err
 		}
 
+		if len(parameters) != 1 {
+			return typing.Invalid, fmt.Errorf("expected 1 parameter for character varying, got %d, value: %q", len(parameters), rawType)
+		}
+
 		precision, err := strconv.ParseInt(parameters[0], 10, 32)
 		if err != nil {
 			return typing.Invalid, fmt.Errorf("failed to parse string precision: %q, err: %w", parameters[0], err)

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -61,6 +61,7 @@ func (RedshiftDialect) DataTypeForKind(kd typing.KindDetails, _ bool, _ config.S
 }
 
 func (RedshiftDialect) KindForDataType(rawType string, stringPrecision string) (typing.KindDetails, error) {
+	// TODO: Deprecate [stringPrecision] as arg
 	rawType = strings.ToLower(rawType)
 	if strings.HasPrefix(rawType, "numeric") {
 		_, parameters, err := sql.ParseDataTypeDefinition(rawType)

--- a/clients/redshift/dialect/typing_test.go
+++ b/clients/redshift/dialect/typing_test.go
@@ -126,7 +126,7 @@ func TestRedshiftDialect_KindForDataType(t *testing.T) {
 	}
 	{
 		// String with precision
-		kd, err := dialect.KindForDataType("character varying(65535)", "")
+		kd, err := dialect.KindForDataType("character varying(65535)", "65535")
 		assert.NoError(t, err)
 		assert.Equal(t, typing.KindDetails{Kind: typing.String.Kind, OptionalStringPrecision: typing.ToPtr(int32(65535))}, kd)
 	}

--- a/clients/redshift/dialect/typing_test.go
+++ b/clients/redshift/dialect/typing_test.go
@@ -126,7 +126,7 @@ func TestRedshiftDialect_KindForDataType(t *testing.T) {
 	}
 	{
 		// String with precision
-		kd, err := dialect.KindForDataType("character varying", "65535")
+		kd, err := dialect.KindForDataType("character varying(65535)", "")
 		assert.NoError(t, err)
 		assert.Equal(t, typing.KindDetails{Kind: typing.String.Kind, OptionalStringPrecision: typing.ToPtr(int32(65535))}, kd)
 	}


### PR DESCRIPTION
Right now, we have a special handling on string precision for Redshift and MSSQL where it's being retrieved from a separate column.

This adds a weird bloat to the dialect's `KindForDataType` signature and also makes it so that we are unable to use this translation logic in the rest of our services.