### PR TITLE
Suppressing Kafka Logs + Add Test

### DIFF
--- a/lib/maputil/sorted_strings_map_test.go
+++ b/lib/maputil/sorted_strings_map_test.go
@@ -11,7 +11,6 @@ func TestSortedStringsMap(t *testing.T) {
 	s.Add("foo", 1)
 	s.Add("bar", 2)
 	s.Add("baz", 3)
-
 	assert.Equal(t, []string{"bar", "baz", "foo"}, s.Keys())
 
 	// Testing all.

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -67,7 +68,10 @@ func StartKafkaConsumer(ctx context.Context, cfg config.Config, inMemDB *models.
 
 				if err != nil {
 					if kafkalib.IsFetchMessageError(err) {
-						slog.Warn("Failed to read kafka message", slog.Any("err", err))
+						if !errors.Is(err, context.DeadlineExceeded) {
+							slog.Warn("Failed to read kafka message", slog.Any("err", err))
+						}
+
 						time.Sleep(500 * time.Millisecond)
 						continue
 					} else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Suppresses noisy Kafka fetch warnings on deadline timeouts and adds a test asserting `SortedStringsMap.All()` iteration order.
> 
> - **Consumer / Kafka**:
>   - Adjust `StartKafkaConsumer` fetch error handling in `processes/consumer/kafka.go` to skip warning logs when `errors.Is(err, context.DeadlineExceeded)`.
> - **Tests**:
>   - Extend `lib/maputil/sorted_strings_map_test.go` to iterate over `s.All()` and assert sorted keys order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a967c601b139b0a0bc8c6db449fac51aedec456. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->