### PR TITLE
[postgres] Adding the ability to parse versions

### DIFF
--- a/lib/db/postgres.go
+++ b/lib/db/postgres.go
@@ -1,0 +1,43 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+)
+
+func RetrieveVersion(ctx context.Context, db *sql.DB) (int, error) {
+	var version string
+	if err := db.QueryRowContext(ctx, "SELECT version()").Scan(&version); err != nil {
+		return 0, fmt.Errorf("failed to scan version: %w", err)
+	}
+
+	pgVersion, err := parseVersion(version)
+	if err != nil {
+		slog.Error("Failed to parse version", slog.String("version", version), slog.Any("err", err))
+		return 0, fmt.Errorf("failed to parse version: %w", err)
+	}
+
+	return pgVersion, nil
+}
+
+func parseVersion(versionString string) (int, error) {
+	parts := strings.Split(versionString, " ")
+	if len(parts) < 2 {
+		return 0, fmt.Errorf("invalid version string: %s", versionString)
+	}
+
+	if parts[0] != "PostgreSQL" {
+		return 0, fmt.Errorf("invalid version string: %s", versionString)
+	}
+
+	versionParts := strings.Split(parts[1], ".")
+	if len(versionParts) < 2 {
+		return 0, fmt.Errorf("invalid version string: %s", versionString)
+	}
+
+	return strconv.Atoi(versionParts[0])
+}

--- a/lib/db/postgres_test.go
+++ b/lib/db/postgres_test.go
@@ -1,0 +1,38 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseVersion(t *testing.T) {
+	{
+		version, err := parseVersion("PostgreSQL 16.2 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 7.3.1 20180712 (Red Hat 7.3.1-12), 64-bit")
+		assert.NoError(t, err)
+		assert.Equal(t, 16, version)
+	}
+	{
+		version, err := parseVersion("PostgreSQL 13.15 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-20), 64-bit")
+		assert.NoError(t, err)
+		assert.Equal(t, 13, version)
+	}
+	{
+		version, err := parseVersion("PostgreSQL 14.10 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 7.3.1 20180712 (Red Hat 7.3.1-12), 64-bit")
+		assert.NoError(t, err)
+		assert.Equal(t, 14, version)
+	}
+	{
+		version, err := parseVersion("PostgreSQL 15.4 on x86_64-pc-linux-gnu, compiled by x86_64-pc-linux-gnu-gcc (GCC) 9.5.0, 64-bit")
+		assert.NoError(t, err)
+		assert.Equal(t, 15, version)
+	}
+	{
+		_, err := parseVersion("hi")
+		assert.Error(t, err)
+	}
+	{
+		_, err := parseVersion("PostgreSQL")
+		assert.Error(t, err)
+	}
+}


### PR DESCRIPTION
This used to be in Reader, moving it to be in Transfer instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `RetrieveVersion` and `parseVersion` to get and parse PostgreSQL major version, with tests for valid and invalid inputs.
> 
> - **DB Utilities**
>   - Add `RetrieveVersion(ctx, db)` in `lib/db/postgres.go` to query `SELECT version()` and return the PostgreSQL major version; logs on parse errors.
>   - Add `parseVersion` helper to extract the major version from a PostgreSQL `version()` string.
> - **Tests**
>   - Add `lib/db/postgres_test.go` with cases for multiple PostgreSQL versions and invalid strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d2932aef2dfb833853699b422763a9c774a4312. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->