### PR TITLE
[aws] Implement ExternalID.

### DIFF
--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -173,7 +173,7 @@ func LoadRedshift(ctx context.Context, cfg config.Config, _store *db.Store) (*St
 			return nil, err
 		}
 
-		creds, err := awslib.GenerateSTSCredentials(ctx, os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), cfg.Redshift.RoleARN, "ArtieTransfer")
+		creds, err := awslib.GenerateSTSCredentials(ctx, os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"), cfg.Redshift.RoleARN, "ArtieTransfer", awslib.OptionalParams{})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
ExternalID is an optional param that you can have when assuming into any AWS role.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional ExternalID to STS AssumeRole, stores it for refresh, and updates Redshift to use the new GenerateSTSCredentials signature.
> 
> - **AWS Library (`lib/awslib/sts.go`)**:
>   - Introduce `OptionalParams` with `ExternalID`.
>   - Extend `GenerateSTSCredentials(...)` to accept `OptionalParams`; conditionally set `AssumeRoleInput.ExternalId`.
>   - Persist `_awsExternalID` in `Credentials` and include it during token `refresh`.
>   - Minor refactor: build `assumeRoleInput` before calling `AssumeRole`.
> - **Redshift Client (`clients/redshift/redshift.go`)**:
>   - Update call to `GenerateSTSCredentials(...)` to pass `awslib.OptionalParams{}` to match new signature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0b16cb58ab3a3c0aa3569ad89ef50ae8a580094. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->