### PR TITLE
[IntegerConverter] Reject floats with fractional parts

### DIFF
--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -253,8 +254,14 @@ type IntegerConverter struct{}
 func (IntegerConverter) Convert(value any) (string, error) {
 	switch parsedVal := value.(type) {
 	case float32:
+		if float64(parsedVal) != math.Trunc(float64(parsedVal)) {
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+		}
 		return Float32ToString(parsedVal), nil
 	case float64:
+		if parsedVal != math.Trunc(parsedVal) {
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+		}
 		return Float64ToString(parsedVal), nil
 	case bool:
 		return fmt.Sprint(BooleanToBit(parsedVal)), nil

--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -254,12 +254,13 @@ type IntegerConverter struct{}
 func (IntegerConverter) Convert(value any) (string, error) {
 	switch parsedVal := value.(type) {
 	case float32:
-		if float64(parsedVal) != math.Trunc(float64(parsedVal)) {
+		f64Val := float64(parsedVal)
+		if math.IsInf(f64Val, 0) || f64Val != math.Trunc(f64Val) {
 			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
 		}
 		return Float32ToString(parsedVal), nil
 	case float64:
-		if parsedVal != math.Trunc(parsedVal) {
+		if math.IsInf(parsedVal, 0) || parsedVal != math.Trunc(parsedVal) {
 			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
 		}
 		return Float64ToString(parsedVal), nil

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -2,6 +2,7 @@ package converters
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 	"time"
 
@@ -251,28 +252,53 @@ func TestIntegerConverter_Convert(t *testing.T) {
 		}
 	}
 	{
-		// Whole number floats should be accepted
-		for _, tc := range []struct {
-			input    any
-			expected string
-		}{
-			{float32(1.0), "1"},
-			{float64(1.0), "1"},
-			{float32(-5.0), "-5"},
-			{float64(-5.0), "-5"},
-			{float64(0.0), "0"},
-		} {
-			parsedVal, err := IntegerConverter{}.Convert(tc.input)
-			assert.NoError(t, err, "input: %v", tc.input)
-			assert.Equal(t, tc.expected, parsedVal, "input: %v", tc.input)
-		}
+		// float32 - whole number
+		parsedVal, err := IntegerConverter{}.Convert(float32(1.0))
+		assert.NoError(t, err)
+		assert.Equal(t, "1", parsedVal)
 	}
 	{
-		// Floats with fractional parts should be rejected
-		for _, val := range []any{float32(0.731), float64(0.731), float32(123.45), float64(123.45)} {
-			_, err := IntegerConverter{}.Convert(val)
-			assert.ErrorContains(t, err, "unexpected value", "val: %v", val)
-		}
+		// float64 - whole number
+		parsedVal, err := IntegerConverter{}.Convert(float64(1.0))
+		assert.NoError(t, err)
+		assert.Equal(t, "1", parsedVal)
+	}
+	{
+		// float32 - negative whole number
+		parsedVal, err := IntegerConverter{}.Convert(float32(-5.0))
+		assert.NoError(t, err)
+		assert.Equal(t, "-5", parsedVal)
+	}
+	{
+		// float64 - zero
+		parsedVal, err := IntegerConverter{}.Convert(float64(0.0))
+		assert.NoError(t, err)
+		assert.Equal(t, "0", parsedVal)
+	}
+	{
+		// float32 - fractional part should be rejected
+		_, err := IntegerConverter{}.Convert(float32(0.731))
+		assert.ErrorContains(t, err, "unexpected value")
+	}
+	{
+		// float64 - fractional part should be rejected
+		_, err := IntegerConverter{}.Convert(float64(123.45))
+		assert.ErrorContains(t, err, "unexpected value")
+	}
+	{
+		// float64 - positive infinity should be rejected
+		_, err := IntegerConverter{}.Convert(math.Inf(1))
+		assert.ErrorContains(t, err, "unexpected value")
+	}
+	{
+		// float64 - negative infinity should be rejected
+		_, err := IntegerConverter{}.Convert(math.Inf(-1))
+		assert.ErrorContains(t, err, "unexpected value")
+	}
+	{
+		// float64 - NaN should be rejected
+		_, err := IntegerConverter{}.Convert(math.NaN())
+		assert.ErrorContains(t, err, "unexpected value")
 	}
 	{
 		// Test decimal.Decimal

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -251,6 +251,30 @@ func TestIntegerConverter_Convert(t *testing.T) {
 		}
 	}
 	{
+		// Whole number floats should be accepted
+		for _, tc := range []struct {
+			input    any
+			expected string
+		}{
+			{float32(1.0), "1"},
+			{float64(1.0), "1"},
+			{float32(-5.0), "-5"},
+			{float64(-5.0), "-5"},
+			{float64(0.0), "0"},
+		} {
+			parsedVal, err := IntegerConverter{}.Convert(tc.input)
+			assert.NoError(t, err, "input: %v", tc.input)
+			assert.Equal(t, tc.expected, parsedVal, "input: %v", tc.input)
+		}
+	}
+	{
+		// Floats with fractional parts should be rejected
+		for _, val := range []any{float32(0.731), float64(0.731), float32(123.45), float64(123.45)} {
+			_, err := IntegerConverter{}.Convert(val)
+			assert.ErrorContains(t, err, "unexpected value", "val: %v", val)
+		}
+	}
+	{
 		// Test decimal.Decimal
 		val, err := IntegerConverter{}.Convert(decimal.NewDecimal(numbers.MustParseDecimal("123")))
 		assert.NoError(t, err)

--- a/lib/typing/values/string_test.go
+++ b/lib/typing/values/string_test.go
@@ -177,8 +177,8 @@ func TestToString(t *testing.T) {
 		{
 			// Float64 value
 			val, err := ToString(45452.999991, typing.Integer)
-			assert.NoError(t, err)
-			assert.Equal(t, "45452.999991", val)
+			assert.ErrorContains(t, err, "unexpected value: '45452.999991', type: float64")
+			assert.Empty(t, val)
 		}
 		{
 			// Integer value


### PR DESCRIPTION
## Summary
- `IntegerConverter.Convert` now validates that `float32`/`float64` values are whole numbers before accepting them, preventing silent pass-through of fractional values like `0.731`.
- This makes float handling consistent with the existing guards on `*decimal.Decimal`, `json.Number`, and `string` inputs, which already reject non-integer values.

## Test plan
- Added tests for whole number floats (`1.0`, `-5.0`, `0.0`) confirming they are accepted and produce correct output.
- Added tests for fractional floats (`0.731`, `123.45`) confirming they are rejected with an `"unexpected value"` error.
- All existing `IntegerConverter` tests continue to pass.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change in integer serialization can break pipelines that previously passed fractional `float32`/`float64` values through as strings. Scope is limited to `typing.Integer` conversion and is covered by added/updated tests.
> 
> **Overview**
> **Integer conversion is now stricter for float inputs.** `IntegerConverter.Convert` validates `float32`/`float64` values are finite and have no fractional component before converting, otherwise returning a `typing.UnexpectedValue` parse error.
> 
> Tests are expanded to cover accepted whole-number floats (including negative/zero) and to assert rejection of fractional values as well as `Inf`/`NaN`; `ToString` integer tests are updated accordingly to expect an error for fractional `float64` input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d7ac9e834c8ca3e5cddb6b3e38f93e4165ef344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->