### PR TITLE
Standardize converter error message format

### DIFF
--- a/clients/shared/default_value.go
+++ b/clients/shared/default_value.go
@@ -34,28 +34,28 @@ func DefaultValue(column columns.Column, dialect sql.Dialect) (any, error) {
 	case typing.Date.Kind:
 		_time, err := typing.ParseDateFromAny(column.DefaultValue())
 		if err != nil {
-			return nil, fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)
+			return nil, fmt.Errorf("failed to convert default value to date: %w", err)
 		}
 
 		return sql.QuoteLiteral(_time.Format(time.DateOnly)), nil
 	case typing.TimeKindDetails.Kind:
 		_time, err := typing.ParseTimeFromAny(column.DefaultValue())
 		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)
+			return "", fmt.Errorf("failed to convert default value to time: %w", err)
 		}
 
 		return sql.QuoteLiteral(_time.Format(typing.PostgresTimeFormatNoTZ)), nil
 	case typing.TimestampNTZ.Kind:
 		_time, err := typing.ParseTimestampNTZFromAny(column.DefaultValue())
 		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)
+			return "", fmt.Errorf("failed to convert default value to timestampNTZ: %w", err)
 		}
 
 		return sql.QuoteLiteral(_time.Format(typing.RFC3339NoTZ)), nil
 	case typing.TimestampTZ.Kind:
 		_time, err := typing.ParseTimestampTZFromAny(column.DefaultValue())
 		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", column.DefaultValue(), err)
+			return "", fmt.Errorf("failed to convert default value to timestampTZ: %w", err)
 		}
 
 		return sql.QuoteLiteral(_time.Format(time.RFC3339Nano)), nil

--- a/clients/shared/values.go
+++ b/clients/shared/values.go
@@ -28,28 +28,28 @@ func ParseValue(colVal any, colKind columns.Column) (any, error) {
 	case typing.Date.Kind:
 		_time, err := typing.ParseDateFromAny(colVal)
 		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
+			return "", fmt.Errorf("failed to convert value to date: %w", err)
 		}
 
 		return _time, nil
 	case typing.TimeKindDetails.Kind:
 		_time, err := typing.ParseTimeFromAny(colVal)
 		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
+			return "", fmt.Errorf("failed to convert value to time: %w", err)
 		}
 
 		return _time, nil
 	case typing.TimestampNTZ.Kind:
 		_time, err := typing.ParseTimestampNTZFromAny(colVal)
 		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
+			return "", fmt.Errorf("failed to convert value to timestampNTZ: %w", err)
 		}
 
 		return _time, nil
 	case typing.TimestampTZ.Kind:
 		_time, err := typing.ParseTimestampTZFromAny(colVal)
 		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time.Time, colVal: '%v', err: %w", colVal, err)
+			return "", fmt.Errorf("failed to convert value to timestampTZ: %w", err)
 		}
 
 		return _time, nil

--- a/lib/typing/converters/primitives/bytes.go
+++ b/lib/typing/converters/primitives/bytes.go
@@ -14,7 +14,7 @@ func AsBytes(value any) ([]byte, error) {
 	default:
 		bytes, err := json.Marshal(value)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal value: %w", err)
+			return nil, fmt.Errorf("failed to convert %T to []byte: %w", value, err)
 		}
 
 		return bytes, nil

--- a/lib/typing/converters/primitives/bytes_test.go
+++ b/lib/typing/converters/primitives/bytes_test.go
@@ -65,6 +65,6 @@ func TestAsBytes(t *testing.T) {
 	{
 		// Unmarshallable value (channel) returns an error.
 		_, err := AsBytes(make(chan int))
-		assert.ErrorContains(t, err, "failed to marshal value")
+		assert.ErrorContains(t, err, "failed to convert chan int to []byte")
 	}
 }

