### PR TITLE
Validate year in other dbz converters

### DIFF
--- a/lib/debezium/converters/timestamp.go
+++ b/lib/debezium/converters/timestamp.go
@@ -1,10 +1,13 @@
 package converters
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/typing"
 )
+
+const maxValidYear = 9999
 
 type Timestamp struct{}
 
@@ -19,7 +22,12 @@ func (t Timestamp) Convert(value any) (any, error) {
 	}
 
 	// Represents the number of milliseconds since the epoch, and does not include timezone information.
-	return time.UnixMilli(castedValue).In(time.UTC), nil
+	ts := time.UnixMilli(castedValue).In(time.UTC)
+	if ts.Year() > maxValidYear {
+		slog.Warn("Timestamp exceeds max year, returning null", slog.Int("year", ts.Year()))
+		return nil, nil
+	}
+	return ts, nil
 }
 
 type MicroTimestamp struct{}
@@ -35,7 +43,12 @@ func (mt MicroTimestamp) Convert(value any) (any, error) {
 	}
 
 	// Represents the number of microseconds since the epoch, and does not include timezone information.
-	return time.UnixMicro(castedValue).In(time.UTC), nil
+	ts := time.UnixMicro(castedValue).In(time.UTC)
+	if ts.Year() > maxValidYear {
+		slog.Warn("Timestamp exceeds max year, returning null", slog.Int("year", ts.Year()))
+		return nil, nil
+	}
+	return ts, nil
 }
 
 type NanoTimestamp struct{}
@@ -51,5 +64,10 @@ func (nt NanoTimestamp) Convert(value any) (any, error) {
 	}
 
 	// Represents the number of nanoseconds since the epoch, and does not include timezone information.
-	return time.UnixMicro(castedValue / 1_000).In(time.UTC), nil
+	ts := time.UnixMicro(castedValue / 1_000).In(time.UTC)
+	if ts.Year() > maxValidYear {
+		slog.Warn("Timestamp exceeds max year, returning null", slog.Int("year", ts.Year()))
+		return nil, nil
+	}
+	return ts, nil
 }

--- a/lib/debezium/converters/timestamp_test.go
+++ b/lib/debezium/converters/timestamp_test.go
@@ -22,6 +22,12 @@ func TestTimestamp_Converter(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "2024-08-30T22:59:59.089", converted.(time.Time).Format(typing.RFC3339NoTZ))
 	}
+	{
+		// Year exceeds 9999 - should return nil
+		converted, err := Timestamp{}.Convert(int64(253_402_300_800_000)) // Year 10000
+		assert.NoError(t, err)
+		assert.Nil(t, converted)
+	}
 }
 
 func TestMicroTimestamp_Converter(t *testing.T) {
@@ -36,6 +42,12 @@ func TestMicroTimestamp_Converter(t *testing.T) {
 		converted, err := MicroTimestamp{}.Convert(int64(1_712_609_795_827_923))
 		assert.NoError(t, err)
 		assert.Equal(t, "2024-04-08T20:56:35.827923", converted.(time.Time).Format(typing.RFC3339NoTZ))
+	}
+	{
+		// Year exceeds 9999 - should return nil
+		converted, err := MicroTimestamp{}.Convert(int64(253_402_300_800_000_000)) // Year 10000
+		assert.NoError(t, err)
+		assert.Nil(t, converted)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds year upper-bound checks to Debezium timestamp converters, returning nil and logging a warning when the year exceeds 9999, with corresponding tests.
> 
> - **Debezium converters**:
>   - Add `maxValidYear` check in `Timestamp.Convert`, `MicroTimestamp.Convert`, and `NanoTimestamp.Convert` to return `nil` when `ts.Year() > 9999` and log a warning via `slog`.
> - **Tests**:
>   - Extend `timestamp_test.go` with cases asserting `nil` for inputs yielding year 10000 across milli/micro converters and keep/verify valid conversions for all (incl. nano).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 642faca77977933d68430c80a8be278cc8baf44c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->