### PR TITLE
Create webhook event type `replication.error` to replace `replication.failed` and `connection.failed`

### DIFF
--- a/lib/webhooks/types.go
+++ b/lib/webhooks/types.go
@@ -19,15 +19,16 @@ const (
 	EventDedupeFailed      EventType = "dedupe.failed"
 
 	EventReplicationStarted EventType = "replication.started"
-	EventReplicationFailed  EventType = "replication.failed"
-	EventConnectionFailed   EventType = "connection.failed"
+	EventReplicationError   EventType = "replication.error"
 	EventRowSkipped         EventType = "row.skipped"
-
-	// Source specific events
-	EventDDLSeen EventType = "ddl.seen"
+	EventDDLSeen            EventType = "ddl.seen"
 
 	// Dashboard specific events
 	EventDEKGenerated EventType = "dek.generated"
+
+	// Moving away from using these - use EventReplicationError instead
+	EventReplicationFailed EventType = "replication.failed"
+	EventConnectionFailed  EventType = "connection.failed"
 )
 
 // AllEventTypes contains all defined event types.
@@ -41,11 +42,13 @@ var AllEventTypes = []EventType{
 	EventDedupeCompleted,
 	EventDedupeFailed,
 	EventReplicationStarted,
-	EventReplicationFailed,
-	EventConnectionFailed,
+	EventReplicationError,
 	EventRowSkipped,
 	EventDDLSeen,
 	EventDEKGenerated,
+
+	EventReplicationFailed,
+	EventConnectionFailed,
 }
 
 type Severity string
@@ -82,14 +85,15 @@ var eventMetadataMap = map[EventType]EventMetadata{
 	EventDedupeFailed:      {SeverityError, "backfill", "Deduplication failed"},
 	// Replication events
 	EventReplicationStarted: {SeverityInfo, "replication", "Replication started"},
-	EventReplicationFailed:  {SeverityError, "replication", "Replication failed"},
+	EventReplicationError:   {SeverityError, "replication", "Replication error"},
 	EventRowSkipped:         {SeverityWarning, "replication", "Row skipped"},
-	// Connection events
-	EventConnectionFailed: {SeverityError, "connection", "Connection failed"},
-	// Source specific events
-	EventDDLSeen: {SeverityInfo, "ddl", "DDL seen"},
-	// Dashboard specific events:
+	EventDDLSeen:            {SeverityInfo, "replication", "DDL seen"},
+	// Dashboard specific events
 	EventDEKGenerated: {SeverityInfo, "dashboard", "Data Encryption Key (DEK) generated"},
+
+	// Deprecated
+	EventReplicationFailed: {SeverityError, "replication", "Replication failed"},
+	EventConnectionFailed:  {SeverityError, "connection", "Connection failed"},
 }
 
 func GetEventMetadata(eventType EventType) EventMetadata {

--- a/lib/webhooks/types_test.go
+++ b/lib/webhooks/types_test.go
@@ -12,7 +12,7 @@ func TestGetEventSeverity(t *testing.T) {
 		EventBackfillCompleted:  SeverityInfo,
 		EventBackfillFailed:     SeverityError,
 		EventReplicationStarted: SeverityInfo,
-		EventReplicationFailed:  SeverityError,
+		EventReplicationError:   SeverityError,
 		EventType("unknown"):    SeverityInfo,
 	}
 
@@ -27,7 +27,7 @@ func TestGetEventMessage(t *testing.T) {
 		EventBackfillCompleted:  "Backfill completed",
 		EventBackfillFailed:     "Backfill failed",
 		EventReplicationStarted: "Replication started",
-		EventReplicationFailed:  "Replication failed",
+		EventReplicationError:   "Replication error",
 		EventType("unknown"):    "Unknown event type",
 	}
 

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	if err != nil {
 		if whClient != nil {
-			whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+			whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 				Error: fmt.Sprintf("Failed to initialize: %s", err),
 			})
 		}
@@ -57,7 +57,7 @@ func main() {
 	if value := os.Getenv("MAX_INIT_SLEEP_SECONDS"); value != "" {
 		castedValue, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
-			whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+			whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 				Error: fmt.Sprintf("Failed to parse max init sleep duration: %s", err),
 			})
 			logger.Fatal("Failed to parse max init sleep duration", slog.Any("err", err), slog.String("value", value))
@@ -65,7 +65,7 @@ func main() {
 
 		randomSeconds, err := cryptography.RandomInt64n(castedValue)
 		if err != nil {
-			whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+			whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 				Error: fmt.Sprintf("Failed to generate sleep duration: %s", err),
 			})
 			logger.Fatal("Failed to generate sleep duration", slog.Any("err", err))
