### PR TITLE
Fix bytes converter

### DIFF
--- a/lib/debezium/converters/bytes_test.go
+++ b/lib/debezium/converters/bytes_test.go
@@ -8,18 +8,6 @@ import (
 
 func TestBytes_Convert(t *testing.T) {
 	{
-		// nil
-		actual, err := Bytes{}.Convert(nil)
-		assert.NoError(t, err)
-		assert.Nil(t, actual)
-	}
-	{
-		// empty string - should return nil, not error
-		actual, err := Bytes{}.Convert("")
-		assert.NoError(t, err)
-		assert.Nil(t, actual)
-	}
-	{
 		// []byte
 		actual, err := Bytes{}.Convert([]byte{40, 39, 38})
 		assert.NoError(t, err)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extend Bytes.Convert to support nil and pass through toast-unavailable placeholder, while preserving []byte, base64-decoding strings, and improving type erroring.
> 
> - **Converters**:
>   - **`lib/debezium/converters/bytes.go` (`Bytes.Convert`)**:
>     - Add handling for `nil` and passthrough for `constants.ToastUnavailableValuePlaceholder`.
>     - Preserve `[]byte` inputs and base64-decode `string` inputs; return clearer error for unsupported types.
>     - Import `github.com/artie-labs/transfer/lib/config/constants`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3ce62fd9c343da4a0a0e3c148969efbd4bed92a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->