### PR TITLE
Improving MSSQL `QuoteIdentifier`

### DIFF
--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -15,7 +15,12 @@ import (
 type MSSQLDialect struct{}
 
 func (MSSQLDialect) QuoteIdentifier(identifier string) string {
-	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(identifier, `"`, ``))
+	charToReplace := []string{`[`, `]`}
+	for _, char := range charToReplace {
+		identifier = strings.ReplaceAll(identifier, char, ``)
+	}
+
+	return fmt.Sprintf(`[%s]`, identifier)
 }
 
 func (MSSQLDialect) EscapeStruct(value string) string {


### PR DESCRIPTION
To properly escape in `MSSQL`, we should be using `[identifier]`. `"identifier"` works too technically if you have `QUOTED_IDENTIFIERS` enabled.