### PR TITLE
Move executing merge statements into the destination

### DIFF
--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/artie-labs/transfer/clients/shared"
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/kafkalib/partition"
 	"github.com/artie-labs/transfer/lib/optimization"
@@ -68,4 +69,28 @@ func generateMergeString(bqSettings *partition.BigQuerySettings, dialect sql.Dia
 	}
 
 	return "", fmt.Errorf("unexpected partitionType: %s and/or partitionBy: %s", bqSettings.PartitionType, bqSettings.PartitionBy)
+}
+
+func (s *Store) MergeAndAssertRows(ctx context.Context, tableData *optimization.TableData, statements []string) error {
+	results, err := destination.ExecContextStatements(ctx, s.Store, statements)
+	if err != nil {
+		return fmt.Errorf("failed to execute merge statements: %w", err)
+	}
+
+	var totalRowsAffected int64
+	for _, result := range results {
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+
+		totalRowsAffected += rowsAffected
+	}
+
+	// [totalRowsAffected] may be higher if the table contains duplicate rows.
+	if rows := tableData.NumberOfRows(); rows > uint(totalRowsAffected) {
+		return fmt.Errorf("expected %d rows to be affected, got %d", rows, totalRowsAffected)
+	}
+
+	return nil
 }

--- a/clients/bigquery/merge.go
+++ b/clients/bigquery/merge.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/artie-labs/transfer/clients/shared"
 	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/kafkalib/partition"
 	"github.com/artie-labs/transfer/lib/optimization"
@@ -72,7 +71,7 @@ func generateMergeString(bqSettings *partition.BigQuerySettings, dialect sql.Dia
 }
 
 func (s *Store) MergeAndAssertRows(ctx context.Context, tableData *optimization.TableData, statements []string) error {
-	results, err := destination.ExecContextStatements(ctx, s.Store, statements)
+	results, err := s.ExecContextStatements(ctx, statements)
 	if err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)
 	}

--- a/clients/databricks/store.go
+++ b/clients/databricks/store.go
@@ -52,7 +52,7 @@ func (s Store) Merge(ctx context.Context, tableData *optimization.TableData) (bo
 	return true, nil
 }
 
-func (s *Store) MergeAndAssertRows(ctx context.Context, tableData *optimization.TableData, statements []string) error {
+func (s Store) MergeAndAssertRows(ctx context.Context, tableData *optimization.TableData, statements []string) error {
 	results, err := s.ExecContextStatements(ctx, statements)
 	if err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/artie-labs/transfer/clients/shared"
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/db"
+	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
@@ -60,6 +61,30 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (b
 	}
 
 	return true, nil
+}
+
+func (s *Store) MergeAndAssertRows(ctx context.Context, tableData *optimization.TableData, statements []string) error {
+	results, err := destination.ExecContextStatements(ctx, s.Store, statements)
+	if err != nil {
+		return fmt.Errorf("failed to execute merge statements: %w", err)
+	}
+
+	var totalRowsAffected int64
+	for _, result := range results {
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+
+		totalRowsAffected += rowsAffected
+	}
+
+	// [totalRowsAffected] may be higher if the table contains duplicate rows.
+	if rows := tableData.NumberOfRows(); rows > uint(totalRowsAffected) {
+		return fmt.Errorf("expected %d rows to be affected, got %d", rows, totalRowsAffected)
+	}
+
+	return nil
 }
 
 func (s *Store) Append(ctx context.Context, tableData *optimization.TableData, _ bool) error {

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/artie-labs/transfer/clients/shared"
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/db"
-	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
@@ -64,7 +63,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (b
 }
 
 func (s *Store) MergeAndAssertRows(ctx context.Context, tableData *optimization.TableData, statements []string) error {
-	results, err := destination.ExecContextStatements(ctx, s.Store, statements)
+	results, err := s.ExecContextStatements(ctx, statements)
 	if err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)
 	}

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -77,7 +77,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (b
 }
 
 func (s *Store) MergeAndAssertRows(ctx context.Context, tableData *optimization.TableData, statements []string) error {
-	results, err := destination.ExecContextStatements(ctx, s.Store, statements)
+	results, err := s.ExecContextStatements(ctx, statements)
 	if err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)
 	}

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -148,25 +148,5 @@ func Merge(ctx context.Context, dest destination.Destination, tableData *optimiz
 		return fmt.Errorf("failed to generate merge statements: %w", err)
 	}
 
-	results, err := destination.ExecContextStatements(ctx, dest, mergeStatements)
-	if err != nil {
-		return fmt.Errorf("failed to execute merge statements: %w", err)
-	}
-
-	var totalRowsAffected int64
-	for _, result := range results {
-		rowsAffected, err := result.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("failed to get rows affected: %w", err)
-		}
-
-		totalRowsAffected += rowsAffected
-	}
-
-	// [totalRowsAffected] may be higher if the table contains duplicate rows.
-	if rows := tableData.NumberOfRows(); rows > uint(totalRowsAffected) {
-		return fmt.Errorf("expected %d rows to be affected, got %d", rows, totalRowsAffected)
-	}
-
-	return nil
+	return dest.MergeAndAssertRows(ctx, tableData, mergeStatements)
 }