--- a/lib/typing/converters/primitives/converter.go
+++ b/lib/typing/converters/primitives/converter.go
@@ -16,7 +16,7 @@ func (Int64Converter) Convert(value any) (int64, error) {
 	case string:
 		parsed, err := strconv.ParseInt(castValue, 10, 64)
 		if err != nil {
-			return 0, fmt.Errorf("failed to parse string to int64: %w", err)
+			return 0, fmt.Errorf("failed to convert %T to int64: %w", value, err)
 		}
 		return parsed, nil
 	case int8:
@@ -30,32 +30,31 @@ func (Int64Converter) Convert(value any) (int64, error) {
 	case int64:
 		return castValue, nil
 	case float64:
-		// We'll check for overflow and make sure there's no precision loss
 		if castValue > math.MaxInt64 || castValue < math.MinInt64 {
-			return 0, fmt.Errorf("value %f overflows int64", castValue)
+			return 0, fmt.Errorf("failed to convert %T to int64: value %f overflows int64", value, castValue)
 		}
 
 		if math.Trunc(castValue) != castValue {
-			return 0, fmt.Errorf("float64 (%f) has fractional component", castValue)
+			return 0, fmt.Errorf("failed to convert %T to int64: value %f has fractional component", value, castValue)
 		}
 
 		return int64(castValue), nil
 	case json.Number:
 		val, err := castValue.Int64()
 		if err != nil {
-			return 0, fmt.Errorf("failed to parse json.Number to int64: %w", err)
+			return 0, fmt.Errorf("failed to convert %T to int64: %w", value, err)
 		}
 		return val, nil
 	case *decimal.Decimal:
 		val, err := castValue.Value().Int64()
 		if err != nil {
-			return 0, fmt.Errorf("failed to convert decimal to int64: %w", err)
+			return 0, fmt.Errorf("failed to convert %T to int64: %w", value, err)
 		}
 
 		return val, nil
 	}
 
-	return 0, fmt.Errorf("failed to parse int64, unsupported type: %T", value)
+	return 0, fmt.Errorf("failed to convert %T to int64: unsupported type", value)
 }
 
 type BooleanConverter struct{}
@@ -68,7 +67,7 @@ func (BooleanConverter) Convert(value any) (bool, error) {
 		return castValue, nil
 	}
 
-	return false, fmt.Errorf("failed to parse boolean, unsupported type: %T", value)
+	return false, fmt.Errorf("failed to convert %T to bool: unsupported type", value)
 }
 
 type Float32Converter struct{}
@@ -79,23 +78,23 @@ func (Float32Converter) Convert(value any) (float32, error) {
 		return castValue, nil
 	case float64:
 		if castValue > math.MaxFloat32 || castValue < -math.MaxFloat32 {
-			return 0, fmt.Errorf("value overflows float32")
+			return 0, fmt.Errorf("failed to convert %T to float32: value overflows float32", value)
 		}
 
 		return float32(castValue), nil
 	case json.Number:
 		parsed, err := strconv.ParseFloat(castValue.String(), 32)
 		if err != nil {
-			return 0, fmt.Errorf("failed to parse json.Number to float32: %w", err)
+			return 0, fmt.Errorf("failed to convert %T to float32: %w", value, err)
 		}
 		return float32(parsed), nil
 	case string:
 		parsed, err := strconv.ParseFloat(castValue, 32)
 		if err != nil {
-			return 0, fmt.Errorf("failed to parse string to float32: %w", err)
+			return 0, fmt.Errorf("failed to convert %T to float32: %w", value, err)
 		}
 		return float32(parsed), nil
 	}
 
-	return 0, fmt.Errorf("failed to parse float32, unsupported type: %T", value)
+	return 0, fmt.Errorf("failed to convert %T to float32: unsupported type", value)
 }

