### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -1,4 +1,6 @@
 name: Go checks
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/artie-labs/transfer/security/code-scanning/2](https://github.com/artie-labs/transfer/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the least privilege required. In this case, the workflow only needs to read repository contents, so you should set `contents: read`. This can be done either at the root of the workflow (to apply to all jobs) or at the job level. The best practice is to add it at the root level, just below the `name` and before the `on` key, so that all jobs inherit these permissions unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
