### PR TITLE
Emit metrics when there's an error flushing

### DIFF
--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -95,7 +95,6 @@ func FlushSingleTopic(ctx context.Context, inMemDB *models.DatabaseData, dest de
 					slog.Info("Flushing table", slog.String("tableID", table.GetTableID().String()), slog.String("reason", args.Reason))
 					return flush(ctx, dest, table)
 				})
-
 				if err != nil {
 					tags["what"] = result.What
 					metricsClient.Timing("flush", time.Since(start), tags)


### PR DESCRIPTION
We're not getting paged about merge failures anymore because those events aren't getting recorded. https://github.com/artie-labs/transfer/pull/1443 changed this code to use an errgroup instead of waitgroup, and made it early return in case of error: https://github.com/artie-labs/transfer/pull/1443/changes?diff=split#diff-20d9a861ef295ca7f519544e409a322b71e99963291fbad5e0498c6a05f94e62R96

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Records `flush` timing metrics with `what` tag even when flushing fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ea1b9c7e1c1643203f5975f2f172aeabe316f7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->