### PR TITLE
Add checks for month and day in Date.Convert()

### DIFF
--- a/lib/debezium/converters/date.go
+++ b/lib/debezium/converters/date.go
@@ -26,6 +26,16 @@ func (d Date) Convert(value any) (any, error) {
 		return nil, nil
 	}
 
+	if date.Month() > 12 {
+		slog.Warn("Date exceeds 12 months, setting this to null to avoid encoding errors", slog.Any("month", date.Month()))
+		return nil, nil
+	}
+
+	if date.Day() > 31 {
+		slog.Warn("Date exceeds 31 days, setting this to null to avoid encoding errors", slog.Int("day", date.Day()))
+		return nil, nil
+	}
+
 	// Represents the number of days since the epoch.
 	return date.Format(time.DateOnly), nil
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds strict validation to the date converter to prevent encoding errors.
> 
> - In `Date.Convert`, add checks for `date.Month() > 12` and `date.Day() > 31`; log warnings and return `nil` for invalid values
> - Retains existing guard for years > 9999; normal formatting unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43f340b1f7f69cdbf36ee4b98d21c9a13a071bf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->