### PR TITLE
[BigQuery] Fix invalid JSON

### DIFF
--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -267,7 +267,7 @@ func encodeStructToJSONString(value any) (string, error) {
 			return fmt.Sprintf(`{"key":"%s"}`, constants.ToastUnavailableValuePlaceholder), nil
 		}
 
-		// Validate JSON before returning it
+		// If the value is invalid JSON, then let's wrap it in quotes, so it doesn't get misinterpreted as a JSON string by BigQuery.
 		if !json.Valid([]byte(stringValue)) {
 			return fmt.Sprintf("%q", stringValue), nil
 		}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves struct-to-JSON encoding for BigQuery by skipping empty strings and quoting invalid JSON strings to avoid misinterpretation.
> 
> - **BigQuery storage writer**:
>   - **Struct JSON encoding (`encodeStructToJSONString`)**:
>     - Return empty output for empty string inputs (treated as unset).
>     - Quote invalid JSON strings to prevent misinterpretation by BigQuery.
>     - Preserve placeholder handling for `constants.ToastUnavailableValuePlaceholder`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 885576fef1ee3703a9d5c22338c5d082381a061d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->