### PR TITLE
Add a setting for including full source table name as a column

### DIFF
--- a/lib/cdc/event.go
+++ b/lib/cdc/event.go
@@ -19,6 +19,7 @@ type Event interface {
 	Operation() string
 	DeletePayload() bool
 	GetTableName() string
+	GetFullTableName() string
 	GetSourceMetadata() (string, error)
 	GetData(tc kafkalib.TopicConfig) (map[string]any, error)
 	GetOptionalSchema() (map[string]typing.KindDetails, error)

--- a/lib/cdc/mongo/debezium.go
+++ b/lib/cdc/mongo/debezium.go
@@ -108,6 +108,11 @@ func (s *SchemaEventPayload) GetTableName() string {
 	return s.Payload.Source.Collection
 }
 
+func (s *SchemaEventPayload) GetFullTableName() string {
+	// MongoDB doesn't have schemas, the full table name is the same as the table name.
+	return s.GetTableName()
+}
+
 func (s *SchemaEventPayload) GetSourceMetadata() (string, error) {
 	json, err := json.Marshal(s.Payload.Source)
 	if err != nil {

--- a/lib/cdc/util/relational_event.go
+++ b/lib/cdc/util/relational_event.go
@@ -97,6 +97,14 @@ func (s *SchemaEventPayload) GetTableName() string {
 	return s.Payload.Source.Table
 }
 
+func (s *SchemaEventPayload) GetFullTableName() string {
+	if s.Payload.Source.Schema != "" {
+		return s.Payload.Source.Schema + "." + s.Payload.Source.Table
+	}
+
+	return s.Payload.Source.Table
+}
+
 func (s *SchemaEventPayload) GetSourceMetadata() (string, error) {
 	json, err := json.Marshal(s.Payload.Source)
 	if err != nil {

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -23,12 +23,13 @@ const (
 	// not a real column and should never be included in the target table.
 	OnlySetDeleteColumnMarker = ArtiePrefix + "_only_set_delete"
 
-	DeletionConfidencePadding   = 4 * time.Hour
-	UpdateColumnMarker          = ArtiePrefix + "_updated_at"
-	DatabaseUpdatedColumnMarker = ArtiePrefix + "_db_updated_at"
-	OperationColumnMarker       = ArtiePrefix + "_operation"
-	ExceededValueMarker         = ArtiePrefix + "_exceeded_value"
-	SourceMetadataColumnMarker  = ArtiePrefix + "_source_metadata"
+	DeletionConfidencePadding       = 4 * time.Hour
+	UpdateColumnMarker              = ArtiePrefix + "_updated_at"
+	DatabaseUpdatedColumnMarker     = ArtiePrefix + "_db_updated_at"
+	OperationColumnMarker           = ArtiePrefix + "_operation"
+	ExceededValueMarker             = ArtiePrefix + "_exceeded_value"
+	SourceMetadataColumnMarker      = ArtiePrefix + "_source_metadata"
+	FullSourceTableNameColumnMarker = ArtiePrefix + "_full_source_table_name"
 
 	TemporaryTableTTL = 6 * time.Hour
 
@@ -53,6 +54,7 @@ var ArtieColumns = []string{
 	DatabaseUpdatedColumnMarker,
 	OperationColumnMarker,
 	SourceMetadataColumnMarker,
+	FullSourceTableNameColumnMarker,
 }
 
 // ExporterKind is used for the Telemetry package

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -43,19 +43,20 @@ func (m MultiStepMergeSettings) Validate() error {
 }
 
 type TopicConfig struct {
-	Database                 string `yaml:"db"`
-	TableName                string `yaml:"tableName"`
-	Schema                   string `yaml:"schema"`
-	Topic                    string `yaml:"topic"`
-	CDCFormat                string `yaml:"cdcFormat"`
-	CDCKeyFormat             string `yaml:"cdcKeyFormat"`
-	DropDeletedColumns       bool   `yaml:"dropDeletedColumns"`
-	SoftDelete               bool   `yaml:"softDelete"`
-	SkippedOperations        string `yaml:"skippedOperations,omitempty"`
-	IncludeArtieUpdatedAt    bool   `yaml:"includeArtieUpdatedAt"`
-	IncludeArtieOperation    bool   `yaml:"includeArtieOperation"`
-	IncludeDatabaseUpdatedAt bool   `yaml:"includeDatabaseUpdatedAt"`
-	IncludeSourceMetadata    bool   `yaml:"includeSourceMetadata"`
+	Database                   string `yaml:"db"`
+	TableName                  string `yaml:"tableName"`
+	Schema                     string `yaml:"schema"`
+	Topic                      string `yaml:"topic"`
+	CDCFormat                  string `yaml:"cdcFormat"`
+	CDCKeyFormat               string `yaml:"cdcKeyFormat"`
+	DropDeletedColumns         bool   `yaml:"dropDeletedColumns"`
+	SoftDelete                 bool   `yaml:"softDelete"`
+	SkippedOperations          string `yaml:"skippedOperations,omitempty"`
+	IncludeArtieUpdatedAt      bool   `yaml:"includeArtieUpdatedAt"`
+	IncludeArtieOperation      bool   `yaml:"includeArtieOperation"`
+	IncludeDatabaseUpdatedAt   bool   `yaml:"includeDatabaseUpdatedAt"`
+	IncludeSourceMetadata      bool   `yaml:"includeSourceMetadata"`
+	IncludeFullSourceTableName bool   `yaml:"includeFullSourceTableName"`
 	// TODO: Deprecate BigQueryPartitionSettings and use AdditionalMergePredicates instead.
 	BigQueryPartitionSettings *partition.BigQuerySettings `yaml:"bigQueryPartitionSettings,omitempty"`
 	AdditionalMergePredicates []partition.MergePredicates `yaml:"additionalMergePredicates,omitempty"`

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -295,6 +295,10 @@ func (t *TableData) BuildColumnsToKeep() []string {
 		colsMap.Add(constants.SourceMetadataColumnMarker, true)
 	}
 
+	if t.TopicConfig().IncludeFullSourceTableName {
+		colsMap.Add(constants.FullSourceTableNameColumnMarker, true)
+	}
+
 	return colsMap.Keys()
 }
 

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -339,4 +339,9 @@ func TestTableData_BuildColumnsToKeep(t *testing.T) {
 		td := TableData{mode: config.Replication, topicConfig: kafkalib.TopicConfig{IncludeSourceMetadata: true}}
 		assert.ElementsMatch(t, []string{constants.SourceMetadataColumnMarker}, td.BuildColumnsToKeep())
 	}
+	{
+		// Include full source table name is true
+		td := TableData{mode: config.Replication, topicConfig: kafkalib.TopicConfig{IncludeFullSourceTableName: true}}
+		assert.ElementsMatch(t, []string{constants.FullSourceTableNameColumnMarker}, td.BuildColumnsToKeep())
+	}
 }

--- a/lib/typing/columns/diff_test.go
+++ b/lib/typing/columns/diff_test.go
@@ -55,6 +55,11 @@ func TestShouldSkipColumn(t *testing.T) {
 		assert.True(t, shouldSkipColumn(constants.SourceMetadataColumnMarker, []string{constants.DeleteColumnMarker}))
 	}
 	{
+		// Test full source table name
+		assert.False(t, shouldSkipColumn(constants.FullSourceTableNameColumnMarker, []string{constants.UpdateColumnMarker, constants.FullSourceTableNameColumnMarker}))
+		assert.True(t, shouldSkipColumn(constants.FullSourceTableNameColumnMarker, []string{constants.UpdateColumnMarker}))
+	}
+	{
 		// Test operation column in replication mode
 		assert.True(t, shouldSkipColumn(constants.OperationColumnMarker, []string{}))
 	}

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -152,6 +152,10 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc kafkalib.TopicConfi
 		cols.AddColumn(columns.NewColumn(constants.SourceMetadataColumnMarker, typing.Struct))
 	}
 
+	if tc.IncludeFullSourceTableName {
+		evtData[constants.FullSourceTableNameColumnMarker] = event.GetFullTableName()
+	}
+
 	tblName := cmp.Or(tc.TableName, event.GetTableName())
 	if cfgMode == config.History {
 		if !strings.HasSuffix(tblName, constants.HistoryModeSuffix) {


### PR DESCRIPTION
Re-introducing the initial version of https://github.com/artie-labs/transfer/pull/1356 so it's possible to use the source table name as part of a compound key in the destination table, for tables that are fanned in across schemas.