### PR TITLE
[Kafka] Log topic and fetch timeout when timeout happens

### DIFF
--- a/lib/kafkalib/consumer.go
+++ b/lib/kafkalib/consumer.go
@@ -14,6 +14,10 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
+const (
+	FetchMessageTimeout = 5 * time.Minute
+)
+
 type ctxKey string
 
 func BuildContextKey(topic string) ctxKey {
@@ -340,7 +344,7 @@ func (c *ConsumerProvider) LockAndProcess(ctx context.Context, lock bool, do fun
 }
 
 func (c *ConsumerProvider) FetchMessageAndProcess(ctx context.Context, do func(artie.Message) error) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, FetchMessageTimeout)
 	defer cancel()
 
 	msg, err := c.Consumer.FetchMessage(ctx)

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -68,7 +68,7 @@ func StartKafkaConsumer(ctx context.Context, cfg config.Config, inMemDB *models.
 
 				if err != nil {
 					if fetchErr, ok := kafkalib.IsFetchMessageError(err); ok && errors.Is(fetchErr.Err, context.DeadlineExceeded) {
-						slog.Warn("Failed to read kafka message", slog.Any("err", err))
+						slog.Warn("Failed to read kafka message", slog.Any("err", err), slog.String("topic", topic), slog.Duration("timeout", kafkalib.FetchMessageTimeout))
 						time.Sleep(500 * time.Millisecond)
 						continue
 					} else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes fetch timeout as `FetchMessageTimeout` and enriches Kafka fetch-timeout logs with topic and timeout details.
> 
> - **Kafka consumer**:
>   - Define `FetchMessageTimeout` const and use it in `ConsumerProvider.FetchMessageAndProcess`.
>   - Improve timeout warning: include `topic` and `timeout` in log when fetch hits `context.DeadlineExceeded`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a66ab000af2fd51451080343189e0736e5fb4d46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->