### PR TITLE
Expose options for tuning kafka fetches with franz-go

### DIFF
--- a/lib/kafkalib/consumer.go
+++ b/lib/kafkalib/consumer.go
@@ -372,6 +372,20 @@ func InjectFranzGoConsumerProvidersIntoContext(ctx context.Context, cfg *Kafka) 
 			}),
 		)
 
+		// Apply optional fetch tuning settings if configured
+		if cfg.FetchMaxBytes > 0 {
+			clientOpts = append(clientOpts, kgo.FetchMaxBytes(cfg.FetchMaxBytes))
+		}
+		if cfg.FetchMaxPartitionBytes > 0 {
+			clientOpts = append(clientOpts, kgo.FetchMaxPartitionBytes(cfg.FetchMaxPartitionBytes))
+		}
+		if cfg.FetchMinBytes > 0 {
+			clientOpts = append(clientOpts, kgo.FetchMinBytes(cfg.FetchMinBytes))
+		}
+		if cfg.FetchMaxWaitMs > 0 {
+			clientOpts = append(clientOpts, kgo.FetchMaxWait(time.Duration(cfg.FetchMaxWaitMs)*time.Millisecond))
+		}
+
 		client, err := kgo.NewClient(clientOpts...)
 		if err != nil {
 			closeClients()

--- a/lib/kafkalib/kafka.go
+++ b/lib/kafkalib/kafka.go
@@ -24,6 +24,16 @@ type Kafka struct {
 	// This prevents relying on broker auto-creation and allows graceful startup
 	// when topics may not exist yet.
 	WaitForTopics bool `yaml:"waitForTopics,omitempty"`
+
+	// Franz-go fetch tuning options (optional, uses library defaults if not set)
+	// FetchMaxBytes is the maximum bytes per broker per fetch call (default: 50 MiB)
+	FetchMaxBytes int32 `yaml:"fetchMaxBytes,omitempty"`
+	// FetchMaxPartitionBytes is the maximum bytes per partition per fetch (default: 1 MiB)
+	FetchMaxPartitionBytes int32 `yaml:"fetchMaxPartitionBytes,omitempty"`
+	// FetchMinBytes is the minimum bytes the broker waits to accumulate before responding (default: 1 byte)
+	FetchMinBytes int32 `yaml:"fetchMinBytes,omitempty"`
+	// FetchMaxWaitMs is how long the broker waits to accumulate FetchMinBytes in milliseconds (default: 5000ms)
+	FetchMaxWaitMs int32 `yaml:"fetchMaxWaitMs,omitempty"`
 }
 
 func (k *Kafka) Topics() []string {


### PR DESCRIPTION
Right now we're just using franz-go's defaults for these (specified in comments) - this will let us override them in the config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional franz-go fetch tuning to Kafka config and wires them into consumer client creation.
> 
> - New optional `Kafka` fields: `fetchMaxBytes`, `fetchMaxPartitionBytes`, `fetchMinBytes`, `fetchMaxWaitMs` with docs
> - `consumer.go`: when building franz-go clients, conditionally apply `kgo.FetchMaxBytes`, `kgo.FetchMaxPartitionBytes`, `kgo.FetchMinBytes`, and `kgo.FetchMaxWait` based on config
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8de7271ccf9a610c0ff908eb20bb0bc92f9c7593. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->