### PR TITLE
Helper function for inferring type from column name

### DIFF
--- a/lib/cdc/eventtracking/event.go
+++ b/lib/cdc/eventtracking/event.go
@@ -2,6 +2,7 @@ package eventtracking
 
 import (
 	"maps"
+	"strings"
 	"time"
 
 	"github.com/artie-labs/transfer/lib/config/constants"
@@ -75,10 +76,12 @@ func (e *EventPayload) GetOptionalSchema() (map[string]typing.KindDetails, error
 func (e *EventPayload) GetColumns(reservedColumns map[string]bool) (*columns.Columns, error) {
 	var cols columns.Columns
 	for k := range e.Properties {
-		cols.AddColumn(columns.NewColumn(columns.EscapeName(k, reservedColumns), typing.Invalid))
+		colName := columns.EscapeName(k, reservedColumns)
+		cols.AddColumn(columns.NewColumn(colName, inferTypeFromColumnName(colName)))
 	}
 	for k := range e.ExtraFields {
-		cols.AddColumn(columns.NewColumn(columns.EscapeName(k, reservedColumns), typing.Invalid))
+		colName := columns.EscapeName(k, reservedColumns)
+		cols.AddColumn(columns.NewColumn(colName, inferTypeFromColumnName(colName)))
 	}
 
 	cols.AddColumn(columns.NewColumn(columns.EscapeName("id", reservedColumns), typing.String))
@@ -86,4 +89,21 @@ func (e *EventPayload) GetColumns(reservedColumns map[string]bool) (*columns.Col
 	cols.AddColumn(columns.NewColumn(columns.EscapeName("event", reservedColumns), typing.String))
 
 	return &cols, nil
+}
+
+// inferTypeFromColumnName is non-exhaustive and checks for some common patterns that
+// should be interpreted as a specific column type. This is helpful for polymorphic fields
+// like IDs and timestamps, which can come through as either string or numeric; we want to
+// avoid picking too narrow a type if the first value we see for it is numeric.
+func inferTypeFromColumnName(column string) typing.KindDetails {
+	lowerName := strings.ToLower(column)
+	if strings.HasSuffix(lowerName, "_id") {
+		return typing.String
+	} else if strings.HasSuffix(lowerName, "_at") || strings.HasSuffix(lowerName, "_started") {
+		return typing.TimestampTZ
+	}
+
+	// Defaulting to [typing.Invalid] indicates that we don't know the type yet, so
+	// it will be inferred downstream based on the first non-nil value.
+	return typing.Invalid
 }


### PR DESCRIPTION
This is a first line of defense for common columns with ambiguous types, to make sure we pick a wide enough type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Infer types for event-tracking columns using name patterns (e.g., *_id -> string, *_at|*_started -> timestamptz) instead of defaulting to unknown.
> 
> - **Event Tracking (`lib/cdc/eventtracking/event.go`)**:
>   - **Type inference in `GetColumns`**: For `properties` and `extraFields`, use `inferTypeFromColumnName` to set initial types instead of defaulting to `typing.Invalid`.
>   - **Helper**: Add `inferTypeFromColumnName`
>     - `*_id` -> `typing.String`
>     - `*_at`, `*_started` -> `typing.TimestampTZ`
>     - Otherwise -> `typing.Invalid`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b67906f2726c57a78cca51d840c59ea2dfd46480. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->