### PR TITLE
Destination interface refactor

### DIFF
--- a/lib/destination/ddl/ddl.go
+++ b/lib/destination/ddl/ddl.go
@@ -59,10 +59,10 @@ func BuildCreateTableSQL(settings config.SharedDestinationColumnSettings, dialec
 // DropTemporaryTable - this will drop the temporary table from Snowflake w/ stages and BigQuery
 // It has a safety check to make sure the tableName contains the `constants.ArtiePrefix` key.
 // Temporary tables look like this: database.schema.tableName__artie__RANDOM_STRING(5)_expiryUnixTs
-func DropTemporaryTable(ctx context.Context, dest destination.Destination, tableIdentifier sql.TableIdentifier, shouldReturnError bool) error {
+func DropTemporaryTable(ctx context.Context, executor destination.SQLExecutor, tableIdentifier sql.TableIdentifier, shouldReturnError bool) error {
 	if strings.Contains(strings.ToLower(tableIdentifier.Table()), constants.ArtiePrefix) {
 		sqlCommand := fmt.Sprintf("DROP TABLE IF EXISTS %s", tableIdentifier.FullyQualifiedName())
-		if _, err := dest.ExecContext(ctx, sqlCommand); err != nil {
+		if _, err := executor.ExecContext(ctx, sqlCommand); err != nil {
 			slog.Warn("Failed to drop temporary table, it will get garbage collected by the TTL...",
 				slog.Any("err", err),
 				slog.String("sqlCommand", sqlCommand),

--- a/lib/destination/destination.go
+++ b/lib/destination/destination.go
@@ -14,23 +14,9 @@ import (
 	webhooksclient "github.com/artie-labs/transfer/lib/webhooksClient"
 )
 
-type Destination interface {
-	Baseline
-
-	// SQL specific commands
-	Dialect() sqllib.Dialect
-	Dedupe(ctx context.Context, tableID sqllib.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool) error
-	SweepTemporaryTables(ctx context.Context, whClient *webhooksclient.Client) error
-	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
-	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
-	Begin() (*sql.Tx, error)
-
-	// Helper functions for merge
-	GetTableConfig(ctx context.Context, tableID sqllib.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error)
-	// LoadDataIntoTable is used to load data into staging tables, and also to append data directly to a target table (for history mode and OLAP-destination backfills)
-	LoadDataIntoTable(ctx context.Context, tableData *optimization.TableData, tableConfig *types.DestinationTableConfig, tableID, parentTableID sqllib.TableIdentifier, additionalSettings types.AdditionalSettings, createTempTable bool) error
-}
-
+// Baseline is the core interface that all destinations must implement.
+// This interface is used by blob/object storage (S3, GCS), HTTP-based destinations,
+// and SQL-based destinations. The consumer code (process.go, flush.go) uses this interface.
 type Baseline interface {
 	GetConfig() config.Config
 
@@ -41,22 +27,67 @@ type Baseline interface {
 	DropTable(ctx context.Context, tableID sqllib.TableIdentifier) error
 }
 
-// ExecContextStatements executes one or more statements against a [Destination].
+// DialectAware is an optional interface for destinations that have a SQL dialect.
+// This is used for building reserved column names and SQL-based operations.
+type DialectAware interface {
+	Dialect() sqllib.Dialect
+}
+
+// SQLExecutor is an interface for destinations that can execute SQL commands.
+// This is typically used by SQL-based destinations (Snowflake, BigQuery, Postgres, etc.)
+type SQLExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	Begin() (*sql.Tx, error)
+}
+
+// TemporaryTableManager is an interface for destinations that manage temporary tables.
+// This is called at startup to clean up orphaned temporary tables.
+type TemporaryTableManager interface {
+	SweepTemporaryTables(ctx context.Context, whClient *webhooksclient.Client) error
+}
+
+// Deduplicator is an interface for destinations that support row deduplication.
+type Deduplicator interface {
+	Dedupe(ctx context.Context, tableID sqllib.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool) error
+}
+
+// DataLoader is an interface for destinations that support loading data into tables
+// with table configuration awareness. This is used for SQL-based merge and append operations.
+type DataLoader interface {
+	GetTableConfig(ctx context.Context, tableID sqllib.TableIdentifier, dropDeletedColumns bool) (*types.DestinationTableConfig, error)
+	// LoadDataIntoTable is used to load data into staging tables, and also to append data directly to a target table (for history mode and OLAP-destination backfills)
+	LoadDataIntoTable(ctx context.Context, tableData *optimization.TableData, tableConfig *types.DestinationTableConfig, tableID, parentTableID sqllib.TableIdentifier, additionalSettings types.AdditionalSettings, createTempTable bool) error
+}
+
+// Destination is the full interface for SQL-based destinations.
+// It composes all the granular interfaces to provide full SQL destination capabilities.
+// This is used by destinations like Snowflake, BigQuery, Postgres, Redshift, MSSQL, etc.
+type Destination interface {
+	Baseline
+	DialectAware
+	SQLExecutor
+	TemporaryTableManager
+	Deduplicator
+	DataLoader
+}
+
+// ExecContextStatements executes one or more statements against a [SQLExecutor].
 // If there is more than one statement, the statements will be executed inside of a transaction.
-func ExecContextStatements(ctx context.Context, dest Destination, statements []string) ([]sql.Result, error) {
+func ExecContextStatements(ctx context.Context, executor SQLExecutor, statements []string) ([]sql.Result, error) {
 	switch len(statements) {
 	case 0:
 		return nil, fmt.Errorf("statements is empty")
 	case 1:
 		slog.Debug("Executing...", slog.String("query", statements[0]))
-		result, err := dest.ExecContext(ctx, statements[0])
+		result, err := executor.ExecContext(ctx, statements[0])
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute statement: %w", err)
 		}
 
 		return []sql.Result{result}, nil
 	default:
-		tx, err := dest.Begin()
+		tx, err := executor.Begin()
 		if err != nil {
 			return nil, fmt.Errorf("failed to start tx: %w", err)
 		}
@@ -88,9 +119,11 @@ func ExecContextStatements(ctx context.Context, dest Destination, statements []s
 	}
 }
 
+// BuildReservedColumnNames returns a map of reserved column names for a destination.
+// It checks if the destination implements DialectAware to get the dialect's reserved columns.
 func BuildReservedColumnNames(baseline Baseline) map[string]bool {
-	if _dest, ok := baseline.(Destination); ok {
-		if dialect := _dest.Dialect(); dialect != nil {
+	if dialectAware, ok := baseline.(DialectAware); ok {
+		if dialect := dialectAware.Dialect(); dialect != nil {
 			return dialect.ReservedColumnNames()
 		}
 	}

--- a/lib/destination/utils/load.go
+++ b/lib/destination/utils/load.go
@@ -22,10 +22,16 @@ import (
 	"github.com/artie-labs/transfer/lib/destination"
 )
 
+// IsOutputBaseline returns true if the output destination only implements the Baseline interface
+// (e.g., blob/object storage like S3, GCS, or specialized destinations like Iceberg, Redis).
+// These destinations implement Merge and Append directly without using shared SQL-based logic.
 func IsOutputBaseline(cfg config.Config) bool {
 	return cfg.Output == constants.S3 || cfg.Output == constants.GCS || cfg.Output == constants.Iceberg || cfg.Output == constants.Redis
 }
 
+// LoadBaseline loads destinations that only implement the Baseline interface.
+// These are typically blob/object storage destinations (S3, GCS) or specialized
+// destinations like Iceberg and Redis that implement Merge and Append directly.
 func LoadBaseline(ctx context.Context, cfg config.Config) (destination.Baseline, error) {
 	switch cfg.Output {
 	case constants.S3:
@@ -59,6 +65,9 @@ func LoadBaseline(ctx context.Context, cfg config.Config) (destination.Baseline,
 	return nil, fmt.Errorf("invalid baseline output source specified: %q", cfg.Output)
 }
 
+// LoadDestination loads SQL-based destinations that implement the full Destination interface.
+// These destinations use SQL for data operations and implement additional interfaces like
+// SQLExecutor, DialectAware, TemporaryTableManager, Deduplicator, and DataLoader.
 func LoadDestination(ctx context.Context, cfg config.Config, store *db.Store) (destination.Destination, error) {
 	switch cfg.Output {
 	case constants.Snowflake:


### PR DESCRIPTION
Refactor the `Destination` interface into granular interfaces to support diverse destination types (SQL, Blob, HTTP) while maintaining generic consumer code.

---
<a href="https://cursor.com/background-agent?bcId=bc-3addb76c-0f45-427c-b7ca-2f6ceae262ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3addb76c-0f45-427c-b7ca-2f6ceae262ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

