### PR TITLE
[Kafka] Adding a guardrail for high watermark check

### DIFF
--- a/lib/artie/message.go
+++ b/lib/artie/message.go
@@ -64,6 +64,10 @@ func (m Message) Partition() int {
 	return m.message.Partition
 }
 
+func (m Message) Offset() int64 {
+	return m.message.Offset
+}
+
 func (m Message) Key() []byte {
 	return m.message.Key
 }

--- a/lib/config/constants/constants.go
+++ b/lib/config/constants/constants.go
@@ -5,6 +5,10 @@ import (
 )
 
 const (
+	// Environment variables:
+	// [KafkaHWMEnvVar] - If set, we will have an additional Kafka high watermark check to prevent duplicate messages.
+	KafkaHWMEnvVar = "KAFKA_HWM"
+
 	NullValuePlaceholder             = "__artie_null_value"
 	ToastUnavailableValuePlaceholder = "__debezium_unavailable_value"
 

--- a/lib/environ/environment.go
+++ b/lib/environ/environment.go
@@ -3,6 +3,7 @@ package environ
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -19,4 +20,12 @@ func MustGetEnv(envVars ...string) error {
 	}
 
 	return nil
+}
+
+func GetBoolEnv(key string) (bool, error) {
+	if val := os.Getenv(key); val != "" {
+		return strconv.ParseBool(val)
+	}
+
+	return false, nil
 }

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -13,6 +13,7 @@ import (
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/cryptography"
+	"github.com/artie-labs/transfer/lib/environ"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/stringutil"
@@ -291,6 +292,20 @@ func (e *Event) Save(cfg config.Config, inMemDB *models.DatabaseData, tc kafkali
 			// Iterate over this again just in case.
 			for _, col := range e.columns.GetColumns() {
 				td.AddInMemoryCol(col)
+			}
+		}
+	}
+
+	kafkaCheck, err := environ.GetBoolEnv(constants.KafkaHWMEnvVar)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to get kafka check: %w", err)
+	}
+
+	if kafkaCheck {
+		if msg, ok := td.PartitionsToLastMessage[message.Partition()]; ok {
+			if msg.Offset() > message.Offset() {
+				// This means that we already processed this message.
+				return false, "", nil
 			}
 		}
 	}


### PR DESCRIPTION
If this environment variable is enabled, we'll have an additional guardrail to skip messages where the offset is lower than what we have seen.

This may happen if the Kafka cluster is overloaded and rebalances.