### PR TITLE
[Kafka] Log consumption timeout at the DEBUG level

### DIFF
--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -67,7 +67,7 @@ func StartKafkaConsumer(ctx context.Context, cfg config.Config, inMemDB *models.
 				})
 				if err != nil {
 					if fetchErr, ok := kafkalib.IsFetchMessageError(err); ok && errors.Is(fetchErr.Err, context.DeadlineExceeded) {
-						slog.Warn("Failed to read kafka message", slog.Any("err", err), slog.String("topic", topic), slog.Duration("timeout", kafkalib.FetchMessageTimeout))
+						slog.Debug("Failed to read kafka message", slog.Any("err", err), slog.String("topic", topic), slog.Duration("timeout", kafkalib.FetchMessageTimeout))
 						time.Sleep(500 * time.Millisecond)
 						continue
 					} else {


### PR DESCRIPTION
Reduce log spam

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades Kafka read-timeout logging from warn to debug in `processes/consumer/kafka.go` to reduce log noise.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecd27cae20fd97b0642a7d3eb455ce66492b11c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->