@@ -85,7 +85,7 @@ func main() {
 	metricsClient := metrics.LoadExporter(settings.Config)
 	dest, err := utils.Load(ctx, settings.Config)
 	if err != nil {
-		whClient.SendEvent(ctx, webhooks.EventConnectionFailed, webhooks.EventProperties{
+		whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 			Error: fmt.Sprintf("Unable to load destination: %s", err),
 		})
 		logger.Fatal("Unable to load destination", slog.Any("err", err))
@@ -93,7 +93,7 @@ func main() {
 
 	if sqlDest, ok := dest.(destination.SQLDestination); ok {
 		if err = sqlDest.SweepTemporaryTables(ctx); err != nil {
-			whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+			whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 				Error: fmt.Sprintf("Failed to clean up temporary tables: %s", err),
 			})
 			logger.Fatal("Failed to clean up temporary tables", slog.Any("err", err))
@@ -108,13 +108,13 @@ func main() {
 	case config.FranzGoClient:
 		ctx, err = kafkalib.InjectFranzGoConsumerProvidersIntoContext(ctx, settings.Config.Kafka)
 		if err != nil {
-			whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+			whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 				Error: fmt.Sprintf("Failed to initialize Kafka client: %s", err),
 			})
 			logger.Fatal("Failed to inject franz-go consumer providers into context", slog.Any("err", err))
 		}
 	default:
-		whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+		whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 			Error: fmt.Sprintf("Failed to initialize: Kafka client %q not supported", settings.Config.KafkaClient),
 		})
 		logger.Fatal(fmt.Sprintf("Kafka client: %q not supported", settings.Config.KafkaClient))
@@ -136,7 +136,7 @@ func main() {
 		case constants.Kafka:
 			consumer.StartKafkaConsumer(ctx, settings.Config, inMemDB, dest, metricsClient, whClient)
 		default:
-			whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+			whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 				Error: fmt.Sprintf("Failed to initialize: message queue %q not supported", settings.Config.Queue),
 			})
 			logger.Fatal(fmt.Sprintf("Message queue: %q not supported", settings.Config.Queue))

--- a/processes/consumer/flush.go
+++ b/processes/consumer/flush.go
@@ -128,7 +128,7 @@ func FlushSingleTopic(ctx context.Context, inMemDB *models.DatabaseData, dest de
 		}
 
 		if err = grp.Wait(); err != nil {
-			whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+			whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 				Topic: topic,
 				Error: fmt.Sprintf("Failed to flush table: %s", err),
 			})

--- a/processes/consumer/kafka.go
+++ b/processes/consumer/kafka.go
@@ -24,7 +24,7 @@ import (
 func StartKafkaConsumer(ctx context.Context, cfg config.Config, inMemDB *models.DatabaseData, dest destination.Destination, metricsClient base.Client, whClient *webhooks.Client) {
 	encryptionKey, err := cfg.SharedDestinationSettings.BuildEncryptionKey(ctx)
 	if err != nil {
-		whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+		whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 			Error: fmt.Sprintf("Failed to build encryption key: %s", err),
 		})
 		logger.Fatal("Failed to build encryption key", slog.Any("err", err))
@@ -47,7 +47,7 @@ func StartKafkaConsumer(ctx context.Context, cfg config.Config, inMemDB *models.
 			defer logger.RecoverFatal()
 			kafkaConsumer, err := kafkalib.GetConsumerFromContext(ctx, topic)
 			if err != nil {
-				whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+				whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 					Error: fmt.Sprintf("Failed to start Kafka consumer: %s", err),
 					Topic: topic,
 				})
@@ -56,7 +56,7 @@ func StartKafkaConsumer(ctx context.Context, cfg config.Config, inMemDB *models.
 
 			if cfg.Kafka.WaitForTopics {
 				if err := kafkaConsumer.WaitForTopic(ctx); err != nil {
-					whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+					whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 						Error: fmt.Sprintf("Failed waiting for Kafka topic to exist: %s", err),
 						Topic: topic,
 					})
@@ -82,7 +82,7 @@ func StartKafkaConsumer(ctx context.Context, cfg config.Config, inMemDB *models.
 
 					tableID, err := args.process(ctx, cfg, inMemDB, dest, metricsClient)
 					if err != nil {
-						whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+						whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 							Error: fmt.Sprintf("Failed to process message: %s", err),
 							Topic: msg.Topic(),
 						})
@@ -102,7 +102,7 @@ func StartKafkaConsumer(ctx context.Context, cfg config.Config, inMemDB *models.
 						fetchRetries++
 						continue
 					} else {
-						whClient.SendEvent(ctx, webhooks.EventReplicationFailed, webhooks.EventProperties{
+						whClient.SendEvent(ctx, webhooks.EventReplicationError, webhooks.EventProperties{
 							Error: fmt.Sprintf("Failed to fetch and process message: %s", err),
 							Topic: topic,
 						})


### PR DESCRIPTION
Replication doesn't "fail" in the same way that backfills do because it will keep retrying forever, so I think "error" is more accurate.

Also moving off of `connection.failed` in favor of `replication.error` when it happens in streaming and `backfill.failed` when it happens in backfills.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes emitted webhook event types for replication/connection errors, which may affect downstream consumers and dashboards relying on the old `replication.failed`/`connection.failed` events.
> 
> **Overview**
> Introduces a new webhook event type `replication.error` and switches transfer’s replication/streaming error reporting to emit this event instead of `replication.failed` and `connection.failed`.
> 
> Updates webhook metadata/tests accordingly, reclassifies `ddl.seen` under the replication category, and keeps the old failure event types registered as **deprecated** for compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae08f727b5fd78735dcfefc50198645bb8ac65cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->