### PR TITLE
More BigQuery Date Skipping

### DIFF
--- a/clients/bigquery/partition.go
+++ b/clients/bigquery/partition.go
@@ -18,7 +18,7 @@ func buildDistinctDates(colName string, rows []optimization.Row, reservedColumnN
 	for _, row := range rows {
 		val, ok := row.GetValue(colName)
 		if !ok || val == nil {
-			// If any row has a nil value, skip distinct dates filtering, this will end up in `__NULL__`
+			// Skip distinct date filtering if there are nil or missing values. They will all end up in the `__NULL__` partition.
 			return nil, nil
 		}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts BigQuery date partitioning behavior to be more tolerant of missing/nullable partition values.
> 
> - `buildDistinctDates`: when the partition column is missing or `nil`, skip distinct-date filtering instead of erroring; affected rows go to the `__NULL__` partition
> - Adds a clarifying doc comment to `buildDistinctDates`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f3573dfe921833c021df08d8e42acef3e304ef1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->