--- a/lib/typing/converters/primitives/converter_test.go
+++ b/lib/typing/converters/primitives/converter_test.go
@@ -81,42 +81,42 @@ func TestInt64Converter_Convert(t *testing.T) {
 		{
 			// float64 - has fractional component
 			_, err := converter.Convert(float64(1234.5))
-			assert.ErrorContains(t, err, "float64 (1234.500000) has fractional component")
+			assert.ErrorContains(t, err, "failed to convert float64 to int64: value 1234.500000 has fractional component")
 		}
 		{
 			// float64 - small fractional component
 			_, err := converter.Convert(float64(1234.1))
-			assert.ErrorContains(t, err, "float64 (1234.100000) has fractional component")
+			assert.ErrorContains(t, err, "failed to convert float64 to int64: value 1234.100000 has fractional component")
 		}
 		{
 			// float64 - negative fractional component
 			_, err := converter.Convert(float64(-1234.5))
-			assert.ErrorContains(t, err, "float64 (-1234.500000) has fractional component")
+			assert.ErrorContains(t, err, "failed to convert float64 to int64: value -1234.500000 has fractional component")
 		}
 		{
 			// float64 - positive overflow
 			_, err := converter.Convert(float64(math.MaxInt64) * 2)
-			assert.ErrorContains(t, err, "overflows int64")
+			assert.ErrorContains(t, err, "failed to convert float64 to int64: value")
 		}
 		{
 			// float64 - negative overflow
 			_, err := converter.Convert(float64(math.MinInt64) * 2)
-			assert.ErrorContains(t, err, "overflows int64")
+			assert.ErrorContains(t, err, "failed to convert float64 to int64: value")
 		}
 		{
 			// float64 - positive infinity
 			_, err := converter.Convert(math.Inf(1))
-			assert.ErrorContains(t, err, "overflows int64")
+			assert.ErrorContains(t, err, "failed to convert float64 to int64: value")
 		}
 		{
 			// float64 - negative infinity
 			_, err := converter.Convert(math.Inf(-1))
-			assert.ErrorContains(t, err, "overflows int64")
+			assert.ErrorContains(t, err, "failed to convert float64 to int64: value")
 		}
 		{
 			// float64 - NaN
 			_, err := converter.Convert(math.NaN())
-			assert.ErrorContains(t, err, "has fractional component")
+			assert.ErrorContains(t, err, "failed to convert float64 to int64: value")
 		}
 	}
 	{
@@ -169,12 +169,12 @@ func TestFloat32Converter_Convert(t *testing.T) {
 		{
 			// Max float
 			_, err := converter.Convert(math.MaxFloat64)
-			assert.ErrorContains(t, err, "value overflows float32")
+			assert.ErrorContains(t, err, "failed to convert float64 to float32: value overflows float32")
 		}
 		{
 			// Min float
 			_, err := converter.Convert(-math.MaxFloat64)
-			assert.ErrorContains(t, err, "value overflows float32")
+			assert.ErrorContains(t, err, "failed to convert float64 to float32: value overflows float32")
 		}
 		{
 			actual, err := converter.Convert(float64(123.55))
@@ -203,6 +203,6 @@ func TestFloat32Converter_Convert(t *testing.T) {
 	{
 		// Irrelevant
 		_, err := converter.Convert(true)
-		assert.ErrorContains(t, err, "failed to parse float32, unsupported type: bool")
+		assert.ErrorContains(t, err, "failed to convert bool to float32: unsupported type")
 	}
 }

--- a/lib/typing/converters/string_converter.go
+++ b/lib/typing/converters/string_converter.go
@@ -74,15 +74,13 @@ func (BooleanConverter) Convert(value any) (string, error) {
 	case bool:
 		return fmt.Sprint(castedValue), nil
 	default:
-		// Try to cast the value into a string and see if we can parse it
-		// If not, then return an error
 		switch strings.ToLower(fmt.Sprint(value)) {
 		case "0", "false":
 			return "false", nil
 		case "1", "true":
 			return "true", nil
 		default:
-			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.InvalidBooleanValue)
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.InvalidBooleanValue)
 		}
 	}
 }
@@ -126,7 +124,7 @@ func (StringConverter) ConvertNew(value any) (string, error) {
 			return ArrayConverter{}.Convert(value)
 		}
 
-		return "", fmt.Errorf("unsupported value: %v, type: %T", value, value)
+		return "", fmt.Errorf("unexpected value '%v' of type %T", value, value)
 	}
 }
 
@@ -161,7 +159,7 @@ func (BytesConverter) Convert(value any) (string, error) {
 	case []byte:
 		return base64.StdEncoding.EncodeToString(castedValue), nil
 	default:
-		return "", fmt.Errorf("unexpected value: '%v', type: %T", value, value)
+		return "", fmt.Errorf("unexpected value '%v' of type %T", value, value)
 	}
 }
 
