### PR TITLE
Adding webhooks

### DIFF
--- a/lib/config/types.go
+++ b/lib/config/types.go
@@ -96,4 +96,12 @@ type Config struct {
 			Settings map[string]any         `yaml:"settings,omitempty"`
 		}
 	}
+
+	Webhooks *WebhookConfig `yaml:"webhooks,omitempty"`
+}
+
+type WebhookConfig struct {
+	Enabled    bool     `yaml:"enabled"`
+	URLs       []string `yaml:"urls"`
+	BufferSize int      `yaml:"bufferSize,omitempty"`
 }

--- a/processes/webhook/example_test.go
+++ b/processes/webhook/example_test.go
@@ -1,0 +1,68 @@
+package webhook_test
+
+import (
+	"context"
+
+	"github.com/artie-labs/transfer/processes/webhook"
+)
+
+// Example shows how to use the webhook service in your application
+func Example() {
+	// 1. Create a webhook service with configuration
+	svc := webhook.NewService(webhook.Config{
+		URLs: []string{
+			"https://your-app.com/webhooks/artie",
+			"https://backup-receiver.com/notify",
+		},
+		BufferSize: 1000, // Optional: defaults to 1000
+	})
+
+	// 2. Start the service with your application context
+	ctx := context.Background()
+	svc.Start(ctx)
+
+	// 3. Publish events from anywhere in your codebase
+	// The service handles delivery, retries, and error handling automatically
+
+	// Example: Publishing a merge start event
+	svc.Publish(
+		webhook.EventMergeStarted,
+		webhook.StatusSuccess,
+		map[string]any{
+			"table":     "users",
+			"database":  "production",
+			"timestamp": "2024-01-15T10:30:00Z",
+		},
+	)
+
+	// Example: Publishing a merge completion event
+	svc.Publish(
+		webhook.EventMergeFinished,
+		webhook.StatusSuccess,
+		map[string]any{
+			"table":     "users",
+			"database":  "production",
+			"rows":      1500,
+			"duration":  "2.5s",
+			"timestamp": "2024-01-15T10:30:02Z",
+		},
+	)
+
+	// Example: Publishing a failure event
+	svc.Publish(
+		webhook.EventMergeFinished,
+		webhook.StatusFailed,
+		map[string]any{
+			"table":    "orders",
+			"database": "production",
+			"error":    "connection timeout",
+		},
+	)
+
+	// The service will:
+	// - Queue events in a buffered channel (non-blocking)
+	// - Deliver to all configured URLs in parallel
+	// - Automatically retry on network errors and 5xx responses
+	// - Log errors after all retry attempts are exhausted
+	// - Gracefully shutdown when context is cancelled
+}

--- a/processes/webhook/loader.go
+++ b/processes/webhook/loader.go
@@ -1,0 +1,23 @@
+package webhook
+
+import (
+	"context"
+
+	"github.com/artie-labs/transfer/lib/config"
+)
+
+// LoadFromConfig creates and starts a webhook service from the configuration
+// Returns nil if webhooks are not configured
+func LoadFromConfig(ctx context.Context, cfg config.Config) *Service {
+	if cfg.Webhooks == nil || len(cfg.Webhooks.URLs) == 0 {
+		return nil
+	}
+
+	svc := NewService(Config{
+		URLs:       cfg.Webhooks.URLs,
+		BufferSize: cfg.Webhooks.BufferSize,
+	})
+
+	svc.Start(ctx)
+	return svc
+}

--- a/processes/webhook/webhook.go
+++ b/processes/webhook/webhook.go
@@ -2,8 +2,25 @@ package webhook
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
+	"syscall"
+	"time"
+
+	"github.com/artie-labs/transfer/lib/retry"
+)
+
+const (
+	// Retry configuration
+	retryBaseMs    = 100
+	retryMaxMs     = 5000
+	maxRetries     = 3
+	requestTimeout = 30 * time.Second
 )
 
 type Status string
@@ -20,31 +37,189 @@ const (
 	EventMergeFinished Event = "merge_finished"
 )
 
