### PR TITLE
Supporting additional primary keys

### DIFF
--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -65,8 +65,12 @@ type TopicConfig struct {
 	// [ColumnsToInclude] can be used to specify the exact columns that should be written to the destination.
 	ColumnsToInclude []string `yaml:"columnsToInclude,omitempty"`
 	// [ColumnsToExclude] can be used to exclude columns from being written to the destination.
-	ColumnsToExclude       []string                `yaml:"columnsToExclude,omitempty"`
-	PrimaryKeysOverride    []string                `yaml:"primaryKeysOverride,omitempty"`
+	ColumnsToExclude    []string `yaml:"columnsToExclude,omitempty"`
+	PrimaryKeysOverride []string `yaml:"primaryKeysOverride,omitempty"`
+
+	// [IncludePrimaryKeys] - This is used to specify an additional column that can be used as part of the primary key
+	// An example of this could be to include the full source table name.
+	IncludePrimaryKeys     []string                `yaml:"includePrimaryKeys,omitempty"`
 	MultiStepMergeSettings *MultiStepMergeSettings `yaml:"multiStepMergeSettings,omitempty"`
 
 	// Internal metadata
@@ -140,6 +144,11 @@ func (t TopicConfig) Validate() error {
 	// You can't specify both [ColumnsToInclude] and [ColumnsToExclude]
 	if len(t.ColumnsToInclude) > 0 && len(t.ColumnsToExclude) > 0 {
 		return fmt.Errorf("cannot specify both columnsToInclude and columnsToExclude")
+	}
+
+	// You cannot have both [PrimaryKeysOverride] and [IncludePrimaryKeys]
+	if len(t.PrimaryKeysOverride) > 0 && len(t.IncludePrimaryKeys) > 0 {
+		return fmt.Errorf("cannot specify both primaryKeysOverride and includePrimaryKeys")
 	}
 
 	return nil

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -122,6 +122,14 @@ func ToMemoryEvent(event cdc.Event, pkMap map[string]any, tc kafkalib.TopicConfi
 		for pk := range pkMap {
 			pks = append(pks, pk)
 		}
+
+		for _, pk := range tc.IncludePrimaryKeys {
+			// If it's not already included in the [pkMap], let's add it.
+			if _, ok := pkMap[pk]; !ok {
+				pks = append(pks, pk)
+			}
+		}
+
 	}
 
 	if cols != nil {


### PR DESCRIPTION
This PR supports specifying additional primary keys to the particular table. 

This setting is useful for workloads where we are fanning source tables into one target table and if the source table's primary key is not unique across the different tables.

With this feature, customers can add the full source table name as an additional primary key column