### PR TITLE
Revert "Adding merge assertion checks (#1351)"

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -265,11 +265,7 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, primary
 
 	defer func() { _ = ddl.DropTemporaryTable(ctx, s, stagingTableID, false) }()
 
-	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
-		return fmt.Errorf("failed to dedupe: %w", err)
-	}
-
-	return nil
+	return destination.ExecContextStatements(ctx, s, dedupeQueries)
 }
 
 func (s *Store) SweepTemporaryTables(_ context.Context) error {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -120,12 +120,7 @@ func (s *Store) SweepTemporaryTables(ctx context.Context) error {
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool) error {
 	stagingTableID := shared.TempTableID(tableID)
 	dedupeQueries := s.Dialect().BuildDedupeQueries(tableID, stagingTableID, primaryKeys, includeArtieUpdatedAt)
-
-	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
-		return fmt.Errorf("failed to dedupe: %w", err)
-	}
-
-	return nil
+	return destination.ExecContextStatements(ctx, s, dedupeQueries)
 }
 
 func LoadRedshift(ctx context.Context, cfg config.Config, _store *db.Store) (*Store, error) {

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -148,25 +148,8 @@ func Merge(ctx context.Context, dest destination.Destination, tableData *optimiz
 		return fmt.Errorf("failed to generate merge statements: %w", err)
 	}
 
-	results, err := destination.ExecContextStatements(ctx, dest, mergeStatements)
-	if err != nil {
+	if err = destination.ExecContextStatements(ctx, dest, mergeStatements); err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)
 	}
-
-	var totalRowsAffected int64
-	for _, result := range results {
-		rowsAffected, err := result.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("failed to get rows affected: %w", err)
-		}
-
-		totalRowsAffected += rowsAffected
-	}
-
-	// [totalRowsAffected] may be higher if the table contains duplicate rows.
-	if rows := tableData.NumberOfRows(); rows > uint(totalRowsAffected) {
-		return fmt.Errorf("expected %d rows to be affected, got %d", rows, totalRowsAffected)
-	}
-
 	return nil
 }

--- a/clients/shared/multi_step_merge.go
+++ b/clients/shared/multi_step_merge.go
@@ -199,7 +199,7 @@ func merge(ctx context.Context, dwh destination.Destination, tableData *optimiza
 		mergeStatements = _mergeStatements
 	}
 
