### PR TITLE
Improve flush

### DIFF
--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -37,6 +37,7 @@ func Flush(ctx context.Context, inMemDB *models.DatabaseData, dest destination.B
 	return nil
 }
 
+// TODO: Write a test for [FlushSingleTopic]
 func FlushSingleTopic(ctx context.Context, inMemDB *models.DatabaseData, dest destination.Baseline, metricsClient base.Client, args Args, topic string, shouldLock bool) error {
 	if inMemDB == nil {
 		return nil

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -55,15 +55,18 @@ func FlushSingleTopic(ctx context.Context, inMemDB *models.DatabaseData, dest de
 	var grp errgroup.Group
 	var commitOffset atomic.Bool
 	err = consumer.LockAndProcess(ctx, shouldLock, func() error {
+		// If there are more tables, let's ensure that ALL tables in this topic are flushable.
+		// If not, let's hold off and wait for the next flush cycle. This is to avoid a situation where we flush a fraction of the tables in this topic
+		// And commit the offset (when we shouldn't), or clear memory of all the tables in this topic (when we shouldn't).
 		for _, table := range tables {
-			// Also in the example: https://pkg.go.dev/golang.org/x/sync/errgroup#example-Group-Parallel
-			table := table // https://golang.org/doc/faq#closures_and_goroutines
-			grp.Go(func() error {
-				if args.CoolDown != nil && table.ShouldSkipFlush(*args.CoolDown) {
-					slog.Debug("Skipping flush because we are currently in a flush cooldown", slog.String("tableID", table.GetTableID().String()))
-					return nil
-				}
+			if args.CoolDown != nil && table.ShouldSkipFlush(*args.CoolDown) {
+				slog.Debug("Skipping flush because we are currently in a flush cooldown", slog.String("tableID", table.GetTableID().String()))
+				return nil
+			}
+		}
 
+		for _, table := range tables {
+			grp.Go(func() error {
 				retryCfg, err := retry.NewJitterRetryConfig(1_000, 30_000, 15, retry.AlwaysRetry)
 				if err != nil {
 					return err


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Only flush a topic when all its tables are eligible (not in cooldown); otherwise skip this cycle and then flush tables in parallel.
> 
> - **Consumer flush logic (`processes/consumer/flush.go`)**:
>   - Enforce all-or-nothing topic flushing: pre-check all `tables` and skip the entire topic if any table `ShouldSkipFlush` due to `CoolDown`.
>   - Restructure processing: perform eligibility check first, then launch per-table flushes in parallel via `errgroup`.
>   - Minor: add TODO for testing `FlushSingleTopic`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit befb28b39beb27e7bb500ceeb0ee2854c342440f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->