### PR TITLE
Only use reusable staging tables in Append() when UseTempTable is true

### DIFF
--- a/clients/shared/append.go
+++ b/clients/shared/append.go
@@ -43,7 +43,7 @@ func Append(ctx context.Context, dest destination.Destination, tableData *optimi
 	}
 
 	config := dest.GetConfig()
-	if config.IsStagingTableReuseEnabled() {
+	if opts.UseTempTable && config.IsStagingTableReuseEnabled() {
 		if stagingManager, ok := dest.(ReusableStagingTableManager); ok {
 			return stagingManager.PrepareReusableStagingTable(
 				ctx,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Gate reusable staging table preparation in `Append` behind `opts.UseTempTable`; otherwise use standard temporary table flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c89b031af96876eed6f93fa24c5cf637ed2f2733. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->