### PR TITLE
Refactor flush to be topic specific

### DIFF
--- a/models/event/event.go
+++ b/models/event/event.go
@@ -277,7 +277,7 @@ func (e *Event) Save(cfg config.Config, inMemDB *models.DatabaseData, tc kafkali
 	}
 
 	// Does the table exist?
-	td := inMemDB.GetOrCreateTableData(e.tableID)
+	td := inMemDB.GetOrCreateTableData(e.tableID, tc.Topic)
 	td.Lock()
 	defer td.Unlock()
 	if td.Empty() {

--- a/models/event/event_save_test.go
+++ b/models/event/event_save_test.go
@@ -46,7 +46,7 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	_, _, err = event.Save(e.cfg, e.db, topicConfig, artie.NewMessage(kafka.Message{}))
 	assert.NoError(e.T(), err)
 
-	optimization := e.db.GetOrCreateTableData(event.GetTableID())
+	optimization := e.db.GetOrCreateTableData(event.GetTableID(), topicConfig.Topic)
 	// Check the in-memory DB columns.
 	var found int
 	for _, col := range optimization.ReadOnlyInMemoryCols().GetColumns() {
@@ -77,7 +77,7 @@ func (e *EventsTestSuite) TestSaveEvent() {
 	_, _, err = edgeCaseEvent.Save(e.cfg, e.db, topicConfig, artie.NewMessage(kafka.Message{}))
 	assert.NoError(e.T(), err)
 
-	td := e.db.GetOrCreateTableData(edgeCaseEvent.GetTableID())
+	td := e.db.GetOrCreateTableData(edgeCaseEvent.GetTableID(), topicConfig.Topic)
 	inMemCol, ok := td.ReadOnlyInMemoryCols().GetColumn(badColumn)
 	assert.True(e.T(), ok)
 	assert.Equal(e.T(), typing.Invalid, inMemCol.KindDetails)
@@ -100,7 +100,7 @@ func (e *EventsTestSuite) TestEvent_SaveCasing() {
 	_, _, err = event.Save(e.cfg, e.db, topicConfig, artie.NewMessage(kafka.Message{}))
 	assert.NoError(e.T(), err)
 
-	td := e.db.GetOrCreateTableData(event.GetTableID())
+	td := e.db.GetOrCreateTableData(event.GetTableID(), topicConfig.Topic)
 	var rowData map[string]any
 	for _, row := range td.Rows() {
 		if id, ok := row.GetValue("id"); ok {
@@ -143,7 +143,7 @@ func (e *EventsTestSuite) TestEventSaveOptionalSchema() {
 	_, _, err = event.Save(e.cfg, e.db, topicConfig, artie.NewMessage(kafkaMsg))
 	assert.NoError(e.T(), err)
 
-	td := e.db.GetOrCreateTableData(event.GetTableID())
+	td := e.db.GetOrCreateTableData(event.GetTableID(), topicConfig.Topic)
 	{
 		// Optional schema w/ string
 		column, ok := td.ReadOnlyInMemoryCols().GetColumn("created_at_date_string")
@@ -190,7 +190,7 @@ func (e *EventsTestSuite) TestEvent_SaveColumnsNoData() {
 	_, _, err = evt.Save(e.cfg, e.db, topicConfig, artie.NewMessage(kafka.Message{}))
 	assert.NoError(e.T(), err)
 
-	td := e.db.GetOrCreateTableData(evt.GetTableID())
+	td := e.db.GetOrCreateTableData(evt.GetTableID(), topicConfig.Topic)
 	var prevKey string
 	for _, col := range td.ReadOnlyInMemoryCols().GetColumns() {
 		if col.Name() == constants.DeleteColumnMarker || col.Name() == constants.OnlySetDeleteColumnMarker {
@@ -249,7 +249,7 @@ func (e *EventsTestSuite) TestEventSaveColumns() {
 	_, _, err = event.Save(e.cfg, e.db, topicConfig, artie.NewMessage(kafka.Message{}))
 	assert.NoError(e.T(), err)
 
-	td := e.db.GetOrCreateTableData(event.GetTableID())
+	td := e.db.GetOrCreateTableData(event.GetTableID(), topicConfig.Topic)
 	{
 		// String
 		column, ok := td.ReadOnlyInMemoryCols().GetColumn("randomcol")
@@ -296,11 +296,11 @@ func (e *EventsTestSuite) TestEventSaveTestDeleteFlag() {
 	assert.NoError(e.T(), err)
 	_, _, err = event.Save(e.cfg, e.db, topicConfig, artie.NewMessage(kafka.Message{}))
 	assert.NoError(e.T(), err)
-	assert.False(e.T(), e.db.GetOrCreateTableData(event.GetTableID()).ContainOtherOperations())
-	assert.True(e.T(), e.db.GetOrCreateTableData(event.GetTableID()).ContainsHardDeletes())
+	assert.False(e.T(), e.db.GetOrCreateTableData(event.GetTableID(), topicConfig.Topic).ContainOtherOperations())
+	assert.True(e.T(), e.db.GetOrCreateTableData(event.GetTableID(), topicConfig.Topic).ContainsHardDeletes())
 
 	event.deleted = false
 	_, _, err = event.Save(e.cfg, e.db, topicConfig, artie.NewMessage(kafka.Message{}))
 	assert.NoError(e.T(), err)
-	assert.True(e.T(), e.db.GetOrCreateTableData(event.GetTableID()).ContainOtherOperations())
+	assert.True(e.T(), e.db.GetOrCreateTableData(event.GetTableID(), topicConfig.Topic).ContainOtherOperations())
 }

--- a/models/memory.go
+++ b/models/memory.go
@@ -90,7 +90,7 @@ func (d *DatabaseData) TableData() map[cdc.TableID]*TableData {
 	return d.tableData
 }
 
-func (d *DatabaseData) GetTopicToTableDatas() map[string][]*TableData {
+func (d *DatabaseData) GetTopicToTables() map[string][]*TableData {
 	out := make(map[string][]*TableData)
 	for _, v := range d.tableData {
 		if _, ok := out[v.topic]; !ok {

--- a/models/memory.go
+++ b/models/memory.go
@@ -90,10 +90,14 @@ func (d *DatabaseData) TableData() map[cdc.TableID]*TableData {
 	return d.tableData
 }
 
-func (d *DatabaseData) GetTopicToTableData() map[string]*TableData {
-	out := make(map[string]*TableData)
+func (d *DatabaseData) GetTopicToTableDatas() map[string][]*TableData {
+	out := make(map[string][]*TableData)
 	for _, v := range d.tableData {
-		out[v.topic] = v
+		if _, ok := out[v.topic]; !ok {
+			out[v.topic] = make([]*TableData, 0)
+		}
+
+		out[v.topic] = append(out[v.topic], v)
 	}
 
 	return out

--- a/models/memory_test.go
+++ b/models/memory_test.go
@@ -19,10 +19,11 @@ func TestTableData_Complete(t *testing.T) {
 	}
 	{
 		// Exists after we created it.
-		td := db.GetOrCreateTableData(tableID)
+		td := db.GetOrCreateTableData(tableID, "topic")
 		assert.True(t, td.Empty())
 		_, ok := db.TableData()[tableID]
 		assert.True(t, ok)
+		assert.Equal(t, "topic", td.topic)
 
 		// Various ways to wipe the database data
 		{

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -35,11 +35,11 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 
 	// Read lock to examine the map of tables
 	inMemDB.RLock()
-	allTables := inMemDB.GetTopicToTables()
+	topicToTables := inMemDB.GetTopicToTables()
 	inMemDB.RUnlock()
 
 	if args.Topic != "" {
-		if _, ok := allTables[args.Topic]; !ok {
+		if _, ok := topicToTables[args.Topic]; !ok {
 			// Should never happen
 			return fmt.Errorf("topic %q does not exist in the in-memory database", args.Topic)
 		}
@@ -47,7 +47,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 
 	// Flush will take everything in memory and call the destination to create temp tables.
 	var wg sync.WaitGroup
-	for topic, tables := range allTables {
+	for topic, tables := range topicToTables {
 		if args.Topic != "" && args.Topic != topic {
 			// If the table is specified within args and the table does not match the database, skip this flush.
 			continue

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -49,7 +49,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 	var wg sync.WaitGroup
 	for topic, tables := range topicToTables {
 		if args.Topic != "" && args.Topic != topic {
-			// If the table is specified within args and the table does not match the database, skip this flush.
+			// If topic was specified and doesn't match this topic, we'll skip flushing this topic.
 			continue
 		}
 

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -35,7 +35,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 
 	// Read lock to examine the map of tables
 	inMemDB.RLock()
-	allTables := inMemDB.GetTopicToTableDatas()
+	allTables := inMemDB.GetTopicToTables()
 	inMemDB.RUnlock()
 
 	if args.Topic != "" {

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -25,9 +25,6 @@ type Args struct {
 	Reason string
 }
 
-// Flush will merge/append and commit the offset on the specified topics within `args.SpecificTable`.
-// If the table list is empty, it'll flush everything. This is the default behavior for the time duration based flush.
-// Table specific flushes will be triggered based on the size of the pool (length and size wise).
 func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.Baseline, metricsClient base.Client, args Args) error {
 	if inMemDB == nil {
 		return nil

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -45,11 +45,11 @@ func (f *FlushTestSuite) TestMemoryBasic() {
 		_, _, err = evt.Save(f.cfg, f.db, topicConfig, artie.NewMessage(kafkaMsg))
 		assert.NoError(f.T(), err)
 
-		td := f.db.GetOrCreateTableData(expectedTableID)
+		td := f.db.GetOrCreateTableData(expectedTableID, topicConfig.Topic)
 		assert.Equal(f.T(), int(td.NumberOfRows()), i+1)
 	}
 
-	assert.Equal(f.T(), f.db.GetOrCreateTableData(expectedTableID).NumberOfRows(), uint(5))
+	assert.Equal(f.T(), f.db.GetOrCreateTableData(expectedTableID, topicConfig.Topic).NumberOfRows(), uint(5))
 }
 
 func (f *FlushTestSuite) TestShouldFlush() {
@@ -109,7 +109,7 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 					"cat":                               "dog",
 				}, nil)
 
-				evt, err := event.ToMemoryEvent(mockEvent, map[string]any{"id": fmt.Sprintf("pk-%d", i)}, kafkalib.TopicConfig{Schema: tableID.Schema}, config.Replication)
+				evt, err := event.ToMemoryEvent(mockEvent, map[string]any{"id": fmt.Sprintf("pk-%d", i)}, kafkalib.TopicConfig{Schema: tableID.Schema, Topic: topicConfig.Topic}, config.Replication)
 				assert.NoError(f.T(), err)
 
 				kafkaMsg := kafka.Message{Partition: 1, Offset: int64(i)}
@@ -123,14 +123,13 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 
 	// Verify all the tables exist.
 	for idx := range tableIDs {
-		td := f.db.GetOrCreateTableData(tableIDs[idx])
+		td := f.db.GetOrCreateTableData(tableIDs[idx], topicConfig.Topic)
 		assert.Len(f.T(), td.Rows(), 5)
 	}
 
 	f.fakeBaseline.MergeReturns(true, nil)
 	assert.NoError(f.T(), Flush(f.T().Context(), f.db, f.baseline, metrics.NullMetricsProvider{}, Args{}))
 	assert.Equal(f.T(), f.fakeConsumer.CommitMessagesCallCount(), len(tableIDs)) // Commit 3 times because 3 topics.
-
 	for i := range len(tableIDs) {
 		_, kafkaMessages := f.fakeConsumer.CommitMessagesArgsForCall(i)
 		assert.Equal(f.T(), len(kafkaMessages), 1) // There's only 1 partition right now

--- a/processes/consumer/flush_test.go
+++ b/processes/consumer/flush_test.go
@@ -130,7 +130,8 @@ func (f *FlushTestSuite) TestMemoryConcurrency() {
 	f.fakeBaseline.MergeReturns(true, nil)
 	assert.NoError(f.T(), Flush(f.T().Context(), f.db, f.baseline, metrics.NullMetricsProvider{}, Args{}))
 	assert.Equal(f.T(), f.fakeConsumer.CommitMessagesCallCount(), len(tableIDs)) // Commit 3 times because 3 topics.
-	for i := range len(tableIDs) {
+
+	for i := range f.fakeConsumer.CommitMessagesCallCount() {
 		_, kafkaMessages := f.fakeConsumer.CommitMessagesArgsForCall(i)
 		assert.Equal(f.T(), len(kafkaMessages), 1) // There's only 1 partition right now
 

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -86,8 +86,8 @@ func (p processArgs) process(ctx context.Context, cfg config.Config, inMemDB *mo
 
 	if shouldFlush {
 		err = Flush(ctx, inMemDB, dest, metricsClient, Args{
-			Reason:          flushReason,
-			SpecificTableID: evt.GetTableID(),
+			Reason: flushReason,
+			Topic:  topicConfig.tc.Topic,
 		})
 		if err != nil {
 			tags["what"] = "flush_fail"

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -174,7 +174,7 @@ func TestProcessMessageFailures(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, tableID, actualTableID)
 
-	td := memoryDB.GetOrCreateTableData(tableID)
+	td := memoryDB.GetOrCreateTableData(tableID, msg.Topic())
 	// Check that there are corresponding row(s) in the memory DB
 	assert.Len(t, td.Rows(), 1)
 
@@ -337,7 +337,7 @@ func TestProcessMessageSkip(t *testing.T) {
 			TopicToConfigFormatMap: tcFmtMap,
 		}
 
-		td := memoryDB.GetOrCreateTableData(tableID)
+		td := memoryDB.GetOrCreateTableData(tableID, msg.Topic())
 		assert.Equal(t, 0, int(td.NumberOfRows()))
 
 		actualTableID, err := args.process(ctx, cfg, memDB, &mocks.FakeBaseline{}, metrics.NullMetricsProvider{})


### PR DESCRIPTION
This PR refactors how we are flushing specific tables to be topics based.

For the most part, topic to table is 1:1 and flushing based on specific tables is fine. However, this is not great for fan-in and could cause possible issues downstream.

By moving to be topic specific:

1. Changes nothing for normal 1:1 tables.
2. For fan-in tables, this means that we will flush every table from the unified topic. This is desired because we are committing offsets at the end. 