### PR TITLE
Rename `PrepareTemporaryTable()` to `LoadDataIntoTable()`

### DIFF
--- a/clients/bigquery/bigquery.go
+++ b/clients/bigquery/bigquery.go
@@ -98,14 +98,14 @@ func (s *Store) Append(ctx context.Context, tableData *optimization.TableData, u
 	return nil
 }
 
-func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tempTableID, _ sql.TableIdentifier, opts types.AdditionalSettings, createTempTable bool) error {
+func (s *Store) LoadDataIntoTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tableID, _ sql.TableIdentifier, opts types.AdditionalSettings, createTempTable bool) error {
 	if createTempTable {
-		if err := shared.CreateTempTable(ctx, s, tableData, dwh, opts.ColumnSettings, tempTableID); err != nil {
+		if err := shared.CreateTempTable(ctx, s, tableData, dwh, opts.ColumnSettings, tableID); err != nil {
 			return err
 		}
 	}
 
-	bqTempTableID, err := typing.AssertType[dialect.TableIdentifier](tempTableID)
+	bqTempTableID, err := typing.AssertType[dialect.TableIdentifier](tableID)
 	if err != nil {
 		return err
 	}

--- a/clients/iceberg/staging.go
+++ b/clients/iceberg/staging.go
@@ -75,8 +75,8 @@ func (s *Store) writeTemporaryTableFile(tableData *optimization.TableData, newTa
 	return file.FilePath, nil
 }
 
-func (s Store) PrepareTemporaryTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tempTableID sql.TableIdentifier) error {
-	fp, err := s.writeTemporaryTableFile(tableData, tempTableID)
+func (s Store) LoadDataIntoTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tableID sql.TableIdentifier) error {
+	fp, err := s.writeTemporaryTableFile(tableData, tableID)
 	if err != nil {
 		return fmt.Errorf("failed to load temporary table: %w", err)
 	}
@@ -99,7 +99,7 @@ func (s Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizatio
 	}
 
 	// Load the data into a temporary view
-	command := s.Dialect().BuildCreateTemporaryView(tempTableID.EscapedTable(), colParts, s3URI)
+	command := s.Dialect().BuildCreateTemporaryView(tableID.EscapedTable(), colParts, s3URI)
 	if err := s.apacheLivyClient.ExecContext(ctx, command); err != nil {
 		return fmt.Errorf("failed to load temporary table: %w", err)
 	}

--- a/clients/iceberg/store.go
+++ b/clients/iceberg/store.go
@@ -80,7 +80,7 @@ func (s Store) Append(ctx context.Context, tableData *optimization.TableData, us
 	}
 
 	// Load the data into a temporary view
-	if err = s.PrepareTemporaryTable(ctx, tableData, tableConfig, tempTableID); err != nil {
+	if err = s.LoadDataIntoTable(ctx, tableData, tableConfig, tempTableID); err != nil {
 		return fmt.Errorf("failed to prepare temporary table: %w", err)
 	}
 
@@ -168,7 +168,7 @@ func (s Store) Merge(ctx context.Context, tableData *optimization.TableData) (bo
 		return false, fmt.Errorf("failed to merge columns from destination: %w for table %q", err, tableData.Name())
 	}
 
-	if err = s.PrepareTemporaryTable(ctx, tableData, tableConfig, temporaryTableID); err != nil {
+	if err = s.LoadDataIntoTable(ctx, tableData, tableConfig, temporaryTableID); err != nil {
 		return false, fmt.Errorf("failed to prepare temporary table: %w", err)
 	}
 

--- a/clients/mssql/staging.go
+++ b/clients/mssql/staging.go
@@ -14,9 +14,9 @@ import (
 	"github.com/artie-labs/transfer/lib/typing/columns"
 )
 
-func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tempTableID, _ sql.TableIdentifier, opts types.AdditionalSettings, createTempTable bool) error {
+func (s *Store) LoadDataIntoTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tableID, _ sql.TableIdentifier, opts types.AdditionalSettings, createTempTable bool) error {
 	if createTempTable {
-		if err := shared.CreateTempTable(ctx, s, tableData, dwh, opts.ColumnSettings, tempTableID); err != nil {
+		if err := shared.CreateTempTable(ctx, s, tableData, dwh, opts.ColumnSettings, tableID); err != nil {
 			return err
 		}
 	}
@@ -36,7 +36,7 @@ func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimizati
 	}()
 
 	cols := tableData.ReadOnlyInMemoryCols().ValidColumns()
-	stmt, err := tx.Prepare(mssql.CopyIn(tempTableID.FullyQualifiedName(), mssql.BulkOptions{}, columns.ColumnNames(cols)...))
+	stmt, err := tx.Prepare(mssql.CopyIn(tableID.FullyQualifiedName(), mssql.BulkOptions{}, columns.ColumnNames(cols)...))
 	if err != nil {
 		return fmt.Errorf("failed to prepare bulk insert: %w", err)
 	}

--- a/clients/postgres/staging.go
+++ b/clients/postgres/staging.go
@@ -60,14 +60,14 @@ func (s *Store) buildStagingIterator(tableData *optimization.TableData) (pgx.Cop
 	return &stagingIterator{data: values, idx: 0}, nil
 }
 
-func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tempTableID, _ sql.TableIdentifier, opts types.AdditionalSettings, createTempTable bool) error {
+func (s *Store) LoadDataIntoTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tableID, _ sql.TableIdentifier, opts types.AdditionalSettings, createTempTable bool) error {
 	if createTempTable {
-		if err := shared.CreateTempTable(ctx, s, tableData, dwh, opts.ColumnSettings, tempTableID); err != nil {
+		if err := shared.CreateTempTable(ctx, s, tableData, dwh, opts.ColumnSettings, tableID); err != nil {
 			return err
 		}
 	}
 
-	castedTableID, ok := tempTableID.(dialect.TableIdentifier)
+	castedTableID, ok := tableID.(dialect.TableIdentifier)
 	if !ok {
 		return fmt.Errorf("failed to cast table identifier to dialect.TableIdentifier")
 	}

--- a/clients/shared/append.go
+++ b/clients/shared/append.go
@@ -68,7 +68,7 @@ func Append(ctx context.Context, dest destination.Destination, tableData *optimi
 			// Override tableID with tempTableID if we're using a temporary table
 			tempTableID = opts.TempTableID
 		}
-		return dest.PrepareTemporaryTable(
+		return dest.LoadDataIntoTable(
 			ctx,
 			tableData,
 			tableConfig,

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -98,7 +98,7 @@ func Merge(ctx context.Context, dest destination.Destination, tableData *optimiz
 			}
 		}()
 
-		if err = dest.PrepareTemporaryTable(ctx, tableData, tableConfig, temporaryTableID, tableID, types.AdditionalSettings{ColumnSettings: opts.ColumnSettings}, true); err != nil {
+		if err = dest.LoadDataIntoTable(ctx, tableData, tableConfig, temporaryTableID, tableID, types.AdditionalSettings{ColumnSettings: opts.ColumnSettings}, true); err != nil {
 			return fmt.Errorf("failed to prepare temporary table: %w", err)
 		}
 

--- a/clients/shared/multi_step_merge.go
+++ b/clients/shared/multi_step_merge.go
@@ -95,7 +95,7 @@ func MultiStepMerge(ctx context.Context, dest destination.Destination, tableData
 	if msmSettings.IsFirstFlush() {
 		// If it's the first flush, we'll just load the data directly into the MSM table.
 		// Don't need to create the temporary table, we've already created it above.
-		if err = dest.PrepareTemporaryTable(ctx, tableData, msmTableConfig, msmTableID, msmTableID, types.AdditionalSettings{ColumnSettings: opts.ColumnSettings}, false); err != nil {
+		if err = dest.LoadDataIntoTable(ctx, tableData, msmTableConfig, msmTableID, msmTableID, types.AdditionalSettings{ColumnSettings: opts.ColumnSettings}, false); err != nil {
 			return false, fmt.Errorf("failed to prepare temporary table: %w", err)
 		}
 	} else {
@@ -134,7 +134,7 @@ func merge(ctx context.Context, dwh destination.Destination, tableData *optimiza
 	}()
 
 	if opts.PrepareTemporaryTable {
-		if err := dwh.PrepareTemporaryTable(ctx, tableData, tableConfig, temporaryTableID, targetTableID, types.AdditionalSettings{ColumnSettings: opts.ColumnSettings}, true); err != nil {
+		if err := dwh.LoadDataIntoTable(ctx, tableData, tableConfig, temporaryTableID, targetTableID, types.AdditionalSettings{ColumnSettings: opts.ColumnSettings}, true); err != nil {
 			return fmt.Errorf("failed to prepare temporary table: %w", err)
 		}
 	}

--- a/clients/snowflake/staging.go
+++ b/clients/snowflake/staging.go
@@ -63,7 +63,7 @@ func (s Store) useExternalStage() bool {
 	return s.config.Snowflake.ExternalStage != nil && s.config.Snowflake.ExternalStage.Enabled
 }
 
-func (s *Store) PrepareTemporaryTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tempTableID, _ sql.TableIdentifier, additionalSettings types.AdditionalSettings, createTempTable bool) error {
+func (s *Store) LoadDataIntoTable(ctx context.Context, tableData *optimization.TableData, dwh *types.DestinationTableConfig, tempTableID, _ sql.TableIdentifier, additionalSettings types.AdditionalSettings, createTempTable bool) error {
 	if createTempTable {
 		if err := shared.CreateTempTable(ctx, s, tableData, dwh, additionalSettings.ColumnSettings, tempTableID); err != nil {
 			return err

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -188,7 +188,7 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 		s.mockDB.ExpectQuery(fmt.Sprintf(`COPY INTO "DATABASE"\."SCHEMA"\."TEMP___ARTIE_.*" \("USER_ID","FIRST_NAME","LAST_NAME","DUSTY"\) FROM \(SELECT \$1,\$2,\$3,\$4 FROM @"DATABASE"\."SCHEMA"\."%%TEMP___ARTIE_.*"\) FILES = \('%s'\)`, expectedFileName)).
 			WillReturnRows(sqlmock.NewRows([]string{"rows_loaded"}).AddRow(fmt.Sprintf("%d", tableData.NumberOfRows())))
 
-		assert.NoError(s.T(), s.stageStore.PrepareTemporaryTable(s.T().Context(), tableData, snowflakeTableConfig, tempTableID, tempTableID, types.AdditionalSettings{}, true))
+		assert.NoError(s.T(), s.stageStore.LoadDataIntoTable(s.T().Context(), tableData, snowflakeTableConfig, tempTableID, tempTableID, types.AdditionalSettings{}, true))
 		assert.NoError(s.T(), s.mockDB.ExpectationsWereMet())
 	}
 	{
@@ -199,7 +199,7 @@ func (s *SnowflakeTestSuite) TestPrepareTempTable() {
 		s.mockDB.ExpectQuery(fmt.Sprintf(`COPY INTO "DATABASE"\."SCHEMA"\."TEMP___ARTIE_.*" \("USER_ID","FIRST_NAME","LAST_NAME","DUSTY"\) FROM \(SELECT \$1,\$2,\$3,\$4 FROM @"DATABASE"\."SCHEMA"\."%%TEMP___ARTIE_.*"\) FILES = \('%s'\)`, expectedFileName)).
 			WillReturnRows(sqlmock.NewRows([]string{"rows_loaded"}).AddRow(fmt.Sprintf("%d", tableData.NumberOfRows())))
 
-		assert.NoError(s.T(), s.stageStore.PrepareTemporaryTable(s.T().Context(), tableData, snowflakeTableConfig, tempTableID, tempTableID, types.AdditionalSettings{}, false))
+		assert.NoError(s.T(), s.stageStore.LoadDataIntoTable(s.T().Context(), tableData, snowflakeTableConfig, tempTableID, tempTableID, types.AdditionalSettings{}, false))
 		assert.NoError(s.T(), s.mockDB.ExpectationsWereMet())
 	}
 }

--- a/integration_tests/postgres/checks/staging.go
+++ b/integration_tests/postgres/checks/staging.go
@@ -34,7 +34,7 @@ func TestStagingTable(ctx context.Context, store *postgres.Store) error {
 	}
 
 	tc := types.NewDestinationTableConfig(cols.GetColumns(), false)
-	if err := store.PrepareTemporaryTable(ctx, tableData, tc, tableID, tableID, types.AdditionalSettings{}, true); err != nil {
+	if err := store.LoadDataIntoTable(ctx, tableData, tc, tableID, tableID, types.AdditionalSettings{}, true); err != nil {
 		return fmt.Errorf("failed to prepare temporary table: %w", err)
 	}
 

--- a/lib/destination/destination.go
+++ b/lib/destination/destination.go
@@ -26,7 +26,8 @@ type Destination interface {
 
 	// Helper functions for merge
 	GetTableConfig(ctx context.Context, tableID sqllib.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error)
-	PrepareTemporaryTable(ctx context.Context, tableData *optimization.TableData, tableConfig *types.DestinationTableConfig, tempTableID, parentTableID sqllib.TableIdentifier, additionalSettings types.AdditionalSettings, createTempTable bool) error
+	// LoadDataIntoTable is used to load data into staging tables, and also to append data directly to a target table (for history mode and OLAP-destination backfills)
+	LoadDataIntoTable(ctx context.Context, tableData *optimization.TableData, tableConfig *types.DestinationTableConfig, tableID, parentTableID sqllib.TableIdentifier, additionalSettings types.AdditionalSettings, createTempTable bool) error
 }
 
 type Baseline interface {


### PR DESCRIPTION
https://artie-labs.slack.com/archives/C07L5JNEZGR/p1762211301213709?thread_ts=1762211128.591919&cid=C07L5JNEZGR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames `PrepareTemporaryTable` to `LoadDataIntoTable` across all destinations, updates the `Destination` interface and all call sites/tests accordingly.
> 
> - **API/Interface**:
>   - Replace `Destination.PrepareTemporaryTable` with `Destination.LoadDataIntoTable(...)` (adds doc comment); adjust parameter names (`tempTableID` -> `tableID`).
> - **Destinations**:
>   - BigQuery, Databricks, Iceberg, MSSQL, Postgres, Redshift, Snowflake: rename method implementation to `LoadDataIntoTable` and update internal references.
> - **Shared Logic**:
>   - Update callers in `clients/shared/{append.go,merge.go,multi_step_merge.go}` to use `LoadDataIntoTable`.
> - **Tests/Integration**:
>   - Update Snowflake tests and Postgres integration check to call `LoadDataIntoTable`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9dc2edd55bbba5f7f8f05e624f9f3e03526dd43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->