-	if _, err := destination.ExecContextStatements(ctx, dwh, mergeStatements); err != nil {
+	if err := destination.ExecContextStatements(ctx, dwh, mergeStatements); err != nil {
 		return fmt.Errorf("failed to execute merge statements: %w", err)
 	}
 

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -89,12 +89,7 @@ func (s *Store) GetConfigMap() *types.DestinationTableConfigMap {
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool) error {
 	stagingTableID := shared.TempTableID(tableID)
 	dedupeQueries := s.Dialect().BuildDedupeQueries(tableID, stagingTableID, primaryKeys, includeArtieUpdatedAt)
-
-	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
-		return fmt.Errorf("failed to dedupe: %w", err)
-	}
-
-	return nil
+	return destination.ExecContextStatements(ctx, s, dedupeQueries)
 }
 
 func LoadSnowflake(ctx context.Context, cfg config.Config, _store *db.Store) (*Store, error) {

--- a/clients/snowflake/snowflake_test.go
+++ b/clients/snowflake/snowflake_test.go
@@ -119,7 +119,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeNilEdgeCase() {
 
 	// Set up expectations for MERGE - use regex pattern to match the actual table name with suffix
 	mergeQueryRegex := regexp.QuoteMeta(`MERGE INTO "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
-	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, int64(len(rowsData))))
+	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for DROP TABLE - use regex pattern to match the actual table name with suffix
 	dropQueryRegex := regexp.QuoteMeta(`DROP TABLE IF EXISTS "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
@@ -185,7 +185,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeReestablishAuth() {
 
 	// Set up expectations for MERGE - use regex pattern to match the actual table name with suffix
 	mergeQueryRegex := regexp.QuoteMeta(`MERGE INTO "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
-	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, int64(len(rowsData))))
+	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for DROP TABLE - use regex pattern to match the actual table name with suffix
 	dropQueryRegex := regexp.QuoteMeta(`DROP TABLE IF EXISTS "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
@@ -248,7 +248,7 @@ func (s *SnowflakeTestSuite) TestExecuteMerge() {
 
 	// Set up expectations for MERGE - use regex pattern to match the actual table name with suffix
 	mergeQueryRegex := regexp.QuoteMeta(`MERGE INTO "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
-	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, int64(len(rowsData))))
+	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for DROP TABLE - use regex pattern to match the actual table name with suffix
 	dropQueryRegex := regexp.QuoteMeta(`DROP TABLE IF EXISTS "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
@@ -328,7 +328,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 
 	// Set up expectations for MERGE - use regex pattern to match the actual table name with suffix
 	mergeQueryRegex := regexp.QuoteMeta(`MERGE INTO "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
-	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, int64(len(rowsData))))
+	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for DROP TABLE - use regex pattern to match the actual table name with suffix
 	dropQueryRegex := regexp.QuoteMeta(`DROP TABLE IF EXISTS "CUSTOMER"."PUBLIC"."`) + `.*` + regexp.QuoteMeta(`"`)
@@ -370,7 +370,7 @@ func (s *SnowflakeTestSuite) TestExecuteMergeDeletionFlagRemoval() {
 	s.mockDB.ExpectQuery(copyQueryRegex2).WillReturnRows(sqlmock.NewRows([]string{"rows_loaded"}).AddRow(fmt.Sprintf("%d", tableData.NumberOfRows())))
 
 	// Set up expectations for MERGE - use regex pattern to match the actual table name with suffix
-	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, int64(len(rowsData))))
+	s.mockDB.ExpectExec(mergeQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	// Set up expectations for DROP TABLE - use regex pattern to match the actual table name with suffix
 	s.mockDB.ExpectExec(dropQueryRegex).WillReturnResult(sqlmock.NewResult(0, 0))

--- a/lib/destination/destination.go
+++ b/lib/destination/destination.go
@@ -39,22 +39,21 @@ type Baseline interface {
 
 // ExecContextStatements executes one or more statements against a [Destination].
 // If there is more than one statement, the statements will be executed inside of a transaction.
-func ExecContextStatements(ctx context.Context, dest Destination, statements []string) ([]sql.Result, error) {
+func ExecContextStatements(ctx context.Context, dest Destination, statements []string) error {
 	switch len(statements) {
 	case 0:
-		return nil, fmt.Errorf("statements is empty")
+		return fmt.Errorf("statements is empty")
 	case 1:
 		slog.Debug("Executing...", slog.String("query", statements[0]))
-		result, err := dest.ExecContext(ctx, statements[0])
-		if err != nil {
-			return nil, fmt.Errorf("failed to execute statement: %w", err)
+		if _, err := dest.ExecContext(ctx, statements[0]); err != nil {
+			return fmt.Errorf("failed to execute statement: %w", err)
 		}
 
-		return []sql.Result{result}, nil
+		return nil
 	default:
 		tx, err := dest.Begin()
 		if err != nil {
-			return nil, fmt.Errorf("failed to start tx: %w", err)
+			return fmt.Errorf("failed to start tx: %w", err)
 		}
 		var committed bool
 		defer func() {
@@ -65,21 +64,17 @@ func ExecContextStatements(ctx context.Context, dest Destination, statements []s
 			}
 		}()
 
-		var results []sql.Result
 		for _, statement := range statements {
 			slog.Debug("Executing...", slog.String("query", statement))
-			result, err := tx.ExecContext(ctx, statement)
-			if err != nil {
-				return nil, fmt.Errorf("failed to execute statement: %q, err: %w", statement, err)
+			if _, err = tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("failed to execute statement: %q, err: %w", statement, err)
 			}
-
-			results = append(results, result)
 		}
 
 		if err = tx.Commit(); err != nil {
-			return nil, fmt.Errorf("failed to commit statements: %v, err: %w", statements, err)
+			return fmt.Errorf("failed to commit statements: %v, err: %w", statements, err)
 		}
 		committed = true
-		return results, nil
+		return nil
 	}
 }


### PR DESCRIPTION
This reverts commit b239cb8f7227156a1337dd06f02db052e2da2322.

Undoing this for now since it does not account for the in-memory optimization we have for rows that get inserted and deleted, all within one flush cycle.