### PR TITLE
Update BigQuery Annotation

### DIFF
--- a/lib/kafkalib/partition/settings.go
+++ b/lib/kafkalib/partition/settings.go
@@ -19,8 +19,9 @@ var ValidPartitionBy = []string{
 
 type MergePredicates struct {
 	PartitionField string `yaml:"partitionField" json:"partitionField"`
-	PartitionBy    string `yaml:"partitionBy" json:"partitionBy"`
-	PartitionType  string `yaml:"partitionType" json:"partitionType"`
+	// TODO: - Flip to start using this.
+	PartitionBy   string `yaml:"partitionBy" json:"partitionBy"`
+	PartitionType string `yaml:"partitionType" json:"partitionType"`
 }
 
 type BigQuerySettings struct {


### PR DESCRIPTION
* Adding new annotation here so that we can start to support multiple partition types
* Further moving us off of BigQueryPartitionField

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d1e11e65d052ea05960c9042023ff296662c2ecb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->