### PR TITLE
Minor refactor around config

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"cmp"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -80,37 +81,20 @@ func readFileToConfig(pathToConfig string) (*Config, error) {
 	defer file.Close()
 
 	var bytes []byte
-	bytes, err = io.ReadAll(file)
-	if err != nil {
+	if bytes, err = io.ReadAll(file); err != nil {
 		return nil, err
 	}
 
 	var config Config
-	err = yaml.Unmarshal(bytes, &config)
-	if err != nil {
+	if err = yaml.Unmarshal(bytes, &config); err != nil {
 		return nil, err
 	}
 
-	if config.Queue == "" {
-		// We default to Kafka for backwards compatibility
-		config.Queue = constants.Kafka
-	}
-
-	if config.FlushIntervalSeconds == 0 {
-		config.FlushIntervalSeconds = defaultFlushTimeSeconds
-	}
-
-	if config.BufferRows == 0 {
-		config.BufferRows = defaultBufferPoolSize
-	}
-
-	if config.FlushSizeKb == 0 {
-		config.FlushSizeKb = defaultFlushSizeKb
-	}
-
-	if config.Mode == "" {
-		config.Mode = Replication
-	}
+	config.Queue = cmp.Or(config.Queue, constants.Kafka)
+	config.FlushIntervalSeconds = cmp.Or(config.FlushIntervalSeconds, defaultFlushTimeSeconds)
+	config.BufferRows = cmp.Or(config.BufferRows, defaultBufferPoolSize)
+	config.FlushSizeKb = cmp.Or(config.FlushSizeKb, defaultFlushSizeKb)
+	config.Mode = cmp.Or(config.Mode, Replication)
 
 	return &config, nil
 }


### PR DESCRIPTION
Using `cmp.Or` and inlining more to be consistent with the rest of our codebase.