### PR TITLE
[bytea] Toast

### DIFF
--- a/lib/debezium/converters/bytes.go
+++ b/lib/debezium/converters/bytes.go
@@ -27,6 +27,11 @@ func (Bytes) Convert(value any) (any, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to base64 decode: %w", err)
 		}
+
+		if string(data) == constants.ToastUnavailableValuePlaceholder {
+			return constants.ToastUnavailableValuePlaceholder, nil
+		}
+
 		return data, nil
 	default:
 		return nil, fmt.Errorf("expected []byte or string, got %T", value)


### PR DESCRIPTION
This data is base64 encoded, we needed to decode and then check the string value!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **fix(Bytes converter): handle TOAST placeholder after decode**
> 
> - Updates `Bytes.Convert` to check the base64-decoded value and return `constants.ToastUnavailableValuePlaceholder` if it matches, in addition to the pre-decode check. Other behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26b57997e4d3c3dce75505f5cce6b5ac774e994d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->