### PR TITLE
Change KindDetails.Kind from string to typed int enum

### DIFF
--- a/clients/bigquery/dialect/typing.go
+++ b/clients/bigquery/dialect/typing.go
@@ -49,7 +49,7 @@ func (BigQueryDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, s
 		return "string", nil
 	}
 
-	return kindDetails.Kind, nil
+	return kindDetails.Kind.String(), nil
 }
 
 func (BigQueryDialect) KindForDataType(rawBqType string) (typing.KindDetails, error) {

--- a/clients/databricks/dialect/typing.go
+++ b/clients/databricks/dialect/typing.go
@@ -45,7 +45,7 @@ func (DatabricksDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool,
 		return "STRING", nil
 	}
 
-	return kindDetails.Kind, nil
+	return kindDetails.Kind.String(), nil
 }
 
 func (DatabricksDialect) KindForDataType(rawType string) (typing.KindDetails, error) {

--- a/clients/iceberg/dialect/data_types.go
+++ b/clients/iceberg/dialect/data_types.go
@@ -40,7 +40,7 @@ func (IcebergDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, _ 
 	case typing.TimestampTZ.Kind:
 		return "TIMESTAMP", nil
 	default:
-		return kindDetails.Kind, nil
+		return kindDetails.Kind.String(), nil
 	}
 }
 

--- a/clients/mssql/dialect/typing.go
+++ b/clients/mssql/dialect/typing.go
@@ -54,7 +54,7 @@ func (MSSQLDialect) DataTypeForKind(kindDetails typing.KindDetails, isPk bool, _
 		return "NVARCHAR(MAX)", nil
 	}
 
-	return kindDetails.Kind, nil
+	return kindDetails.Kind.String(), nil
 }
 
 func (MSSQLDialect) KindForDataType(rawType string) (typing.KindDetails, error) {

--- a/clients/mysql/dialect/typing.go
+++ b/clients/mysql/dialect/typing.go
@@ -54,7 +54,7 @@ func (MySQLDialect) DataTypeForKind(kindDetails typing.KindDetails, isPk bool, _
 		return "TEXT", nil
 	}
 
-	return kindDetails.Kind, nil
+	return kindDetails.Kind.String(), nil
 }
 
 func (MySQLDialect) KindForDataType(rawType string) (typing.KindDetails, error) {

--- a/clients/postgres/dialect/dialect.go
+++ b/clients/postgres/dialect/dialect.go
@@ -318,7 +318,7 @@ func (pd PostgresDialect) buildNoMergeDeleteQuery(tableID sql.TableIdentifier, s
 	)
 }
 
