### PR TITLE
Fix previous row bug

### DIFF
--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -180,9 +180,17 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 	if prevRow, ok := t.rowsData[pk]; ok {
 		prevRowSize = prevRow.GetApproxSize()
 		if delete {
+			prevRowData := prevRow.GetData()
 			// If the row was deleted, preserve the previous values that we have in memory
-			rowData = prevRow.GetData()
-			rowData[constants.DeleteColumnMarker] = true
+			for key, value := range prevRowData {
+				val, ok := rowData[key]
+				if val == nil || !ok {
+					rowData[key] = value
+				}
+			}
+
+			// Setting this to the previous row for idempotency.
+			rowData[constants.OnlySetDeleteColumnMarker] = prevRowData[constants.OnlySetDeleteColumnMarker]
 		} else {
 			for key, val := range rowData {
 				if val == constants.ToastUnavailableValuePlaceholder {

--- a/lib/optimization/table_data.go
+++ b/lib/optimization/table_data.go
@@ -181,10 +181,10 @@ func (t *TableData) InsertRow(pk string, rowData map[string]any, delete bool) {
 		prevRowSize = prevRow.GetApproxSize()
 		if delete {
 			prevRowData := prevRow.GetData()
-			// If the row was deleted, preserve the previous values that we have in memory
+			// If the current row was deleted, we should preserve the previous values that we have in memory
+			// However, if the current row has a value for the column, then we should use that value instead.
 			for key, value := range prevRowData {
-				val, ok := rowData[key]
-				if val == nil || !ok {
+				if rowData[key] == nil {
 					rowData[key] = value
 				}
 			}

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -230,16 +230,38 @@ func TestTableData_InsertRowSoftDelete(t *testing.T) {
 		assert.Equal(t, false, td.Rows()[0].GetData()[constants.DeleteColumnMarker])
 	}
 	{
-		// Another scenario, let's update a row and then delete it and inspect the operation.
-		td := NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{SoftDelete: true}, "foo")
-		assert.Equal(t, 0, int(td.NumberOfRows()))
-		td.InsertRow("123", map[string]any{"id": "123", "name": "dana", "foo": "abc", constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false, constants.OperationColumnMarker: "u"}, false)
-		td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeleteColumnMarker: true, constants.OperationColumnMarker: "d"}, true)
-		assert.Equal(t, "dana", td.Rows()[0].GetData()["name"])
-		assert.Equal(t, "abc", td.Rows()[0].GetData()["foo"])
-		assert.Equal(t, "d", td.Rows()[0].GetData()[constants.OperationColumnMarker])
-		assert.True(t, td.Rows()[0].GetData()[constants.DeleteColumnMarker].(bool))
-		assert.False(t, td.Rows()[0].GetData()[constants.OnlySetDeleteColumnMarker].(bool))
+		// Update followed by a delete
+		{
+			// Let's update a row and then delete it and inspect the operation.
+			td := NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{SoftDelete: true}, "foo")
+			assert.Equal(t, 0, int(td.NumberOfRows()))
+			td.InsertRow("123", map[string]any{"id": "123", "name": "dana", "foo": "abc", constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false, constants.OperationColumnMarker: "u"}, false)
+			td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeleteColumnMarker: true, constants.OperationColumnMarker: "d"}, true)
+			assert.Equal(t, 1, int(td.NumberOfRows()))
+
+			data := td.Rows()[0].GetData()
+			assert.Equal(t, "dana", data["name"])
+			assert.Equal(t, "abc", data["foo"])
+			assert.Equal(t, "d", data[constants.OperationColumnMarker])
+			assert.True(t, data[constants.DeleteColumnMarker].(bool))
+			assert.False(t, data[constants.OnlySetDeleteColumnMarker].(bool))
+		}
+		{
+			// Another scenario, it should not overwrite the previous database timestamp
+			td := NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{SoftDelete: true}, "foo")
+			assert.Equal(t, 0, int(td.NumberOfRows()))
+			td.InsertRow("123", map[string]any{"id": "123", "name": "dana", "foo": "abc", constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false, constants.OperationColumnMarker: "u", constants.DatabaseUpdatedColumnMarker: "a"}, false)
+			td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeleteColumnMarker: true, constants.OperationColumnMarker: "d", constants.DatabaseUpdatedColumnMarker: "b"}, true)
+			assert.Equal(t, 1, int(td.NumberOfRows()))
+
+			data := td.Rows()[0].GetData()
+			assert.Equal(t, "dana", data["name"])
+			assert.Equal(t, "abc", data["foo"])
+			assert.Equal(t, "b", data[constants.DatabaseUpdatedColumnMarker])
+			assert.Equal(t, "d", data[constants.OperationColumnMarker])
+			assert.True(t, data[constants.DeleteColumnMarker].(bool))
+			assert.False(t, data[constants.OnlySetDeleteColumnMarker].(bool))
+		}
 	}
 }
 

--- a/lib/optimization/table_data_test.go
+++ b/lib/optimization/table_data_test.go
@@ -229,6 +229,18 @@ func TestTableData_InsertRowSoftDelete(t *testing.T) {
 		assert.Nil(t, td.Rows()[0].GetData()["foo"])
 		assert.Equal(t, false, td.Rows()[0].GetData()[constants.DeleteColumnMarker])
 	}
+	{
+		// Another scenario, let's update a row and then delete it and inspect the operation.
+		td := NewTableData(nil, config.Replication, nil, kafkalib.TopicConfig{SoftDelete: true}, "foo")
+		assert.Equal(t, 0, int(td.NumberOfRows()))
+		td.InsertRow("123", map[string]any{"id": "123", "name": "dana", "foo": "abc", constants.DeleteColumnMarker: false, constants.OnlySetDeleteColumnMarker: false, constants.OperationColumnMarker: "u"}, false)
+		td.InsertRow("123", map[string]any{"id": "123", constants.DeleteColumnMarker: true, constants.OnlySetDeleteColumnMarker: true, constants.OperationColumnMarker: "d"}, true)
+		assert.Equal(t, "dana", td.Rows()[0].GetData()["name"])
+		assert.Equal(t, "abc", td.Rows()[0].GetData()["foo"])
+		assert.Equal(t, "d", td.Rows()[0].GetData()[constants.OperationColumnMarker])
+		assert.True(t, td.Rows()[0].GetData()[constants.DeleteColumnMarker].(bool))
+		assert.False(t, td.Rows()[0].GetData()[constants.OnlySetDeleteColumnMarker].(bool))
+	}
 }
 
 func TestMergeColumn(t *testing.T) {


### PR DESCRIPTION
## Problem

If we receive a delete payload and the previous row value exists, we are taking every value from that previous row. This assumption is mostly correct, with the exception of system (Artie) generated columns.

The problem with this assumption for system level columns is that we will end up with a row in the target (if soft delete + include operation column is enabled) to be `deleted = true, operation ='u'`

## Fix

Instead, we should iterate over all the keys from the previous row and if the value is present in the current row, we should not overwrite. 

With the only exception to Artie `only set deleted column` where we should always be taking that from the previous row for correctness.