### PR TITLE
Improve logging for type checking failure

### DIFF
--- a/clients/shared/table_config.go
+++ b/clients/shared/table_config.go
@@ -54,7 +54,7 @@ func (g GetTableCfgArgs) query(ctx context.Context) ([]columns.Column, error) {
 	for _, row := range rows {
 		col, err := g.buildColumnFromRow(row)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build column from row: %w", err)
+			return nil, fmt.Errorf("failed to build column from row for table %q: %w", g.TableID.Table(), err)
 		}
 
 		cols = append(cols, col)
@@ -86,11 +86,11 @@ func (g GetTableCfgArgs) buildColumnFromRow(row map[string]any) (columns.Column,
 
 	kindDetails, err := g.Destination.Dialect().KindForDataType(kindColName)
 	if err != nil {
-		return columns.Column{}, fmt.Errorf("failed to get kind details: %w", err)
+		return columns.Column{}, fmt.Errorf("failed to get kind details for column %q (data_type=%q): %w", row[g.ColumnNameForName], kindColName, err)
 	}
 
 	if kindDetails.Kind == typing.Invalid.Kind {
-		return columns.Column{}, fmt.Errorf("failed to get kind details: unable to map type: %q to dwh type", row[g.ColumnNameForDataType])
+		return columns.Column{}, fmt.Errorf("failed to get kind details: unable to map type: %q to dwh type for column %q", row[g.ColumnNameForDataType], row[g.ColumnNameForName])
 	}
 
 	colName, err := asString(row[g.ColumnNameForName])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk since this only changes error message text and adds more context when table/column type resolution fails, without altering query or mapping behavior.
> 
> **Overview**
> Improves diagnostics in `clients/shared/table_config.go` by enriching errors during table description parsing: failures in `buildColumnFromRow` now include the table name, and type-mapping errors include the offending column name and `data_type` value.
> 
> No functional behavior changes beyond more specific error strings to make type-checking/mapping failures easier to identify.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b816530049ea297a53ec494c2509cf75832c11bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->