-var kindDetailsMap = map[string]string{
+var kindDetailsMap = map[typing.KindType]string{
 	typing.UUID.Kind:            "uuid",
 	typing.Interval.Kind:        "interval",
 	typing.Float.Kind:           "double precision",

--- a/clients/postgres/dialect/dialect_test.go
+++ b/clients/postgres/dialect/dialect_test.go
@@ -266,7 +266,7 @@ func TestDataTypeForKind(t *testing.T) {
 		{
 			name: "unsupported kind",
 			kd: typing.KindDetails{
-				Kind: "unsupported_kind",
+				Kind: typing.KindType(999),
 			},
 			wantErr: true,
 		},

--- a/clients/redshift/dialect/typing.go
+++ b/clients/redshift/dialect/typing.go
@@ -59,7 +59,7 @@ func (RedshiftDialect) DataTypeForKind(kd typing.KindDetails, _ bool, _ config.S
 		return "VARCHAR(MAX)", nil
 	}
 
-	return kd.Kind, nil
+	return kd.Kind.String(), nil
 }
 
 func (RedshiftDialect) KindForDataType(rawType string) (typing.KindDetails, error) {

--- a/clients/snowflake/dialect/typing.go
+++ b/clients/snowflake/dialect/typing.go
@@ -32,7 +32,7 @@ func (SnowflakeDialect) DataTypeForKind(kindDetails typing.KindDetails, _ bool, 
 		return "string", nil
 	}
 
-	return kindDetails.Kind, nil
+	return kindDetails.Kind.String(), nil
 }
 
 // KindForDataType converts a Snowflake type to a KindDetails.

--- a/lib/typing/parquet.go
+++ b/lib/typing/parquet.go
@@ -20,7 +20,7 @@ func millisecondsAfterMidnight(t time.Time) int32 {
 	return int32(t.Sub(midnight).Milliseconds())
 }
 
-var kindToArrowType = map[string]arrow.DataType{
+var kindToArrowType = map[KindType]arrow.DataType{
 	String.Kind:  arrow.BinaryTypes.String,
 	Boolean.Kind: arrow.FixedWidthTypes.Boolean,
 	// Number data types:

--- a/lib/typing/typing.go
+++ b/lib/typing/typing.go
@@ -1,6 +1,8 @@
 package typing
 
 import (
+	"fmt"
+
 	"github.com/artie-labs/transfer/lib/typing/decimal"
 )
 
@@ -13,9 +15,66 @@ const (
 	BigIntegerKind
 )
 
+type KindType int
+
+const (
+	KindInvalid KindType = iota
+	KindFloat
+	KindInteger
+	KindDecimal
+	KindBoolean
+	KindArray
+	KindStruct
+	KindString
+	KindBytes
+	KindDate
+	KindTime
+	KindTimestampNTZ
+	KindTimestampTZ
+	KindUUID
+	KindInterval
+)
+
+func (k KindType) String() string {
+	switch k {
+	case KindInvalid:
+		return "invalid"
+	case KindFloat:
+		return "float"
+	case KindInteger:
+		return "int"
+	case KindDecimal:
+		return "decimal"
+	case KindBoolean:
+		return "bool"
+	case KindArray:
+		return "array"
+	case KindStruct:
+		return "struct"
+	case KindString:
+		return "string"
+	case KindBytes:
+		return "bytes"
+	case KindDate:
+		return "date"
+	case KindTime:
+		return "time"
+	case KindTimestampNTZ:
+		return "timestamp_ntz"
+	case KindTimestampTZ:
+		return "timestamp_tz"
+	case KindUUID:
+		return "uuid"
+	case KindInterval:
+		return "interval"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(k))
+	}
+}
+
 // TODO: KindDetails should store the raw data type from the target table (if exists).
 type KindDetails struct {
-	Kind                   string
+	Kind                   KindType
 	ExtendedDecimalDetails *decimal.Details
 
 	// Optional kind details metadata
@@ -38,67 +97,67 @@ func BuildIntegerKind(optionalKind OptionalIntegerKind) KindDetails {
 
 var (
 	Invalid = KindDetails{
-		Kind: "invalid",
+		Kind: KindInvalid,
 	}
 
 	Float = KindDetails{
-		Kind: "float",
+		Kind: KindFloat,
 	}
 
 	Integer = KindDetails{
-		Kind:                "int",
+		Kind:                KindInteger,
 		OptionalIntegerKind: ToPtr(NotSpecifiedKind),
 	}
 
 	EDecimal = KindDetails{
-		Kind: "decimal",
+		Kind: KindDecimal,
 	}
 
 	Boolean = KindDetails{
-		Kind: "bool",
+		Kind: KindBoolean,
 	}
 
 	Array = KindDetails{
-		Kind: "array",
+		Kind: KindArray,
 	}
 
 	Struct = KindDetails{
-		Kind: "struct",
+		Kind: KindStruct,
 	}
 
 	String = KindDetails{
-		Kind: "string",
+		Kind: KindString,
 	}
 
 	Bytes = KindDetails{
-		Kind: "bytes",
+		Kind: KindBytes,
 	}
 
 	// Time data types
 	Date = KindDetails{
-		Kind: "date",
+		Kind: KindDate,
 	}
 
 	TimeKindDetails = KindDetails{
-		Kind: "time",
+		Kind: KindTime,
 	}
 
 	TimestampNTZ = KindDetails{
-		Kind: "timestamp_ntz",
+		Kind: KindTimestampNTZ,
 	}
 
 	TimestampTZ = KindDetails{
-		Kind: "timestamp_tz",
+		Kind: KindTimestampTZ,
 	}
 
 	// [UUID] - This is only populated for Postgres for now.
 	UUID = KindDetails{
-		Kind: "uuid",
+		Kind: KindUUID,
 	}
 
 	// [Interval] - This is only populated for Postgres for now.
 	Interval = KindDetails{
-		Kind: "interval",
+		Kind: KindInterval,
 	}
 )
 


### PR DESCRIPTION
## Summary
- Replaces the `string`-based `KindDetails.Kind` field with a `KindType int` enum (`iota` constants) to enable compile-time safety and exhaustive switch checking via linters like `exhaustive`
- Adds a `String()` method on `KindType` that returns the same string values as before, preserving backward-compatible error messages and logging
- Updates map key types (`map[string]` → `map[KindType]`) in `parquet.go` and `postgres/dialect` and converts fallback `return kindDetails.Kind` to `.Kind.String()` in dialect `DataTypeForKind` methods

## Test plan
- [x] All existing unit tests pass (verified locally via `go test`)
- [x] Integration test packages compile successfully
- [x] CI passes


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core typing used across multiple destination dialects and Parquet conversion, so any missed conversion could cause incorrect type mapping at runtime. Behavior should be mostly preserved via `KindType.String()`, but downstream formatting/logging and map lookups now depend on the new enum values.
> 
> **Overview**
> Refactors `typing.KindDetails.Kind` from a free-form `string` to a typed `KindType` enum, adding a `KindType.String()` method to preserve the previous string representations.
> 
> Updates dialect type-mapping fallbacks (BigQuery/Databricks/Iceberg/MSSQL/MySQL/Redshift/Snowflake) to return `kd.Kind.String()` and adjusts map keys (Postgres `kindDetailsMap`, Parquet `kindToArrowType`) to use `KindType` instead of `string`, with tests updated to use an invalid enum value for unsupported-kind cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8878f323f5e431e106f98c9f7862134d894647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->