### PR TITLE
Add mode parameter to BuildCreateTableQuery()

### DIFF
--- a/clients/bigquery/dialect/ddl.go
+++ b/clients/bigquery/dialect/ddl.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing"
 )
 
-func (BigQueryDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, temporary bool, colSQLParts []string) string {
+func (BigQueryDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, temporary bool, _ config.Mode, colSQLParts []string) string {
 	query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", tableID.FullyQualifiedName(), strings.Join(colSQLParts, ","))
 
 	if temporary {

--- a/clients/bigquery/dialect/dialect_test.go
+++ b/clients/bigquery/dialect/dialect_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/mocks"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -58,13 +59,13 @@ func TestBigQueryDialect_BuildCreateTableQuery(t *testing.T) {
 
 	// Temporary:
 	assert.Contains(t,
-		BigQueryDialect{}.BuildCreateTableQuery(fakeTableID, true, []string{"{PART_1}", "{PART_2}"}),
+		BigQueryDialect{}.BuildCreateTableQuery(fakeTableID, true, config.Replication, []string{"{PART_1}", "{PART_2}"}),
 		`CREATE TABLE IF NOT EXISTS {TABLE} ({PART_1},{PART_2}) OPTIONS (expiration_timestamp = TIMESTAMP(`,
 	)
 	// Not temporary:
 	assert.Equal(t,
 		`CREATE TABLE IF NOT EXISTS {TABLE} ({PART_1},{PART_2})`,
-		BigQueryDialect{}.BuildCreateTableQuery(fakeTableID, false, []string{"{PART_1}", "{PART_2}"}),
+		BigQueryDialect{}.BuildCreateTableQuery(fakeTableID, false, config.Replication, []string{"{PART_1}", "{PART_2}"}),
 	)
 }
 

--- a/clients/databricks/dialect/ddl.go
+++ b/clients/databricks/dialect/ddl.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
-func (DatabricksDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, colSQLParts []string) string {
+func (DatabricksDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, _ config.Mode, colSQLParts []string) string {
 	// Databricks doesn't have a concept of temporary tables.
 	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", tableID.FullyQualifiedName(), strings.Join(colSQLParts, ", "))
 }

--- a/clients/databricks/dialect/dialect_test.go
+++ b/clients/databricks/dialect/dialect_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/mocks"
 )
@@ -84,14 +85,14 @@ func TestDatabricksDialect_BuildCreateTableQuery(t *testing.T) {
 		// Temporary
 		assert.Equal(t,
 			`CREATE TABLE IF NOT EXISTS {TABLE} ({PART_1}, {PART_2})`,
-			DatabricksDialect{}.BuildCreateTableQuery(fakeTableID, true, []string{"{PART_1}", "{PART_2}"}),
+			DatabricksDialect{}.BuildCreateTableQuery(fakeTableID, true, config.Replication, []string{"{PART_1}", "{PART_2}"}),
 		)
 	}
 	{
 		// Not temporary
 		assert.Equal(t,
 			`CREATE TABLE IF NOT EXISTS {TABLE} ({PART_1}, {PART_2})`,
-			DatabricksDialect{}.BuildCreateTableQuery(fakeTableID, false, []string{"{PART_1}", "{PART_2}"}),
+			DatabricksDialect{}.BuildCreateTableQuery(fakeTableID, false, config.Replication, []string{"{PART_1}", "{PART_2}"}),
 		)
 	}
 }

--- a/clients/iceberg/dialect/dialect.go
+++ b/clients/iceberg/dialect/dialect.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -183,7 +184,7 @@ func (IcebergDialect) BuildDescribeTableQuery(tableID sql.TableIdentifier) (stri
 	return fmt.Sprintf("DESCRIBE TABLE %s", tableID.FullyQualifiedName()), nil, nil
 }
 
-func (IcebergDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, colSQLParts []string) string {
+func (IcebergDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, _ config.Mode, colSQLParts []string) string {
 	// Iceberg does not support temporary tables.
 	// Format version is required: https://iceberg.apache.org/spec/#table-metadata-fields
 	return fmt.Sprintf(

--- a/clients/iceberg/table.go
+++ b/clients/iceberg/table.go
@@ -56,7 +56,7 @@ func (s Store) CreateTable(ctx context.Context, tableID sql.TableIdentifier, tab
 		return fmt.Errorf("failed to build column parts: %w", err)
 	}
 
-	if err := s.apacheLivyClient.ExecContext(ctx, s.Dialect().BuildCreateTableQuery(tableID, false, colParts)); err != nil {
+	if err := s.apacheLivyClient.ExecContext(ctx, s.Dialect().BuildCreateTableQuery(tableID, false, config.Replication, colParts)); err != nil {
 		return fmt.Errorf("failed to create table: %w", err)
 	}
 

--- a/clients/motherduck/dialect/dialect.go
+++ b/clients/motherduck/dialect/dialect.go
@@ -132,7 +132,7 @@ func (DuckDBDialect) IsTableDoesNotExistErr(err error) bool {
 	return strings.Contains(err.Error(), "does not exist")
 }
 
-func (DuckDBDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, temporary bool, colSQLParts []string) string {
+func (DuckDBDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, temporary bool, _ config.Mode, colSQLParts []string) string {
 	// We will create temporary tables in DuckDB the exact same way as we do for permanent tables.
 	// This is because temporary tables are session scoped and this will not work for us as we leverage connection pooling.
 	return fmt.Sprintf("CREATE TABLE %s (%s);", tableID.FullyQualifiedName(), strings.Join(colSQLParts, ","))

--- a/clients/mssql/dialect/ddl.go
+++ b/clients/mssql/dialect/ddl.go
@@ -6,6 +6,7 @@ import (
 
 	mssql "github.com/microsoft/go-mssqldb"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing"
 )
@@ -47,7 +48,7 @@ func (MSSQLDialect) BuildDropColumnQuery(tableID sql.TableIdentifier, colName st
 	return fmt.Sprintf("ALTER TABLE %s DROP %s", tableID.FullyQualifiedName(), colName)
 }
 
-func (MSSQLDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, colSQLParts []string) string {
+func (MSSQLDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, _ config.Mode, colSQLParts []string) string {
 	// Microsoft SQL Server uses the same syntax for temporary and permanent tables.
 	// Microsoft SQL Server doesn't support IF NOT EXISTS
 	return fmt.Sprintf("CREATE TABLE %s (%s);", tableID.FullyQualifiedName(), strings.Join(colSQLParts, ","))

--- a/clients/mssql/dialect/dialect_test.go
+++ b/clients/mssql/dialect/dialect_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/mocks"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -61,12 +62,12 @@ func TestMSSQLDialect_BuildCreateTableQuery(t *testing.T) {
 	// Temporary:
 	assert.Equal(t,
 		`CREATE TABLE {TABLE} ({PART_1},{PART_2});`,
-		MSSQLDialect{}.BuildCreateTableQuery(fakeTableID, true, []string{"{PART_1}", "{PART_2}"}),
+		MSSQLDialect{}.BuildCreateTableQuery(fakeTableID, true, config.Replication, []string{"{PART_1}", "{PART_2}"}),
 	)
 	// Not temporary:
 	assert.Equal(t,
 		`CREATE TABLE {TABLE} ({PART_1},{PART_2});`,
-		MSSQLDialect{}.BuildCreateTableQuery(fakeTableID, false, []string{"{PART_1}", "{PART_2}"}),
+		MSSQLDialect{}.BuildCreateTableQuery(fakeTableID, false, config.Replication, []string{"{PART_1}", "{PART_2}"}),
 	)
 }
 

--- a/clients/postgres/dialect/dialect.go
+++ b/clients/postgres/dialect/dialect.go
@@ -54,7 +54,7 @@ func (PostgresDialect) IsTableDoesNotExistErr(err error) bool {
 	return false
 }
 
-func (PostgresDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, colSQLParts []string) string {
+func (PostgresDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, _ config.Mode, colSQLParts []string) string {
 	// We will create temporary tables in Postgres the exact same way as we do for permanent tables.
 	// This is because temporary tables are session scoped and this will not work for us as we leverage connection pooling.
 	return fmt.Sprintf("CREATE TABLE %s (%s);", tableID.FullyQualifiedName(), strings.Join(colSQLParts, ","))

--- a/clients/redshift/dialect/ddl.go
+++ b/clients/redshift/dialect/ddl.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing"
 )
@@ -48,7 +49,7 @@ func (RedshiftDialect) BuildDropColumnQuery(tableID sql.TableIdentifier, colName
 	return fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", tableID.FullyQualifiedName(), colName)
 }
 
-func (RedshiftDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, colSQLParts []string) string {
+func (RedshiftDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, _ bool, _ config.Mode, colSQLParts []string) string {
 	// Redshift uses the same syntax for temporary and permanent tables.
 	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s);", tableID.FullyQualifiedName(), strings.Join(colSQLParts, ","))
 }

--- a/clients/redshift/dialect/dialect_test.go
+++ b/clients/redshift/dialect/dialect_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/mocks"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -37,12 +38,12 @@ func TestRedshiftDialect_BuildCreateTableQuery(t *testing.T) {
 	// Temporary:
 	assert.Equal(t,
 		`CREATE TABLE IF NOT EXISTS {TABLE} ({PART_1},{PART_2});`,
-		RedshiftDialect{}.BuildCreateTableQuery(fakeTableID, true, []string{"{PART_1}", "{PART_2}"}),
+		RedshiftDialect{}.BuildCreateTableQuery(fakeTableID, true, config.Replication, []string{"{PART_1}", "{PART_2}"}),
 	)
 	// Not temporary:
 	assert.Equal(t,
 		`CREATE TABLE IF NOT EXISTS {TABLE} ({PART_1},{PART_2});`,
-		RedshiftDialect{}.BuildCreateTableQuery(fakeTableID, false, []string{"{PART_1}", "{PART_2}"}),
+		RedshiftDialect{}.BuildCreateTableQuery(fakeTableID, false, config.Replication, []string{"{PART_1}", "{PART_2}"}),
 	)
 }
 

--- a/clients/snowflake/dialect/ddl.go
+++ b/clients/snowflake/dialect/ddl.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/sql"
 )
 
-func (SnowflakeDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, temporary bool, colSQLParts []string) string {
+func (SnowflakeDialect) BuildCreateTableQuery(tableID sql.TableIdentifier, temporary bool, _ config.Mode, colSQLParts []string) string {
 	query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s)", tableID.FullyQualifiedName(), strings.Join(colSQLParts, ","))
 	if temporary {
 		query = fmt.Sprintf("CREATE TRANSIENT TABLE IF NOT EXISTS %s (%s)", tableID.FullyQualifiedName(), strings.Join(colSQLParts, ","))

--- a/clients/snowflake/dialect/dialect_test.go
+++ b/clients/snowflake/dialect/dialect_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/mocks"
 	"github.com/artie-labs/transfer/lib/typing"
@@ -39,12 +40,12 @@ func TestSnowflakeDialect_BuildCreateTableQuery(t *testing.T) {
 	// Temporary:
 	assert.Equal(t,
 		`CREATE TRANSIENT TABLE IF NOT EXISTS {TABLE} ({PART_1},{PART_2}) DATA_RETENTION_TIME_IN_DAYS = 0 STAGE_COPY_OPTIONS = ( PURGE = TRUE ) STAGE_FILE_FORMAT = ( TYPE = 'csv' FIELD_DELIMITER= '\t' FIELD_OPTIONALLY_ENCLOSED_BY='"' NULL_IF='__artie_null_value' EMPTY_FIELD_AS_NULL=FALSE)`,
-		SnowflakeDialect{}.BuildCreateTableQuery(fakeTableID, true, []string{"{PART_1}", "{PART_2}"}),
+		SnowflakeDialect{}.BuildCreateTableQuery(fakeTableID, true, config.Replication, []string{"{PART_1}", "{PART_2}"}),
 	)
 	// Not temporary:
 	assert.Equal(t,
 		`CREATE TABLE IF NOT EXISTS {TABLE} ({PART_1},{PART_2})`,
-		SnowflakeDialect{}.BuildCreateTableQuery(fakeTableID, false, []string{"{PART_1}", "{PART_2}"}),
+		SnowflakeDialect{}.BuildCreateTableQuery(fakeTableID, false, config.Replication, []string{"{PART_1}", "{PART_2}"}),
 	)
 }
 

--- a/integration_tests/postgres/checks/dialect.go
+++ b/integration_tests/postgres/checks/dialect.go
@@ -8,6 +8,7 @@ import (
 	"github.com/artie-labs/transfer/clients/postgres"
 	"github.com/artie-labs/transfer/clients/postgres/dialect"
 	"github.com/artie-labs/transfer/clients/shared"
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/db"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -100,7 +101,7 @@ func testTable(ctx context.Context, store *postgres.Store, pgDialect dialect.Pos
 	}
 
 	// Now let's create the table and it should then exist.
-	if _, err := store.ExecContext(ctx, pgDialect.BuildCreateTableQuery(testTableID, false, []string{"pk int PRIMARY KEY", "col text"})); err != nil {
+	if _, err := store.ExecContext(ctx, pgDialect.BuildCreateTableQuery(testTableID, false, config.Replication, []string{"pk int PRIMARY KEY", "col text"})); err != nil {
 		return fmt.Errorf("failed to create table: %w", err)
 	}
 
@@ -168,7 +169,7 @@ func testAddDropColumn(ctx context.Context, store *postgres.Store, pgDialect dia
 	testTableID := store.IdentifierFor(kafkalib.DatabaseAndSchemaPair{Schema: "public"}, testTableName)
 
 	// Create a test table first
-	createTableSQL := pgDialect.BuildCreateTableQuery(testTableID, false, []string{"pk int PRIMARY KEY", "col1 text"})
+	createTableSQL := pgDialect.BuildCreateTableQuery(testTableID, false, config.Replication, []string{"pk int PRIMARY KEY", "col1 text"})
 	if _, err := store.ExecContext(ctx, createTableSQL); err != nil {
 		return fmt.Errorf("failed to create test table: %w", err)
 	}
@@ -239,7 +240,7 @@ func testSweep(ctx context.Context, store *postgres.Store, pgDialect dialect.Pos
 	for range 5 {
 		tableID := shared.TempTableID(dialect.NewTableIdentifier("public", "test_sweep"))
 		expectedNames = append(expectedNames, tableID.FullyQualifiedName())
-		if _, err := store.ExecContext(ctx, pgDialect.BuildCreateTableQuery(tableID, true, []string{"pk int PRIMARY KEY"})); err != nil {
+		if _, err := store.ExecContext(ctx, pgDialect.BuildCreateTableQuery(tableID, true, config.Replication, []string{"pk int PRIMARY KEY"})); err != nil {
 			return fmt.Errorf("failed to create table: %w", err)
 		}
 	}
@@ -277,7 +278,7 @@ func testSweep(ctx context.Context, store *postgres.Store, pgDialect dialect.Pos
 func testBuildIsNotToastValueExpression(ctx context.Context, store *postgres.Store, pgDialect dialect.PostgresDialect) error {
 	tableName := fmt.Sprintf("test_toast_%s", strings.ToLower(stringutil.Random(5)))
 	tableID := store.IdentifierFor(kafkalib.DatabaseAndSchemaPair{Schema: "public"}, tableName)
-	if _, err := store.ExecContext(ctx, pgDialect.BuildCreateTableQuery(tableID, false, []string{"id int PRIMARY KEY", "col text"})); err != nil {
+	if _, err := store.ExecContext(ctx, pgDialect.BuildCreateTableQuery(tableID, false, config.Replication, []string{"id int PRIMARY KEY", "col text"})); err != nil {
 		return fmt.Errorf("failed to create test table: %w", err)
 	}
 

--- a/integration_tests/shared/destination_types.go
+++ b/integration_tests/shared/destination_types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/maputil"
 	"github.com/artie-labs/transfer/lib/sql"
@@ -12,7 +13,7 @@ import (
 )
 
 func RedshiftCreateTable(ctx context.Context, dest destination.Destination, tableID sql.TableIdentifier) error {
-	query := dest.Dialect().BuildCreateTableQuery(tableID, false, []string{
+	query := dest.Dialect().BuildCreateTableQuery(tableID, false, config.Replication, []string{
 		"c_int2 INT2",
 		"c_int4 INT4",
 		"c_int8 INT8",

--- a/integration_tests/shared/destination_types.snowflake.go
+++ b/integration_tests/shared/destination_types.snowflake.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/maputil"
 	"github.com/artie-labs/transfer/lib/sql"
@@ -13,7 +14,7 @@ import (
 )
 
 func SnowflakeCreateTable(ctx context.Context, dest destination.Destination, tableID sql.TableIdentifier) error {
-	query := dest.Dialect().BuildCreateTableQuery(tableID, false, []string{
+	query := dest.Dialect().BuildCreateTableQuery(tableID, false, config.Replication, []string{
 		"c_array ARRAY",
 		"c_bigint BIGINT",
 		"c_boolean BOOLEAN",

--- a/integration_tests/shared/destination_types_mssql.go
+++ b/integration_tests/shared/destination_types_mssql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/maputil"
 	"github.com/artie-labs/transfer/lib/sql"
@@ -12,7 +13,7 @@ import (
 )
 
 func MSSQLCreateTable(ctx context.Context, dest destination.Destination, tableID sql.TableIdentifier) error {
-	query := dest.Dialect().BuildCreateTableQuery(tableID, false, []string{
+	query := dest.Dialect().BuildCreateTableQuery(tableID, false, config.Replication, []string{
 		"c_char CHAR",
 		"c_char_5 CHAR(5)",
 		"c_varchar VARCHAR",

--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -53,7 +53,7 @@ func BuildCreateTableSQL(settings config.SharedDestinationColumnSettings, dialec
 		parts = append(parts, pkStatement)
 	}
 
-	return dialect.BuildCreateTableQuery(tableIdentifier, temporaryTable, parts), nil
+	return dialect.BuildCreateTableQuery(tableIdentifier, temporaryTable, mode, parts), nil
 }
 
 // DropTemporaryTable - this will drop the temporary table from Snowflake w/ stages and BigQuery

--- a/lib/sql/dialect.go
+++ b/lib/sql/dialect.go
@@ -37,7 +37,7 @@ type Dialect interface {
 	// [IsColumnAlreadyExistsErr] - This is only needed if the SQL Dialect does not supporting adding column if not exists.
 	IsColumnAlreadyExistsErr(err error) bool
 	IsTableDoesNotExistErr(err error) bool
-	BuildCreateTableQuery(tableID TableIdentifier, temporary bool, colSQLParts []string) string
+	BuildCreateTableQuery(tableID TableIdentifier, temporary bool, mode config.Mode, colSQLParts []string) string
 	BuildDropTableQuery(tableID TableIdentifier) string
 	BuildTruncateTableQuery(tableID TableIdentifier) string
 	BuildDedupeQueries(tableID, stagingTableID TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool) []string


### PR DESCRIPTION
Needed for the Clickhouse implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a mode argument to BuildCreateTableQuery in the Dialect interface and update all dialects, DDL builder, and tests/integration tests to pass config.Replication.
> 
> - **Core API**:
>   - Update `sql.Dialect.BuildCreateTableQuery` signature to `BuildCreateTableQuery(tableID, temporary, mode, colSQLParts)`.
> - **Dialects**:
>   - Implement new signature in `bigquery`, `databricks`, `iceberg`, `motherduck` (DuckDB), `mssql`, `postgres`, `redshift`, and `snowflake` (mode unused for now).
> - **DDL/Plumbing**:
>   - `lib/destination/ddl.BuildCreateTableSQL` now forwards `mode` to `BuildCreateTableQuery`.
>   - `clients/iceberg/table.CreateTable` updated to pass `config.Replication`.
> - **Tests/Integration**:
>   - Update all unit/integration tests and helpers to pass `config.Replication` when creating tables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f89892e1d0975089f9bfc437905417cd653e259. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->