### PR TITLE
Increasing Redis Client Test Coverage from	13.7%	to 40.2%

### DIFF
--- a/clients/redis/redis_test.go
+++ b/clients/redis/redis_test.go
@@ -117,16 +117,13 @@ func TestStore_Dialect(t *testing.T) {
 
 func TestStore_Dedupe(t *testing.T) {
 	store := &Store{}
-	err := store.Dedupe(t.Context(), nil, nil, false)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "dedupe is not supported for Redis")
+	assert.ErrorContains(t, store.Dedupe(t.Context(), nil, nil, false), "dedupe is not supported for Redis")
 }
 
 func TestStore_SweepTemporaryTables(t *testing.T) {
 	store := &Store{}
 	// Should return nil as Redis doesn't have temp tables to sweep
-	err := store.SweepTemporaryTables(t.Context(), nil)
-	assert.NoError(t, err)
+	assert.NoError(t, store.SweepTemporaryTables(t.Context(), nil))
 }
 
 func TestStore_ExecContext(t *testing.T) {
@@ -155,9 +152,7 @@ func TestStore_Begin(t *testing.T) {
 
 func TestStore_LoadDataIntoTable(t *testing.T) {
 	store := &Store{}
-	err := store.LoadDataIntoTable(t.Context(), nil, nil, nil, nil, types.AdditionalSettings{}, false)
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "LoadDataIntoTable is not supported for Redis")
+	assert.ErrorContains(t, store.LoadDataIntoTable(t.Context(), nil, nil, nil, nil, types.AdditionalSettings{}, false), "LoadDataIntoTable is not supported for Redis")
 }
 
 func TestStore_GetTableConfig(t *testing.T) {


### PR DESCRIPTION
Increasing Redis Client Test Coverage from 13.7% to 40.2%

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Redis client coverage by adding focused unit tests for core behaviors.
> 
> - Validate `Store` Redis config (host/port/db) and `GetConfig`
> - Verify `IdentifierFor`/`TableIdentifier` and `GetTableConfig` caching
> - Assert `Dialect` is nil and unsupported ops return errors: `Dedupe`, `ExecContext`, `QueryContext`, `Begin`, `LoadDataIntoTable`
> - Test retry logic via `IsRetryableError` and `isRedisRetryableError`
> - Confirm temp table sweep is a no-op
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b23a3fcfa07f3d10f0f1f292a6cfa3f141345c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->