### PR TITLE
[Kafka franz-go] Crash on fetch message error that is not context.DeadlineExceeded

### DIFF
--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -67,11 +67,8 @@ func StartKafkaConsumer(ctx context.Context, cfg config.Config, inMemDB *models.
 				})
 
 				if err != nil {
-					if fetchErr, ok := kafkalib.IsFetchMessageError(err); ok {
-						if !errors.Is(fetchErr.Err, context.DeadlineExceeded) {
-							slog.Warn("Failed to read kafka message", slog.Any("err", err))
-						}
-
+					if fetchErr, ok := kafkalib.IsFetchMessageError(err); ok && errors.Is(fetchErr.Err, context.DeadlineExceeded) {
+						slog.Warn("Failed to read kafka message", slog.Any("err", err))
 						time.Sleep(500 * time.Millisecond)
 						continue
 					} else {


### PR DESCRIPTION
https://app.datadoghq.com/logs?query=service%3Atransfer%20pod_name%3Atransfer-fbf0ef56-8fe9-4998-a7f5-f3020da21543%2A%20status%3A%28error%20OR%20warn%29&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice%2Cpod_name&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1760971468085&to_ts=1760985419836&live=false


Seeing these two errors where we probably want to crash:

```
Failed to read kafka message err="failed to fetch message: unable to join group session: unable to dial: dial tcp 172.31.47.168:9096: connect: connection timed out"
```

```
Failed to read kafka message err="failed to fetch message: unable to join group session: UNKNOWN_MEMBER_ID: The coordinator is not aware of this member."
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only context.DeadlineExceeded fetch errors are retried; other Kafka fetch-message errors now trigger a fatal exit.
> 
> - **Kafka Consumer (`processes/consumer/kafka.go`)**:
>   - Adjust fetch error handling:
>     - Only `context.DeadlineExceeded` emits a warn, sleeps, and retries.
>     - All other fetch-message errors now log fatal and exit the loop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7101637fce01d261f12dff1813f29e74580346dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->