### PR TITLE
Make Tests Fast Again

### DIFF
--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -53,7 +53,7 @@ jobs:
         run: test -z $(gofmt -l .)
 
       - name: Save Go cache
-        # if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: actions/cache/save@v5
         with:
           # Caches the compiled build cache.
@@ -63,7 +63,7 @@ jobs:
           key: "${{ runner.os }}-go-${{ hashFiles('go.mod') }}-${{ env.GO_CACHE_DATE }}"
 
       - name: Save Go cache (today)
-        # if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: actions/cache/save@v5
         with:
           # Caches the compiled build cache.


### PR DESCRIPTION
Unit tests go from ~5 minutes to ~50 seconds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up Go CI by caching compiled build artifacts.
> 
> - Adds `GO_CACHE_DATE` env and cache restore step to `github/workflows/go-checks.yml`, restoring `~/.cache/go-build` using date- and `go.mod`-hash–based keys with fallbacks
> - Saves the build cache on `master` with two keys (`OS-go-<hash>-<date>` and `OS-go-<date>`) to keep cache fresh and provide a fallback
> - No application code changes; only CI workflow updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d27f3a82d8cf008574e2aab12c2d5123c3b8bd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->