### PR TITLE
[Kafka] Add backward-compatible KafkaClient config

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -71,6 +71,7 @@ func readFileToConfig(pathToConfig string) (*Config, error) {
 	config.BufferRows = cmp.Or(config.BufferRows, defaultBufferPoolSize)
 	config.FlushSizeKb = cmp.Or(config.FlushSizeKb, defaultFlushSizeKb)
 	config.Mode = cmp.Or(config.Mode, Replication)
+	config.KafkaClient = cmp.Or(config.KafkaClient, KafkaGoClient)
 
 	return &config, nil
 }

--- a/lib/config/types.go
+++ b/lib/config/types.go
@@ -12,6 +12,13 @@ const (
 	Replication Mode = "replication"
 )
 
+type KafkaClient string
+
+const (
+	KafkaGoClient KafkaClient = "kafka-go"
+	FranzGoClient KafkaClient = "franz-go"
+)
+
 type Sentry struct {
 	DSN string `yaml:"dsn"`
 }
@@ -57,9 +64,10 @@ type Reporting struct {
 }
 
 type Config struct {
-	Mode   Mode                      `yaml:"mode"`
-	Output constants.DestinationKind `yaml:"outputSource"`
-	Queue  constants.QueueKind       `yaml:"queue"`
+	KafkaClient KafkaClient               `yaml:"kafkaClient,omitempty"`
+	Mode        Mode                      `yaml:"mode"`
+	Output      constants.DestinationKind `yaml:"outputSource"`
+	Queue       constants.QueueKind       `yaml:"queue"`
 
 	// Flush rules
 	FlushIntervalSeconds int  `yaml:"flushIntervalSeconds"`

--- a/main.go
+++ b/main.go
@@ -86,9 +86,14 @@ func main() {
 	slog.Info("Starting...", slog.String("version", version))
 
 	inMemDB := models.NewMemoryDB()
-	ctx, err = kafkalib.InjectConsumerProvidersIntoContext(ctx, settings.Config.Kafka)
-	if err != nil {
-		logger.Fatal("Failed to inject consumer providers into context", slog.Any("err", err))
+	switch settings.Config.KafkaClient {
+	case config.KafkaGoClient:
+		ctx, err = kafkalib.InjectConsumerProvidersIntoContext(ctx, settings.Config.Kafka)
+		if err != nil {
+			logger.Fatal("Failed to inject kafka-go consumer providers into context", slog.Any("err", err))
+		}
+	default:
+		logger.Fatal(fmt.Sprintf("Kafka client: %q not supported", settings.Config.KafkaClient))
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce configurable `KafkaClient` with default `"kafka-go"` and wire main to use it for consumer injection.
> 
> - **Config**:
>   - Add `KafkaClient` enum (`"kafka-go"`, `"franz-go"`) and include `Config.KafkaClient` (`yaml:"kafkaClient"`).
>   - Default `KafkaClient` to `"kafka-go"` during config load.
> - **Runtime**:
>   - Gate consumer provider injection on `KafkaClient`; support `"kafka-go"`, fail for others.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e99ef0f8f9ff80edfad565913428dbb56ebc67b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->