@@ -170,7 +168,7 @@ type DateConverter struct{}
 func (DateConverter) Convert(value any) (string, error) {
 	_time, err := typing.ParseDateFromAny(value)
 	if err != nil {
-		return "", fmt.Errorf("failed to cast colVal as date, colVal: '%v', err: %w", value, err)
+		return "", fmt.Errorf("failed to convert value to date: %w", err)
 	}
 
 	return _time.Format(time.DateOnly), nil
@@ -185,7 +183,7 @@ func (TimeConverter) Convert(value any) (string, error) {
 	default:
 		_time, err := typing.ParseTimeFromAny(value)
 		if err != nil {
-			return "", fmt.Errorf("failed to cast colVal as time, colVal: '%v', err: %w", value, err)
+			return "", fmt.Errorf("failed to convert value to time: %w", err)
 		}
 
 		return _time.Format(ext.PostgresTimeFormatNoTZ), nil
@@ -205,7 +203,7 @@ type TimestampNTZConverter struct {
 func (t TimestampNTZConverter) Convert(value any) (string, error) {
 	_time, err := typing.ParseTimestampNTZFromAny(value)
 	if err != nil {
-		return "", fmt.Errorf("failed to cast colVal as timestampNTZ, colVal: '%v', err: %w", value, err)
+		return "", fmt.Errorf("failed to convert value to timestampNTZ: %w", err)
 	}
 
 	return _time.Format(cmp.Or(t.layoutOverride, typing.RFC3339NoTZ)), nil
@@ -224,7 +222,7 @@ type TimestampTZConverter struct {
 func (t TimestampTZConverter) Convert(value any) (string, error) {
 	_time, err := typing.ParseTimestampTZFromAny(value)
 	if err != nil {
-		return "", fmt.Errorf("failed to cast colVal as timestampTZ, colVal: '%v', err: %w", value, err)
+		return "", fmt.Errorf("failed to convert value to timestampTZ: %w", err)
 	}
 
 	return _time.Format(cmp.Or(t.layoutOverride, time.RFC3339Nano)), nil
@@ -256,12 +254,12 @@ func (IntegerConverter) Convert(value any) (string, error) {
 	case float32:
 		f64Val := float64(parsedVal)
 		if math.IsInf(f64Val, 0) || f64Val != math.Trunc(f64Val) {
-			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 		}
 		return Float32ToString(parsedVal), nil
 	case float64:
 		if math.IsInf(parsedVal, 0) || parsedVal != math.Trunc(parsedVal) {
-			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 		}
 		return Float64ToString(parsedVal), nil
 	case bool:
@@ -271,23 +269,22 @@ func (IntegerConverter) Convert(value any) (string, error) {
 	case *decimal.Decimal:
 		reduced, _ := new(apd.Decimal).Reduce(parsedVal.Value())
 		if reduced.Exponent < 0 {
-			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 		}
 		return reduced.Text('f'), nil
 	case json.Number:
 		if _, err := strconv.ParseInt(parsedVal.String(), 10, 64); err != nil {
-			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 		}
 		return parsedVal.String(), nil
 	case string:
-		// If it's a string, does it parse properly to an integer? If so, that's fine.
 		if _, err := strconv.ParseInt(parsedVal, 10, 64); err != nil {
-			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 		}
 
 		return parsedVal, nil
 	default:
-		return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+		return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 	}
 }
 
@@ -305,17 +302,16 @@ func (FloatConverter) Convert(value any) (string, error) {
 		return parsedVal.String(), nil
 	case json.Number:
 		if _, err := strconv.ParseFloat(parsedVal.String(), 64); err != nil {
-			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 		}
 		return parsedVal.String(), nil
 	case string:
-		// If it's a string, verify it can be parsed as a float
 		if _, err := strconv.ParseFloat(parsedVal, 64); err != nil {
-			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 		}
 		return parsedVal, nil
 	default:
-		return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+		return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 	}
 }
 
@@ -337,22 +333,21 @@ func (d DecimalConverter) Convert(value any) (string, error) {
 		result = fmt.Sprint(castedColVal)
 	case json.Number:
 		if _, _, err := apd.NewFromString(castedColVal.String()); err != nil {
-			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 		}
 		result = castedColVal.String()
 	case string:
-		// If it's a string, verify it can be parsed as a number.
 		// We use apd.NewFromString instead of strconv.ParseFloat because ParseFloat
 		// can fail with ErrRange for large/precise decimal strings that are still
 		// valid for a decimal/NUMERIC destination.
 		if _, _, err := apd.NewFromString(castedColVal); err != nil {
-			return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+			return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 		}
 		result = castedColVal
 	case *decimal.Decimal:
 		result = castedColVal.String()
 	default:
-		return "", typing.NewParseError(fmt.Sprintf("unexpected value: '%v', type: %T", value, value), typing.UnexpectedValue)
+		return "", typing.NewParseError(fmt.Sprintf("unexpected value '%v' of type %T", value, value), typing.UnexpectedValue)
 	}
 
 	return truncateDecimalString(result, d.MaxScale), nil

--- a/lib/typing/converters/string_converter_test.go
+++ b/lib/typing/converters/string_converter_test.go
@@ -68,7 +68,7 @@ func TestBytesConverter_Convert(t *testing.T) {
 	{
 		// Unsupported type
 		_, err := BytesConverter{}.Convert(42)
-		assert.ErrorContains(t, err, "unexpected value: '42', type: int")
+		assert.ErrorContains(t, err, "unexpected value '42' of type int")
 	}
 }
 
@@ -76,7 +76,7 @@ func TestBooleanConverter_Convert(t *testing.T) {
 	{
 		// Not boolean
 		_, err := BooleanConverter{}.Convert("foo")
-		assert.ErrorContains(t, err, `unexpected value: 'foo', type: string`)
+		assert.ErrorContains(t, err, `unexpected value 'foo' of type string`)
 
 		// Should be a ParseError with UnexpectedBooleanValue kind
 		parseError, ok := typing.BuildParseError(err)
@@ -129,7 +129,7 @@ func TestFloatConverter_Convert(t *testing.T) {
 	{
 		// Unexpected type
 		_, err := FloatConverter{}.Convert(true)
-		assert.ErrorContains(t, err, `unexpected value: 'true', type: bool`)
+		assert.ErrorContains(t, err, `unexpected value 'true' of type bool`)
 
 		// Should be a ParseError with UnexpectedValue kind
 		parseError, ok := typing.BuildParseError(err)
@@ -139,7 +139,7 @@ func TestFloatConverter_Convert(t *testing.T) {
 	{
 		// Invalid string that can't be parsed as a float
 		_, err := FloatConverter{}.Convert("tNLc2OHz")
-		assert.ErrorContains(t, err, `unexpected value: 'tNLc2OHz', type: string`)
+		assert.ErrorContains(t, err, `unexpected value 'tNLc2OHz' of type string`)
 
 		// Should be a ParseError with UnexpectedValue kind
 		parseError, ok := typing.BuildParseError(err)
@@ -356,7 +356,7 @@ func TestDecimalConverter_Convert(t *testing.T) {
 	{
 		// Invalid string that can't be parsed as a number
 		_, err := DecimalConverter{}.Convert("tNLc2OHz")
-		assert.ErrorContains(t, err, `unexpected value: 'tNLc2OHz', type: string`)
+		assert.ErrorContains(t, err, `unexpected value 'tNLc2OHz' of type string`)
 
 		// Should be a ParseError with UnexpectedValue kind
 		parseError, ok := typing.BuildParseError(err)
@@ -366,7 +366,7 @@ func TestDecimalConverter_Convert(t *testing.T) {
 	{
 		// Unexpected type
 		_, err := DecimalConverter{}.Convert(true)
-		assert.ErrorContains(t, err, `unexpected value: 'true', type: bool`)
+		assert.ErrorContains(t, err, `unexpected value 'true' of type bool`)
 
 		// Should be a ParseError with UnexpectedValue kind
 		parseError, ok := typing.BuildParseError(err)

--- a/lib/typing/values/string_test.go
+++ b/lib/typing/values/string_test.go
@@ -170,7 +170,7 @@ func TestToString(t *testing.T) {
 		{
 			// Invalid (string value)
 			_, err := ToString("foo", typing.Integer)
-			assert.ErrorContains(t, err, `converter converters.IntegerConverter failed to convert value: unexpected value: 'foo', type: string`)
+			assert.ErrorContains(t, err, `converter converters.IntegerConverter failed to convert value: unexpected value 'foo' of type string`)
 		}
 		{
 			// Float32 value
@@ -181,7 +181,7 @@ func TestToString(t *testing.T) {
 		{
 			// Float64 value
 			val, err := ToString(45452.999991, typing.Integer)
-			assert.ErrorContains(t, err, "unexpected value: '45452.999991', type: float64")
+			assert.ErrorContains(t, err, "unexpected value '45452.999991' of type float64")
 			assert.Empty(t, val)
 		}
 		{


### PR DESCRIPTION
## Summary

- Unified error messages across all converter packages (`lib/typing/converters`, `lib/typing/converters/primitives`, `clients/shared`) to use three consistent patterns:
  - **Type mismatch / unexpected value**: `"unexpected value '<val>' of type <T>"`
  - **Wrapping upstream parse errors**: `"failed to convert value to <kind>: <err>"` (or `"failed to convert default value to <kind>: <err>"`)
  - **Primitives errors**: `"failed to convert <T> to <target>: <reason>"`
- Removed leaked variable names (`colVal`) from error messages
- Eliminated inconsistencies between `"unexpected value"`, `"unsupported value"`, `"failed to cast colVal"`, and `"failed to parse"` phrasings

## Test plan

- [x] All existing tests updated to match new error format
- [x] `go vet ./lib/typing/... ./clients/shared/...` passes
- [x] `go test -race` passes for all affected packages


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error message strings across conversion helpers and their tests, with no functional conversion logic changes.
> 
> **Overview**
> Standardizes converter-related error messages across `clients/shared` and `lib/typing/converters` to use consistent wording and include type context (e.g., `failed to convert <T> to <target>` and `unexpected value '<v>' of type <T>`), removing leaked variable names like `colVal`.
> 
> Updates unit tests to match the new error text, including `primitives` converters and string/date/time/timestamp parsing wrappers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c63ff10f10af63c89e6e73e429e4a0dcbd3388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->