+// Action represents a webhook event to be delivered
 type Action struct {
-	url      string
-	event    string
-	metadata map[string]any
-	status   Status
+	Event    Event          `json:"event"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+	Status   Status         `json:"status"`
 }
 
-func (a Action) BuildPayload() (*http.Request, error) {
-	payload := map[string]any{
-		"url":      a.url,
-		"event":    a.event,
-		"metadata": a.metadata,
-		"status":   a.status,
+// Config holds webhook service configuration
+type Config struct {
+	// URLs is a list of webhook endpoints to deliver events to
+	URLs []string
+	// HTTPClient allows injection of custom HTTP client for testing
+	HTTPClient *http.Client
+	// BufferSize sets the channel buffer size (default: 1000)
+	BufferSize int
+}
+
+// Service manages webhook delivery
+type Service struct {
+	config  Config
+	actions chan Action
+	client  *http.Client
+}
+
+// NewService creates a new webhook service
+func NewService(cfg Config) *Service {
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{
+			Timeout: requestTimeout,
+		}
+	}
+	if cfg.BufferSize == 0 {
+		cfg.BufferSize = 1000
 	}
 
-	jsonPayload, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
+	return &Service{
+		config:  cfg,
+		actions: make(chan Action, cfg.BufferSize),
+		client:  cfg.HTTPClient,
+	}
+}
+
+// Publish sends an event to the webhook service for delivery
+// This is non-blocking and returns immediately
+func (s *Service) Publish(event Event, status Status, metadata map[string]any) {
+	action := Action{
+		Event:    event,
+		Status:   status,
+		Metadata: metadata,
 	}
 
-	req, err := http.NewRequest("POST", a.url, bytes.NewBuffer(jsonPayload))
+	select {
+	case s.actions <- action:
+		// Successfully queued
+	default:
+		slog.Warn("Webhook action channel is full, dropping event",
+			slog.String("event", string(event)),
+			slog.String("status", string(status)),
+		)
+	}
+}
+
+// Start begins processing webhook events in the background
+func (s *Service) Start(ctx context.Context) {
+	if len(s.config.URLs) == 0 {
+		slog.Info("No webhook URLs configured, webhook service disabled")
+		return
+	}
+
+	slog.Info("Starting webhook service",
+		slog.Int("urls", len(s.config.URLs)),
+		slog.Int("bufferSize", s.config.BufferSize),
+	)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				slog.Info("Webhook service shutting down")
+				return
+			case action := <-s.actions:
+				s.deliverToAllURLs(ctx, action)
+			}
+		}
+	}()
+}
+
+// deliverToAllURLs delivers the action to all configured webhook URLs
+func (s *Service) deliverToAllURLs(ctx context.Context, action Action) {
+	for _, url := range s.config.URLs {
+		if err := s.deliverWithRetry(ctx, url, action); err != nil {
+			slog.Error("Failed to deliver webhook after retries",
+				slog.String("url", url),
+				slog.String("event", string(action.Event)),
+				slog.Any("err", err),
+			)
+		}
+	}
+}
+
+// deliverWithRetry attempts to deliver a webhook with exponential backoff
+func (s *Service) deliverWithRetry(ctx context.Context, url string, action Action) error {
+	retryCfg, err := retry.NewJitterRetryConfig(retryBaseMs, retryMaxMs, maxRetries, isRetryableHTTPError)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to create retry config: %w", err)
+	}
+
+	return retry.WithRetries(retryCfg, func(attempt int, _ error) error {
+		return s.deliver(ctx, url, action, attempt)
+	})
+}
+
+// deliver sends a single webhook request
+func (s *Service) deliver(ctx context.Context, url string, action Action, attempt int) error {
+	payload, err := json.Marshal(action)
+	if err != nil {
+		return fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	return req, nil
+	req.Header.Set("User-Agent", "Artie-Transfer-Webhook/1.0")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read and discard body to reuse connection
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if attempt > 0 {
+			slog.Info("Webhook delivered successfully after retry",
+				slog.String("url", url),
+				slog.String("event", string(action.Event)),
+				slog.Int("attempt", attempt+1),
+				slog.Int("statusCode", resp.StatusCode),
+			)
+		}
+		return nil
+	}
+
+	return &httpError{
+		statusCode: resp.StatusCode,
+		url:        url,
+	}
+}
+
+// httpError represents an HTTP error response
+type httpError struct {
+	statusCode int
+	url        string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("webhook request to %s failed with status %d", e.url, e.statusCode)
+}
+
+// isRetryableHTTPError determines if an error should be retried
+func isRetryableHTTPError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Retry network errors
+	if errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ETIMEDOUT) ||
+		errors.Is(err, io.EOF) {
+		return true
+	}
+
+	// Retry HTTP 5xx errors and 429 (rate limit)
+	var httpErr *httpError
+	if errors.As(err, &httpErr) {
+		return httpErr.statusCode >= 500 || httpErr.statusCode == 429
+	}
+
+	return false
 }

--- a/processes/webhook/webhook_test.go
+++ b/processes/webhook/webhook_test.go
@@ -1,0 +1,357 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewService(t *testing.T) {
+	cfg := Config{
+		URLs: []string{"http://example.com/webhook"},
+	}
+
+	svc := NewService(cfg)
+	assert.NotNil(t, svc)
+	assert.NotNil(t, svc.client)
+	assert.Equal(t, 1000, svc.config.BufferSize)
+}
+
+func TestPublish(t *testing.T) {
+	cfg := Config{
+		URLs:       []string{"http://example.com/webhook"},
+		BufferSize: 10,
+	}
+
+	svc := NewService(cfg)
+
+	// Test successful publish
+	svc.Publish(EventMergeStarted, StatusSuccess, map[string]any{"table": "users"})
+
+	// Verify action was queued
+	select {
+	case action := <-svc.actions:
+		assert.Equal(t, EventMergeStarted, action.Event)
+		assert.Equal(t, StatusSuccess, action.Status)
+		assert.Equal(t, "users", action.Metadata["table"])
+	case <-time.After(time.Second):
+		t.Fatal("Action was not queued")
+	}
+}
+
+func TestPublish_FullBuffer(t *testing.T) {
+	cfg := Config{
+		URLs:       []string{"http://example.com/webhook"},
+		BufferSize: 1,
+	}
+
+	svc := NewService(cfg)
+
+	// Fill the buffer
+	svc.Publish(EventMergeStarted, StatusSuccess, nil)
+
+	// This should not block and should drop the event
+	done := make(chan bool)
+	go func() {
+		svc.Publish(EventMergeFinished, StatusSuccess, nil)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Successfully returned without blocking
+	case <-time.After(time.Second):
+		t.Fatal("Publish blocked when buffer was full")
+	}
+}
+
+func TestDeliver_Success(t *testing.T) {
+	var receivedPayload Action
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Artie-Transfer-Webhook/1.0", r.Header.Get("User-Agent"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		mu.Lock()
+		err = json.Unmarshal(body, &receivedPayload)
+		mu.Unlock()
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		URLs: []string{server.URL},
+	}
+	svc := NewService(cfg)
+
+	action := Action{
+		Event:    EventMergeStarted,
+		Status:   StatusSuccess,
+		Metadata: map[string]any{"table": "orders", "rows": 100},
+	}
+
+	err := svc.deliver(context.Background(), server.URL, action, 0)
+	require.NoError(t, err)
+
+	mu.Lock()
+	assert.Equal(t, EventMergeStarted, receivedPayload.Event)
+	assert.Equal(t, StatusSuccess, receivedPayload.Status)
+	assert.Equal(t, "orders", receivedPayload.Metadata["table"])
+	assert.Equal(t, float64(100), receivedPayload.Metadata["rows"]) // JSON unmarshals numbers as float64
+	mu.Unlock()
+}
+
+func TestDeliver_Retry5xx(t *testing.T) {
+	attemptCount := 0
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attemptCount++
+		currentAttempt := attemptCount
+		mu.Unlock()
+
+		if currentAttempt < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		URLs: []string{server.URL},
+	}
+	svc := NewService(cfg)
+
+	action := Action{
+		Event:  EventMergeFinished,
+		Status: StatusSuccess,
+	}
+
+	err := svc.deliverWithRetry(context.Background(), server.URL, action)
+	require.NoError(t, err)
+
+	mu.Lock()
+	assert.Equal(t, 3, attemptCount, "Should have retried until success")
+	mu.Unlock()
+}
+
+func TestDeliver_NoRetry4xx(t *testing.T) {
+	attemptCount := 0
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attemptCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		URLs: []string{server.URL},
+	}
+	svc := NewService(cfg)
+
+	action := Action{
+		Event:  EventMergeFinished,
+		Status: StatusFailed,
+	}
+
+	err := svc.deliverWithRetry(context.Background(), server.URL, action)
+	require.Error(t, err)
+
+	mu.Lock()
+	assert.Equal(t, 1, attemptCount, "Should not retry 4xx errors")
+	mu.Unlock()
+}
+
+func TestDeliver_Retry429(t *testing.T) {
+	attemptCount := 0
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attemptCount++
+		currentAttempt := attemptCount
+		mu.Unlock()
+
+		if currentAttempt < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		URLs: []string{server.URL},
+	}
+	svc := NewService(cfg)
+
+	action := Action{
+		Event:  EventMergeStarted,
+		Status: StatusSuccess,
+	}
+
+	err := svc.deliverWithRetry(context.Background(), server.URL, action)
+	require.NoError(t, err)
+
+	mu.Lock()
+	assert.Equal(t, 2, attemptCount, "Should retry rate limit errors")
+	mu.Unlock()
+}
+
+func TestStart_NoURLs(t *testing.T) {
+	cfg := Config{
+		URLs: []string{},
+	}
+	svc := NewService(cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Should return immediately without starting goroutine
+	svc.Start(ctx)
+
+	// Publish should still work (just goes to channel)
+	svc.Publish(EventMergeStarted, StatusSuccess, nil)
+}
+
+func TestStart_MultipleURLs(t *testing.T) {
+	receivedCount := 0
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	// Create two test servers
+	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		receivedCount++
+		mu.Unlock()
+		wg.Done()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server1.Close()
+
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		receivedCount++
+		mu.Unlock()
+		wg.Done()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server2.Close()
+
+	cfg := Config{
+		URLs: []string{server1.URL, server2.URL},
+	}
+	svc := NewService(cfg)
+
+	ctx := context.Background()
+	svc.Start(ctx)
+
+	wg.Add(2) // Expect both servers to receive
+	svc.Publish(EventMergeStarted, StatusSuccess, map[string]any{"test": "data"})
+
+	// Wait for both webhooks to be delivered
+	done := make(chan bool)
+	go func() {
+		wg.Wait()
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		mu.Lock()
+		assert.Equal(t, 2, receivedCount, "Both webhooks should have been delivered")
+		mu.Unlock()
+	case <-time.After(5 * time.Second):
+		t.Fatal("Webhooks were not delivered in time")
+	}
+}
+
+func TestStart_ContextCancellation(t *testing.T) {
+	cfg := Config{
+		URLs: []string{"http://example.com/webhook"},
+	}
+	svc := NewService(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	svc.Start(ctx)
+
+	// Give it a moment to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel context
+	cancel()
+
+	// Service should stop gracefully
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestIsRetryableHTTPError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "500 error",
+			err:      &httpError{statusCode: 500, url: "http://test"},
+			expected: true,
+		},
+		{
+			name:     "502 error",
+			err:      &httpError{statusCode: 502, url: "http://test"},
+			expected: true,
+		},
+		{
+			name:     "503 error",
+			err:      &httpError{statusCode: 503, url: "http://test"},
+			expected: true,
+		},
+		{
+			name:     "429 rate limit",
+			err:      &httpError{statusCode: 429, url: "http://test"},
+			expected: true,
+		},
+		{
+			name:     "400 error",
+			err:      &httpError{statusCode: 400, url: "http://test"},
+			expected: false,
+		},
+		{
+			name:     "404 error",
+			err:      &httpError{statusCode: 404, url: "http://test"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isRetryableHTTPError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a webhook service to publish merge events to configured URLs with buffered delivery and retries, plus config support and loader.
> 
> - **Backend**:
>   - **Webhook Service** (`processes/webhook`):
>     - Implements `Service` with `Publish` (non-blocking queue) and `Start` (background processing).
>     - Delivers JSON `Action` payloads (event/status/metadata) via HTTP POST with headers and retry/backoff.
>     - Defines `Event` (`merge_started`, `merge_finished`) and `Status` (`success`, `failed`).
>   - **Loader** (`processes/webhook/loader.go`): Builds and starts service from `config.Config.Webhooks` (uses `URLs`, `bufferSize`).
> - **Config**:
>   - Adds `Config.Webhooks` and `WebhookConfig` (`enabled`, `urls`, `bufferSize`) in `lib/config/types.go`.
> - **Tests/Examples**:
>   - Comprehensive unit tests for publish, delivery, retries, and startup; example usage added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 375753ac66d98b0f59becdd851a45171803d5ddd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->