### PR TITLE
Don't cache tests in make race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test:
 
 .PHONY: race
 race:
-	go test -race ./...
+	go test -count 1 -race ./...
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Makefile to ensure race tests always re-run.
> 
> - Changes `race` target to `go test -count 1 -race ./...` to bypass the Go test cache
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8354d96b80fdafec25d1a7415a9a86ba1d8987c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->