### PR TITLE
Change log level from Warn to Error for failed webhook event 

### DIFF
--- a/lib/webhooksClient/client.go
+++ b/lib/webhooksClient/client.go
@@ -43,6 +43,6 @@ func (c *Client) SendEvent(ctx context.Context, eventType webhooksutil.EventType
 		return
 	}
 	if err := c.client.SendEvent(ctx, eventType, properties); err != nil {
-		slog.Warn("Failed to send webhook event", slog.String("event", string(eventType)), slog.Any("err", err))
+		slog.Error("Failed to send webhook event", slog.String("event", string(eventType)), slog.Any("err", err))
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Logging adjustment**
> 
> - In `lib/webhooksClient/client.go`, change failure logging in `SendEvent` from `slog.Warn` to `slog.Error` when `client.SendEvent` returns an error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be89447066a6a171aeb26c239913461eed851e71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->