### PR TITLE
Handle converting floats/ints to timestamps (assume unix ms)

### DIFF
--- a/lib/typing/parse_timestamp.go
+++ b/lib/typing/parse_timestamp.go
@@ -68,6 +68,21 @@ func ParseTimeFromAny(val any) (time.Time, error) {
 	}
 }
 
+// floatMillisToTime converts a float64 Unix timestamp in milliseconds to time.Time,
+// preserving fractional milliseconds as nanoseconds.
+func floatMillisToTime(ms float64) time.Time {
+	msInt := int64(ms)
+	fracMs := ms - float64(msInt)
+	// Convert fractional milliseconds to nanoseconds (1 ms = 1,000,000 ns)
+	additionalNanos := int64(fracMs * 1e6)
+	return time.UnixMilli(msInt).Add(time.Duration(additionalNanos) * time.Nanosecond)
+}
+
+// int64MillisToTime converts an int64 Unix timestamp in milliseconds to time.Time.
+func int64MillisToTime(ms int64) time.Time {
+	return time.UnixMilli(ms)
+}
+
 func ParseTimestampNTZFromAny(val any) (time.Time, error) {
 	switch convertedVal := val.(type) {
 	case nil:
@@ -81,6 +96,10 @@ func ParseTimestampNTZFromAny(val any) (time.Time, error) {
 		}
 
 		return ts, nil
+	case float64:
+		return floatMillisToTime(convertedVal), nil
+	case int64:
+		return int64MillisToTime(convertedVal), nil
 	default:
 		return time.Time{}, fmt.Errorf("unsupported type: %T", convertedVal)
 	}
@@ -95,14 +114,9 @@ func ParseTimestampTZFromAny(val any) (time.Time, error) {
 	case string:
 		return parseTimestampTZ(convertedVal)
 	case float64:
-		// Handle float64 timestamps that may include fractional milliseconds.
-		msInt := int64(convertedVal)
-		fracMs := convertedVal - float64(msInt)
-		// Convert fractional milliseconds to nanoseconds (1 ms = 1,000,000 ns)
-		additionalNanos := int64(fracMs * 1e6)
-		return time.UnixMilli(msInt).Add(time.Duration(additionalNanos) * time.Nanosecond), nil
+		return floatMillisToTime(convertedVal), nil
 	case int64:
-		return time.UnixMilli(convertedVal), nil
+		return int64MillisToTime(convertedVal), nil
 	default:
 		return time.Time{}, fmt.Errorf("unsupported type: %T", convertedVal)
 	}

--- a/lib/typing/parse_timestamp_test.go
+++ b/lib/typing/parse_timestamp_test.go
@@ -152,4 +152,30 @@ func TestParseTimestampNTZFromAny(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, tsString, ts.Format(RFC3339NoTZ))
 	}
+	{
+		// int64 - milliseconds
+		value, err := ParseTimestampNTZFromAny(int64(1703123456789))
+		assert.NoError(t, err)
+		assert.Equal(t, "2023-12-21T01:50:56.789", value.UTC().Format(RFC3339NoTZ))
+	}
+	{
+		// float64 - whole milliseconds (no fractional part)
+		value, err := ParseTimestampNTZFromAny(float64(1703123456789))
+		assert.NoError(t, err)
+		assert.Equal(t, "2023-12-21T01:50:56.789", value.UTC().Format(RFC3339NoTZ))
+	}
+	{
+		// float64 - milliseconds with fractional microseconds
+		value, err := ParseTimestampNTZFromAny(float64(1703123456789.123))
+		assert.NoError(t, err)
+		// Truncate to microseconds since float64 may have small nanosecond inaccuracies
+		assert.Equal(t, "2023-12-21T01:50:56.789123", value.UTC().Truncate(time.Microsecond).Format(RFC3339NoTZ))
+	}
+	{
+		// float64 - milliseconds with half-millisecond precision (exact in float64)
+		value, err := ParseTimestampNTZFromAny(float64(1703123456789.5))
+		assert.NoError(t, err)
+		// 0.5 ms = 500 microseconds = 500,000 nanoseconds
+		assert.Equal(t, "2023-12-21T01:50:56.7895", value.UTC().Format(RFC3339NoTZ))
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add parsing of float64/int64 Unix millisecond timestamps (including fractional ms) in `ParseTimestamp{NTZ,TZ}FromAny`, with helpers and tests.
> 
> - **Typing / Timestamp parsing**:
>   - Add support for Unix millisecond inputs in `ParseTimestampNTZFromAny` and `ParseTimestampTZFromAny`:
>     - Accept `float64` and `int64` values; preserve fractional milliseconds as nanoseconds.
>     - New helpers: `floatMillisToTime` and `int64MillisToTime`.
>   - Expand tests in `lib/typing/parse_timestamp_test.go` to cover whole ms, fractional ms (microseconds/half-ms), and UTC/NTZ formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eb725a5dfff90ac6eba8bfd42acbb380c7e134e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->