### PR TITLE
Remove `Query` and standardize on `QueryContext`

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -123,7 +123,7 @@ func (s *Store) IdentifierFor(databaseAndSchema kafkalib.DatabaseAndSchemaPair, 
 	return dialect.NewTableIdentifier(s.config.BigQuery.ProjectID, databaseAndSchema.Database, table)
 }
 
-func (s *Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
+func (s *Store) GetTableConfig(ctx context.Context, tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
 	return shared.GetTableCfgArgs{
 		Destination:           s,
 		TableID:               tableID,
@@ -132,7 +132,7 @@ func (s *Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns b
 		ColumnNameForDataType: "data_type",
 		ColumnNameForComment:  "description",
 		DropDeletedColumns:    dropDeletedColumns,
-	}.GetTableConfig()
+	}.GetTableConfig(ctx)
 }
 
 func (s *Store) GetConfigMap() *types.DestinationTableConfigMap {

--- a/clients/databricks/store.go
+++ b/clients/databricks/store.go
@@ -89,7 +89,7 @@ func (s Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, primaryK
 	return nil
 }
 
-func (s Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
+func (s Store) GetTableConfig(ctx context.Context, tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
 	return shared.GetTableCfgArgs{
 		Destination:           s,
 		TableID:               tableID,
@@ -98,7 +98,7 @@ func (s Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns bo
 		ColumnNameForDataType: "data_type",
 		ColumnNameForComment:  "comment",
 		DropDeletedColumns:    dropDeletedColumns,
-	}.GetTableConfig()
+	}.GetTableConfig(ctx)
 }
 
 func (s Store) PrepareTemporaryTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tempTableID sql.TableIdentifier, _ sql.TableIdentifier, opts types.AdditionalSettings, createTempTable bool) error {

--- a/clients/mssql/store.go
+++ b/clients/mssql/store.go
@@ -93,7 +93,7 @@ func (s *Store) Dedupe(_ context.Context, _ sql.TableIdentifier, _ []string, _ b
 	return nil // dedupe is not necessary for MS SQL
 }
 
-func (s *Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
+func (s *Store) GetTableConfig(ctx context.Context, tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
 	return shared.GetTableCfgArgs{
 		Destination:           s,
 		TableID:               tableID,
@@ -102,7 +102,7 @@ func (s *Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns b
 		ColumnNameForDataType: "data_type",
 		ColumnNameForComment:  "description",
 		DropDeletedColumns:    dropDeletedColumns,
-	}.GetTableConfig()
+	}.GetTableConfig(ctx)
 }
 
 func LoadStore(cfg config.Config) (*Store, error) {

--- a/clients/postgres/postgres.go
+++ b/clients/postgres/postgres.go
@@ -88,7 +88,7 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, primary
 	return fmt.Errorf("dedupe not implemented for PostgreSQL")
 }
 
-func (s *Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
+func (s *Store) GetTableConfig(ctx context.Context, tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -100,7 +100,7 @@ func (s *Store) dialect() dialect.RedshiftDialect {
 	return dialect.RedshiftDialect{}
 }
 
-func (s *Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
+func (s *Store) GetTableConfig(ctx context.Context, tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
 	return shared.GetTableCfgArgs{
 		Destination:           s,
 		TableID:               tableID,
@@ -109,7 +109,7 @@ func (s *Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns b
 		ColumnNameForDataType: "data_type",
 		ColumnNameForComment:  "description",
 		DropDeletedColumns:    dropDeletedColumns,
-	}.GetTableConfig()
+	}.GetTableConfig(ctx)
 }
 
 func (s *Store) SweepTemporaryTables(ctx context.Context) error {

--- a/clients/shared/append.go
+++ b/clients/shared/append.go
@@ -16,7 +16,7 @@ func Append(ctx context.Context, dest destination.Destination, tableData *optimi
 	}
 
 	tableID := dest.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
-	tableConfig, err := dest.GetTableConfig(tableID, tableData.TopicConfig().DropDeletedColumns)
+	tableConfig, err := dest.GetTableConfig(ctx, tableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
 		return fmt.Errorf("failed to get table config: %w", err)
 	}

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -36,7 +36,7 @@ func Merge(ctx context.Context, dest destination.Destination, tableData *optimiz
 	stop := hb.Start()
 	defer stop()
 
-	tableConfig, err := dest.GetTableConfig(tableID, tableData.TopicConfig().DropDeletedColumns)
+	tableConfig, err := dest.GetTableConfig(ctx, tableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
 		return fmt.Errorf("failed to get table config: %w", err)
 	}

--- a/clients/shared/multi_step_merge.go
+++ b/clients/shared/multi_step_merge.go
@@ -33,7 +33,7 @@ func MultiStepMerge(ctx context.Context, dest destination.Destination, tableData
 
 	msmTableID := dest.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), fmt.Sprintf("%s_%s_msm", constants.ArtiePrefix, tableData.Name()))
 	targetTableID := dest.IdentifierFor(tableData.TopicConfig().BuildDatabaseAndSchemaPair(), tableData.Name())
-	targetTableConfig, err := dest.GetTableConfig(targetTableID, tableData.TopicConfig().DropDeletedColumns)
+	targetTableConfig, err := dest.GetTableConfig(ctx, targetTableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
 		return false, fmt.Errorf("failed to get table config: %w", err)
 	}
@@ -50,7 +50,7 @@ func MultiStepMerge(ctx context.Context, dest destination.Destination, tableData
 		}
 	}
 
-	msmTableConfig, err := dest.GetTableConfig(msmTableID, tableData.TopicConfig().DropDeletedColumns)
+	msmTableConfig, err := dest.GetTableConfig(ctx, msmTableID, tableData.TopicConfig().DropDeletedColumns)
 	if err != nil {
 		return false, fmt.Errorf("failed to get table config: %w", err)
 	}

--- a/clients/shared/table_config.go
+++ b/clients/shared/table_config.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,7 +31,7 @@ type GetTableCfgArgs struct {
 	DropDeletedColumns   bool
 }
 
-func (g GetTableCfgArgs) GetTableConfig() (*types.DestinationTableConfig, error) {
+func (g GetTableCfgArgs) GetTableConfig(ctx context.Context) (*types.DestinationTableConfig, error) {
 	if tableConfig := g.ConfigMap.GetTableConfig(g.TableID); tableConfig != nil {
 		return tableConfig, nil
 	}
@@ -40,7 +41,7 @@ func (g GetTableCfgArgs) GetTableConfig() (*types.DestinationTableConfig, error)
 		return nil, fmt.Errorf("failed to generate describe table query: %w", err)
 	}
 
-	rows, err := g.Destination.Query(query, args...)
+	rows, err := g.Destination.QueryContext(ctx, query, args...)
 	defer func() {
 		if rows != nil {
 			err = rows.Close()

--- a/clients/shared/table_config_test.go
+++ b/clients/shared/table_config_test.go
@@ -29,7 +29,7 @@ func TestGetTableConfig(t *testing.T) {
 		Destination: &mocks.FakeDestination{},
 		TableID:     fakeTableID,
 		ConfigMap:   cm,
-	}.GetTableConfig()
+	}.GetTableConfig(t.Context())
 
 	assert.NoError(t, err)
 	assert.Equal(t, tableCfg, actualTableCfg)

--- a/clients/snowflake/ddl_test.go
+++ b/clients/snowflake/ddl_test.go
@@ -110,7 +110,7 @@ func (s *SnowflakeTestSuite) TestGetTableConfig() {
 	tableData := optimization.NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{Database: "customers", Schema: "public", TableName: "orders22"}, "foo")
 	s.mockDB.ExpectQuery(`DESC TABLE "CUSTOMERS"."PUBLIC"."FOO"`).WillReturnError(fmt.Errorf("Table '%s' does not exist or not authorized", fqName))
 
-	tableConfig, err := s.stageStore.GetTableConfig(s.identifierFor(tableData), tableData.TopicConfig().DropDeletedColumns)
+	tableConfig, err := s.stageStore.GetTableConfig(s.T().Context(), s.identifierFor(tableData), tableData.TopicConfig().DropDeletedColumns)
 	assert.NotNil(s.T(), tableConfig, "config is nil")
 	assert.NoError(s.T(), err)
 

--- a/clients/snowflake/snowflake.go
+++ b/clients/snowflake/snowflake.go
@@ -51,7 +51,7 @@ func (s *Store) DropTable(ctx context.Context, tableID sql.TableIdentifier) erro
 	return nil
 }
 
-func (s *Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
+func (s *Store) GetTableConfig(ctx context.Context, tableID sql.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error) {
 	return shared.GetTableCfgArgs{
 		Destination:           s,
 		TableID:               tableID,
@@ -60,7 +60,7 @@ func (s *Store) GetTableConfig(tableID sql.TableIdentifier, dropDeletedColumns b
 		ColumnNameForDataType: "type",
 		ColumnNameForComment:  "comment",
 		DropDeletedColumns:    dropDeletedColumns,
-	}.GetTableConfig()
+	}.GetTableConfig(ctx)
 }
 
 func (s *Store) SweepTemporaryTables(ctx context.Context) error {

--- a/integration_tests/shared/baseline.go
+++ b/integration_tests/shared/baseline.go
@@ -1,6 +1,7 @@
 package shared
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -8,8 +9,8 @@ import (
 	"github.com/artie-labs/transfer/lib/apachelivy"
 )
 
-func (tf *TestFramework) verifyRowCountIceberg(expected int) error {
-	resp, err := tf.iceberg.GetApacheLivyClient().QueryContext(tf.ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", tf.tableID.FullyQualifiedName()))
+func (tf *TestFramework) verifyRowCountIceberg(ctx context.Context, expected int) error {
+	resp, err := tf.iceberg.GetApacheLivyClient().QueryContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", tf.tableID.FullyQualifiedName()))
 	if err != nil {
 		return fmt.Errorf("failed to query table: %w", err)
 	}
@@ -36,14 +37,14 @@ func (tf *TestFramework) verifyRowCountIceberg(expected int) error {
 	return nil
 }
 
-func (tf *TestFramework) verifyDataContentIceberg(rowCount int) error {
+func (tf *TestFramework) verifyDataContentIceberg(ctx context.Context, rowCount int) error {
 	// Limit this to 1k rows since that's the default limit for Livy.
 	iters := rowCount / 1000
 	totalRows := 0
 	for iter := 0; iter < iters; iter++ {
 		offset := iter * 1000
 		query := fmt.Sprintf("SELECT id, name, value, json_data, json_array, json_string, json_boolean, json_number FROM %s ORDER BY id LIMIT 1000 OFFSET %d", tf.tableID.FullyQualifiedName(), offset)
-		resp, err := tf.iceberg.GetApacheLivyClient().QueryContext(tf.ctx, query)
+		resp, err := tf.iceberg.GetApacheLivyClient().QueryContext(ctx, query)
 		if err != nil {
 			return fmt.Errorf("failed to query table: %w", err)
 		}

--- a/integration_tests/shared/destination.go
+++ b/integration_tests/shared/destination.go
@@ -1,9 +1,12 @@
 package shared
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
-func (tf *TestFramework) verifyRowCountDestination(expected int) error {
-	rows, err := tf.dest.Query(fmt.Sprintf("SELECT COUNT(*) FROM %s", tf.tableID.FullyQualifiedName()))
+func (tf *TestFramework) verifyRowCountDestination(ctx context.Context, expected int) error {
+	rows, err := tf.dest.QueryContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", tf.tableID.FullyQualifiedName()))
 	if err != nil {
 		return fmt.Errorf("failed to query table: %w", err)
 	}
@@ -26,7 +29,7 @@ func (tf *TestFramework) verifyRowCountDestination(expected int) error {
 	return nil
 }
 
-func (tf *TestFramework) verifyDataContentDestination(rowCount int) error {
+func (tf *TestFramework) verifyDataContentDestination(ctx context.Context, rowCount int) error {
 	baseQuery := fmt.Sprintf("SELECT id, name, value, json_data, json_array, json_string, json_boolean, json_number FROM %s ORDER BY id", tf.tableID.FullyQualifiedName())
 
 	if tf.BigQuery() {
@@ -34,7 +37,7 @@ func (tf *TestFramework) verifyDataContentDestination(rowCount int) error {
 		baseQuery = fmt.Sprintf("SELECT id, name, value, TO_JSON_STRING(json_data), TO_JSON_STRING(json_array) FROM %s ORDER BY id", tf.tableID.FullyQualifiedName())
 	}
 
-	rows, err := tf.dest.Query(baseQuery)
+	rows, err := tf.dest.QueryContext(ctx, baseQuery)
 	if err != nil {
 		return fmt.Errorf("failed to query table data: %w", err)
 	}

--- a/integration_tests/shared/framework.go
+++ b/integration_tests/shared/framework.go
@@ -143,12 +143,12 @@ func (tf *TestFramework) VerifyRowCount(expected int) error {
 	return tf.verifyRowCountDestination(expected)
 }
 
-func (tf *TestFramework) VerifyDataContent(rowCount int) error {
+func (tf *TestFramework) VerifyDataContent(ctx context.Context, rowCount int) error {
 	if tf.iceberg != nil {
 		return tf.verifyDataContentIceberg(rowCount)
 	}
 
-	return tf.verifyDataContentDestination(rowCount)
+	return tf.verifyDataContentDestination(ctx, rowCount)
 }
 
 func (tf *TestFramework) Cleanup(tableID sql.TableIdentifier) error {

--- a/lib/db/db.go
+++ b/lib/db/db.go
@@ -17,7 +17,6 @@ const (
 
 type Store interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
-	Query(query string, args ...any) (*sql.Rows, error)
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 	Begin() (*sql.Tx, error)
@@ -62,10 +61,6 @@ func (s *storeWrapper) QueryContext(ctx context.Context, query string, args ...a
 
 func (s *storeWrapper) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
 	return s.DB.QueryRowContext(ctx, query, args...)
-}
-
-func (s *storeWrapper) Query(query string, args ...any) (*sql.Rows, error) {
-	return s.DB.Query(query, args...)
 }
 
 func (s *storeWrapper) Begin() (*sql.Tx, error) {

--- a/lib/destination/destination.go
+++ b/lib/destination/destination.go
@@ -21,12 +21,11 @@ type Destination interface {
 	Dedupe(ctx context.Context, tableID sqllib.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool) error
 	SweepTemporaryTables(ctx context.Context) error
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
-	Query(query string, args ...any) (*sql.Rows, error)
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
 	Begin() (*sql.Tx, error)
 
 	// Helper functions for merge
-	GetTableConfig(tableID sqllib.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error)
+	GetTableConfig(ctx context.Context, tableID sqllib.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error)
 	PrepareTemporaryTable(ctx context.Context, tableData *optimization.TableData, tableConfig *types.DestinationTableConfig, tempTableID sqllib.TableIdentifier, parentTableID sqllib.TableIdentifier, additionalSettings types.AdditionalSettings, createTempTable bool) error
 }
 


### PR DESCRIPTION
As per title, we don't need to have both - we also prefer query context anyways, so this PR removes `Query`.