### PR TITLE
[int64] Address `*decimal.Decimal`

### DIFF
--- a/lib/typing/converters/primitives/converter.go
+++ b/lib/typing/converters/primitives/converter.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+
+	"github.com/artie-labs/transfer/lib/typing/decimal"
 )
 
 type Int64Converter struct{}
@@ -37,6 +39,13 @@ func (Int64Converter) Convert(value any) (int64, error) {
 		}
 
 		return int64(castValue), nil
+	case *decimal.Decimal:
+		val, err := castValue.Value().Int64()
+		if err != nil {
+			return 0, fmt.Errorf("failed to convert decimal to int64: %w", err)
+		}
+
+		return val, nil
 	}
 
 	return 0, fmt.Errorf("failed to parse int64, unsupported type: %T", value)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add Int64Converter handling for *decimal.Decimal by converting via Value().Int64().
> 
> - **Typing/Primitives**:
>   - **Int64Converter**: Add support for `*decimal.Decimal` inputs, converting with `Value().Int64()` and returning errors on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c1a401b393c813140a3d46830a3dd8e35c62e8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->