--- a/clients/snowflake/writes.go
+++ b/clients/snowflake/writes.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/artie-labs/transfer/clients/shared"
 	"github.com/artie-labs/transfer/lib/config/constants"
-	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/sql"
@@ -46,7 +45,7 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (b
 }
 
 func (s *Store) MergeAndAssertRows(ctx context.Context, tableData *optimization.TableData, statements []string) error {
-	results, err := destination.ExecContextStatements(ctx, s.Store, statements)
+	results, err := s.ExecContextStatements(ctx, statements)
 	if err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)
 	}

--- a/clients/snowflake/writes.go
+++ b/clients/snowflake/writes.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/artie-labs/transfer/clients/shared"
 	"github.com/artie-labs/transfer/lib/config/constants"
+	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/sql"
@@ -42,4 +43,28 @@ func (s *Store) Merge(ctx context.Context, tableData *optimization.TableData) (b
 	}
 
 	return true, nil
+}
+
+func (s *Store) MergeAndAssertRows(ctx context.Context, tableData *optimization.TableData, statements []string) error {
+	results, err := destination.ExecContextStatements(ctx, s.Store, statements)
+	if err != nil {
+		return fmt.Errorf("failed to execute merge statements: %w", err)
+	}
+
+	var totalRowsAffected int64
+	for _, result := range results {
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected: %w", err)
+		}
+
+		totalRowsAffected += rowsAffected
+	}
+
+	// [totalRowsAffected] may be higher if the table contains duplicate rows.
+	if rows := tableData.NumberOfRows(); rows > uint(totalRowsAffected) {
+		return fmt.Errorf("expected %d rows to be affected, got %d", rows, totalRowsAffected)
+	}
+
+	return nil
 }

--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -22,6 +22,7 @@ type Store interface {
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 	Begin() (*sql.Tx, error)
 	IsRetryableError(err error) bool
+	ExecContextStatements(ctx context.Context, statements []string) ([]sql.Result, error)
 }
 
 type storeWrapper struct {

--- a/lib/db/statements.go
+++ b/lib/db/statements.go
@@ -1,0 +1,53 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+)
+
+func (s *storeWrapper) ExecContextStatements(ctx context.Context, statements []string) ([]sql.Result, error) {
+	switch len(statements) {
+	case 0:
+		return nil, fmt.Errorf("statements is empty")
+	case 1:
+		slog.Debug("Executing...", slog.String("query", statements[0]))
+		result, err := s.ExecContext(ctx, statements[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute statement: %w", err)
+		}
+
+		return []sql.Result{result}, nil
+	default:
+		tx, err := s.Begin()
+		if err != nil {
+			return nil, fmt.Errorf("failed to start tx: %w", err)
+		}
+		var committed bool
+		defer func() {
+			if !committed {
+				if rollbackErr := tx.Rollback(); rollbackErr != nil {
+					slog.Warn("Unable to rollback", slog.Any("err", rollbackErr))
+				}
+			}
+		}()
+
+		var results []sql.Result
+		for _, statement := range statements {
+			slog.Debug("Executing...", slog.String("query", statement))
+			result, err := tx.ExecContext(ctx, statement)
+			if err != nil {
+				return nil, fmt.Errorf("failed to execute statement: %q, err: %w", statement, err)
+			}
+
+			results = append(results, result)
+		}
+
+		if err = tx.Commit(); err != nil {
+			return nil, fmt.Errorf("failed to commit statements: %v, err: %w", statements, err)
+		}
+		committed = true
+		return results, nil
+	}
+}

--- a/lib/destination/destination.go
+++ b/lib/destination/destination.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/artie-labs/transfer/lib/db"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
@@ -41,7 +40,7 @@ type Baseline interface {
 
 // ExecContextStatements executes one or more statements against a [Destination].
 // If there is more than one statement, the statements will be executed inside of a transaction.
-func ExecContextStatements(ctx context.Context, store db.Store, statements []string) ([]sql.Result, error) {
+func ExecContextStatements(ctx context.Context, store Destination, statements []string) ([]sql.Result, error) {
 	switch len(statements) {
 	case 0:
 		return nil, fmt.Errorf("statements is empty")


### PR DESCRIPTION
This PR moves from having a centralized place execute merge statements and do row assertion checks to be on the destination itself.

This PR isn't adding any additional functionality other than to move where the logic is being executed.

Once this is merged, we can then layer in destination specific logic instead of relying only on `RowsAffected`