### PR TITLE
[ClickHouse] Add ClientInfo in connection options

### DIFF
--- a/clients/clickhouse/clickhouse.go
+++ b/clients/clickhouse/clickhouse.go
@@ -50,6 +50,17 @@ func LoadClickhouse(ctx context.Context, cfg config.Config, _store *db.Store) (*
 			Password: cfg.Clickhouse.Password,
 		},
 		TLS: tlsConfig,
+		ClientInfo: clickhouse.ClientInfo{
+			Products: []struct {
+				Name    string
+				Version string
+			}{
+				{
+					Name:    "artie-transfer",
+					Version: "1.0.0",
+				},
+			},
+		},
 	}))
 
 	if err := store.GetDatabase().Ping(); err != nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds product metadata to the ClickHouse connection configuration.
> 
> - Extends `clickhouse.Options` in `clients/clickhouse/clickhouse.go` to include `ClientInfo` with a `Products` entry (`name: artie-transfer`, `version: 1.0.0`)
> - No other logic changes; connection setup and ping remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d91aa451cd9e87f87f18ec30985d6b7d3d4cb44a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->