### PR TITLE
Refactoring Redshift to not use the string precision argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,3 +96,7 @@ test-parquet: parquet-venv
 	@cd integration_tests/parquet && go run main.go
 	@echo "Running parquet verification (Python)..."
 	@cd integration_tests/parquet && venv/bin/python verify_parquet.py --file-path output/test.parquet
+
+.PHONY: dest-itest-types
+dest-itest-types:
+	go run integration_tests/destination_types/main.go --config .personal/integration_tests/redshift.yaml

--- a/clients/redshift/dialect/ddl.go
+++ b/clients/redshift/dialect/ddl.go
@@ -20,10 +20,10 @@ func (RedshiftDialect) BuildDescribeTableQuery(tableID sql.TableIdentifier) (str
 SELECT
     c.column_name,
     CASE
-        WHEN c.data_type = 'numeric' THEN
-            'numeric(' || COALESCE(CAST(c.numeric_precision AS VARCHAR), '') || ',' || COALESCE(CAST(c.numeric_scale AS VARCHAR), '') || ')'
-        WHEN c.data_type = 'character varying' THEN
-            'character varying(' || COALESCE(CAST(c.character_maximum_length AS VARCHAR), '') || ')'
+        WHEN c.data_type IN ('numeric') THEN
+            c.data_type + '(' + CAST(c.numeric_precision AS VARCHAR) + ',' + CAST(c.numeric_scale AS VARCHAR) + ')'
+        WHEN c.data_type IN ('character varying') THEN
+            c.data_type + '(' + CAST(c.character_maximum_length AS VARCHAR) + ')'
         ELSE
             c.data_type
     END AS data_type,

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -68,6 +68,7 @@ func (RedshiftDialect) KindForDataType(rawType string, _ string) (typing.KindDet
 
 	switch dataType {
 	case "numeric":
+		fmt.Println("parameters", parameters)
 		return typing.ParseNumeric(parameters)
 	case "character varying":
 		if len(parameters) != 1 {

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -68,7 +68,6 @@ func (RedshiftDialect) KindForDataType(rawType string, _ string) (typing.KindDet
 
 	switch dataType {
 	case "numeric":
-		fmt.Println("parameters", parameters)
 		return typing.ParseNumeric(parameters)
 	case "character varying":
 		if len(parameters) != 1 {

--- a/integration_tests/destination_types/main.go
+++ b/integration_tests/destination_types/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/artie-labs/transfer/lib/config"
+	"github.com/artie-labs/transfer/lib/destination"
+	"github.com/artie-labs/transfer/lib/destination/utils"
+	"github.com/artie-labs/transfer/lib/logger"
+)
+
+type DestinationTypes struct {
+	destination destination.Destination
+}
+
+func (d DestinationTypes) Run() error {
+	return nil
+}
+
+func main() {
+	ctx := context.Background()
+	settings, err := config.LoadSettings(os.Args, true)
+	if err != nil {
+		logger.Fatal("Failed to load settings", slog.Any("err", err))
+	}
+
+	dest, err := utils.LoadDestination(ctx, settings.Config, nil)
+	if err != nil {
+		logger.Fatal("Failed to load destination", slog.Any("err", err))
+	}
+
+	destinationTypes := DestinationTypes{destination: dest}
+
+	if err := destinationTypes.Run(); err != nil {
+		logger.Fatal("Failed to run destination types", slog.Any("err", err))
+	}
+}

--- a/integration_tests/destination_types/main.go
+++ b/integration_tests/destination_types/main.go
@@ -49,6 +49,8 @@ func (d DestinationTypes) Run(ctx context.Context) error {
 		if err := shared.RedshiftAssertColumns(ctx, d.destination, d.tableID); err != nil {
 			return fmt.Errorf("failed to assert columns: %w", err)
 		}
+
+		return nil
 	}
 
 	return fmt.Errorf("unsupported destination dialect: %T", d.destination.Dialect())
@@ -83,4 +85,6 @@ func main() {
 	if err := destinationTypes.Run(ctx); err != nil {
 		logger.Fatal("Failed to run destination types", slog.Any("err", err))
 	}
+
+	slog.Info(fmt.Sprintf("✌️ ✌️ ✌️ Destination types test completed successfully for: %T", dest.Dialect()))
 }

--- a/integration_tests/shared/destination_types.go
+++ b/integration_tests/shared/destination_types.go
@@ -1,0 +1,163 @@
+package shared
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/artie-labs/transfer/lib/destination"
+	"github.com/artie-labs/transfer/lib/maputil"
+	"github.com/artie-labs/transfer/lib/sql"
+	"github.com/artie-labs/transfer/lib/typing"
+	"github.com/artie-labs/transfer/lib/typing/columns"
+)
+
+func RedshiftCreateTable(ctx context.Context, dest destination.Destination, tableID sql.TableIdentifier) error {
+	query := dest.Dialect().BuildCreateTableQuery(tableID, false, []string{
+		"c_int2", "INT2",
+		"c_int4", "INT4",
+		"c_int8", "INT8",
+		"c_varchar_max", "VARCHAR(MAX)",
+		"c_varchar_12345", "VARCHAR(12345)",
+		"c_boolean", "BOOLEAN NULL",
+		"c_date", "DATE",
+		"c_time", "TIME",
+		"c_timestamp_ntz", "TIMESTAMP WITHOUT TIME ZONE",
+		"c_timestamp_tz", "TIMESTAMP WITH TIME ZONE",
+		"c_decimal_10_2", "DECIMAL(10, 2)",
+		"c_super", "SUPER",
+	})
+
+	_, err := dest.ExecContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to create table: %w", err)
+	}
+
+	return nil
+}
+
+func RedshiftAssertColumns(ctx context.Context, dest destination.Destination, tableID sql.TableIdentifier) error {
+	query, args, err := dest.Dialect().BuildDescribeTableQuery(tableID)
+	if err != nil {
+		return fmt.Errorf("failed to build describe table query: %w", err)
+	}
+
+	sqlRows, err := dest.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to query columns: %w", err)
+	}
+
+	rows, err := sql.RowsToObjects(sqlRows)
+	if err != nil {
+		return fmt.Errorf("failed to convert rows to map slice: %w", err)
+	}
+
+	var foundCols []columns.Column
+	for _, row := range rows {
+		columnName, err := maputil.GetTypeFromMap[string](row, "column_name")
+		if err != nil {
+			return fmt.Errorf("failed to get column name: %w", err)
+		}
+
+		columnType, err := maputil.GetTypeFromMap[string](row, "data_type")
+		if err != nil {
+			return fmt.Errorf("failed to get column type: %w", err)
+		}
+
+		kd, err := dest.Dialect().KindForDataType(columnType, "")
+		if err != nil {
+			return fmt.Errorf("failed to get kind for data type: %w", err)
+		}
+
+		foundCols = append(foundCols, columns.NewColumn(columnName, kd))
+	}
+
+	if len(foundCols) != 12 {
+		return fmt.Errorf("expected 12 columns, got %d", len(foundCols))
+	}
+
+	for _, col := range foundCols {
+		switch col.Name() {
+		case "c_int2":
+			if err := assertEqual(col.KindDetails.Kind, typing.Integer.Kind); err != nil {
+				return err
+			}
+			if err := assertEqual(col.KindDetails.OptionalIntegerKind, typing.ToPtr(typing.SmallIntegerKind)); err != nil {
+				return err
+			}
+		case "c_int4":
+			if err := assertEqual(col.KindDetails.Kind, typing.Integer.Kind); err != nil {
+				return err
+			}
+			if err := assertEqual(col.KindDetails.OptionalIntegerKind, typing.ToPtr(typing.IntegerKind)); err != nil {
+				return err
+			}
+		case "c_int8":
+			if err := assertEqual(col.KindDetails.Kind, typing.Integer.Kind); err != nil {
+				return err
+			}
+			if err := assertEqual(col.KindDetails.OptionalIntegerKind, typing.ToPtr(typing.BigIntegerKind)); err != nil {
+				return err
+			}
+		case "c_varchar_max":
+			if err := assertEqual(col.KindDetails.Kind, typing.String.Kind); err != nil {
+				return err
+			}
+			if err := assertEqual(col.KindDetails.OptionalStringPrecision, nil); err != nil {
+				return err
+			}
+		case "c_varchar_12345":
+			if err := assertEqual(col.KindDetails.Kind, typing.String.Kind); err != nil {
+				return err
+			}
+			if err := assertEqual(col.KindDetails.OptionalStringPrecision, typing.ToPtr(int32(12345))); err != nil {
+				return err
+			}
+		case "c_boolean":
+			if err := assertEqual(col.KindDetails.Kind, typing.Boolean.Kind); err != nil {
+				return err
+			}
+		case "c_date":
+			if err := assertEqual(col.KindDetails.Kind, typing.Date.Kind); err != nil {
+				return err
+			}
+		case "c_time":
+			if err := assertEqual(col.KindDetails.Kind, typing.Time.Kind); err != nil {
+				return err
+			}
+		case "c_timestamp_ntz":
+			if err := assertEqual(col.KindDetails.Kind, typing.TimestampNTZ.Kind); err != nil {
+				return err
+			}
+		case "c_timestamp_tz":
+			if err := assertEqual(col.KindDetails.Kind, typing.TimestampTZ.Kind); err != nil {
+				return err
+			}
+		case "c_decimal_10_2":
+			if err := assertEqual(col.KindDetails.Kind, typing.EDecimal.Kind); err != nil {
+				return err
+			}
+
+			if err := assertEqual(col.KindDetails.ExtendedDecimalDetails.Precision, 10); err != nil {
+				return err
+			}
+
+			if err := assertEqual(col.KindDetails.ExtendedDecimalDetails.Scale, 2); err != nil {
+				return err
+			}
+		case "c_super":
+			if err := assertEqual(col.KindDetails.Kind, typing.Struct.Kind); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unexpected column: %q", col.Name())
+		}
+	}
+}
+
+func assertEqual(actual, expected any) error {
+	if actual != expected {
+		return fmt.Errorf("expected %v, got %v", expected, actual)
+	}
+
+	return nil
+}

--- a/integration_tests/shared/destination_types.go
+++ b/integration_tests/shared/destination_types.go
@@ -13,18 +13,18 @@ import (
 
 func RedshiftCreateTable(ctx context.Context, dest destination.Destination, tableID sql.TableIdentifier) error {
 	query := dest.Dialect().BuildCreateTableQuery(tableID, false, []string{
-		"c_int2", "INT2",
-		"c_int4", "INT4",
-		"c_int8", "INT8",
-		"c_varchar_max", "VARCHAR(MAX)",
-		"c_varchar_12345", "VARCHAR(12345)",
-		"c_boolean", "BOOLEAN NULL",
-		"c_date", "DATE",
-		"c_time", "TIME",
-		"c_timestamp_ntz", "TIMESTAMP WITHOUT TIME ZONE",
-		"c_timestamp_tz", "TIMESTAMP WITH TIME ZONE",
-		"c_decimal_10_2", "DECIMAL(10, 2)",
-		"c_super", "SUPER",
+		"c_int2 INT2",
+		"c_int4 INT4",
+		"c_int8 INT8",
+		"c_varchar_max VARCHAR(MAX)",
+		"c_varchar_12345 VARCHAR(12345)",
+		"c_boolean BOOLEAN NULL",
+		"c_date DATE",
+		"c_time TIME",
+		"c_timestamp_ntz TIMESTAMP WITHOUT TIME ZONE",
+		"c_timestamp_tz TIMESTAMP WITH TIME ZONE",
+		"c_decimal_10_2 DECIMAL(10, 2)",
+		"c_super SUPER",
 	})
 
 	_, err := dest.ExecContext(ctx, query)
@@ -78,85 +78,87 @@ func RedshiftAssertColumns(ctx context.Context, dest destination.Destination, ta
 	for _, col := range foundCols {
 		switch col.Name() {
 		case "c_int2":
-			if err := assertEqual(col.KindDetails.Kind, typing.Integer.Kind); err != nil {
+			if err := assertEqual("c_int2", col.KindDetails.Kind, typing.Integer.Kind); err != nil {
 				return err
 			}
-			if err := assertEqual(col.KindDetails.OptionalIntegerKind, typing.ToPtr(typing.SmallIntegerKind)); err != nil {
+			if err := assertEqual("c_int2", *col.KindDetails.OptionalIntegerKind, typing.SmallIntegerKind); err != nil {
 				return err
 			}
 		case "c_int4":
-			if err := assertEqual(col.KindDetails.Kind, typing.Integer.Kind); err != nil {
+			if err := assertEqual("c_int4", col.KindDetails.Kind, typing.Integer.Kind); err != nil {
 				return err
 			}
-			if err := assertEqual(col.KindDetails.OptionalIntegerKind, typing.ToPtr(typing.IntegerKind)); err != nil {
+			if err := assertEqual("c_int4", *col.KindDetails.OptionalIntegerKind, typing.IntegerKind); err != nil {
 				return err
 			}
 		case "c_int8":
-			if err := assertEqual(col.KindDetails.Kind, typing.Integer.Kind); err != nil {
+			if err := assertEqual("c_int8", col.KindDetails.Kind, typing.Integer.Kind); err != nil {
 				return err
 			}
-			if err := assertEqual(col.KindDetails.OptionalIntegerKind, typing.ToPtr(typing.BigIntegerKind)); err != nil {
+			if err := assertEqual("c_int8", *col.KindDetails.OptionalIntegerKind, typing.BigIntegerKind); err != nil {
 				return err
 			}
 		case "c_varchar_max":
-			if err := assertEqual(col.KindDetails.Kind, typing.String.Kind); err != nil {
+			if err := assertEqual("c_varchar_max", col.KindDetails.Kind, typing.String.Kind); err != nil {
 				return err
 			}
-			if err := assertEqual(col.KindDetails.OptionalStringPrecision, nil); err != nil {
+			if err := assertEqual("c_varchar_max", col.KindDetails.OptionalStringPrecision, nil); err != nil {
 				return err
 			}
 		case "c_varchar_12345":
-			if err := assertEqual(col.KindDetails.Kind, typing.String.Kind); err != nil {
+			if err := assertEqual("c_varchar_12345", col.KindDetails.Kind, typing.String.Kind); err != nil {
 				return err
 			}
-			if err := assertEqual(col.KindDetails.OptionalStringPrecision, typing.ToPtr(int32(12345))); err != nil {
+			if err := assertEqual("c_varchar_12345", *col.KindDetails.OptionalStringPrecision, int32(12345)); err != nil {
 				return err
 			}
 		case "c_boolean":
-			if err := assertEqual(col.KindDetails.Kind, typing.Boolean.Kind); err != nil {
+			if err := assertEqual("c_boolean", col.KindDetails.Kind, typing.Boolean.Kind); err != nil {
 				return err
 			}
 		case "c_date":
-			if err := assertEqual(col.KindDetails.Kind, typing.Date.Kind); err != nil {
+			if err := assertEqual("c_date", col.KindDetails.Kind, typing.Date.Kind); err != nil {
 				return err
 			}
 		case "c_time":
-			if err := assertEqual(col.KindDetails.Kind, typing.Time.Kind); err != nil {
+			if err := assertEqual("c_time", col.KindDetails.Kind, typing.Time.Kind); err != nil {
 				return err
 			}
 		case "c_timestamp_ntz":
-			if err := assertEqual(col.KindDetails.Kind, typing.TimestampNTZ.Kind); err != nil {
+			if err := assertEqual("c_timestamp_ntz", col.KindDetails.Kind, typing.TimestampNTZ.Kind); err != nil {
 				return err
 			}
 		case "c_timestamp_tz":
-			if err := assertEqual(col.KindDetails.Kind, typing.TimestampTZ.Kind); err != nil {
+			if err := assertEqual("c_timestamp_tz", col.KindDetails.Kind, typing.TimestampTZ.Kind); err != nil {
 				return err
 			}
 		case "c_decimal_10_2":
-			if err := assertEqual(col.KindDetails.Kind, typing.EDecimal.Kind); err != nil {
+			if err := assertEqual("c_decimal_10_2", col.KindDetails.Kind, typing.EDecimal.Kind); err != nil {
 				return err
 			}
 
-			if err := assertEqual(col.KindDetails.ExtendedDecimalDetails.Precision, 10); err != nil {
+			if err := assertEqual("c_decimal_10_2", col.KindDetails.ExtendedDecimalDetails.Precision, 10); err != nil {
 				return err
 			}
 
-			if err := assertEqual(col.KindDetails.ExtendedDecimalDetails.Scale, 2); err != nil {
+			if err := assertEqual("c_decimal_10_2", col.KindDetails.ExtendedDecimalDetails.Scale, 2); err != nil {
 				return err
 			}
 		case "c_super":
-			if err := assertEqual(col.KindDetails.Kind, typing.Struct.Kind); err != nil {
+			if err := assertEqual("c_super", col.KindDetails.Kind, typing.Struct.Kind); err != nil {
 				return err
 			}
 		default:
 			return fmt.Errorf("unexpected column: %q", col.Name())
 		}
 	}
+
+	return nil
 }
 
-func assertEqual(actual, expected any) error {
+func assertEqual(label string, actual, expected any) error {
 	if actual != expected {
-		return fmt.Errorf("expected %v, got %v", expected, actual)
+		return fmt.Errorf("%q: expected %v, got %v", label, expected, actual)
 	}
 
 	return nil

--- a/integration_tests/shared/destination_types.go
+++ b/integration_tests/shared/destination_types.go
@@ -102,7 +102,7 @@ func RedshiftAssertColumns(ctx context.Context, dest destination.Destination, ta
 			if err := assertEqual("c_varchar_max", col.KindDetails.Kind, typing.String.Kind); err != nil {
 				return err
 			}
-			if err := assertEqual("c_varchar_max", col.KindDetails.OptionalStringPrecision, nil); err != nil {
+			if err := assertEqual("c_varchar_max", *col.KindDetails.OptionalStringPrecision, int32(65535)); err != nil {
 				return err
 			}
 		case "c_varchar_12345":
@@ -137,11 +137,12 @@ func RedshiftAssertColumns(ctx context.Context, dest destination.Destination, ta
 				return err
 			}
 
-			if err := assertEqual("c_decimal_10_2", col.KindDetails.ExtendedDecimalDetails.Precision, 10); err != nil {
+			fmt.Println("col.KindDetails.ExtendedDecimalDetails.Precision", fmt.Sprintf("%d", col.KindDetails.ExtendedDecimalDetails.Precision))
+			if err := assertEqual("c_decimal_10_2", col.KindDetails.ExtendedDecimalDetails.Precision, int32(10)); err != nil {
 				return err
 			}
 
-			if err := assertEqual("c_decimal_10_2", col.KindDetails.ExtendedDecimalDetails.Scale, 2); err != nil {
+			if err := assertEqual("c_decimal_10_2", col.KindDetails.ExtendedDecimalDetails.Scale, int32(2)); err != nil {
 				return err
 			}
 		case "c_super":

--- a/integration_tests/shared/destination_types.go
+++ b/integration_tests/shared/destination_types.go
@@ -137,12 +137,11 @@ func RedshiftAssertColumns(ctx context.Context, dest destination.Destination, ta
 				return err
 			}
 
-			fmt.Println("col.KindDetails.ExtendedDecimalDetails.Precision", fmt.Sprintf("%d", col.KindDetails.ExtendedDecimalDetails.Precision))
-			if err := assertEqual("c_decimal_10_2", col.KindDetails.ExtendedDecimalDetails.Precision, int32(10)); err != nil {
+			if err := assertEqual("c_decimal_10_2", int(col.KindDetails.ExtendedDecimalDetails.Precision()), 10); err != nil {
 				return err
 			}
 
-			if err := assertEqual("c_decimal_10_2", col.KindDetails.ExtendedDecimalDetails.Scale, int32(2)); err != nil {
+			if err := assertEqual("c_decimal_10_2", int(col.KindDetails.ExtendedDecimalDetails.Scale()), 2); err != nil {
 				return err
 			}
 		case "c_super":


### PR DESCRIPTION
We have been relying on a hybrid approach to retrieve the string precision for some time now. This PR fully deprecates the old method and I've also added an integration test to make sure the transition is safe.