### PR TITLE
Upgrade ducktape/api to v0.1.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/apache/arrow/go/v17 v17.0.0
-	github.com/artie-labs/ducktape/api v0.1.4
+	github.com/artie-labs/ducktape/api v0.1.5
 	github.com/aws/aws-sdk-go-v2 v1.38.1
 	github.com/aws/aws-sdk-go-v2/config v1.29.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.65

--- a/go.sum
+++ b/go.sum
@@ -698,8 +698,8 @@ github.com/apache/arrow/go/v17 v17.0.0/go.mod h1:jR7QHkODl15PfYyjM2nU+yTLScZ/qfj
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
 github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
-github.com/artie-labs/ducktape/api v0.1.4 h1:kZ/wcceH+RYs+tKO/+fjQm98E9DM58lQ7jVg3yh96xA=
-github.com/artie-labs/ducktape/api v0.1.4/go.mod h1:3wVFmxGoT1EJd18eJHm5GlJcI+1CCb2i7gkM7HYC9Q4=
+github.com/artie-labs/ducktape/api v0.1.5 h1:ELmiUksiBu7IsSuLsJ+qDQYAFvw/KnbezjZwSDUDCRY=
+github.com/artie-labs/ducktape/api v0.1.5/go.mod h1:3wVFmxGoT1EJd18eJHm5GlJcI+1CCb2i7gkM7HYC9Q4=
 github.com/aws/aws-sdk-go-v2 v1.16.12/go.mod h1:C+Ym0ag2LIghJbXhfXZ0YEEp49rBWowxKzJLUoob0ts=
 github.com/aws/aws-sdk-go-v2 v1.38.1 h1:j7sc33amE74Rz0M/PoCpsZQ6OunLqys/m5antM0J+Z8=
 github.com/aws/aws-sdk-go-v2 v1.38.1/go.mod h1:9Q0OoGQoboYIAJyslFyF1f5K1Ryddop8gqMhWx/n4Wg=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bump dependency github.com/artie-labs/ducktape/api from v0.1.4 to v0.1.5.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c39964da571c875ded2a938d169d6b853ca9ebc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->