### PR TITLE
[Kafka] Change default Kafka consumer to franz-go

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -87,7 +87,7 @@ func readFileToConfig(pathToConfig string) (*Config, error) {
 	config.BufferRows = cmp.Or(config.BufferRows, defaultBufferPoolSize)
 	config.FlushSizeKb = cmp.Or(config.FlushSizeKb, defaultFlushSizeKb)
 	config.Mode = cmp.Or(config.Mode, Replication)
-	config.KafkaClient = cmp.Or(config.KafkaClient, KafkaGoClient)
+	config.KafkaClient = cmp.Or(config.KafkaClient, FranzGoClient)
 
 	return &config, nil
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the default Kafka consumer implementation used when `kafkaClient` is not specified.
> 
> - In `lib/config/config.go`, default `config.KafkaClient` now resolves to `FranzGoClient` instead of `KafkaGoClient`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0de9a6e723820a4bc906ec586ee4cbe97d13884. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->