### PR TITLE
Include schema tag when emitting metrics to datadog

### DIFF
--- a/lib/artie/metrics/message.go
+++ b/lib/artie/metrics/message.go
@@ -9,22 +9,24 @@ import (
 )
 
 // EmitRowLag will diff against the partition's high watermark and the message's offset
-func EmitRowLag(m artie.Message, metricsClient base.Client, mode config.Mode, groupID, table string) {
+func EmitRowLag(m artie.Message, metricsClient base.Client, mode config.Mode, groupID, schema, table string) {
 	metricsClient.GaugeWithSample(
 		"row.lag",
 		float64(m.HighWaterMark()-m.Offset()),
 		map[string]string{
 			"mode":    mode.String(),
 			"groupID": groupID,
+			"schema":  schema,
 			"table":   table,
 		},
 		0.5)
 }
 
-func EmitIngestionLag(m artie.Message, metricsClient base.Client, mode config.Mode, groupID, table string) {
+func EmitIngestionLag(m artie.Message, metricsClient base.Client, mode config.Mode, groupID, schema, table string) {
 	metricsClient.Timing("ingestion.lag", time.Since(m.PublishTime()), map[string]string{
 		"mode":    mode.String(),
 		"groupID": groupID,
+		"schema":  schema,
 		"table":   table,
 	})
 }

--- a/models/event/event.go
+++ b/models/event/event.go
@@ -155,8 +155,9 @@ func (e *Event) EmitExecutionTimeLag(metricsClient base.Client) {
 		"row.execution_time_lag",
 		float64(time.Since(e.executionTime).Milliseconds()),
 		map[string]string{
-			"mode":  e.mode.String(),
-			"table": e.table,
+			"mode":   e.mode.String(),
+			"table":  e.table,
+			"schema": e.tableID.Schema,
 		}, 0.5)
 }
 

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -71,8 +71,8 @@ func StartKafkaConsumer(ctx context.Context, cfg config.Config, inMemDB *models.
 						logger.Fatal("Failed to process message", slog.Any("err", err), slog.String("topic", msg.Topic()))
 					}
 
-					metrics.EmitIngestionLag(msg, metricsClient, cfg.Mode, kafkaConsumer.GetGroupID(), tableID.Table)
-					metrics.EmitRowLag(msg, metricsClient, cfg.Mode, kafkaConsumer.GetGroupID(), tableID.Table)
+					metrics.EmitIngestionLag(msg, metricsClient, cfg.Mode, kafkaConsumer.GetGroupID(), tableID.Schema, tableID.Table)
+					metrics.EmitRowLag(msg, metricsClient, cfg.Mode, kafkaConsumer.GetGroupID(), tableID.Schema, tableID.Table)
 
 					return nil
 				})


### PR DESCRIPTION
We include the schema when emitting rows processed, but not when emitting ingestion/row lag. This will allow us to properly query those metrics if a pipeline has tables with the same name in different schemas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds schema context to lag metrics for disambiguation across similarly named tables.
> 
> - `metrics.EmitRowLag` and `metrics.EmitIngestionLag` now accept `schema` and tag emitted metrics with `schema`
> - `Event.EmitExecutionTimeLag` tags `row.execution_time_lag` with `schema` via `tableID.Schema`
> - Kafka consumer updates call sites to pass `tableID.Schema` when emitting lag metrics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c7797d60e43b446b42a853269f29f62e4858cc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->