### PR TITLE
Adding Snowflake reserved keywords

### DIFF
--- a/clients/snowflake/dialect/dialect.go
+++ b/clients/snowflake/dialect/dialect.go
@@ -16,18 +16,18 @@ type SnowflakeDialect struct{}
 // ReservedColumnNames - This is sourced from: https://docs.snowflake.com/en/sql-reference/reserved-keywords
 func (SnowflakeDialect) ReservedColumnNames() []string {
 	return []string{
-		"CASE",
-		"CAST",
-		"CONSTRAINT",
-		"CURRENT_DATE",
-		"CURRENT_TIMESTAMP",
-		"CURRENT_USER",
-		"FALSE",
-		"LOCALTIME",
-		"LOCALTIMESTAMP",
-		"TRUE",
-		"TRY_CAST",
-		"WHEN",
+		"case",
+		"cast",
+		"constraint",
+		"current_date",
+		"current_timestamp",
+		"current_user",
+		"false",
+		"localtime",
+		"localtimestamp",
+		"true",
+		"try_cast",
+		"when",
 	}
 }
 

--- a/lib/sql/dialect.go
+++ b/lib/sql/dialect.go
@@ -28,6 +28,7 @@ type TableIdentifier interface {
 }
 
 type Dialect interface {
+	// ReservedColumnNames - This is a list of column names that are reserved by the SQL Dialect. This needs to be all in lowercase.
 	ReservedColumnNames() []string
 	QuoteIdentifier(identifier string) string
 	EscapeStruct(value string) string


### PR DESCRIPTION
Sourced from: https://docs.snowflake.com/en/sql-reference/reserved-keywords

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Snowflake reserved keyword list to the dialect and document the lowercase contract in the SQL Dialect interface.
> 
> - **Snowflake Dialect**:
>   - Implement `ReservedColumnNames()` to return a curated list of Snowflake reserved keywords (lowercase) sourced from Snowflake docs.
> - **SQL Dialect Interface**:
>   - Document the `ReservedColumnNames()` contract requiring all-lowercase names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9817966521fef5ec0c932d8fea64e996a896f449. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->