### PR TITLE
Renaming Time

### DIFF
--- a/clients/bigquery/converters/converters_test.go
+++ b/clients/bigquery/converters/converters_test.go
@@ -83,7 +83,7 @@ func TestStringConverter_Convert(t *testing.T) {
 		}
 		{
 			// Time
-			val, err := NewStringConverter(typing.Time).Convert(time.Date(2021, 1, 1, 9, 10, 11, 123_456_789, time.UTC))
+			val, err := NewStringConverter(typing.TimeKindDetails).Convert(time.Date(2021, 1, 1, 9, 10, 11, 123_456_789, time.UTC))
 			assert.NoError(t, err)
 			assert.Equal(t, "09:10:11.123456", val)
 		}

--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -26,7 +26,7 @@ func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, s
 		return "json", nil
 	case typing.Date.Kind:
 		return "date", nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		return "time", nil
 	case typing.TimestampNTZ.Kind:
 		return "datetime", nil
@@ -95,7 +95,7 @@ func (BigQueryDialect) KindForDataType(rawBqType string) (typing.KindDetails, er
 	case "datetime":
 		return typing.TimestampNTZ, nil
 	case "time":
-		return typing.Time, nil
+		return typing.TimeKindDetails, nil
 	case "date":
 		return typing.Date, nil
 	default:

--- a/clients/bigquery/dialect/typing_test.go
+++ b/clients/bigquery/dialect/typing_test.go
@@ -32,7 +32,7 @@ func TestBigQueryDialect_DataTypeForKind(t *testing.T) {
 func TestBigQueryDialect_KindForDataType_NoDataLoss(t *testing.T) {
 	kindDetails := []typing.KindDetails{
 		typing.TimestampTZ,
-		typing.Time,
+		typing.TimeKindDetails,
 		typing.Date,
 		typing.String,
 		typing.Boolean,
@@ -169,7 +169,7 @@ func TestBigQueryDialect_KindForDataType(t *testing.T) {
 		// Time
 		kd, err := dialect.KindForDataType("time")
 		assert.NoError(t, err)
-		assert.Equal(t, typing.Time, kd)
+		assert.Equal(t, typing.TimeKindDetails, kd)
 	}
 	{
 		// Timestamp (Timestamp TZ)

--- a/clients/bigquery/storagewrite.go
+++ b/clients/bigquery/storagewrite.go
@@ -41,7 +41,7 @@ func columnToTableFieldSchema(column columns.Column) (*storagepb.TableFieldSchem
 		fieldType = storagepb.TableFieldSchema_STRING
 	case typing.Date.Kind:
 		fieldType = storagepb.TableFieldSchema_DATE
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		fieldType = storagepb.TableFieldSchema_TIME
 	case typing.TimestampNTZ.Kind:
 		fieldType = storagepb.TableFieldSchema_DATETIME
@@ -214,7 +214,7 @@ func rowToMessage(row map[string]any, columns []columns.Column, messageDescripto
 
 			daysSinceEpoch := _time.Unix() / (60 * 60 * 24)
 			message.Set(field, protoreflect.ValueOfInt32(int32(daysSinceEpoch)))
-		case typing.Time.Kind:
+		case typing.TimeKindDetails.Kind:
 			_time, err := typing.ParseTimeFromAny(value)
 			if err != nil {
 				if config.SharedDestinationSettings.SkipBadTimestamps {

--- a/clients/bigquery/storagewrite_test.go
+++ b/clients/bigquery/storagewrite_test.go
@@ -45,7 +45,7 @@ func TestColumnToTableFieldSchema(t *testing.T) {
 	}
 	{
 		// Time
-		fieldSchema, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.Time))
+		fieldSchema, err := columnToTableFieldSchema(columns.NewColumn("foo", typing.TimeKindDetails))
 		assert.NoError(t, err)
 		assert.Equal(t, storagepb.TableFieldSchema_TIME, fieldSchema.Type)
 	}
@@ -166,7 +166,7 @@ func TestRowToMessage(t *testing.T) {
 		columns.NewColumn("c_numeric", typing.EDecimal),
 		columns.NewColumn("c_string", typing.String),
 		columns.NewColumn("c_string_decimal", typing.String),
-		columns.NewColumn("c_time", typing.Time),
+		columns.NewColumn("c_time", typing.TimeKindDetails),
 		columns.NewColumn("c_timestamp", typing.TimestampTZ),
 		columns.NewColumn("c_date", typing.Date),
 		columns.NewColumn("c_datetime", typing.TimestampNTZ),

--- a/clients/clickhouse/dialect/dialect.go
+++ b/clients/clickhouse/dialect/dialect.go
@@ -152,7 +152,7 @@ func (ClickhouseDialect) DataTypeForKind(kd typing.KindDetails, isPk bool, setti
 		return "String", nil
 	case typing.Date.Kind:
 		return "Date", nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		// clickhouse-go v2.40.3 does not support the Time type.
 		// Using v2.41.0 requires us to upgrade our Go toolchain to 1.25.x
 		// See: https://github.com/ClickHouse/clickhouse-go/releases/tag/v2.41.0
@@ -199,7 +199,7 @@ func (ClickhouseDialect) KindForDataType(_type string) (typing.KindDetails, erro
 	case "date":
 		return typing.Date, nil
 	case "time":
-		return typing.Time, nil
+		return typing.TimeKindDetails, nil
 	case "datetime":
 		return typing.TimestampNTZ, nil
 	}

--- a/clients/clickhouse/load.go
+++ b/clients/clickhouse/load.go
@@ -122,7 +122,7 @@ func parseValue(value any, col columns.Column) (any, error) {
 		}
 		return parsedTime, nil
 
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		parsedTime, err := typing.ParseTimeFromAny(value)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse time: %w", err)

--- a/clients/databricks/dialect/typing.go
+++ b/clients/databricks/dialect/typing.go
@@ -26,7 +26,7 @@ func (DatabricksDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool,
 		return "BOOLEAN", nil
 	case typing.Date.Kind:
 		return "DATE", nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		return "STRING", nil
 	case typing.TimestampNTZ.Kind:
 		// This is currently in public preview, to use this, the customer will need to enable [timestampNtz] in their delta tables.

--- a/clients/databricks/dialect/typing_test.go
+++ b/clients/databricks/dialect/typing_test.go
@@ -25,10 +25,10 @@ func TestDatabricksDialect_DataTypeForKind(t *testing.T) {
 		// Arrays:
 		typing.Array: "ARRAY<string>",
 		// Date and timestamp data types:
-		typing.Date:         "DATE",
-		typing.TimestampTZ:  "TIMESTAMP",
-		typing.TimestampNTZ: "TIMESTAMP_NTZ",
-		typing.Time:         "STRING",
+		typing.Date:            "DATE",
+		typing.TimestampTZ:     "TIMESTAMP",
+		typing.TimestampNTZ:    "TIMESTAMP_NTZ",
+		typing.TimeKindDetails: "STRING",
 	}
 
 	for kind, expected := range kindDetailsToExpectedMap {

--- a/clients/iceberg/dialect/data_types.go
+++ b/clients/iceberg/dialect/data_types.go
@@ -18,7 +18,7 @@ func (IcebergDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, _ 
 		typing.Array.Kind,
 		typing.Struct.Kind,
 		typing.String.Kind,
-		typing.Time.Kind:
+		typing.TimeKindDetails.Kind:
 		return "STRING", nil
 	case typing.Float.Kind:
 		return "DOUBLE", nil

--- a/clients/iceberg/dialect/data_types_test.go
+++ b/clients/iceberg/dialect/data_types_test.go
@@ -22,10 +22,10 @@ func TestIcebergDialect_DataTypeForKind(t *testing.T) {
 		// Boolean:
 		typing.Boolean: "BOOLEAN",
 		// String and related data types:
-		typing.String: "STRING",
-		typing.Time:   "STRING",
-		typing.Array:  "STRING",
-		typing.Struct: "STRING",
+		typing.String:          "STRING",
+		typing.TimeKindDetails: "STRING",
+		typing.Array:           "STRING",
+		typing.Struct:          "STRING",
 		// Float:
 		typing.Float: "DOUBLE",
 		// Decimals:

--- a/clients/motherduck/dialect/dialect.go
+++ b/clients/motherduck/dialect/dialect.go
@@ -62,7 +62,7 @@ func (DuckDBDialect) DataTypeForKind(kd typing.KindDetails, isPk bool, settings 
 		return "text", nil
 	case typing.Date.Kind:
 		return "date", nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		return "time", nil
 	case typing.TimestampNTZ.Kind:
 		return "timestamp", nil
@@ -112,7 +112,7 @@ func (DuckDBDialect) KindForDataType(_type string) (typing.KindDetails, error) {
 	case "date":
 		return typing.Date, nil
 	case "time":
-		return typing.Time, nil
+		return typing.TimeKindDetails, nil
 	case "timestamp", "datetime":
 		return typing.TimestampNTZ, nil
 	case "timestamp with time zone", "timestamptz":

--- a/clients/motherduck/dialect/dialect_test.go
+++ b/clients/motherduck/dialect/dialect_test.go
@@ -153,7 +153,7 @@ func TestKindForDataType(t *testing.T) {
 	{
 		kind, err := dd.KindForDataType("time")
 		assert.NoError(t, err)
-		assert.Equal(t, typing.Time, kind)
+		assert.Equal(t, typing.TimeKindDetails, kind)
 	}
 	{
 		kind, err := dd.KindForDataType("timestamp")
@@ -291,7 +291,7 @@ func TestDataTypeForKind(t *testing.T) {
 
 	// Time
 	{
-		result, err := dd.DataTypeForKind(typing.Time, false, config.SharedDestinationColumnSettings{})
+		result, err := dd.DataTypeForKind(typing.TimeKindDetails, false, config.SharedDestinationColumnSettings{})
 		assert.NoError(t, err)
 		assert.Equal(t, "time", result)
 	}

--- a/clients/motherduck/staging.go
+++ b/clients/motherduck/staging.go
@@ -158,7 +158,7 @@ func convertValue(value any, kd typing.KindDetails) (driver.Value, error) {
 			return nil, err
 		}
 		return timeVal, nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		// Parse time strings into time.Time for DuckDB appender
 		timeVal, err := typing.ParseTimeFromAny(value)
 		if err != nil {

--- a/clients/motherduck/staging_test.go
+++ b/clients/motherduck/staging_test.go
@@ -99,7 +99,7 @@ func TestConvertValue(t *testing.T) {
 
 	// Time type
 	{
-		result, err := convertValue("14:30:00", typing.Time)
+		result, err := convertValue("14:30:00", typing.TimeKindDetails)
 		assert.NoError(t, err)
 		assert.IsType(t, time.Time{}, result)
 	}

--- a/clients/mssql/dialect/typing.go
+++ b/clients/mssql/dialect/typing.go
@@ -41,7 +41,7 @@ func (MSSQLDialect) DataTypeForKind(kindDetails typing.KindDetails, isPk bool, _
 		return "BIT", nil
 	case typing.Date.Kind:
 		return "DATE", nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		return "TIME", nil
 	case typing.TimestampNTZ.Kind:
 		// Using datetime2 because it's the recommendation, and it provides more precision: https://stackoverflow.com/a/1884088
@@ -102,7 +102,7 @@ func (MSSQLDialect) KindForDataType(rawType string) (typing.KindDetails, error) 
 	case "datetimeoffset":
 		return typing.TimestampTZ, nil
 	case "time":
-		return typing.Time, nil
+		return typing.TimeKindDetails, nil
 	case "date":
 		return typing.Date, nil
 	case "bit":

--- a/clients/mssql/dialect/typing_test.go
+++ b/clients/mssql/dialect/typing_test.go
@@ -58,7 +58,7 @@ func TestMSSQLDialect_KindForDataType(t *testing.T) {
 		"real":           typing.Float,
 		"bit":            typing.Boolean,
 		"date":           typing.Date,
-		"time":           typing.Time,
+		"time":           typing.TimeKindDetails,
 		"datetime":       typing.TimestampNTZ,
 		"datetime2":      typing.TimestampNTZ,
 		"datetimeoffset": typing.TimestampTZ,

--- a/clients/mssql/values.go
+++ b/clients/mssql/values.go
@@ -32,7 +32,7 @@ func parseValue(colVal any, colKind columns.Column) (any, error) {
 		}
 
 		return _time, nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		_time, err := typing.ParseTimeFromAny(colVal)
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)

--- a/clients/postgres/dialect/dialect.go
+++ b/clients/postgres/dialect/dialect.go
@@ -202,15 +202,15 @@ WHEN NOT MATCHED AND COALESCE(%s, false) = false THEN INSERT (%s) VALUES (%s)`,
 }
 
 var kindDetailsMap = map[typing.KindDetails]string{
-	typing.Float:        "double precision",
-	typing.Boolean:      "boolean",
-	typing.Struct:       "jsonb",
-	typing.Array:        "jsonb",
-	typing.String:       "text",
-	typing.Date:         "date",
-	typing.Time:         "time",
-	typing.TimestampNTZ: "timestamp without time zone",
-	typing.TimestampTZ:  "timestamp with time zone",
+	typing.Float:           "double precision",
+	typing.Boolean:         "boolean",
+	typing.Struct:          "jsonb",
+	typing.Array:           "jsonb",
+	typing.String:          "text",
+	typing.Date:            "date",
+	typing.TimeKindDetails: "time",
+	typing.TimestampNTZ:    "timestamp without time zone",
+	typing.TimestampTZ:     "timestamp with time zone",
 }
 
 func (PostgresDialect) DataTypeForKind(kd typing.KindDetails, isPk bool, settings config.SharedDestinationColumnSettings) (string, error) {
@@ -259,7 +259,7 @@ var dataTypeMap = map[string]typing.KindDetails{
 	"double precision": typing.Float,
 	// Date and timestamp data types:
 	"date":                        typing.Date,
-	"time":                        typing.Time,
+	"time":                        typing.TimeKindDetails,
 	"timestamp with time zone":    typing.TimestampTZ,
 	"timestamp without time zone": typing.TimestampNTZ,
 	// Other data types:

--- a/clients/postgres/dialect/dialect_test.go
+++ b/clients/postgres/dialect/dialect_test.go
@@ -33,7 +33,7 @@ func TestKindForDataType(t *testing.T) {
 		"boolean": typing.Boolean,
 		// Date and timestamp data types:
 		"date":                           typing.Date,
-		"time":                           typing.Time,
+		"time":                           typing.TimeKindDetails,
 		"timestamp with time zone":       typing.TimestampTZ,
 		"timestamp(5) with time zone":    typing.TimestampTZ,
 		"timestamp without time zone":    typing.TimestampNTZ,
@@ -129,7 +129,7 @@ func TestDataTypeForKind(t *testing.T) {
 		},
 		{
 			name:     "time",
-			kd:       typing.Time,
+			kd:       typing.TimeKindDetails,
 			expected: "time",
 		},
 		{

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -47,7 +47,7 @@ func (RedshiftDialect) DataTypeForKind(kd typing.KindDetails, _ bool, _ config.S
 		return "BOOLEAN NULL", nil
 	case typing.Date.Kind:
 		return "DATE", nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		return "TIME", nil
 	case typing.TimestampNTZ.Kind:
 		return "TIMESTAMP WITHOUT TIME ZONE", nil
@@ -109,7 +109,7 @@ func (RedshiftDialect) KindForDataType(rawType string) (typing.KindDetails, erro
 	case "timestamp with time zone":
 		return typing.TimestampTZ, nil
 	case "time without time zone":
-		return typing.Time, nil
+		return typing.TimeKindDetails, nil
 	case "date":
 		return typing.Date, nil
 	case "boolean":

--- a/clients/redshift/dialect/typing_test.go
+++ b/clients/redshift/dialect/typing_test.go
@@ -140,7 +140,7 @@ func TestRedshiftDialect_KindForDataType(t *testing.T) {
 			// Time
 			kd, err := dialect.KindForDataType("time without time zone")
 			assert.NoError(t, err)
-			assert.Equal(t, typing.Time, kd)
+			assert.Equal(t, typing.TimeKindDetails, kd)
 		}
 		{
 			// Date

--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -38,7 +38,7 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 		}
 
 		return sql.QuoteLiteral(_time.Format(time.DateOnly)), nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		_time, err := typing.ParseTimeFromAny(column.DefaultValue())
 		if err != nil {
 			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)

--- a/clients/shared/default_value_test.go
+++ b/clients/shared/default_value_test.go
@@ -101,7 +101,7 @@ func TestColumn_DefaultValue(t *testing.T) {
 	}
 	{
 		// TIME
-		col := columns.NewColumnWithDefaultValue("", typing.Time, birthday)
+		col := columns.NewColumnWithDefaultValue("", typing.TimeKindDetails, birthday)
 		for _, dialect := range dialects {
 			actualValue, actualErr := DefaultValue(col, dialect)
 			assert.NoError(t, actualErr, fmt.Sprintf("dialect: %v", dialect))

--- a/clients/snowflake/dialect/typing.go
+++ b/clients/snowflake/dialect/typing.go
@@ -20,7 +20,7 @@ func (SnowflakeDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, 
 		return "boolean", nil
 	case typing.Date.Kind:
 		return "date", nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		return "time", nil
 	case typing.TimestampNTZ.Kind:
 		return "timestamp_ntz", nil
@@ -81,7 +81,7 @@ func (SnowflakeDialect) KindForDataType(snowflakeType string) (typing.KindDetail
 	case "timestamp", "datetime", "timestamp_ntz":
 		return typing.TimestampNTZ, nil
 	case "time":
-		return typing.Time, nil
+		return typing.TimeKindDetails, nil
 	case "date":
 		return typing.Date, nil
 	default:

--- a/clients/snowflake/dialect/typing_test.go
+++ b/clients/snowflake/dialect/typing_test.go
@@ -19,9 +19,9 @@ func TestSnowflakeDialect_DataTypeForKind(t *testing.T) {
 		// Struct:
 		typing.Struct: "variant",
 		// Date and timestamp data types:
-		typing.Date:        "date",
-		typing.Time:        "time",
-		typing.TimestampTZ: "timestamp_tz",
+		typing.Date:            "date",
+		typing.TimeKindDetails: "time",
+		typing.TimestampTZ:     "timestamp_tz",
 	}
 
 	for kd, expected := range expectedKindDetailsToValueMap {

--- a/clients/snowflake/staging_test.go
+++ b/clients/snowflake/staging_test.go
@@ -92,13 +92,13 @@ func (s *SnowflakeTestSuite) TestCastColValStaging() {
 		// Bad Time values
 		{
 			// SkipBadTimestamps is enabled, so we won't error, we'll just return null.
-			result, err := castColValStaging("not-a-time", typing.Time, config.SharedDestinationSettings{SkipBadTimestamps: true})
+			result, err := castColValStaging("not-a-time", typing.TimeKindDetails, config.SharedDestinationSettings{SkipBadTimestamps: true})
 			assert.NoError(s.T(), err)
 			assert.Equal(s.T(), constants.NullValuePlaceholder, result.Value)
 		}
 		{
 			// SkipBadTimestamps is disabled, so we'll error.
-			_, err := castColValStaging("not-a-time", typing.Time, config.SharedDestinationSettings{SkipBadTimestamps: false})
+			_, err := castColValStaging("not-a-time", typing.TimeKindDetails, config.SharedDestinationSettings{SkipBadTimestamps: false})
 			assert.Error(s.T(), err)
 		}
 	}
@@ -166,7 +166,7 @@ func (s *SnowflakeTestSuite) TestCastColValStaging() {
 		}
 		{
 			// SkipBadValues handles bad Time values
-			result, err := castColValStaging("not-a-time", typing.Time, config.SharedDestinationSettings{SkipBadValues: true})
+			result, err := castColValStaging("not-a-time", typing.TimeKindDetails, config.SharedDestinationSettings{SkipBadValues: true})
 			assert.NoError(s.T(), err)
 			assert.Equal(s.T(), constants.NullValuePlaceholder, result.Value)
 		}

--- a/integration_tests/parquet/main.go
+++ b/integration_tests/parquet/main.go
@@ -45,7 +45,7 @@ func createComprehensiveTestTable() *optimization.TableData {
 
 	// Date/Time types
 	cols.AddColumn(columns.NewColumn("birth_date", typing.Date))
-	cols.AddColumn(columns.NewColumn("lunch_time", typing.Time))
+	cols.AddColumn(columns.NewColumn("lunch_time", typing.TimeKindDetails))
 	cols.AddColumn(columns.NewColumn("created_at", typing.TimestampTZ))
 	cols.AddColumn(columns.NewColumn("updated_at", typing.TimestampNTZ))
 

--- a/integration_tests/shared/destination_types.go
+++ b/integration_tests/shared/destination_types.go
@@ -122,7 +122,7 @@ func RedshiftAssertColumns(ctx context.Context, dest destination.Destination, ta
 				return err
 			}
 		case "c_time":
-			if err := assertEqual("c_time", col.KindDetails.Kind, typing.Time.Kind); err != nil {
+			if err := assertEqual("c_time", col.KindDetails.Kind, typing.TimeKindDetails.Kind); err != nil {
 				return err
 			}
 		case "c_timestamp_ntz":

--- a/integration_tests/shared/destination_types.snowflake.go
+++ b/integration_tests/shared/destination_types.snowflake.go
@@ -193,7 +193,7 @@ func SnowflakeAssertColumns(ctx context.Context, dest destination.Destination, t
 				return err
 			}
 		case "c_time":
-			if err := assertEqual(col.Name(), col.KindDetails.Kind, typing.Time.Kind); err != nil {
+			if err := assertEqual(col.Name(), col.KindDetails.Kind, typing.TimeKindDetails.Kind); err != nil {
 				return err
 			}
 		case "c_variant":

--- a/integration_tests/shared/destination_types_mssql.go
+++ b/integration_tests/shared/destination_types_mssql.go
@@ -209,7 +209,7 @@ func MSSQLAssertColumns(ctx context.Context, dest destination.Destination, table
 				return err
 			}
 		case "c_time":
-			if err := assertEqual("c_time", col.KindDetails.Kind, typing.Time.Kind); err != nil {
+			if err := assertEqual("c_time", col.KindDetails.Kind, typing.TimeKindDetails.Kind); err != nil {
 				return err
 			}
 		case "c_date":

--- a/lib/debezium/converters/time.go
+++ b/lib/debezium/converters/time.go
@@ -11,7 +11,7 @@ import (
 type Time struct{}
 
 func (t Time) ToKindDetails() typing.KindDetails {
-	return typing.Time
+	return typing.TimeKindDetails
 }
 
 func (t Time) Convert(val any) (any, error) {
@@ -27,7 +27,7 @@ func (t Time) Convert(val any) (any, error) {
 type NanoTime struct{}
 
 func (n NanoTime) ToKindDetails() typing.KindDetails {
-	return typing.Time
+	return typing.TimeKindDetails
 }
 
 func (n NanoTime) Convert(value any) (any, error) {
@@ -43,7 +43,7 @@ func (n NanoTime) Convert(value any) (any, error) {
 type MicroTime struct{}
 
 func (m MicroTime) ToKindDetails() typing.KindDetails {
-	return typing.Time
+	return typing.TimeKindDetails
 }
 
 func (m MicroTime) Convert(value any) (any, error) {
@@ -99,7 +99,7 @@ func (t TimeWithTimezone) layout() string {
 }
 
 func (t TimeWithTimezone) ToKindDetails() typing.KindDetails {
-	return typing.Time
+	return typing.TimeKindDetails
 }
 
 func (t TimeWithTimezone) Convert(value any) (any, error) {

--- a/lib/debezium/converters/time_test.go
+++ b/lib/debezium/converters/time_test.go
@@ -130,7 +130,7 @@ func TestTime_Convert(t *testing.T) {
 }
 
 func TestNanoTime_Converter(t *testing.T) {
-	assert.Equal(t, typing.Time, NanoTime{}.ToKindDetails())
+	assert.Equal(t, typing.TimeKindDetails, NanoTime{}.ToKindDetails())
 	{
 		// Invalid data
 		_, err := NanoTime{}.Convert("123")
@@ -145,7 +145,7 @@ func TestNanoTime_Converter(t *testing.T) {
 }
 
 func TestMicroTime_Converter(t *testing.T) {
-	assert.Equal(t, typing.Time, MicroTime{}.ToKindDetails())
+	assert.Equal(t, typing.TimeKindDetails, MicroTime{}.ToKindDetails())
 	{
 		// Invalid data
 		_, err := MicroTime{}.Convert("123")

--- a/lib/debezium/schema_test.go
+++ b/lib/debezium/schema_test.go
@@ -254,7 +254,7 @@ func TestField_ToKindDetails(t *testing.T) {
 		for _, dbzType := range []SupportedDebeziumType{Time, TimeKafkaConnect, TimeWithTimezone, MicroTime, NanoTime} {
 			kd, err := Field{DebeziumType: dbzType}.ToKindDetails()
 			assert.NoError(t, err)
-			assert.Equal(t, typing.Time, kd)
+			assert.Equal(t, typing.TimeKindDetails, kd)
 		}
 	}
 	{

--- a/lib/optimization/table_data_merge_columns_test.go
+++ b/lib/optimization/table_data_merge_columns_test.go
@@ -132,10 +132,10 @@ func TestTableData_UpdateInMemoryColumnsFromDestination(t *testing.T) {
 				cols.AddColumn(columns.NewColumn("time_column", typing.String))
 				td := &TableData{inMemoryColumns: cols}
 
-				assert.NoError(t, td.MergeColumnsFromDestination(columns.NewColumn("time_column", typing.Time)))
+				assert.NoError(t, td.MergeColumnsFromDestination(columns.NewColumn("time_column", typing.TimeKindDetails)))
 				col, ok := td.inMemoryColumns.GetColumn("time_column")
 				assert.True(t, ok)
-				assert.Equal(t, typing.Time, col.KindDetails)
+				assert.Equal(t, typing.TimeKindDetails, col.KindDetails)
 			}
 			{
 				// Timestamp TZ

--- a/lib/parquetutil/parse_values_test.go
+++ b/lib/parquetutil/parse_values_test.go
@@ -84,7 +84,7 @@ func TestParseValueForArrow(t *testing.T) {
 	}
 	{
 		// Time from string
-		value, err := ParseValueForArrow("12:30:45", typing.Time)
+		value, err := ParseValueForArrow("12:30:45", typing.TimeKindDetails)
 		assert.NoError(t, err)
 
 		// Should be milliseconds since midnight: (12*3600 + 30*60 + 45) * 1000

--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -39,7 +39,7 @@ func GetStringConverter(kd typing.KindDetails, opts GetStringConverterOpts) (Con
 	// Time types
 	case typing.Date.Kind:
 		return DateConverter{}, nil
-	case typing.Time.Kind:
+	case typing.TimeKindDetails.Kind:
 		return TimeConverter{}, nil
 	case typing.TimestampNTZ.Kind:
 		return NewTimestampNTZConverter(opts.TimestampNTZLayoutOverride), nil

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -35,7 +35,7 @@ func TestGetStringConverter(t *testing.T) {
 	}
 	{
 		// Time
-		converter, err := GetStringConverter(typing.Time, GetStringConverterOpts{})
+		converter, err := GetStringConverter(typing.TimeKindDetails, GetStringConverterOpts{})
 		assert.NoError(t, err)
 		assert.IsType(t, TimeConverter{}, converter)
 	}

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -27,8 +27,8 @@ var kindToArrowType = map[string]arrow.DataType{
 	Integer.Kind: arrow.PrimitiveTypes.Int64,
 	Float.Kind:   arrow.PrimitiveTypes.Float32,
 	// Date and time data types:
-	Time.Kind: arrow.FixedWidthTypes.Time32ms,
-	Date.Kind: arrow.FixedWidthTypes.Date32,
+	TimeKindDetails.Kind: arrow.FixedWidthTypes.Time32ms,
+	Date.Kind:            arrow.FixedWidthTypes.Date32,
 }
 
 // ToArrowType converts a KindDetails to the corresponding Arrow data type
@@ -128,7 +128,7 @@ func (kd KindDetails) ParseValueForArrow(value any) (any, error) {
 		}
 
 		return castedValue.String(), nil
-	case Time.Kind:
+	case TimeKindDetails.Kind:
 		_time, err := ParseTimeFromAny(value)
 		if err != nil {
 			return nil, fmt.Errorf("failed to cast value to time: %w", err)

--- a/lib/typing/parquet_test.go
+++ b/lib/typing/parquet_test.go
@@ -37,7 +37,7 @@ func TestKindDetails_ToArrowType(t *testing.T) {
 	}
 	{
 		// Time
-		arrowType, err := Time.ToArrowType()
+		arrowType, err := TimeKindDetails.ToArrowType()
 		assert.NoError(t, err)
 		assert.Equal(t, arrow.FixedWidthTypes.Time32ms, arrowType)
 	}
@@ -89,7 +89,7 @@ func TestKindDetails_ParseValueForArrow(t *testing.T) {
 	{
 		// Time
 		testTime := time.Date(2023, 12, 25, 15, 30, 45, 0, time.UTC)
-		value, err := Time.ParseValueForArrow(testTime)
+		value, err := TimeKindDetails.ParseValueForArrow(testTime)
 		assert.NoError(t, err)
 
 		// Should be milliseconds since midnight

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -73,7 +73,7 @@ var (
 		Kind: "date",
 	}
 
-	Time = KindDetails{
+	TimeKindDetails = KindDetails{
 		Kind: "time",
 	}
 

--- a/lib/typing/values/string_test.go
+++ b/lib/typing/values/string_test.go
@@ -77,13 +77,13 @@ func TestToString(t *testing.T) {
 			// Valid
 			{
 				// String
-				val, err := ToString("2021-01-01T03:52:00Z", typing.Time)
+				val, err := ToString("2021-01-01T03:52:00Z", typing.TimeKindDetails)
 				assert.NoError(t, err)
 				assert.Equal(t, "03:52:00", val)
 			}
 			{
 				// time.Time
-				actualValue, err := ToString(time.Date(2019, time.December, 31, 9, 27, 22, 0, time.UTC), typing.Time)
+				actualValue, err := ToString(time.Date(2019, time.December, 31, 9, 27, 22, 0, time.UTC), typing.TimeKindDetails)
 				assert.NoError(t, err)
 				assert.Equal(t, "09:27:22", actualValue)
 			}

--- a/models/event/event_test.go
+++ b/models/event/event_test.go
@@ -328,7 +328,7 @@ func (e *EventsTestSuite) TestToMemoryEventWithSoftPartitioning() {
 			"randomCol":                         "dusty",
 		}, nil)
 		mockEvent.GetOptionalSchemaReturns(map[string]typing.KindDetails{
-			"created_at": typing.Time,
+			"created_at": typing.TimeKindDetails,
 		}, nil)
 
 		event, err := ToMemoryEvent(e.T().Context(), e.fakeBaseline, mockEvent, map[string]any{"id": "123"}, tc, config.Replication)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes the time kind by replacing `typing.Time` with `typing.TimeKindDetails` throughout the codebase.
> 
> - Updates dialect mappings and reverse mappings for `time` across BigQuery, Postgres, Redshift, Snowflake, ClickHouse, Databricks, Iceberg, and MotherDuck
> - Adjusts value parsing/conversion, default value handling, and storage/load paths to use `typing.TimeKindDetails` (e.g., BigQuery storage writer, MSSQL values, MotherDuck staging, ClickHouse load)
> - Updates converters and utilities (`NewStringConverter`, Debezium time converters, Parquet Arrow mapping and value parsing)
> - Revises tests and integration cases to reflect the new kind and ensure round-trip/encoding behavior remains correct
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17cfdcd2c9a6d45f59047d2ed167ab66af9db4c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->