### PR TITLE
Adding merge assertion checks

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -265,7 +265,11 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, primary
 
 	defer func() { _ = ddl.DropTemporaryTable(ctx, s, stagingTableID, false) }()
 
-	return destination.ExecContextStatements(ctx, s, dedupeQueries)
+	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
+		return fmt.Errorf("failed to dedupe: %w", err)
+	}
+
+	return nil
 }
 
 func (s *Store) SweepTemporaryTables(_ context.Context) error {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -120,7 +120,12 @@ func (s *Store) SweepTemporaryTables(ctx context.Context) error {
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool) error {
 	stagingTableID := shared.TempTableID(tableID)
 	dedupeQueries := s.Dialect().BuildDedupeQueries(tableID, stagingTableID, primaryKeys, includeArtieUpdatedAt)
-	return destination.ExecContextStatements(ctx, s, dedupeQueries)
+
+	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
+		return fmt.Errorf("failed to dedupe: %w", err)
+	}
+
+	return nil
 }
 
 func LoadRedshift(ctx context.Context, cfg config.Config, _store *db.Store) (*Store, error) {

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -163,6 +163,7 @@ func Merge(ctx context.Context, dest destination.Destination, tableData *optimiz
 		totalRowsAffected += rowsAffected
 	}
 
+	// [totalRowsAffected] may be higher if the table contains duplicate rows.
 	if rows := tableData.NumberOfRows(); rows > uint(totalRowsAffected) {
 		return fmt.Errorf("expected %d rows to be affected, got %d", rows, totalRowsAffected)
 	}

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -148,8 +148,9 @@ func Merge(ctx context.Context, dest destination.Destination, tableData *optimiz
 		return fmt.Errorf("failed to generate merge statements: %w", err)
 	}
 
-	if err = destination.ExecContextStatements(ctx, dest, mergeStatements); err != nil {
+	if _, err = destination.ExecContextStatements(ctx, dest, mergeStatements); err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)
 	}
+
 	return nil
 }

--- a/clients/shared/multi_step_merge.go
+++ b/clients/shared/multi_step_merge.go
@@ -199,7 +199,7 @@ func merge(ctx context.Context, dwh destination.Destination, tableData *optimiza
 		mergeStatements = _mergeStatements
 	}
 
-	if err := destination.ExecContextStatements(ctx, dwh, mergeStatements); err != nil {
+	if _, err := destination.ExecContextStatements(ctx, dwh, mergeStatements); err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)
 	}
 

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -89,7 +89,12 @@ func (s *Store) GetConfigMap() *types.DestinationTableConfigMap {
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool) error {
 	stagingTableID := shared.TempTableID(tableID)
 	dedupeQueries := s.Dialect().BuildDedupeQueries(tableID, stagingTableID, primaryKeys, includeArtieUpdatedAt)
-	return destination.ExecContextStatements(ctx, s, dedupeQueries)
+
+	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
+		return fmt.Errorf("failed to dedupe: %w", err)
+	}
+
+	return nil
 }
 
 func LoadSnowflake(ctx context.Context, cfg config.Config, _store *db.Store) (*Store, error) {

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -119,7 +119,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 
 	// Set up expectations for MERGE - use regex pattern to match the actual table name with suffix
 	mergeQueryRegex := regexp.QuoteMeta(`MERGE INTO "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
-	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
+	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, int64(len(rowsData))))
 
 	// Set up expectations for DROP TABLE - use regex pattern to match the actual table name with suffix
 	dropQueryRegex := regexp.QuoteMeta(`DROP TABLE IF EXISTS "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
@@ -185,7 +185,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 
 	// Set up expectations for MERGE - use regex pattern to match the actual table name with suffix
 	mergeQueryRegex := regexp.QuoteMeta(`MERGE INTO "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
-	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
+	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, int64(len(rowsData))))
 
 	// Set up expectations for DROP TABLE - use regex pattern to match the actual table name with suffix
 	dropQueryRegex := regexp.QuoteMeta(`DROP TABLE IF EXISTS "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
@@ -248,7 +248,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 
 	// Set up expectations for MERGE - use regex pattern to match the actual table name with suffix
 	mergeQueryRegex := regexp.QuoteMeta(`MERGE INTO "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
-	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
+	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, int64(len(rowsData))))
 
 	// Set up expectations for DROP TABLE - use regex pattern to match the actual table name with suffix
 	dropQueryRegex := regexp.QuoteMeta(`DROP TABLE IF EXISTS "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
@@ -328,7 +328,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 	// Set up expectations for MERGE - use regex pattern to match the actual table name with suffix
 	mergeQueryRegex := regexp.QuoteMeta(`MERGE INTO "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
-	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
+	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, int64(len(rowsData))))
 
 	// Set up expectations for DROP TABLE - use regex pattern to match the actual table name with suffix
 	dropQueryRegex := regexp.QuoteMeta(`DROP TABLE IF EXISTS "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
@@ -370,7 +370,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	s.mockDB.ExpectQuery(copyQueryRegex2).WillReturnRows(sqlmock.NewRows([]string{"rows_loaded"}).AddRow(fmt.Sprintf("%d", tableData.NumberOfRows())))
 
 	// Set up expectations for MERGE - use regex pattern to match the actual table name with suffix
-	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
+	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, int64(len(rowsData))))
 
 	// Set up expectations for DROP TABLE - use regex pattern to match the actual table name with suffix
 	s.mockDB.ExpectExec(dropQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))


### PR DESCRIPTION
This is similar to the assertion checks we added to staging tables. With this, we'll have a higher guarantee that the rows were written to the target table via merge.