### PR TITLE
Adding UnsupportedDataTypeError

### DIFF
--- a/clients/mssql/dialect/typing.go
+++ b/clients/mssql/dialect/typing.go
@@ -110,6 +110,6 @@ func (MSSQLDialect) KindForDataType(rawType string, stringPrecision string) (typ
 	case "text":
 		return typing.String, nil
 	default:
-		return typing.Invalid, fmt.Errorf("unsupported data type: %q", rawType)
+		return typing.Invalid, typing.NewUnsupportedDataTypeError(fmt.Sprintf("unsupported data type: %q", rawType))
 	}
 }

--- a/clients/mssql/dialect/typing_test.go
+++ b/clients/mssql/dialect/typing_test.go
@@ -39,6 +39,11 @@ func TestMSSQLDialect_DataTypeForKind(t *testing.T) {
 
 func TestMSSQLDialect_KindForDataType(t *testing.T) {
 	dialect := MSSQLDialect{}
+	{
+		// Invalid
+		_, err := dialect.KindForDataType("invalid")
+		assert.True(t, typing.IsUnsupportedDataTypeError(err))
+	}
 
 	colToExpectedKind := map[string]typing.KindDetails{
 		"smallint":       typing.Integer,

--- a/clients/mssql/dialect/typing_test.go
+++ b/clients/mssql/dialect/typing_test.go
@@ -83,4 +83,9 @@ func TestMSSQLDialect_KindForDataType(t *testing.T) {
 		assert.Equal(t, typing.String.Kind, kd.Kind)
 		assert.Equal(t, int32(5), *kd.OptionalStringPrecision)
 	}
+	{
+		// Invalid
+		_, err := dialect.KindForDataType("invalid", "5")
+		assert.True(t, typing.IsUnsupportedDataTypeError(err))
+	}
 }

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -115,6 +115,6 @@ func (RedshiftDialect) KindForDataType(rawType string, _ string) (typing.KindDet
 	case "boolean":
 		return typing.Boolean, nil
 	default:
-		return typing.Invalid, fmt.Errorf("unsupported data type: %q", rawType)
+		return typing.Invalid, typing.NewUnsupportedDataTypeError(fmt.Sprintf("unsupported data type: %q", rawType))
 	}
 }

--- a/clients/redshift/dialect/typing_test.go
+++ b/clients/redshift/dialect/typing_test.go
@@ -61,7 +61,7 @@ func TestRedshiftDialect_KindForDataType(t *testing.T) {
 	dialect := RedshiftDialect{}
 	{
 		// Invalid
-		_, err := dialect.KindForDataType("invalid", "")
+		_, err := dialect.KindForDataType("invalid")
 		assert.True(t, typing.IsUnsupportedDataTypeError(err))
 	}
 	{

--- a/clients/redshift/dialect/typing_test.go
+++ b/clients/redshift/dialect/typing_test.go
@@ -95,13 +95,13 @@ func TestRedshiftDialect_KindForDataType(t *testing.T) {
 	}
 	{
 		// Double
-		{
-			kd, err := dialect.KindForDataType("double precision")
-			assert.NoError(t, err)
-			assert.Equal(t, typing.Float, kd)
+		doubleTypeMap := map[string]typing.KindDetails{
+			"double precision": typing.Float,
+			"DOUBLE precision": typing.Float,
 		}
-		{
-			kd, err := dialect.KindForDataType("DOUBLE precision")
+
+		for rawType, expectedKind := range doubleTypeMap {
+			kd, err := dialect.KindForDataType(rawType)
 			assert.NoError(t, err)
 			assert.Equal(t, expectedKind, kd)
 		}

--- a/clients/redshift/dialect/typing_test.go
+++ b/clients/redshift/dialect/typing_test.go
@@ -60,6 +60,11 @@ func TestRedshiftDialect_DataTypeForKind(t *testing.T) {
 func TestRedshiftDialect_KindForDataType(t *testing.T) {
 	dialect := RedshiftDialect{}
 	{
+		// Invalid
+		_, err := dialect.KindForDataType("invalid", "")
+		assert.True(t, typing.IsUnsupportedDataTypeError(err))
+	}
+	{
 		// Integers
 		{
 			// Small integer

--- a/clients/redshift/dialect/typing_test.go
+++ b/clients/redshift/dialect/typing_test.go
@@ -95,15 +95,15 @@ func TestRedshiftDialect_KindForDataType(t *testing.T) {
 	}
 	{
 		// Double
-		{
-			kd, err := dialect.KindForDataType("double precision", "")
-			assert.NoError(t, err)
-			assert.Equal(t, typing.Float, kd)
+		doubleTypeMap := map[string]typing.KindDetails{
+			"double precision": typing.Float,
+			"DOUBLE precision": typing.Float,
 		}
-		{
-			kd, err := dialect.KindForDataType("DOUBLE precision", "")
+
+		for rawType, expectedKind := range doubleTypeMap {
+			kd, err := dialect.KindForDataType(rawType, "")
 			assert.NoError(t, err)
-			assert.Equal(t, typing.Float, kd)
+			assert.Equal(t, expectedKind, kd)
 		}
 	}
 	{

--- a/lib/typing/errors.go
+++ b/lib/typing/errors.go
@@ -1,0 +1,19 @@
+package typing
+
+import "errors"
+
+type UnsupportedDataTypeError struct {
+	message string
+}
+
+func NewUnsupportedDataTypeError(message string) UnsupportedDataTypeError {
+	return UnsupportedDataTypeError{message: message}
+}
+
+func (u UnsupportedDataTypeError) Error() string {
+	return u.message
+}
+
+func IsUnsupportedDataTypeError(err error) bool {
+	return errors.As(err, &UnsupportedDataTypeError{})
+}

--- a/lib/typing/errors_test.go
+++ b/lib/typing/errors_test.go
@@ -1,0 +1,18 @@
+package typing
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsupportedDataTypeError(t *testing.T) {
+	assert.True(t, IsUnsupportedDataTypeError(NewUnsupportedDataTypeError("foo")))
+
+	// Not relevant
+	assert.False(t, IsUnsupportedDataTypeError(fmt.Errorf("foo")))
+
+	// Nil
+	assert.False(t, IsUnsupportedDataTypeError(nil))
+}


### PR DESCRIPTION
So we can start having better error detection for libraries that are dependent on Transfer's typing, starting with MSSQL and Redshift.