### PR TITLE
Fix Livy too many session create reqs

### DIFF
--- a/lib/apachelivy/types.go
+++ b/lib/apachelivy/types.go
@@ -55,6 +55,10 @@ func (s SessionState) IsReady() bool {
 	return s == StateIdle
 }
 
+func (s SessionState) UsableState() bool {
+	return s == StateIdle || s == StateBusy
+}
+
 type ListSessonResponse struct {
 	Sessions []GetSessionResponse `json:"sessions"`
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reworks Livy session management to reuse usable sessions, wait on creating, and surface throttling/unusable errors instead of deleting/sleep-retrying.
> 
> - **Apache Livy client**:
>   - **Session lifecycle**:
>     - When listing, match sessions by `Name` only; if `CreatingState()`, return an error (wait upstream); if `UsableState()`, reuse existing `sessionID`; otherwise return an error for unusable states.
>     - Remove deletion of terminal sessions and jitter-based sleep/retry loops.
>   - **Session creation**:
>     - On `ErrTooManySessionsCreated`, return a throttling error instead of sleeping and retrying.
>   - **Types**:
>     - Add `CreatingSessionStates` and `UsableSessionStates`, plus helpers: `CreatingState()`, `UsableState()` on `GetSessionResponse`, and `UsableState()` on `SessionState`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9ce1600acc18812fad93982ad0b99908825d30c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->