### PR TITLE
Refactor artie.Message to use proper Go embedding

### DIFF
--- a/lib/artie/message.go
+++ b/lib/artie/message.go
@@ -11,11 +11,7 @@ import (
 )
 
 type Message struct {
-	message kafka.Message
-}
-
-func (m Message) GetMessage() kafka.Message {
-	return m.message
+	kafka.Message
 }
 
 func BuildLogFields(msg kafka.Message) []any {
@@ -28,14 +24,14 @@ func BuildLogFields(msg kafka.Message) []any {
 }
 
 func NewMessage(msg kafka.Message) Message {
-	return Message{message: msg}
+	return Message{msg}
 }
 
 // EmitRowLag will diff against the partition's high watermark and the message's offset
 func (m Message) EmitRowLag(metricsClient base.Client, mode config.Mode, groupID, table string) {
 	metricsClient.GaugeWithSample(
 		"row.lag",
-		float64(m.message.HighWaterMark-m.message.Offset),
+		float64(m.HighWaterMark-m.Offset),
 		map[string]string{
 			"mode":    mode.String(),
 			"groupID": groupID,
@@ -53,25 +49,5 @@ func (m Message) EmitIngestionLag(metricsClient base.Client, mode config.Mode, g
 }
 
 func (m Message) PublishTime() time.Time {
-	return m.message.Time
-}
-
-func (m Message) Topic() string {
-	return m.message.Topic
-}
-
-func (m Message) Partition() int {
-	return m.message.Partition
-}
-
-func (m Message) Offset() int64 {
-	return m.message.Offset
-}
-
-func (m Message) Key() []byte {
-	return m.message.Key
-}
-
-func (m Message) Value() []byte {
-	return m.message.Value
+	return m.Time
 }

--- a/lib/artie/message_test.go
+++ b/lib/artie/message_test.go
@@ -18,8 +18,8 @@ func TestNewMessage(t *testing.T) {
 	}
 
 	msg := NewMessage(kafkaMsg)
-	assert.Equal(t, "test_topic", msg.Topic())
-	assert.Equal(t, 5, msg.Partition())
-	assert.Equal(t, keyString, string(msg.Key()))
-	assert.Equal(t, "kafka_value", string(msg.Value()))
+	assert.Equal(t, "test_topic", msg.Topic)
+	assert.Equal(t, 5, msg.Partition)
+	assert.Equal(t, keyString, string(msg.Key))
+	assert.Equal(t, "kafka_value", string(msg.Value))
 }

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -37,21 +37,21 @@ func (p processArgs) process(ctx context.Context, cfg config.Config, inMemDB *mo
 		metricsClient.Timing("process.message", time.Since(st), tags)
 	}()
 
-	topicConfig, ok := p.TopicToConfigFormatMap.GetTopicFmt(p.Msg.Topic())
+	topicConfig, ok := p.TopicToConfigFormatMap.GetTopicFmt(p.Msg.Topic)
 	if !ok {
 		tags["what"] = "failed_topic_lookup"
-		return cdc.TableID{}, fmt.Errorf("failed to get topic name: %q", p.Msg.Topic())
+		return cdc.TableID{}, fmt.Errorf("failed to get topic name: %q", p.Msg.Topic)
 	}
 
 	tags["database"] = topicConfig.tc.Database
 	tags["schema"] = topicConfig.tc.Schema
-	pkMap, err := topicConfig.GetPrimaryKey(p.Msg.Key(), topicConfig.tc)
+	pkMap, err := topicConfig.GetPrimaryKey(p.Msg.Key, topicConfig.tc)
 	if err != nil {
 		tags["what"] = "marshall_pk_err"
-		return cdc.TableID{}, fmt.Errorf("cannot unmarshal key %q: %w", string(p.Msg.Key()), err)
+		return cdc.TableID{}, fmt.Errorf("cannot unmarshal key %q: %w", string(p.Msg.Key), err)
 	}
 
-	_event, err := topicConfig.GetEventFromBytes(p.Msg.Value())
+	_event, err := topicConfig.GetEventFromBytes(p.Msg.Value)
 	if err != nil {
 		tags["what"] = "marshal_value_err"
 		return cdc.TableID{}, fmt.Errorf("cannot unmarshal event: %w", err)

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -62,12 +62,12 @@ func TestProcessMessageFailures(t *testing.T) {
 
 	var mgo mongo.Debezium
 	tcFmtMap := NewTcFmtMap()
-	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
+	tcFmtMap.Add(msg.Topic, TopicConfigFormatter{
 		tc: kafkalib.TopicConfig{
 			Database:     db,
 			TableName:    table,
 			Schema:       schema,
-			Topic:        msg.Topic(),
+			Topic:        msg.Topic,
 			CDCFormat:    "",
 			CDCKeyFormat: "",
 		},
@@ -80,7 +80,7 @@ func TestProcessMessageFailures(t *testing.T) {
 		TopicToConfigFormatMap: tcFmtMap,
 	}
 
-	_, ok := tcFmtMap.GetTopicFmt(msg.Topic())
+	_, ok := tcFmtMap.GetTopicFmt(msg.Topic)
 	assert.True(t, ok)
 
 	tableName, err = args.process(ctx, cfg, memDB, &mocks.FakeBaseline{}, metrics.NullMetricsProvider{})
@@ -92,14 +92,14 @@ func TestProcessMessageFailures(t *testing.T) {
 		Database:     db,
 		TableName:    table,
 		Schema:       schema,
-		Topic:        msg.Topic(),
+		Topic:        msg.Topic,
 		CDCFormat:    "",
 		CDCKeyFormat: "org.apache.kafka.connect.storage.StringConverter",
 	}
 	tc.Load()
 
 	// Add will just replace the prev setting.
-	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
+	tcFmtMap.Add(msg.Topic, TopicConfigFormatter{
 		tc:     tc,
 		Format: &mgo,
 	})
@@ -158,7 +158,7 @@ func TestProcessMessageFailures(t *testing.T) {
 	}
 }`
 
-	kafkaMessage := msg.GetMessage()
+	kafkaMessage := msg.Message
 	memoryDB := memDB
 	kafkaMessage.Key = []byte(fmt.Sprintf("Struct{id=%v}", 1004))
 	kafkaMessage.Value = []byte(val)
@@ -173,7 +173,7 @@ func TestProcessMessageFailures(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, tableID, actualTableID)
 
-	td := memoryDB.GetOrCreateTableData(tableID, msg.Topic())
+	td := memoryDB.GetOrCreateTableData(tableID, msg.Topic)
 	// Check that there are corresponding row(s) in the memory DB
 	assert.Len(t, td.Rows(), 1)
 
@@ -234,12 +234,12 @@ func TestProcessMessageSkip(t *testing.T) {
 	)
 
 	tcFmtMap := NewTcFmtMap()
-	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
+	tcFmtMap.Add(msg.Topic, TopicConfigFormatter{
 		tc: kafkalib.TopicConfig{
 			Database:     db,
 			TableName:    table,
 			Schema:       schema,
-			Topic:        msg.Topic(),
+			Topic:        msg.Topic,
 			CDCFormat:    "",
 			CDCKeyFormat: "",
 		},
@@ -250,7 +250,7 @@ func TestProcessMessageSkip(t *testing.T) {
 		Database:          db,
 		TableName:         table,
 		Schema:            schema,
-		Topic:             msg.Topic(),
+		Topic:             msg.Topic,
 		CDCFormat:         "",
 		CDCKeyFormat:      "org.apache.kafka.connect.storage.StringConverter",
 		SkippedOperations: "d",
@@ -258,7 +258,7 @@ func TestProcessMessageSkip(t *testing.T) {
 	tc.Load()
 
 	// Add will just replace the prev setting.
-	tcFmtMap.Add(msg.Topic(), TopicConfigFormatter{
+	tcFmtMap.Add(msg.Topic, TopicConfigFormatter{
 		tc:     tc,
 		Format: &mgo,
 	})
@@ -324,7 +324,7 @@ func TestProcessMessageSkip(t *testing.T) {
 	for _, val := range vals {
 		idx += 1
 
-		kafkaMessage := msg.GetMessage()
+		kafkaMessage := msg.Message
 		kafkaMessage.Key = []byte(fmt.Sprintf("Struct{id=%v}", idx))
 		if val != "" {
 			kafkaMessage.Value = []byte(val)
@@ -336,7 +336,7 @@ func TestProcessMessageSkip(t *testing.T) {
 			TopicToConfigFormatMap: tcFmtMap,
 		}
 
-		td := memoryDB.GetOrCreateTableData(tableID, msg.Topic())
+		td := memoryDB.GetOrCreateTableData(tableID, msg.Topic)
 		assert.Equal(t, 0, int(td.NumberOfRows()))
 
 		actualTableID, err := args.process(ctx, cfg, memDB, &mocks.FakeBaseline{}, metrics.NullMetricsProvider{})


### PR DESCRIPTION

## Summary
  Refactored `artie.Message` to use proper Go embedding instead of a named field, following Go best practices for composition.

## Changes
  - Changed from `message kafka.Message` field to embedded `kafka.Message`
  - Removed redundant wrapper methods (`GetMessage()`, `Topic()`, `Key()`, etc.)
  - Updated usage to direct field access (`msg.Topic` vs `msg.Topic()`)

## Benefits
  - More idiomatic Go code
  - Eliminates code duplication
  - Direct access to all `kafka.Message` fields/methods

## Breaking Changes
  ⚠️ Removes public methods - external users need to switch from method calls to field access (e.g., `msg.Topic()` → `msg.Topic`). Impact unclear due to unknown external usage.