### PR TITLE
Fix Panic

### DIFF
--- a/models/event/event.go
+++ b/models/event/event.go
@@ -80,7 +80,9 @@ func ToMemoryEvent(ctx context.Context, dest destination.Baseline, event cdc.Eve
 		}
 
 		data[constants.SourceMetadataColumnMarker] = metadata
-		cols.AddColumn(columns.NewColumn(constants.SourceMetadataColumnMarker, typing.Struct))
+		if cols != nil {
+			cols.AddColumn(columns.NewColumn(constants.SourceMetadataColumnMarker, typing.Struct))
+		}
 	}
 
 	tblName := cmp.Or(tc.TableName, event.GetTableName())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Avoid nil-pointer panic by only adding `__artie_source_metadata` column when `cols` is non-nil.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21b0faea1e6b7f2b831d33627c6cc029e6edb16a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->