### PR TITLE
Guard against nil access of DestinationTableConfigMap.fqNameToConfigMap

### DIFF
--- a/lib/destination/types/types.go
+++ b/lib/destination/types/types.go
@@ -16,6 +16,10 @@ func (d *DestinationTableConfigMap) GetTableConfig(tableID sql.TableIdentifier) 
 	d.RLock()
 	defer d.RUnlock()
 
+	if d.fqNameToConfigMap == nil {
+		return nil
+	}
+
 	tableConfig, ok := d.fqNameToConfigMap[tableID.FullyQualifiedName()]
 	if !ok {
 		return nil
@@ -28,7 +32,9 @@ func (d *DestinationTableConfigMap) RemoveTable(tableID sql.TableIdentifier) {
 	d.Lock()
 	defer d.Unlock()
 
-	delete(d.fqNameToConfigMap, tableID.FullyQualifiedName())
+	if d.fqNameToConfigMap != nil {
+		delete(d.fqNameToConfigMap, tableID.FullyQualifiedName())
+	}
 }
 
 func (d *DestinationTableConfigMap) AddTable(tableID sql.TableIdentifier, config *DestinationTableConfig) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add nil-guard checks to `DestinationTableConfigMap` methods to avoid panics when the internal map is uninitialized.
> 
> - **types**:
>   - Add nil checks in `DestinationTableConfigMap.GetTableConfig` and `RemoveTable` to safely handle uninitialized `fqNameToConfigMap`.
>   - Preserve existing lazy initialization in `AddTable`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7b7dec55ead6769f2ad6da377f86cac73694ad2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->