### PR TITLE
Typing library to skip bad dates (configurable)

### DIFF
--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -37,13 +37,21 @@ func replaceExceededValues(colVal string, kindDetails typing.KindDetails) string
 	return colVal
 }
 
-func castColValStaging(colVal any, colKind typing.KindDetails, _ config.SharedDestinationSettings) (shared.ValueConvertResponse, error) {
+func castColValStaging(colVal any, colKind typing.KindDetails, config config.SharedDestinationSettings) (shared.ValueConvertResponse, error) {
 	if colVal == nil {
 		return shared.ValueConvertResponse{Value: constants.NullValuePlaceholder}, nil
 	}
 
 	value, err := values.ToString(colVal, colKind)
 	if err != nil {
+		if config.SkipBadTimestamps {
+			if parseError, ok := typing.BuildParseError(err); ok {
+				if parseError.GetKind() == typing.UnsupportedDateLayout {
+					return shared.ValueConvertResponse{Value: constants.NullValuePlaceholder}, nil
+				}
+			}
+		}
+
 		return shared.ValueConvertResponse{}, err
 	}
 

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -47,6 +47,7 @@ func castColValStaging(colVal any, colKind typing.KindDetails, config config.Sha
 		if config.SkipBadTimestamps {
 			if parseError, ok := typing.BuildParseError(err); ok {
 				if parseError.GetKind() == typing.UnsupportedDateLayout {
+					slog.Info("Skipping a bad timestamp, returning null", slog.Any("err", err), slog.Any("value", colVal))
 					return shared.ValueConvertResponse{Value: constants.NullValuePlaceholder}, nil
 				}
 			}

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -73,6 +73,20 @@ func (s *SnowflakeTestSuite) TestCastColValStaging() {
 		assert.NoError(s.T(), err)
 		assert.Equal(s.T(), "foo", result.Value)
 	}
+	{
+		// Bad timestamp
+		{
+			// Config is enabled, so we won't error, we'll just return null.
+			result, err := castColValStaging("foo", typing.Date, config.SharedDestinationSettings{SkipBadTimestamps: true})
+			assert.NoError(s.T(), err)
+			assert.Equal(s.T(), constants.NullValuePlaceholder, result.Value)
+		}
+		{
+			// Config is disabled, so we'll error.
+			_, err := castColValStaging("foo", typing.Date, config.SharedDestinationSettings{SkipBadTimestamps: false})
+			assert.Error(s.T(), err)
+		}
+	}
 }
 
 // runTestCaseWithReset runs a test case with a fresh store state

--- a/lib/config/types.go
+++ b/lib/config/types.go
@@ -38,6 +38,8 @@ type SharedDestinationSettings struct {
 	UseNewStringMethod bool `yaml:"useNewStringMethod"`
 	// [EnableMergeAssertion] - This will enable the merge assertion checks for the destination.
 	EnableMergeAssertion bool `yaml:"enableMergeAssertion,omitempty"`
+	// [SkipBadTimestamps] - If enabled, we'll skip over bad timestamp (or alike) values instead of throwing an error.
+	SkipBadTimestamps bool `yaml:"skipBadTimestamps"`
 }
 
 type Reporting struct {

--- a/lib/typing/errors.go
+++ b/lib/typing/errors.go
@@ -17,3 +17,35 @@ func (u UnsupportedDataTypeError) Error() string {
 func IsUnsupportedDataTypeError(err error) bool {
 	return errors.As(err, &UnsupportedDataTypeError{})
 }
+
+type ParseErrorKind string
+
+const (
+	UnsupportedDateLayout ParseErrorKind = "unsupported_date_layout"
+)
+
+type ParseError struct {
+	message string
+	kind    ParseErrorKind
+}
+
+func NewParseError(message string, kind ParseErrorKind) ParseError {
+	return ParseError{message: message, kind: kind}
+}
+
+func (p ParseError) Error() string {
+	return p.message
+}
+
+func (p ParseError) GetKind() ParseErrorKind {
+	return p.kind
+}
+
+func BuildParseError(err error) (ParseError, bool) {
+	var parseError ParseError
+	if errors.As(err, &parseError) {
+		return parseError, true
+	}
+
+	return ParseError{}, false
+}

--- a/lib/typing/parse_timestamp.go
+++ b/lib/typing/parse_timestamp.go
@@ -38,7 +38,7 @@ func ParseDateFromAny(val any) (time.Time, error) {
 			return ts, nil
 		}
 
-		return time.Time{}, fmt.Errorf("unsupported value: %q", convertedVal)
+		return time.Time{}, NewParseError(fmt.Sprintf("unsupported value: %q", convertedVal), UnsupportedDateLayout)
 	default:
 		return time.Time{}, fmt.Errorf("unsupported type: %T", convertedVal)
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add SkipBadTimestamps setting to return null for unsupported date/timestamp values during staging, using new typed ParseError to detect unsupported date layouts.
> 
> - **Snowflake Staging**:
>   - `castColValStaging` now accepts `config` and, when `sharedDestinationSettings.skipBadTimestamps` is true, returns `__artie_null_value` instead of error for bad timestamps detected via typed parse errors.
> - **Config**:
>   - Add `sharedDestinationSettings.skipBadTimestamps` flag.
> - **Typing**:
>   - Introduce `ParseError` with `UnsupportedDateLayout` kind and helpers; `ParseDateFromAny` now returns `ParseError` for unsupported layouts.
> - **Tests**:
>   - Add tests verifying null-return vs error behavior based on `SkipBadTimestamps`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bc94c8f03868c65fbcbd7891efbf6753ce507e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->