### PR TITLE
Use omitempty

### DIFF
--- a/lib/kafkalib/partition/settings.go
+++ b/lib/kafkalib/partition/settings.go
@@ -18,7 +18,7 @@ var ValidPartitionBy = []string{
 // We need the JSON annotations here for our dashboard to import the settings correctly.
 
 type MergePredicates struct {
-	PartitionField string `yaml:"partitionField" json:"partitionField"`
+	PartitionField string `yaml:"partitionField" json:"partitionField,omitempty"`
 	// TODO: - Flip to start using this.
 	PartitionBy   string `yaml:"partitionBy" json:"partitionBy,omitempty"`
 	PartitionType string `yaml:"partitionType" json:"partitionType,omitempty"`


### PR DESCRIPTION
If there's nothing being set, we can just do omitempty so we don't write out an empty string.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use json omitempty on MergePredicates fields to omit empty values from serialized output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 900a39d0909c2fb1fd1352e155b6421b5c4924d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->