### PR TITLE
Wrap toast placeholder in quotes for json columns in postgres

### DIFF
--- a/clients/postgres/staging.go
+++ b/clients/postgres/staging.go
@@ -130,7 +130,7 @@ func parseValue(value any, col columns.Column) (any, error) {
 	case typing.Struct.Kind:
 		// If it's the toast placeholder value, wrap it in quotes so it's valid json
 		if value == constants.ToastUnavailableValuePlaceholder {
-			return fmt.Sprintf(`"%s"`, value), nil
+			return fmt.Sprintf(`%q`, value), nil
 		}
 		return value, nil
 	default:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Quotes the toast placeholder for struct/json values during Postgres staging copy to produce valid JSON.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b5174cb12e8f40cc8a70b30e0d455bc85287500. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->