### PR TITLE
[bigquery] Moving this function into a library rather on the BigQuery destination interface

### DIFF
--- a/lib/bigquerylib/bigquery.go
+++ b/lib/bigquerylib/bigquery.go
@@ -1,0 +1,51 @@
+package bigquerylib
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+)
+
+type Client struct {
+	client *bigquery.Client
+}
+
+func NewClient(ctx context.Context, client *bigquery.Client) *Client {
+	return &Client{client: client}
+}
+
+// [UndeleteTable] - Adding this functionality to restore a deleted table.
+// Ref: https://cloud.google.com/bigquery/docs/samples/bigquery-undelete-table
+func (c Client) UndeleteTable(ctx context.Context, datasetID string, deletedTableName string, restoredTableName string, restoreTime time.Time) error {
+	slog.Info("Restoring table",
+		slog.String("datasetID", datasetID),
+		slog.String("deletedTableName", deletedTableName),
+		slog.String("restoredTableName", restoredTableName),
+		slog.String("restoreTime", restoreTime.Format(time.RFC3339)),
+	)
+
+	ds := c.client.Dataset(datasetID)
+	snapshotTableID := fmt.Sprintf("%s@%d", deletedTableName, restoreTime.UnixNano()/1e6)
+
+	// Construct and run a copy job.
+	copier := ds.Table(restoredTableName).CopierFrom(ds.Table(snapshotTableID))
+	copier.WriteDisposition = bigquery.WriteTruncate
+	job, err := copier.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to run copy job: %w", err)
+	}
+
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to wait for copy job: %w", err)
+	}
+
+	if err := status.Err(); err != nil {
+		return fmt.Errorf("failed to wait for copy job: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Doing this so that we can import this functionality into different parts of our app without having to import the whole BigQuery destination. This PR makes it a lot more portable.

I also renamed this function to be closer aligned with the docs