### PR TITLE
[Dialect] Stubbing out reserved column names

### DIFF
--- a/clients/bigquery/dialect/dialect.go
+++ b/clients/bigquery/dialect/dialect.go
@@ -23,6 +23,10 @@ func BQExpiresDate(time time.Time) string {
 
 type BigQueryDialect struct{}
 
+func (BigQueryDialect) ReservedColumnNames() []string {
+	return nil
+}
+
 func (BigQueryDialect) QuoteIdentifier(identifier string) string {
 	// BigQuery needs backticks to quote.
 	return fmt.Sprintf("`%s`", strings.ReplaceAll(identifier, "`", ""))

--- a/clients/databricks/dialect/dialect.go
+++ b/clients/databricks/dialect/dialect.go
@@ -14,6 +14,10 @@ import (
 
 type DatabricksDialect struct{}
 
+func (DatabricksDialect) ReservedColumnNames() []string {
+	return nil
+}
+
 func (DatabricksDialect) QuoteIdentifier(identifier string) string {
 	return fmt.Sprintf("`%s`", strings.ReplaceAll(identifier, "`", ""))
 }

--- a/clients/iceberg/dialect/dialect.go
+++ b/clients/iceberg/dialect/dialect.go
@@ -12,6 +12,10 @@ import (
 
 type IcebergDialect struct{}
 
+func (IcebergDialect) ReservedColumnNames() []string {
+	return nil
+}
+
 func (IcebergDialect) BuildIdentifier(identifier string) string {
 	return strings.ToLower(identifier)
 }

--- a/clients/mssql/dialect/dialect.go
+++ b/clients/mssql/dialect/dialect.go
@@ -14,6 +14,10 @@ import (
 
 type MSSQLDialect struct{}
 
+func (MSSQLDialect) ReservedColumnNames() []string {
+	return nil
+}
+
 func (MSSQLDialect) QuoteIdentifier(identifier string) string {
 	charToReplace := []string{`[`, `]`}
 	for _, char := range charToReplace {

--- a/clients/postgres/dialect/dialect.go
+++ b/clients/postgres/dialect/dialect.go
@@ -29,6 +29,10 @@ WHERE c.table_schema = $1 AND c.table_name = $2;`
 
 type PostgresDialect struct{}
 
+func (PostgresDialect) ReservedColumnNames() []string {
+	return nil
+}
+
 func (PostgresDialect) QuoteIdentifier(identifier string) string {
 	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(identifier, `"`, `""`))
 }

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -12,6 +12,10 @@ import (
 
 type RedshiftDialect struct{}
 
+func (RedshiftDialect) ReservedColumnNames() []string {
+	return nil
+}
+
 func (rd RedshiftDialect) QuoteIdentifier(identifier string) string {
 	// Preserve the existing behavior of Redshift identifiers being lowercased due to not being quoted.
 	return fmt.Sprintf(`"%s"`, strings.ToLower(strings.ReplaceAll(identifier, `"`, ``)))

--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -13,6 +13,10 @@ import (
 
 type SnowflakeDialect struct{}
 
+func (SnowflakeDialect) ReservedColumnNames() []string {
+	return nil
+}
+
 func (SnowflakeDialect) QuoteIdentifier(identifier string) string {
 	return fmt.Sprintf(`"%s"`, strings.ToUpper(strings.ReplaceAll(identifier, `"`, ``)))
 }

--- a/lib/sql/dialect.go
+++ b/lib/sql/dialect.go
@@ -28,6 +28,7 @@ type TableIdentifier interface {
 }
 
 type Dialect interface {
+	ReservedColumnNames() []string
 	QuoteIdentifier(identifier string) string
 	EscapeStruct(value string) string
 	DataTypeForKind(kd typing.KindDetails, isPk bool, settings config.SharedDestinationColumnSettings) (string, error)


### PR DESCRIPTION
So we use this as part of escape column names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `ReservedColumnNames()` in `sql.Dialect` and stub it (returning nil) across all dialect implementations.
> 
> - **Dialect Interface**:
>   - Add `ReservedColumnNames()` to `lib/sql/dialect.go`.
> - **Dialect Implementations**:
>   - Stub `ReservedColumnNames()` (returns `nil`) in:
>     - `clients/bigquery/dialect/dialect.go`
>     - `clients/databricks/dialect/dialect.go`
>     - `clients/iceberg/dialect/dialect.go`
>     - `clients/mssql/dialect/dialect.go`
>     - `clients/postgres/dialect/dialect.go`
>     - `clients/redshift/dialect/dialect.go`
>     - `clients/snowflake/dialect/dialect.go`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 688e851cabd4eae44e3d46c657236b3e37bda898. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->