### PR TITLE
Use Kafka broker version 3.9.0 in E2E tests

### DIFF
--- a/e2e_tests/postgres/docker-compose.yaml
+++ b/e2e_tests/postgres/docker-compose.yaml
@@ -10,13 +10,13 @@ services:
     volumes:
       - ./sql/create_db.sql:/docker-entrypoint-initdb.d/create_db.sql
   zookeeper:
-    image: quay.io/debezium/zookeeper:2.0
+    image: quay.io/debezium/zookeeper:3.1
     ports:
       - 2181:2181
       - 2888:2888
       - 3888:3888
   kafka:
-    image: quay.io/debezium/kafka:2.0
+    image: quay.io/debezium/kafka:3.1
     container_name: kafka
     ports:
       - 9092:9092


### PR DESCRIPTION
looks like the container pulls Kafka 3.9.0
<img width="1286" height="37" alt="Screenshot 2025-09-04 at 5 56 40 PM" src="https://github.com/user-attachments/assets/af4f78ac-4ee8-4947-aab1-41a342061442" />

https://quay.io/repository/debezium/kafka/manifest/sha256:e734fed2d2e546b2389460888f37759f42499c7eb47ba7bf8d7187941874b64b
https://quay.io/repository/debezium/kafka/manifest/sha256:d8c48852ac7b5826964bfa79b9f12a5105a3b43c511f33f907abd76bc395aecb