### PR TITLE
[Redshift] Make dedupes incremental

### DIFF
--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	dedupeBatchSize         = 1_000_000
-	dedupeRangeBatchMaxRows = 150_000
+	dedupeRangeBatchMaxRows = 20_000
 )
 
 type Store struct {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -198,8 +198,8 @@ func (s *Store) dedupeByRange(
 	pkCSV, orderByCSV, joinClause, firstPK string,
 	minPK, maxPK, totalRows int64,
 ) error {
-	pkSpan := maxPK - minPK + 1
 	numChunks := max((totalRows+dedupeBatchSize-1)/dedupeBatchSize, 1)
+	pkSpan := maxPK - minPK + 1
 	rangeSize := max((pkSpan+numChunks-1)/numChunks, 1)
 
 	slog.Info("Starting range-based dedupe",
@@ -210,14 +210,14 @@ func (s *Store) dedupeByRange(
 		slog.Int64("rangeSize", rangeSize),
 	)
 
-	for chunk, rangeStart := 0, minPK; rangeStart <= maxPK; chunk, rangeStart = chunk+1, rangeStart+rangeSize {
-		rangeEnd := rangeStart + rangeSize
-		if rangeEnd < rangeStart {
-			rangeEnd = maxPK + 1
+	for chunk, rangeStart := int64(0), minPK; rangeStart <= maxPK; chunk++ {
+		rangeEnd := rangeStart + rangeSize - 1
+		if rangeEnd > maxPK || rangeEnd < rangeStart {
+			rangeEnd = maxPK
 		}
 
-		rangeFilter := fmt.Sprintf("%s >= %d AND %s < %d", firstPK, rangeStart, firstPK, rangeEnd)
-		qualifiedRangeFilter := fmt.Sprintf("%s.%s >= %d AND %s.%s < %d",
+		rangeFilter := fmt.Sprintf("%s >= %d AND %s <= %d", firstPK, rangeStart, firstPK, rangeEnd)
+		qualifiedRangeFilter := fmt.Sprintf("%s.%s >= %d AND %s.%s <= %d",
 			tableID.EscapedTable(), firstPK, rangeStart,
 			tableID.EscapedTable(), firstPK, rangeEnd,
 		)
@@ -225,6 +225,11 @@ func (s *Store) dedupeByRange(
 		if err := s.dedupeSubBatched(ctx, tableID, baseTableID, pkCSV, orderByCSV, joinClause, rangeFilter, qualifiedRangeFilter, fmt.Sprintf("chunk %d", chunk)); err != nil {
 			return err
 		}
+
+		if rangeEnd == maxPK {
+			break
+		}
+		rangeStart = rangeEnd + 1
 	}
 
 	return nil

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -26,8 +26,8 @@ import (
 )
 
 const (
-	dedupeBatchSize    = 10_000_000
-	dedupeSubBatchSize = 100_000
+	dedupeBatchSize = 10_000_000
+	dedupeMaxRows   = 500_000
 )
 
 type Store struct {
@@ -172,11 +172,25 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 		return nil
 	}
 
+	// Try range-based dedupe (requires numeric first PK for range arithmetic).
 	var minPK, maxPK int64
-	if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM %s", firstPK, firstPK, tableID.FullyQualifiedName())).Scan(&minPK, &maxPK); err != nil {
-		return fmt.Errorf("failed to get PK bounds for range-based dedupe: %w", err)
+	boundsErr := s.QueryRowContext(ctx, fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM %s", firstPK, firstPK, tableID.FullyQualifiedName())).Scan(&minPK, &maxPK)
+	if boundsErr == nil {
+		return s.dedupeByRange(ctx, tableID, baseTableID, pkCSV, orderByCSV, joinClause, firstPK, minPK, maxPK, totalRows)
 	}
 
+	// Non-integer PK — fall back to sub-batched dedupe without range partitioning.
+	slog.Warn("First primary key is not numeric, falling back to non-range dedupe", slog.Any("err", boundsErr))
+	return s.dedupeSubBatched(ctx, tableID, baseTableID, pkCSV, orderByCSV, joinClause, "true", "true", "")
+}
+
+func (s *Store) dedupeByRange(
+	ctx context.Context,
+	tableID sql.TableIdentifier,
+	baseTableID sql.TableIdentifier,
+	pkCSV, orderByCSV, joinClause, firstPK string,
+	minPK, maxPK, totalRows int64,
+) error {
 	pkSpan := maxPK - minPK + 1
 	numChunks := max((totalRows+dedupeBatchSize-1)/dedupeBatchSize, 1)
 	rangeSize := max((pkSpan+numChunks-1)/numChunks, 1)
@@ -189,8 +203,7 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 		slog.Int64("rangeSize", rangeSize),
 	)
 
-	chunk := 0
-	for rangeStart := minPK; rangeStart <= maxPK; rangeStart += rangeSize {
+	for chunk, rangeStart := 0, minPK; rangeStart <= maxPK; chunk, rangeStart = chunk+1, rangeStart+rangeSize {
 		rangeEnd := rangeStart + rangeSize
 		if rangeEnd < rangeStart {
 			rangeEnd = maxPK + 1
@@ -202,108 +215,162 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 			tableID.EscapedTable(), firstPK, rangeEnd,
 		)
 
-		for subBatch := 0; ; subBatch++ {
-			suffix := strings.ToLower(stringutil.Random(5))
-			dupPKsTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("dup_%d_%d_%s", chunk, subBatch, suffix))
-			keepersTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("keep_%d_%d_%s", chunk, subBatch, suffix))
+		if err := s.dedupeSubBatched(ctx, tableID, baseTableID, pkCSV, orderByCSV, joinClause, rangeFilter, qualifiedRangeFilter, fmt.Sprintf("chunk %d", chunk)); err != nil {
+			return err
+		}
+	}
 
-			cleanup := func() {
-				_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
-				_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", keepersTableID.EscapedTable()))
-			}
+	return nil
+}
 
-			// Step 1: Find up to dedupeSubBatchSize duplicate PKs within this PK range.
-			createDupPKs := fmt.Sprintf(
-				`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1 LIMIT %d)`,
+// dedupeSubBatched finds duplicate PK groups within the given range and processes them in sub-batches
+// sized to keep total touched rows under dedupeMaxRows.
+// rangeFilter scopes step 1 (GROUP BY) and step 2 (keepers). Use "true" for no scoping.
+// qualifiedRangeFilter scopes the DELETE (columns prefixed with table name for USING disambiguation). Use "true" for no scoping.
+func (s *Store) dedupeSubBatched(
+	ctx context.Context,
+	tableID sql.TableIdentifier,
+	baseTableID sql.TableIdentifier,
+	pkCSV, orderByCSV, joinClause, rangeFilter, qualifiedRangeFilter, logPrefix string,
+) error {
+	totalDeduped := int64(0)
+
+	for {
+		suffix := strings.ToLower(stringutil.Random(5))
+		dupPKsTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("dup_%s", suffix))
+		keepersTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("keep_%s", suffix))
+
+		cleanup := func() {
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", keepersTableID.EscapedTable()))
+		}
+
+		// Step 1: Find duplicate PKs with their row counts. We use SUM(cnt) on this
+		// small temp table to know exactly how many rows the keepers query will touch,
+		// and LIMIT to keep that under dedupeMaxRows.
+		createDupPKs := fmt.Sprintf(
+			`CREATE TEMPORARY TABLE %s AS (SELECT %s, COUNT(*) AS cnt FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1)`,
+			dupPKsTableID.EscapedTable(),
+			pkCSV, tableID.FullyQualifiedName(), rangeFilter, pkCSV,
+		)
+
+		if _, err := s.ExecContext(ctx, createDupPKs); err != nil {
+			cleanup()
+			return fmt.Errorf("failed to find duplicate PKs (%s): %w", logPrefix, err)
+		}
+
+		var totalDupRows int64
+		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COALESCE(SUM(cnt), 0) FROM %s", dupPKsTableID.EscapedTable())).Scan(&totalDupRows); err != nil {
+			cleanup()
+			return fmt.Errorf("failed to sum duplicate rows (%s): %w", logPrefix, err)
+		}
+
+		if totalDupRows == 0 {
+			cleanup()
+			break
+		}
+
+		// If total rows exceed the threshold, trim the dup PKs table down to a subset
+		// whose cumulative row count fits within dedupeMaxRows.
+		if totalDupRows > dedupeMaxRows {
+			trimQuery := fmt.Sprintf(
+				`DELETE FROM %s WHERE (%s) NOT IN (SELECT %s FROM (SELECT %s, cnt, SUM(cnt) OVER (ORDER BY cnt ASC ROWS UNBOUNDED PRECEDING) AS running_total FROM %s) WHERE running_total <= %d)`,
 				dupPKsTableID.EscapedTable(),
-				pkCSV, tableID.FullyQualifiedName(), rangeFilter, pkCSV, dedupeSubBatchSize,
+				pkCSV,
+				pkCSV,
+				pkCSV,
+				dupPKsTableID.EscapedTable(),
+				dedupeMaxRows,
 			)
 
-			if _, err := s.ExecContext(ctx, createDupPKs); err != nil {
+			if _, err := s.ExecContext(ctx, trimQuery); err != nil {
 				cleanup()
-				return fmt.Errorf("failed to find duplicate PKs (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
+				return fmt.Errorf("failed to trim duplicate PKs (%s): %w", logPrefix, err)
 			}
 
-			var count int64
-			if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", dupPKsTableID.EscapedTable())).Scan(&count); err != nil {
+			// Re-check after trim
+			if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COALESCE(SUM(cnt), 0) FROM %s", dupPKsTableID.EscapedTable())).Scan(&totalDupRows); err != nil {
 				cleanup()
-				return fmt.Errorf("failed to count duplicate PKs (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
+				return fmt.Errorf("failed to re-sum duplicate rows (%s): %w", logPrefix, err)
 			}
 
-			if count == 0 {
+			if totalDupRows == 0 {
 				cleanup()
 				break
 			}
-
-			slog.Info("Found duplicate PK groups",
-				slog.Int("chunk", chunk),
-				slog.Int("subBatch", subBatch),
-				slog.Int64("pkGroups", count),
-				slog.Int64("rangeStart", rangeStart),
-				slog.Int64("rangeEnd", rangeEnd),
-			)
-
-			// Step 2: Build keepers — range filter lets Redshift skip blocks via zone maps before the semi-join.
-			createKeepers := fmt.Sprintf(
-				`CREATE TEMPORARY TABLE %s AS (SELECT * FROM %s WHERE %s AND (%s) IN (SELECT %s FROM %s) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1)`,
-				keepersTableID.EscapedTable(),
-				tableID.FullyQualifiedName(),
-				rangeFilter,
-				pkCSV,
-				pkCSV, dupPKsTableID.EscapedTable(),
-				pkCSV, orderByCSV,
-			)
-
-			if _, err := s.ExecContext(ctx, createKeepers); err != nil {
-				cleanup()
-				return fmt.Errorf("failed to create keepers table (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
-			}
-
-			// Step 3: Atomic delete + re-insert.
-			tx, err := s.Begin(ctx)
-			if err != nil {
-				cleanup()
-				return fmt.Errorf("failed to begin transaction (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
-			}
-
-			deleteQuery := fmt.Sprintf("DELETE FROM %s USING %s stg WHERE %s AND %s",
-				tableID.FullyQualifiedName(),
-				dupPKsTableID.EscapedTable(),
-				joinClause,
-				qualifiedRangeFilter,
-			)
-
-			if _, err := tx.ExecContext(ctx, deleteQuery); err != nil {
-				_ = tx.Rollback()
-				cleanup()
-				return fmt.Errorf("failed to delete dupes (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
-			}
-
-			insertQuery := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s",
-				tableID.FullyQualifiedName(),
-				keepersTableID.EscapedTable(),
-			)
-
-			if _, err := tx.ExecContext(ctx, insertQuery); err != nil {
-				_ = tx.Rollback()
-				cleanup()
-				return fmt.Errorf("failed to re-insert deduped rows (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
-			}
-
-			if err := tx.Commit(); err != nil {
-				cleanup()
-				return fmt.Errorf("failed to commit dedupe (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
-			}
-
-			cleanup()
-			slog.Info("Dedupe sub-batch complete",
-				slog.Int("chunk", chunk),
-				slog.Int("subBatch", subBatch),
-				slog.Int64("pkGroupsDeduped", count),
-			)
 		}
 
-		chunk++
+		var pkGroups int64
+		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", dupPKsTableID.EscapedTable())).Scan(&pkGroups); err != nil {
+			cleanup()
+			return fmt.Errorf("failed to count PK groups (%s): %w", logPrefix, err)
+		}
+
+		slog.Info("Processing duplicate PK groups",
+			slog.String("scope", logPrefix),
+			slog.Int64("pkGroups", pkGroups),
+			slog.Int64("totalDupRows", totalDupRows),
+		)
+
+		// Step 2: Build keepers — range filter lets Redshift skip blocks via zone maps.
+		createKeepers := fmt.Sprintf(
+			`CREATE TEMPORARY TABLE %s AS (SELECT * FROM %s WHERE %s AND (%s) IN (SELECT %s FROM %s) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1)`,
+			keepersTableID.EscapedTable(),
+			tableID.FullyQualifiedName(),
+			rangeFilter,
+			pkCSV,
+			pkCSV, dupPKsTableID.EscapedTable(),
+			pkCSV, orderByCSV,
+		)
+
+		if _, err := s.ExecContext(ctx, createKeepers); err != nil {
+			cleanup()
+			return fmt.Errorf("failed to create keepers table (%s): %w", logPrefix, err)
+		}
+
+		// Step 3: Atomic delete + re-insert.
+		tx, err := s.Begin(ctx)
+		if err != nil {
+			cleanup()
+			return fmt.Errorf("failed to begin transaction (%s): %w", logPrefix, err)
+		}
+
+		deleteQuery := fmt.Sprintf("DELETE FROM %s USING %s stg WHERE %s AND %s",
+			tableID.FullyQualifiedName(),
+			dupPKsTableID.EscapedTable(),
+			joinClause,
+			qualifiedRangeFilter,
+		)
+
+		if _, err := tx.ExecContext(ctx, deleteQuery); err != nil {
+			_ = tx.Rollback()
+			cleanup()
+			return fmt.Errorf("failed to delete dupes (%s): %w", logPrefix, err)
+		}
+
+		insertQuery := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s",
+			tableID.FullyQualifiedName(),
+			keepersTableID.EscapedTable(),
+		)
+
+		if _, err := tx.ExecContext(ctx, insertQuery); err != nil {
+			_ = tx.Rollback()
+			cleanup()
+			return fmt.Errorf("failed to re-insert deduped rows (%s): %w", logPrefix, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			cleanup()
+			return fmt.Errorf("failed to commit dedupe (%s): %w", logPrefix, err)
+		}
+
+		cleanup()
+		totalDeduped += pkGroups
+		slog.Info("Dedupe sub-batch complete",
+			slog.String("scope", logPrefix),
+			slog.Int64("pkGroupsDeduped", pkGroups),
+			slog.Int64("totalDeduped", totalDeduped),
+		)
 	}
 
 	return nil

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -316,7 +316,7 @@ func (s *Store) dedupeRange(
 		// Take the next sub-batch: PK groups whose cumulative row count fits within the limit.
 		// The "running_total - cnt < limit" condition guarantees at least one group is always taken.
 		createBatchPKs := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM (SELECT %s, cnt, SUM(cnt) OVER (ORDER BY cnt ASC ROWS UNBOUNDED PRECEDING) AS running_total FROM %s) WHERE running_total - cnt < %d)`,
+			`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM (SELECT %s, cnt, SUM(cnt) OVER (ORDER BY cnt ASC ROWS UNBOUNDED PRECEDING) AS running_total FROM %s) AS sub WHERE sub.running_total - sub.cnt < %d)`,
 			batchPKsTableID.EscapedTable(),
 			pkCSV,
 			pkCSV,

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -3,7 +3,9 @@ package redshift
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
+	"strings"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 
@@ -13,15 +15,17 @@ import (
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/db"
-	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/environ"
 	"github.com/artie-labs/transfer/lib/kafkalib"
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/retry"
 	"github.com/artie-labs/transfer/lib/sql"
+	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/webhooks"
 )
+
+const dedupeBatchSize = 10_000_000
 
 type Store struct {
 	credentialsClause string
@@ -127,11 +131,98 @@ func (s *Store) SweepTemporaryTables(ctx context.Context) error {
 }
 
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair kafkalib.DatabaseAndSchemaPair, primaryKeys []string, includeArtieUpdatedAt bool) error {
-	stagingTableID := shared.BuildStagingTableID(s, pair, tableID)
-	dedupeQueries := s.Dialect().BuildDedupeQueries(tableID, stagingTableID, primaryKeys, includeArtieUpdatedAt)
+	if len(primaryKeys) == 0 {
+		return fmt.Errorf("primary keys cannot be empty")
+	}
 
-	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
-		return fmt.Errorf("failed to dedupe: %w", err)
+	rd := s.dialect()
+	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
+	pkCSV := strings.Join(primaryKeysEscaped, ", ")
+
+	orderCols := make([]string, len(primaryKeysEscaped))
+	copy(orderCols, primaryKeysEscaped)
+	if includeArtieUpdatedAt {
+		orderCols = append(orderCols, rd.QuoteIdentifier(constants.UpdateColumnMarker))
+	}
+
+	var orderByCols []string
+	for _, col := range orderCols {
+		orderByCols = append(orderByCols, fmt.Sprintf("%s ASC", col))
+	}
+	orderByCSV := strings.Join(orderByCols, ", ")
+
+	baseTableID := s.IdentifierFor(pair, tableID.Table())
+
+	var joinClauses []string
+	for _, pk := range primaryKeysEscaped {
+		joinClauses = append(joinClauses, fmt.Sprintf("%s.%s = stg.%s", tableID.EscapedTable(), pk, pk))
+	}
+	joinClause := strings.Join(joinClauses, " AND ")
+
+	for batch := 0; ; batch++ {
+		suffix := fmt.Sprintf("dedupe_%d_%s", batch, strings.ToLower(stringutil.Random(5)))
+		batchTableID := shared.TempTableIDWithSuffix(s, baseTableID, suffix)
+
+		// Temp table holds the one row we want to *keep* per duplicate PK group (rn = 1).
+		// We then delete all rows for those PKs and re-insert the keepers.
+		createTemp := fmt.Sprintf(
+			`CREATE TEMPORARY TABLE %s AS (SELECT * FROM %s WHERE (%s) IN (SELECT %s FROM %s GROUP BY %s HAVING COUNT(*) > 1 LIMIT %d) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1)`,
+			batchTableID.EscapedTable(),
+			tableID.FullyQualifiedName(),
+			pkCSV,
+			pkCSV, tableID.FullyQualifiedName(), pkCSV, dedupeBatchSize,
+			pkCSV, orderByCSV,
+		)
+
+		if _, err := s.ExecContext(ctx, createTemp); err != nil {
+			return fmt.Errorf("failed to create dedupe staging table (batch %d): %w", batch, err)
+		}
+
+		var count int64
+		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", batchTableID.EscapedTable())).Scan(&count); err != nil {
+			return fmt.Errorf("failed to count staging rows (batch %d): %w", batch, err)
+		}
+
+		if count == 0 {
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", batchTableID.EscapedTable()))
+			break
+		}
+
+		tx, err := s.Begin(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to begin transaction (batch %d): %w", batch, err)
+		}
+
+		deleteQuery := fmt.Sprintf("DELETE FROM %s USING %s stg WHERE %s",
+			tableID.FullyQualifiedName(),
+			batchTableID.EscapedTable(),
+			joinClause,
+		)
+
+		if _, err := tx.ExecContext(ctx, deleteQuery); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("failed to delete dupes (batch %d): %w", batch, err)
+		}
+
+		insertQuery := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s",
+			tableID.FullyQualifiedName(),
+			batchTableID.EscapedTable(),
+		)
+
+		if _, err := tx.ExecContext(ctx, insertQuery); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("failed to re-insert deduped rows (batch %d): %w", batch, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("failed to commit dedupe (batch %d): %w", batch, err)
+		}
+
+		if _, err := s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", batchTableID.EscapedTable())); err != nil {
+			return fmt.Errorf("failed to drop staging table (batch %d): %w", batch, err)
+		}
+
+		slog.Info("Dedupe batch complete", slog.Int("batch", batch), slog.Int64("pkGroupsDeduped", count))
 	}
 
 	return nil

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -276,7 +276,7 @@ func (s *Store) dedupeRange(
 
 	// Single scan: find all duplicate PKs in the range.
 	createAllDupPKs := fmt.Sprintf(
-		`CREATE TEMPORARY TABLE %s AS (SELECT %s, COUNT(*) AS cnt FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1)`,
+		`CREATE TEMPORARY TABLE %s AS (SELECT %s, COUNT(*) AS __artie_cnt FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1)`,
 		allDupPKsTableID.EscapedTable(),
 		pkCSV, tableID.FullyQualifiedName(), rangeFilter, pkCSV,
 	)
@@ -314,9 +314,9 @@ func (s *Store) dedupeRange(
 		}
 
 		// Take the next sub-batch: PK groups whose cumulative row count fits within the limit.
-		// The "running_total - cnt < limit" condition guarantees at least one group is always taken.
+		// The "__artie_running - __artie_cnt < limit" condition guarantees at least one group is always taken.
 		createBatchPKs := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM (SELECT %s, cnt, SUM(cnt) OVER (ORDER BY cnt ASC ROWS UNBOUNDED PRECEDING) AS running_total FROM %s) AS sub WHERE sub.running_total - sub.cnt < %d)`,
+			`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM (SELECT %s, __artie_cnt, SUM(__artie_cnt) OVER (ORDER BY __artie_cnt ASC ROWS UNBOUNDED PRECEDING) AS __artie_running FROM %s) AS sub WHERE sub.__artie_running - sub.__artie_cnt < %d)`,
 			batchPKsTableID.EscapedTable(),
 			pkCSV,
 			pkCSV,

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	dedupeBatchSize       = 1_000_000
-	dedupeSubBatchMaxRows = 150_000
+	dedupeRangeBatchMaxRows = 150_000
 )
 
 type Store struct {
@@ -222,7 +222,7 @@ func (s *Store) dedupeByRange(
 			tableID.EscapedTable(), firstPK, rangeEnd,
 		)
 
-		if err := s.dedupeSubBatched(ctx, tableID, baseTableID, pkCSV, orderByCSV, joinClause, rangeFilter, qualifiedRangeFilter, fmt.Sprintf("chunk %d", chunk)); err != nil {
+		if err := s.dedupeRange(ctx, tableID, baseTableID, pkCSV, orderByCSV, joinClause, rangeFilter, qualifiedRangeFilter, fmt.Sprintf("chunk %d", chunk)); err != nil {
 			return err
 		}
 
@@ -235,20 +235,20 @@ func (s *Store) dedupeByRange(
 	return nil
 }
 
-// dedupeSubBatched deduplicates rows within a PK range by processing them in sub-batches.
+// dedupeRange deduplicates rows within a PK range by processing them in sub-batches.
 //
 // Redshift can't distinguish physical rows with identical column values, so deduplication
 // requires a delete-all + re-insert-one pattern: for each duplicate PK group, save the most
 // recent row to a temp table ("keepers"), delete every row matching that PK, then re-insert
 // the keeper. The keepers query uses QUALIFY ROW_NUMBER() which is expensive on wide tables,
-// so we cap each sub-batch at dedupeSubBatchMaxRows to avoid exhausting Redshift resources
+// so we cap each sub-batch at dedupeRangeBatchMaxRows to avoid exhausting Redshift resources
 // (SQLSTATE XX000). The GROUP BY to find duplicate PKs runs once upfront; sub-batches drain
 // from the resulting temp table to avoid re-scanning the main table every iteration.
 //
 // rangeFilter scopes the GROUP BY and keepers queries (e.g. "pk >= 100 AND pk <= 200").
 // qualifiedRangeFilter is the same condition with table-qualified column names for the
 // DELETE ... USING ... WHERE clause. Pass "true" for both to skip range scoping.
-func (s *Store) dedupeSubBatched(
+func (s *Store) dedupeRange(
 	ctx context.Context,
 	tableID sql.TableIdentifier,
 	baseTableID sql.TableIdentifier,
@@ -304,7 +304,7 @@ func (s *Store) dedupeSubBatched(
 			pkCSV,
 			pkCSV,
 			allDupPKsTableID.EscapedTable(),
-			dedupeSubBatchMaxRows,
+			dedupeRangeBatchMaxRows,
 		)
 
 		if _, err := s.ExecContext(ctx, createBatchPKs); err != nil {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -152,6 +152,7 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	orderByCSV := strings.Join(orderByCols, ", ")
 
 	baseTableID := s.IdentifierFor(pair, tableID.Table())
+	firstPK := primaryKeysEscaped[0]
 
 	var joinClauses []string
 	for _, pk := range primaryKeysEscaped {
@@ -159,37 +160,82 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	}
 	joinClause := strings.Join(joinClauses, " AND ")
 
-	for batch := 0; ; batch++ {
-		dupPKsSuffix := fmt.Sprintf("dup_pks_%d_%s", batch, strings.ToLower(stringutil.Random(5)))
-		dupPKsTableID := shared.TempTableIDWithSuffix(s, baseTableID, dupPKsSuffix)
+	var totalRows int64
+	if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", tableID.FullyQualifiedName())).Scan(&totalRows); err != nil {
+		return fmt.Errorf("failed to count rows: %w", err)
+	}
 
-		keepersSuffix := fmt.Sprintf("keepers_%d_%s", batch, strings.ToLower(stringutil.Random(5)))
-		keepersTableID := shared.TempTableIDWithSuffix(s, baseTableID, keepersSuffix)
+	if totalRows == 0 {
+		return nil
+	}
 
-		// Step 1: Lightweight query — only reads the PK column(s) to find which groups have duplicates.
+	var minPK, maxPK int64
+	if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM %s", firstPK, firstPK, tableID.FullyQualifiedName())).Scan(&minPK, &maxPK); err != nil {
+		return fmt.Errorf("failed to get PK bounds for range-based dedupe: %w", err)
+	}
+
+	pkSpan := maxPK - minPK + 1
+	numChunks := max((totalRows+dedupeBatchSize-1)/dedupeBatchSize, 1)
+	rangeSize := max((pkSpan+numChunks-1)/numChunks, 1)
+
+	slog.Info("Starting range-based dedupe",
+		slog.Int64("minPK", minPK),
+		slog.Int64("maxPK", maxPK),
+		slog.Int64("totalRows", totalRows),
+		slog.Int64("numChunks", numChunks),
+		slog.Int64("rangeSize", rangeSize),
+	)
+
+	chunk := 0
+	for rangeStart := minPK; rangeStart <= maxPK; rangeStart += rangeSize {
+		rangeEnd := rangeStart + rangeSize
+		if rangeEnd < rangeStart {
+			rangeEnd = maxPK + 1
+		}
+
+		rangeFilter := fmt.Sprintf("%s >= %d AND %s < %d", firstPK, rangeStart, firstPK, rangeEnd)
+
+		suffix := strings.ToLower(stringutil.Random(5))
+		dupPKsTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("dup_%d_%s", chunk, suffix))
+		keepersTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("keep_%d_%s", chunk, suffix))
+
+		cleanup := func() {
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", keepersTableID.EscapedTable()))
+		}
+
+		// Step 1: Find duplicate PKs within this PK range only.
 		createDupPKs := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM %s GROUP BY %s HAVING COUNT(*) > 1 LIMIT %d)`,
+			`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1)`,
 			dupPKsTableID.EscapedTable(),
-			pkCSV, tableID.FullyQualifiedName(), pkCSV, dedupeBatchSize,
+			pkCSV, tableID.FullyQualifiedName(), rangeFilter, pkCSV,
 		)
 
 		if _, err := s.ExecContext(ctx, createDupPKs); err != nil {
-			return fmt.Errorf("failed to find duplicate PKs (batch %d): %w", batch, err)
+			cleanup()
+			return fmt.Errorf("failed to find duplicate PKs (chunk %d): %w", chunk, err)
 		}
 
 		var count int64
 		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", dupPKsTableID.EscapedTable())).Scan(&count); err != nil {
-			return fmt.Errorf("failed to count duplicate PKs (batch %d): %w", batch, err)
+			cleanup()
+			return fmt.Errorf("failed to count duplicate PKs (chunk %d): %w", chunk, err)
 		}
 
 		if count == 0 {
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
-			break
+			cleanup()
+			chunk++
+			continue
 		}
 
-		slog.Info("Found duplicate PK groups", slog.Int("batch", batch), slog.Int64("pkGroups", count))
+		slog.Info("Found duplicate PK groups in range",
+			slog.Int("chunk", chunk),
+			slog.Int64("pkGroups", count),
+			slog.Int64("rangeStart", rangeStart),
+			slog.Int64("rangeEnd", rangeEnd),
+		)
 
-		// Step 2: Scoped query — only reads rows matching the duplicate PKs (small set), then picks the keeper.
+		// Step 2: Build keepers table — reads only rows matching the small set of duplicate PKs.
 		createKeepers := fmt.Sprintf(
 			`CREATE TEMPORARY TABLE %s AS (SELECT * FROM %s WHERE (%s) IN (SELECT %s FROM %s) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1)`,
 			keepersTableID.EscapedTable(),
@@ -200,14 +246,15 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 		)
 
 		if _, err := s.ExecContext(ctx, createKeepers); err != nil {
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
-			return fmt.Errorf("failed to create keepers table (batch %d): %w", batch, err)
+			cleanup()
+			return fmt.Errorf("failed to create keepers table (chunk %d): %w", chunk, err)
 		}
 
-		// Step 3: Atomic delete + re-insert scoped to the duplicate PKs.
+		// Step 3: Atomic delete + re-insert.
 		tx, err := s.Begin(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to begin transaction (batch %d): %w", batch, err)
+			cleanup()
+			return fmt.Errorf("failed to begin transaction (chunk %d): %w", chunk, err)
 		}
 
 		deleteQuery := fmt.Sprintf("DELETE FROM %s USING %s stg WHERE %s",
@@ -218,7 +265,8 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 
 		if _, err := tx.ExecContext(ctx, deleteQuery); err != nil {
 			_ = tx.Rollback()
-			return fmt.Errorf("failed to delete dupes (batch %d): %w", batch, err)
+			cleanup()
+			return fmt.Errorf("failed to delete dupes (chunk %d): %w", chunk, err)
 		}
 
 		insertQuery := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s",
@@ -228,17 +276,18 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 
 		if _, err := tx.ExecContext(ctx, insertQuery); err != nil {
 			_ = tx.Rollback()
-			return fmt.Errorf("failed to re-insert deduped rows (batch %d): %w", batch, err)
+			cleanup()
+			return fmt.Errorf("failed to re-insert deduped rows (chunk %d): %w", chunk, err)
 		}
 
 		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("failed to commit dedupe (batch %d): %w", batch, err)
+			cleanup()
+			return fmt.Errorf("failed to commit dedupe (chunk %d): %w", chunk, err)
 		}
 
-		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
-		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", keepersTableID.EscapedTable()))
-
-		slog.Info("Dedupe batch complete", slog.Int("batch", batch), slog.Int64("pkGroupsDeduped", count))
+		cleanup()
+		slog.Info("Dedupe chunk complete", slog.Int("chunk", chunk), slog.Int64("pkGroupsDeduped", count))
+		chunk++
 	}
 
 	return nil

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	dedupeBatchSize       = 1_000_000
+	dedupeBatchSize         = 1_000_000
 	dedupeRangeBatchMaxRows = 150_000
 )
 
@@ -155,6 +155,23 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 			return fmt.Errorf("failed to dedupe: %w", err)
 		}
 		return nil
+	}
+
+	if includeArtieUpdatedAt {
+		var colExists bool
+		err := s.QueryRowContext(ctx, fmt.Sprintf(
+			`SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = %s AND table_name = %s AND column_name = %s)`,
+			sql.QuoteLiteral(tableID.Schema()),
+			sql.QuoteLiteral(tableID.Table()),
+			sql.QuoteLiteral(constants.UpdateColumnMarker),
+		)).Scan(&colExists)
+		if err != nil || !colExists {
+			slog.Info("Column not found, incremental dedupe will pick an arbitrary row per PK group",
+				slog.String("column", constants.UpdateColumnMarker),
+				slog.String("table", tableID.FullyQualifiedName()),
+			)
+			includeArtieUpdatedAt = false
+		}
 	}
 
 	pkCSV := strings.Join(primaryKeysEscaped, ", ")

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -147,7 +147,7 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 
 	var orderByCols []string
 	for _, col := range orderCols {
-		orderByCols = append(orderByCols, fmt.Sprintf("%s ASC", col))
+		orderByCols = append(orderByCols, fmt.Sprintf("%s DESC", col))
 	}
 	orderByCSV := strings.Join(orderByCols, ", ")
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -25,7 +25,10 @@ import (
 	"github.com/artie-labs/transfer/lib/webhooks"
 )
 
-const dedupeBatchSize = 10_000_000
+const (
+	dedupeBatchSize    = 10_000_000
+	dedupeSubBatchSize = 100_000
+)
 
 type Store struct {
 	credentialsClause string
@@ -194,99 +197,112 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 		}
 
 		rangeFilter := fmt.Sprintf("%s >= %d AND %s < %d", firstPK, rangeStart, firstPK, rangeEnd)
-
-		suffix := strings.ToLower(stringutil.Random(5))
-		dupPKsTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("dup_%d_%s", chunk, suffix))
-		keepersTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("keep_%d_%s", chunk, suffix))
-
-		cleanup := func() {
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", keepersTableID.EscapedTable()))
-		}
-
-		// Step 1: Find duplicate PKs within this PK range only.
-		createDupPKs := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1)`,
-			dupPKsTableID.EscapedTable(),
-			pkCSV, tableID.FullyQualifiedName(), rangeFilter, pkCSV,
+		qualifiedRangeFilter := fmt.Sprintf("%s.%s >= %d AND %s.%s < %d",
+			tableID.EscapedTable(), firstPK, rangeStart,
+			tableID.EscapedTable(), firstPK, rangeEnd,
 		)
 
-		if _, err := s.ExecContext(ctx, createDupPKs); err != nil {
+		for subBatch := 0; ; subBatch++ {
+			suffix := strings.ToLower(stringutil.Random(5))
+			dupPKsTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("dup_%d_%d_%s", chunk, subBatch, suffix))
+			keepersTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("keep_%d_%d_%s", chunk, subBatch, suffix))
+
+			cleanup := func() {
+				_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
+				_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", keepersTableID.EscapedTable()))
+			}
+
+			// Step 1: Find up to dedupeSubBatchSize duplicate PKs within this PK range.
+			createDupPKs := fmt.Sprintf(
+				`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1 LIMIT %d)`,
+				dupPKsTableID.EscapedTable(),
+				pkCSV, tableID.FullyQualifiedName(), rangeFilter, pkCSV, dedupeSubBatchSize,
+			)
+
+			if _, err := s.ExecContext(ctx, createDupPKs); err != nil {
+				cleanup()
+				return fmt.Errorf("failed to find duplicate PKs (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
+			}
+
+			var count int64
+			if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", dupPKsTableID.EscapedTable())).Scan(&count); err != nil {
+				cleanup()
+				return fmt.Errorf("failed to count duplicate PKs (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
+			}
+
+			if count == 0 {
+				cleanup()
+				break
+			}
+
+			slog.Info("Found duplicate PK groups",
+				slog.Int("chunk", chunk),
+				slog.Int("subBatch", subBatch),
+				slog.Int64("pkGroups", count),
+				slog.Int64("rangeStart", rangeStart),
+				slog.Int64("rangeEnd", rangeEnd),
+			)
+
+			// Step 2: Build keepers — range filter lets Redshift skip blocks via zone maps before the semi-join.
+			createKeepers := fmt.Sprintf(
+				`CREATE TEMPORARY TABLE %s AS (SELECT * FROM %s WHERE %s AND (%s) IN (SELECT %s FROM %s) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1)`,
+				keepersTableID.EscapedTable(),
+				tableID.FullyQualifiedName(),
+				rangeFilter,
+				pkCSV,
+				pkCSV, dupPKsTableID.EscapedTable(),
+				pkCSV, orderByCSV,
+			)
+
+			if _, err := s.ExecContext(ctx, createKeepers); err != nil {
+				cleanup()
+				return fmt.Errorf("failed to create keepers table (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
+			}
+
+			// Step 3: Atomic delete + re-insert.
+			tx, err := s.Begin(ctx)
+			if err != nil {
+				cleanup()
+				return fmt.Errorf("failed to begin transaction (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
+			}
+
+			deleteQuery := fmt.Sprintf("DELETE FROM %s USING %s stg WHERE %s AND %s",
+				tableID.FullyQualifiedName(),
+				dupPKsTableID.EscapedTable(),
+				joinClause,
+				qualifiedRangeFilter,
+			)
+
+			if _, err := tx.ExecContext(ctx, deleteQuery); err != nil {
+				_ = tx.Rollback()
+				cleanup()
+				return fmt.Errorf("failed to delete dupes (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
+			}
+
+			insertQuery := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s",
+				tableID.FullyQualifiedName(),
+				keepersTableID.EscapedTable(),
+			)
+
+			if _, err := tx.ExecContext(ctx, insertQuery); err != nil {
+				_ = tx.Rollback()
+				cleanup()
+				return fmt.Errorf("failed to re-insert deduped rows (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
+			}
+
+			if err := tx.Commit(); err != nil {
+				cleanup()
+				return fmt.Errorf("failed to commit dedupe (chunk %d, sub-batch %d): %w", chunk, subBatch, err)
+			}
+
 			cleanup()
-			return fmt.Errorf("failed to find duplicate PKs (chunk %d): %w", chunk, err)
+			slog.Info("Dedupe sub-batch complete",
+				slog.Int("chunk", chunk),
+				slog.Int("subBatch", subBatch),
+				slog.Int64("pkGroupsDeduped", count),
+			)
 		}
 
-		var count int64
-		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", dupPKsTableID.EscapedTable())).Scan(&count); err != nil {
-			cleanup()
-			return fmt.Errorf("failed to count duplicate PKs (chunk %d): %w", chunk, err)
-		}
-
-		if count == 0 {
-			cleanup()
-			chunk++
-			continue
-		}
-
-		slog.Info("Found duplicate PK groups in range",
-			slog.Int("chunk", chunk),
-			slog.Int64("pkGroups", count),
-			slog.Int64("rangeStart", rangeStart),
-			slog.Int64("rangeEnd", rangeEnd),
-		)
-
-		// Step 2: Build keepers table — reads only rows matching the small set of duplicate PKs.
-		createKeepers := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %s AS (SELECT * FROM %s WHERE (%s) IN (SELECT %s FROM %s) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1)`,
-			keepersTableID.EscapedTable(),
-			tableID.FullyQualifiedName(),
-			pkCSV,
-			pkCSV, dupPKsTableID.EscapedTable(),
-			pkCSV, orderByCSV,
-		)
-
-		if _, err := s.ExecContext(ctx, createKeepers); err != nil {
-			cleanup()
-			return fmt.Errorf("failed to create keepers table (chunk %d): %w", chunk, err)
-		}
-
-		// Step 3: Atomic delete + re-insert.
-		tx, err := s.Begin(ctx)
-		if err != nil {
-			cleanup()
-			return fmt.Errorf("failed to begin transaction (chunk %d): %w", chunk, err)
-		}
-
-		deleteQuery := fmt.Sprintf("DELETE FROM %s USING %s stg WHERE %s",
-			tableID.FullyQualifiedName(),
-			dupPKsTableID.EscapedTable(),
-			joinClause,
-		)
-
-		if _, err := tx.ExecContext(ctx, deleteQuery); err != nil {
-			_ = tx.Rollback()
-			cleanup()
-			return fmt.Errorf("failed to delete dupes (chunk %d): %w", chunk, err)
-		}
-
-		insertQuery := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s",
-			tableID.FullyQualifiedName(),
-			keepersTableID.EscapedTable(),
-		)
-
-		if _, err := tx.ExecContext(ctx, insertQuery); err != nil {
-			_ = tx.Rollback()
-			cleanup()
-			return fmt.Errorf("failed to re-insert deduped rows (chunk %d): %w", chunk, err)
-		}
-
-		if err := tx.Commit(); err != nil {
-			cleanup()
-			return fmt.Errorf("failed to commit dedupe (chunk %d): %w", chunk, err)
-		}
-
-		cleanup()
-		slog.Info("Dedupe chunk complete", slog.Int("chunk", chunk), slog.Int64("pkGroupsDeduped", count))
 		chunk++
 	}
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -276,24 +276,24 @@ func (s *Store) dedupeRange(
 
 	// Single scan: find all duplicate PKs in the range.
 	createAllDupPKs := fmt.Sprintf(
-		`CREATE TEMPORARY TABLE %s AS (SELECT %s, COUNT(*) AS __artie_cnt FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1)`,
-		allDupPKsTableID.EscapedTable(),
+		`CREATE TABLE %s AS (SELECT %s, COUNT(*) AS __artie_cnt FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1)`,
+		allDupPKsTableID.FullyQualifiedName(),
 		pkCSV, tableID.FullyQualifiedName(), rangeFilter, pkCSV,
 	)
 
 	if _, err := s.ExecContext(ctx, createAllDupPKs); err != nil {
-		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 		return fmt.Errorf("failed to find duplicate PKs (%s): %w", logPrefix, err)
 	}
 
 	var totalPKGroups int64
-	if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", allDupPKsTableID.EscapedTable())).Scan(&totalPKGroups); err != nil {
-		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+	if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", allDupPKsTableID.FullyQualifiedName())).Scan(&totalPKGroups); err != nil {
+		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 		return fmt.Errorf("failed to count duplicate PK groups (%s): %w", logPrefix, err)
 	}
 
 	if totalPKGroups == 0 {
-		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 		return nil
 	}
 
@@ -309,31 +309,31 @@ func (s *Store) dedupeRange(
 		keepersTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("keep_%s", suffix))
 
 		cleanup := func() {
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", batchPKsTableID.EscapedTable()))
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", keepersTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", batchPKsTableID.FullyQualifiedName()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", keepersTableID.FullyQualifiedName()))
 		}
 
 		// Take the next sub-batch: PK groups whose cumulative row count fits within the limit.
 		// The "__artie_running - __artie_cnt < limit" condition guarantees at least one group is always taken.
 		createBatchPKs := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM (SELECT %s, __artie_cnt, SUM(__artie_cnt) OVER (ORDER BY __artie_cnt ASC ROWS UNBOUNDED PRECEDING) AS __artie_running FROM %s) AS sub WHERE sub.__artie_running - sub.__artie_cnt < %d)`,
-			batchPKsTableID.EscapedTable(),
+			`CREATE TABLE %s AS (SELECT %s FROM (SELECT %s, __artie_cnt, SUM(__artie_cnt) OVER (ORDER BY __artie_cnt ASC ROWS UNBOUNDED PRECEDING) AS __artie_running FROM %s) AS sub WHERE sub.__artie_running - sub.__artie_cnt < %d)`,
+			batchPKsTableID.FullyQualifiedName(),
 			pkCSV,
 			pkCSV,
-			allDupPKsTableID.EscapedTable(),
+			allDupPKsTableID.FullyQualifiedName(),
 			dedupeRangeBatchMaxRows,
 		)
 
 		if _, err := s.ExecContext(ctx, createBatchPKs); err != nil {
 			cleanup()
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 			return fmt.Errorf("failed to create batch PKs (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		var batchPKGroups int64
-		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", batchPKsTableID.EscapedTable())).Scan(&batchPKGroups); err != nil {
+		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", batchPKsTableID.FullyQualifiedName())).Scan(&batchPKGroups); err != nil {
 			cleanup()
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 			return fmt.Errorf("failed to count batch PK groups (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
@@ -351,30 +351,30 @@ func (s *Store) dedupeRange(
 		// Build keepers via empty-schema clone + INSERT to avoid CTAS encoding analysis,
 		// which fails on tables with large column values (e.g. big JSON blobs).
 		createEmptyKeepers := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %s AS SELECT * FROM %s WHERE 1 = 0`,
-			keepersTableID.EscapedTable(),
+			`CREATE TABLE %s AS SELECT * FROM %s WHERE 1 = 0`,
+			keepersTableID.FullyQualifiedName(),
 			tableID.FullyQualifiedName(),
 		)
 
 		if _, err := s.ExecContext(ctx, createEmptyKeepers); err != nil {
 			cleanup()
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 			return fmt.Errorf("failed to create empty keepers table (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		insertKeepers := fmt.Sprintf(
 			`INSERT INTO %s SELECT * FROM %s WHERE %s AND (%s) IN (SELECT %s FROM %s) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1`,
-			keepersTableID.EscapedTable(),
+			keepersTableID.FullyQualifiedName(),
 			tableID.FullyQualifiedName(),
 			rangeFilter,
 			pkCSV,
-			pkCSV, batchPKsTableID.EscapedTable(),
+			pkCSV, batchPKsTableID.FullyQualifiedName(),
 			pkCSV, orderByCSV,
 		)
 
 		if _, err := s.ExecContext(ctx, insertKeepers); err != nil {
 			cleanup()
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 			return fmt.Errorf("failed to insert keepers (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
@@ -382,13 +382,13 @@ func (s *Store) dedupeRange(
 		tx, err := s.Begin(ctx)
 		if err != nil {
 			cleanup()
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 			return fmt.Errorf("failed to begin transaction (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		deleteQuery := fmt.Sprintf("DELETE FROM %s USING %s stg WHERE %s AND %s",
 			tableID.FullyQualifiedName(),
-			batchPKsTableID.EscapedTable(),
+			batchPKsTableID.FullyQualifiedName(),
 			joinClause,
 			qualifiedRangeFilter,
 		)
@@ -396,38 +396,38 @@ func (s *Store) dedupeRange(
 		if _, err := tx.ExecContext(ctx, deleteQuery); err != nil {
 			_ = tx.Rollback()
 			cleanup()
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 			return fmt.Errorf("failed to delete dupes (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		insertQuery := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s",
 			tableID.FullyQualifiedName(),
-			keepersTableID.EscapedTable(),
+			keepersTableID.FullyQualifiedName(),
 		)
 
 		if _, err := tx.ExecContext(ctx, insertQuery); err != nil {
 			_ = tx.Rollback()
 			cleanup()
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 			return fmt.Errorf("failed to re-insert deduped rows (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		if err := tx.Commit(); err != nil {
 			cleanup()
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 			return fmt.Errorf("failed to commit dedupe (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		// Remove processed PKs from the all-dups table.
 		removePKs := fmt.Sprintf("DELETE FROM %s WHERE (%s) IN (SELECT %s FROM %s)",
-			allDupPKsTableID.EscapedTable(),
+			allDupPKsTableID.FullyQualifiedName(),
 			pkCSV,
-			pkCSV, batchPKsTableID.EscapedTable(),
+			pkCSV, batchPKsTableID.FullyQualifiedName(),
 		)
 
 		if _, err := s.ExecContext(ctx, removePKs); err != nil {
 			cleanup()
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 			return fmt.Errorf("failed to remove processed PKs (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
@@ -441,7 +441,7 @@ func (s *Store) dedupeRange(
 		)
 	}
 
-	_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+	_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.FullyQualifiedName()))
 	return nil
 }
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	dedupeBatchSize = 10_000_000
-	dedupeMaxRows   = 500_000
+	dedupeBatchSize       = 10_000_000
+	dedupeSubBatchMaxRows = 150_000
 )
 
 type Store struct {
@@ -235,117 +235,130 @@ func (s *Store) dedupeByRange(
 	return nil
 }
 
-// dedupeSubBatched finds duplicate PK groups within the given range and processes them in sub-batches
-// sized to keep total touched rows under dedupeMaxRows.
-// rangeFilter scopes step 1 (GROUP BY) and step 2 (keepers). Use "true" for no scoping.
-// qualifiedRangeFilter scopes the DELETE (columns prefixed with table name for USING disambiguation). Use "true" for no scoping.
+// dedupeSubBatched deduplicates rows within a PK range by processing them in sub-batches.
+//
+// Redshift can't distinguish physical rows with identical column values, so deduplication
+// requires a delete-all + re-insert-one pattern: for each duplicate PK group, save the most
+// recent row to a temp table ("keepers"), delete every row matching that PK, then re-insert
+// the keeper. The keepers query uses QUALIFY ROW_NUMBER() which is expensive on wide tables,
+// so we cap each sub-batch at dedupeSubBatchMaxRows to avoid exhausting Redshift resources
+// (SQLSTATE XX000). The GROUP BY to find duplicate PKs runs once upfront; sub-batches drain
+// from the resulting temp table to avoid re-scanning the main table every iteration.
+//
+// rangeFilter scopes the GROUP BY and keepers queries (e.g. "pk >= 100 AND pk <= 200").
+// qualifiedRangeFilter is the same condition with table-qualified column names for the
+// DELETE ... USING ... WHERE clause. Pass "true" for both to skip range scoping.
 func (s *Store) dedupeSubBatched(
 	ctx context.Context,
 	tableID sql.TableIdentifier,
 	baseTableID sql.TableIdentifier,
 	pkCSV, orderByCSV, joinClause, rangeFilter, qualifiedRangeFilter, logPrefix string,
 ) error {
-	totalDeduped := int64(0)
+	allDupsSuffix := strings.ToLower(stringutil.Random(5))
+	allDupPKsTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("alldups_%s", allDupsSuffix))
 
-	for {
+	// Single scan: find all duplicate PKs in the range.
+	createAllDupPKs := fmt.Sprintf(
+		`CREATE TEMPORARY TABLE %s AS (SELECT %s, COUNT(*) AS cnt FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1)`,
+		allDupPKsTableID.EscapedTable(),
+		pkCSV, tableID.FullyQualifiedName(), rangeFilter, pkCSV,
+	)
+
+	if _, err := s.ExecContext(ctx, createAllDupPKs); err != nil {
+		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+		return fmt.Errorf("failed to find duplicate PKs (%s): %w", logPrefix, err)
+	}
+
+	var totalPKGroups int64
+	if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", allDupPKsTableID.EscapedTable())).Scan(&totalPKGroups); err != nil {
+		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+		return fmt.Errorf("failed to count duplicate PK groups (%s): %w", logPrefix, err)
+	}
+
+	if totalPKGroups == 0 {
+		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+		return nil
+	}
+
+	slog.Info("Found duplicate PK groups",
+		slog.String("scope", logPrefix),
+		slog.Int64("pkGroups", totalPKGroups),
+	)
+
+	totalDeduped := int64(0)
+	for batch := 0; ; batch++ {
 		suffix := strings.ToLower(stringutil.Random(5))
-		dupPKsTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("dup_%s", suffix))
+		batchPKsTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("batch_%s", suffix))
 		keepersTableID := shared.TempTableIDWithSuffix(s, baseTableID, fmt.Sprintf("keep_%s", suffix))
 
 		cleanup := func() {
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", batchPKsTableID.EscapedTable()))
 			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", keepersTableID.EscapedTable()))
 		}
 
-		// Step 1: Find duplicate PKs with their row counts. We use SUM(cnt) on this
-		// small temp table to know exactly how many rows the keepers query will touch,
-		// and LIMIT to keep that under dedupeMaxRows.
-		createDupPKs := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %s AS (SELECT %s, COUNT(*) AS cnt FROM %s WHERE %s GROUP BY %s HAVING COUNT(*) > 1)`,
-			dupPKsTableID.EscapedTable(),
-			pkCSV, tableID.FullyQualifiedName(), rangeFilter, pkCSV,
+		// Take the next sub-batch: PK groups whose cumulative row count fits within the limit.
+		// The "running_total - cnt < limit" condition guarantees at least one group is always taken.
+		createBatchPKs := fmt.Sprintf(
+			`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM (SELECT %s, cnt, SUM(cnt) OVER (ORDER BY cnt ASC ROWS UNBOUNDED PRECEDING) AS running_total FROM %s) WHERE running_total - cnt < %d)`,
+			batchPKsTableID.EscapedTable(),
+			pkCSV,
+			pkCSV,
+			allDupPKsTableID.EscapedTable(),
+			dedupeSubBatchMaxRows,
 		)
 
-		if _, err := s.ExecContext(ctx, createDupPKs); err != nil {
+		if _, err := s.ExecContext(ctx, createBatchPKs); err != nil {
 			cleanup()
-			return fmt.Errorf("failed to find duplicate PKs (%s): %w", logPrefix, err)
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			return fmt.Errorf("failed to create batch PKs (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
-		var totalDupRows int64
-		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COALESCE(SUM(cnt), 0) FROM %s", dupPKsTableID.EscapedTable())).Scan(&totalDupRows); err != nil {
+		var batchPKGroups int64
+		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", batchPKsTableID.EscapedTable())).Scan(&batchPKGroups); err != nil {
 			cleanup()
-			return fmt.Errorf("failed to sum duplicate rows (%s): %w", logPrefix, err)
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			return fmt.Errorf("failed to count batch PK groups (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
-		if totalDupRows == 0 {
+		if batchPKGroups == 0 {
 			cleanup()
 			break
 		}
 
-		// If total rows exceed the threshold, trim the dup PKs table down to a subset
-		// whose cumulative row count fits within dedupeMaxRows. The condition
-		// "running_total - cnt < dedupeMaxRows" keeps a group if all *prior* groups
-		// sum to less than the limit, guaranteeing at least one group is always kept.
-		if totalDupRows > dedupeMaxRows {
-			trimQuery := fmt.Sprintf(
-				`DELETE FROM %s WHERE (%s) NOT IN (SELECT %s FROM (SELECT %s, cnt, SUM(cnt) OVER (ORDER BY cnt ASC ROWS UNBOUNDED PRECEDING) AS running_total FROM %s) WHERE running_total - cnt < %d)`,
-				dupPKsTableID.EscapedTable(),
-				pkCSV,
-				pkCSV,
-				pkCSV,
-				dupPKsTableID.EscapedTable(),
-				dedupeMaxRows,
-			)
-
-			if _, err := s.ExecContext(ctx, trimQuery); err != nil {
-				cleanup()
-				return fmt.Errorf("failed to trim duplicate PKs (%s): %w", logPrefix, err)
-			}
-
-			if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COALESCE(SUM(cnt), 0) FROM %s", dupPKsTableID.EscapedTable())).Scan(&totalDupRows); err != nil {
-				cleanup()
-				return fmt.Errorf("failed to re-sum duplicate rows (%s): %w", logPrefix, err)
-			}
-		}
-
-		var pkGroups int64
-		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", dupPKsTableID.EscapedTable())).Scan(&pkGroups); err != nil {
-			cleanup()
-			return fmt.Errorf("failed to count PK groups (%s): %w", logPrefix, err)
-		}
-
 		slog.Info("Processing duplicate PK groups",
 			slog.String("scope", logPrefix),
-			slog.Int64("pkGroups", pkGroups),
-			slog.Int64("totalDupRows", totalDupRows),
+			slog.Int("batch", batch),
+			slog.Int64("pkGroups", batchPKGroups),
 		)
 
-		// Step 2: Build keepers — range filter lets Redshift skip blocks via zone maps.
+		// Build keepers — range filter lets Redshift skip blocks via zone maps.
 		createKeepers := fmt.Sprintf(
 			`CREATE TEMPORARY TABLE %s AS (SELECT * FROM %s WHERE %s AND (%s) IN (SELECT %s FROM %s) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1)`,
 			keepersTableID.EscapedTable(),
 			tableID.FullyQualifiedName(),
 			rangeFilter,
 			pkCSV,
-			pkCSV, dupPKsTableID.EscapedTable(),
+			pkCSV, batchPKsTableID.EscapedTable(),
 			pkCSV, orderByCSV,
 		)
 
 		if _, err := s.ExecContext(ctx, createKeepers); err != nil {
 			cleanup()
-			return fmt.Errorf("failed to create keepers table (%s): %w", logPrefix, err)
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			return fmt.Errorf("failed to create keepers table (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
-		// Step 3: Atomic delete + re-insert.
+		// Atomic delete + re-insert.
 		tx, err := s.Begin(ctx)
 		if err != nil {
 			cleanup()
-			return fmt.Errorf("failed to begin transaction (%s): %w", logPrefix, err)
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			return fmt.Errorf("failed to begin transaction (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		deleteQuery := fmt.Sprintf("DELETE FROM %s USING %s stg WHERE %s AND %s",
 			tableID.FullyQualifiedName(),
-			dupPKsTableID.EscapedTable(),
+			batchPKsTableID.EscapedTable(),
 			joinClause,
 			qualifiedRangeFilter,
 		)
@@ -353,7 +366,8 @@ func (s *Store) dedupeSubBatched(
 		if _, err := tx.ExecContext(ctx, deleteQuery); err != nil {
 			_ = tx.Rollback()
 			cleanup()
-			return fmt.Errorf("failed to delete dupes (%s): %w", logPrefix, err)
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			return fmt.Errorf("failed to delete dupes (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		insertQuery := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s",
@@ -364,23 +378,40 @@ func (s *Store) dedupeSubBatched(
 		if _, err := tx.ExecContext(ctx, insertQuery); err != nil {
 			_ = tx.Rollback()
 			cleanup()
-			return fmt.Errorf("failed to re-insert deduped rows (%s): %w", logPrefix, err)
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			return fmt.Errorf("failed to re-insert deduped rows (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		if err := tx.Commit(); err != nil {
 			cleanup()
-			return fmt.Errorf("failed to commit dedupe (%s): %w", logPrefix, err)
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			return fmt.Errorf("failed to commit dedupe (%s, batch %d): %w", logPrefix, batch, err)
+		}
+
+		// Remove processed PKs from the all-dups table.
+		removePKs := fmt.Sprintf("DELETE FROM %s WHERE (%s) IN (SELECT %s FROM %s)",
+			allDupPKsTableID.EscapedTable(),
+			pkCSV,
+			pkCSV, batchPKsTableID.EscapedTable(),
+		)
+
+		if _, err := s.ExecContext(ctx, removePKs); err != nil {
+			cleanup()
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			return fmt.Errorf("failed to remove processed PKs (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		cleanup()
-		totalDeduped += pkGroups
+		totalDeduped += batchPKGroups
 		slog.Info("Dedupe sub-batch complete",
 			slog.String("scope", logPrefix),
-			slog.Int64("pkGroupsDeduped", pkGroups),
+			slog.Int("batch", batch),
+			slog.Int64("pkGroupsDeduped", batchPKGroups),
 			slog.Int64("totalDeduped", totalDeduped),
 		)
 	}
 
+	_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
 	return nil
 }
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -283,10 +283,12 @@ func (s *Store) dedupeSubBatched(
 		}
 
 		// If total rows exceed the threshold, trim the dup PKs table down to a subset
-		// whose cumulative row count fits within dedupeMaxRows.
+		// whose cumulative row count fits within dedupeMaxRows. The condition
+		// "running_total - cnt < dedupeMaxRows" keeps a group if all *prior* groups
+		// sum to less than the limit, guaranteeing at least one group is always kept.
 		if totalDupRows > dedupeMaxRows {
 			trimQuery := fmt.Sprintf(
-				`DELETE FROM %s WHERE (%s) NOT IN (SELECT %s FROM (SELECT %s, cnt, SUM(cnt) OVER (ORDER BY cnt ASC ROWS UNBOUNDED PRECEDING) AS running_total FROM %s) WHERE running_total <= %d)`,
+				`DELETE FROM %s WHERE (%s) NOT IN (SELECT %s FROM (SELECT %s, cnt, SUM(cnt) OVER (ORDER BY cnt ASC ROWS UNBOUNDED PRECEDING) AS running_total FROM %s) WHERE running_total - cnt < %d)`,
 				dupPKsTableID.EscapedTable(),
 				pkCSV,
 				pkCSV,
@@ -300,15 +302,9 @@ func (s *Store) dedupeSubBatched(
 				return fmt.Errorf("failed to trim duplicate PKs (%s): %w", logPrefix, err)
 			}
 
-			// Re-check after trim
 			if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COALESCE(SUM(cnt), 0) FROM %s", dupPKsTableID.EscapedTable())).Scan(&totalDupRows); err != nil {
 				cleanup()
 				return fmt.Errorf("failed to re-sum duplicate rows (%s): %w", logPrefix, err)
-			}
-
-			if totalDupRows == 0 {
-				cleanup()
-				break
 			}
 		}
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -15,6 +15,7 @@ import (
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/db"
+	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/environ"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -140,6 +141,22 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 
 	rd := s.dialect()
 	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
+	firstPK := primaryKeysEscaped[0]
+
+	var minPK, maxPK int64
+	boundsErr := s.QueryRowContext(ctx, fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM %s",
+		firstPK, firstPK, tableID.FullyQualifiedName(),
+	)).Scan(&minPK, &maxPK)
+	if boundsErr != nil {
+		// Non-numeric PK or empty table — use the original unoptimized dedupe.
+		stagingTableID := shared.BuildStagingTableID(s, pair, tableID)
+		dedupeQueries := s.Dialect().BuildDedupeQueries(tableID, stagingTableID, primaryKeys, includeArtieUpdatedAt)
+		if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
+			return fmt.Errorf("failed to dedupe: %w", err)
+		}
+		return nil
+	}
+
 	pkCSV := strings.Join(primaryKeysEscaped, ", ")
 
 	orderCols := make([]string, len(primaryKeysEscaped))
@@ -155,7 +172,6 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	orderByCSV := strings.Join(orderByCols, ", ")
 
 	baseTableID := s.IdentifierFor(pair, tableID.Table())
-	firstPK := primaryKeysEscaped[0]
 
 	var joinClauses []string
 	for _, pk := range primaryKeysEscaped {
@@ -172,16 +188,7 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 		return nil
 	}
 
-	// Try range-based dedupe (requires numeric first PK for range arithmetic).
-	var minPK, maxPK int64
-	boundsErr := s.QueryRowContext(ctx, fmt.Sprintf("SELECT MIN(%s), MAX(%s) FROM %s", firstPK, firstPK, tableID.FullyQualifiedName())).Scan(&minPK, &maxPK)
-	if boundsErr == nil {
-		return s.dedupeByRange(ctx, tableID, baseTableID, pkCSV, orderByCSV, joinClause, firstPK, minPK, maxPK, totalRows)
-	}
-
-	// Non-integer PK — fall back to sub-batched dedupe without range partitioning.
-	slog.Warn("First primary key is not numeric, falling back to non-range dedupe", slog.Any("err", boundsErr))
-	return s.dedupeSubBatched(ctx, tableID, baseTableID, pkCSV, orderByCSV, joinClause, "true", "true", "")
+	return s.dedupeByRange(ctx, tableID, baseTableID, pkCSV, orderByCSV, joinClause, firstPK, minPK, maxPK, totalRows)
 }
 
 func (s *Store) dedupeByRange(

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	dedupeBatchSize         = 1_000_000
-	dedupeRangeBatchMaxRows = 20_000
+	dedupeRangeBatchMaxRows = 150_000
 )
 
 type Store struct {
@@ -348,9 +348,22 @@ func (s *Store) dedupeRange(
 			slog.Int64("pkGroups", batchPKGroups),
 		)
 
-		// Build keepers — range filter lets Redshift skip blocks via zone maps.
-		createKeepers := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %s AS (SELECT * FROM %s WHERE %s AND (%s) IN (SELECT %s FROM %s) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1)`,
+		// Build keepers via empty-schema clone + INSERT to avoid CTAS encoding analysis,
+		// which fails on tables with large column values (e.g. big JSON blobs).
+		createEmptyKeepers := fmt.Sprintf(
+			`CREATE TEMPORARY TABLE %s AS SELECT * FROM %s WHERE 1 = 0`,
+			keepersTableID.EscapedTable(),
+			tableID.FullyQualifiedName(),
+		)
+
+		if _, err := s.ExecContext(ctx, createEmptyKeepers); err != nil {
+			cleanup()
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
+			return fmt.Errorf("failed to create empty keepers table (%s, batch %d): %w", logPrefix, batch, err)
+		}
+
+		insertKeepers := fmt.Sprintf(
+			`INSERT INTO %s SELECT * FROM %s WHERE %s AND (%s) IN (SELECT %s FROM %s) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1`,
 			keepersTableID.EscapedTable(),
 			tableID.FullyQualifiedName(),
 			rangeFilter,
@@ -359,10 +372,10 @@ func (s *Store) dedupeRange(
 			pkCSV, orderByCSV,
 		)
 
-		if _, err := s.ExecContext(ctx, createKeepers); err != nil {
+		if _, err := s.ExecContext(ctx, insertKeepers); err != nil {
 			cleanup()
 			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", allDupPKsTableID.EscapedTable()))
-			return fmt.Errorf("failed to create keepers table (%s, batch %d): %w", logPrefix, batch, err)
+			return fmt.Errorf("failed to insert keepers (%s, batch %d): %w", logPrefix, batch, err)
 		}
 
 		// Atomic delete + re-insert.

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	dedupeBatchSize       = 10_000_000
+	dedupeBatchSize       = 1_000_000
 	dedupeSubBatchMaxRows = 150_000
 )
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -160,34 +160,51 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	joinClause := strings.Join(joinClauses, " AND ")
 
 	for batch := 0; ; batch++ {
-		suffix := fmt.Sprintf("dedupe_%d_%s", batch, strings.ToLower(stringutil.Random(5)))
-		batchTableID := shared.TempTableIDWithSuffix(s, baseTableID, suffix)
+		dupPKsSuffix := fmt.Sprintf("dup_pks_%d_%s", batch, strings.ToLower(stringutil.Random(5)))
+		dupPKsTableID := shared.TempTableIDWithSuffix(s, baseTableID, dupPKsSuffix)
 
-		// Temp table holds the one row we want to *keep* per duplicate PK group (rn = 1).
-		// We then delete all rows for those PKs and re-insert the keepers.
-		createTemp := fmt.Sprintf(
-			`CREATE TEMPORARY TABLE %s AS (SELECT * FROM %s WHERE (%s) IN (SELECT %s FROM %s GROUP BY %s HAVING COUNT(*) > 1 LIMIT %d) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1)`,
-			batchTableID.EscapedTable(),
-			tableID.FullyQualifiedName(),
-			pkCSV,
+		keepersSuffix := fmt.Sprintf("keepers_%d_%s", batch, strings.ToLower(stringutil.Random(5)))
+		keepersTableID := shared.TempTableIDWithSuffix(s, baseTableID, keepersSuffix)
+
+		// Step 1: Lightweight query — only reads the PK column(s) to find which groups have duplicates.
+		createDupPKs := fmt.Sprintf(
+			`CREATE TEMPORARY TABLE %s AS (SELECT %s FROM %s GROUP BY %s HAVING COUNT(*) > 1 LIMIT %d)`,
+			dupPKsTableID.EscapedTable(),
 			pkCSV, tableID.FullyQualifiedName(), pkCSV, dedupeBatchSize,
-			pkCSV, orderByCSV,
 		)
 
-		if _, err := s.ExecContext(ctx, createTemp); err != nil {
-			return fmt.Errorf("failed to create dedupe staging table (batch %d): %w", batch, err)
+		if _, err := s.ExecContext(ctx, createDupPKs); err != nil {
+			return fmt.Errorf("failed to find duplicate PKs (batch %d): %w", batch, err)
 		}
 
 		var count int64
-		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", batchTableID.EscapedTable())).Scan(&count); err != nil {
-			return fmt.Errorf("failed to count staging rows (batch %d): %w", batch, err)
+		if err := s.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", dupPKsTableID.EscapedTable())).Scan(&count); err != nil {
+			return fmt.Errorf("failed to count duplicate PKs (batch %d): %w", batch, err)
 		}
 
 		if count == 0 {
-			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", batchTableID.EscapedTable()))
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
 			break
 		}
 
+		slog.Info("Found duplicate PK groups", slog.Int("batch", batch), slog.Int64("pkGroups", count))
+
+		// Step 2: Scoped query — only reads rows matching the duplicate PKs (small set), then picks the keeper.
+		createKeepers := fmt.Sprintf(
+			`CREATE TEMPORARY TABLE %s AS (SELECT * FROM %s WHERE (%s) IN (SELECT %s FROM %s) QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1)`,
+			keepersTableID.EscapedTable(),
+			tableID.FullyQualifiedName(),
+			pkCSV,
+			pkCSV, dupPKsTableID.EscapedTable(),
+			pkCSV, orderByCSV,
+		)
+
+		if _, err := s.ExecContext(ctx, createKeepers); err != nil {
+			_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
+			return fmt.Errorf("failed to create keepers table (batch %d): %w", batch, err)
+		}
+
+		// Step 3: Atomic delete + re-insert scoped to the duplicate PKs.
 		tx, err := s.Begin(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to begin transaction (batch %d): %w", batch, err)
@@ -195,7 +212,7 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 
 		deleteQuery := fmt.Sprintf("DELETE FROM %s USING %s stg WHERE %s",
 			tableID.FullyQualifiedName(),
-			batchTableID.EscapedTable(),
+			dupPKsTableID.EscapedTable(),
 			joinClause,
 		)
 
@@ -206,7 +223,7 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 
 		insertQuery := fmt.Sprintf("INSERT INTO %s SELECT * FROM %s",
 			tableID.FullyQualifiedName(),
-			batchTableID.EscapedTable(),
+			keepersTableID.EscapedTable(),
 		)
 
 		if _, err := tx.ExecContext(ctx, insertQuery); err != nil {
@@ -218,9 +235,8 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 			return fmt.Errorf("failed to commit dedupe (batch %d): %w", batch, err)
 		}
 
-		if _, err := s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", batchTableID.EscapedTable())); err != nil {
-			return fmt.Errorf("failed to drop staging table (batch %d): %w", batch, err)
-		}
+		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", dupPKsTableID.EscapedTable()))
+		_, _ = s.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", keepersTableID.EscapedTable()))
 
 		slog.Info("Dedupe batch complete", slog.Int("batch", batch), slog.Int64("pkGroupsDeduped", count))
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Redshift deduplication from a single full-table operation to chunked, transactional delete/reinsert batches, which directly mutates large datasets and could impact correctness/performance if PK assumptions (numeric, rangeable) don’t hold. Falls back to the prior dedupe path for non-numeric/unsupported cases, reducing but not eliminating risk.
> 
> **Overview**
> Redshift `Dedupe` is reworked to be *incremental* for large tables: it now computes PK bounds/row counts and processes deduplication in PK-range “chunks” instead of running the existing full-table `BuildDedupeQueries` flow.
> 
> Within each range it creates temp tables to (1) collect duplicate PK groups once, (2) drain them in sub-batches capped at `dedupeRangeBatchMaxRows`, (3) materialize “keeper” rows (preferring latest by `__artie_updated_at` when present), then performs an atomic transaction to delete duplicates and re-insert keepers. Adds logging and guards (empty PKs error; `__artie_updated_at` existence check), and falls back to the previous dedupe implementation when PK bounds can’t be computed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3486d650b1587ca30283c20d91468de2bb8c108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->