### PR TITLE
Handle nil Kafka message key when PrimaryKeysOverride or IncludePrimaryKeys is configured

### DIFF
--- a/processes/consumer/configs.go
+++ b/processes/consumer/configs.go
@@ -47,6 +47,17 @@ func (t TopicConfigFormatter) ShouldSkip(op string) bool {
 	return ok
 }
 
+// buildPKMap returns the primary key map for an event. When the Kafka message key is empty and primary keys are
+// specified via [TopicConfig.PrimaryKeysOverride] or [TopicConfig.IncludePrimaryKeys], key parsing is skipped
+// and an empty map is returned -- the PK column names come from config and values come from the event payload.
+func (t TopicConfigFormatter) buildPKMap(key []byte, reservedColumns map[string]bool) (map[string]any, error) {
+	if len(key) == 0 && (len(t.tc.PrimaryKeysOverride) > 0 || len(t.tc.IncludePrimaryKeys) > 0) {
+		return map[string]any{}, nil
+	}
+
+	return t.GetPrimaryKey(key, t.tc, reservedColumns)
+}
+
 func NewTopicConfigFormatter(tc kafkalib.TopicConfig, format cdc.Format) TopicConfigFormatter {
 	formatter := TopicConfigFormatter{
 		tc:                tc,

--- a/processes/consumer/process.go
+++ b/processes/consumer/process.go
@@ -49,7 +49,7 @@ func (p processArgs) process(ctx context.Context, cfg config.Config, inMemDB *mo
 
 	tags["database"] = topicConfig.tc.Database
 	tags["schema"] = topicConfig.tc.Schema
-	pkMap, err := topicConfig.GetPrimaryKey(p.Msg.Key(), topicConfig.tc, reservedColumns)
+	pkMap, err := topicConfig.buildPKMap(p.Msg.Key(), reservedColumns)
 	if err != nil {
 		tags["what"] = "marshall_pk_err"
 		return cdc.TableID{}, fmt.Errorf("cannot unmarshal key %q: %w", string(p.Msg.Key()), err)

--- a/processes/consumer/process_test.go
+++ b/processes/consumer/process_test.go
@@ -208,6 +208,153 @@ func TestProcessMessageFailures(t *testing.T) {
 	}
 }
 
+func TestBuildPKMap(t *testing.T) {
+	var mgo mongo.Debezium
+	{
+		// Nil key with PrimaryKeysOverride - should return empty map, no error
+		tcf := NewTopicConfigFormatter(kafkalib.TopicConfig{
+			CDCKeyFormat:        "org.apache.kafka.connect.storage.StringConverter",
+			PrimaryKeysOverride: []string{"_id"},
+		}, &mgo)
+
+		pkMap, err := tcf.buildPKMap(nil, nil)
+		assert.NoError(t, err)
+		assert.Empty(t, pkMap)
+	}
+	{
+		// Nil key with IncludePrimaryKeys - should return empty map, no error
+		tcf := NewTopicConfigFormatter(kafkalib.TopicConfig{
+			CDCKeyFormat:       "org.apache.kafka.connect.storage.StringConverter",
+			IncludePrimaryKeys: []string{"_id"},
+		}, &mgo)
+
+		pkMap, err := tcf.buildPKMap(nil, nil)
+		assert.NoError(t, err)
+		assert.Empty(t, pkMap)
+	}
+	{
+		// Nil key with neither override nor include - should fall through and error
+		tcf := NewTopicConfigFormatter(kafkalib.TopicConfig{
+			CDCKeyFormat: "org.apache.kafka.connect.storage.StringConverter",
+		}, &mgo)
+
+		_, err := tcf.buildPKMap(nil, nil)
+		assert.ErrorContains(t, err, "key is nil")
+	}
+	{
+		// Non-nil key with PrimaryKeysOverride - should still parse the key
+		tcf := NewTopicConfigFormatter(kafkalib.TopicConfig{
+			CDCKeyFormat:        "org.apache.kafka.connect.storage.StringConverter",
+			PrimaryKeysOverride: []string{"_id"},
+		}, &mgo)
+
+		pkMap, err := tcf.buildPKMap([]byte("Struct{id=1001}"), nil)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, pkMap)
+	}
+}
+
+func TestProcessMessageNilKeyWithPrimaryKeyOverride(t *testing.T) {
+	cfg := config.Config{
+		FlushIntervalSeconds: 10,
+		BufferRows:           10,
+		FlushSizeKb:          900,
+	}
+
+	var mgo mongo.Debezium
+	tc := kafkalib.TopicConfig{
+		Database:            testDB,
+		TableName:           table,
+		Schema:              schema,
+		Topic:               "foo",
+		CDCKeyFormat:        "org.apache.kafka.connect.storage.StringConverter",
+		PrimaryKeysOverride: []string{"_id"},
+	}
+
+	tcFmtMap := NewTcFmtMap()
+	tcFmtMap.Add("foo", NewTopicConfigFormatter(tc, &mgo))
+
+	val := `{
+	"schema": {
+		"type": "struct",
+		"fields": [{
+			"type": "struct",
+			"fields": [{
+				"type": "int32",
+				"optional": false,
+				"default": 0,
+				"field": "id"
+			}, {
+				"type": "string",
+				"optional": false,
+				"field": "first_name"
+			}, {
+				"type": "string",
+				"optional": false,
+				"field": "last_name"
+			}, {
+				"type": "string",
+				"optional": false,
+				"field": "email"
+			}],
+			"optional": true,
+			"name": "dbserver1.inventory.customers.Value",
+			"field": "after"
+		}]
+	},
+	"payload": {
+		"before": null,
+		"after": "{\"_id\": {\"$numberLong\": \"1004\"},\"first_name\": \"Anne\",\"last_name\": \"Kretchmar\",\"email\": \"annek@noanswer.org\"}",
+		"patch": null,
+		"filter": null,
+		"updateDescription": null,
+		"source": {
+			"version": "2.0.0.Final",
+			"connector": "mongodb",
+			"name": "dbserver1",
+			"ts_ms": 1668753321000,
+			"snapshot": "true",
+			"db": "inventory",
+			"sequence": null,
+			"rs": "rs0",
+			"collection": "customers",
+			"ord": 29,
+			"lsid": null,
+			"txnNumber": null
+		},
+		"op": "r",
+		"ts_ms": 1668753329387,
+		"transaction": null
+	}
+}`
+
+	kafkaMessage := kgo.Record{
+		Topic: "foo",
+		Key:   nil,
+		Value: []byte(val),
+	}
+
+	memDB := models.NewMemoryDB()
+	args := processArgs{
+		Msg:                    artie.NewFranzGoMessage(kafkaMessage, 0),
+		GroupID:                "foo",
+		TopicToConfigFormatMap: tcFmtMap,
+	}
+
+	actualTableID, err := args.process(t.Context(), cfg, memDB, &mocks.FakeDestination{}, metrics.NullMetricsProvider{})
+	assert.NoError(t, err)
+	assert.Equal(t, tableID, actualTableID)
+
+	td := memDB.GetOrCreateTableData(tableID, "foo")
+	assert.Len(t, td.Rows(), 1)
+
+	for _, row := range td.Rows() {
+		value, ok := row.GetValue("_id")
+		assert.True(t, ok)
+		assert.Equal(t, int64(1004), value)
+	}
+}
+
 func TestProcessMessageSkip(t *testing.T) {
 	cfg := config.Config{
 		FlushIntervalSeconds: 10,


### PR DESCRIPTION
## Summary

- When a source table has no primary key, the Kafka message key is empty/nil. Previously this caused `ParsePartitionKey` to return a `"key is nil"` error, which triggered `logger.Fatal` and crashed the consumer in a loop (1,395 occurrences in Sentry — TRANSFER-BA).
- When `PrimaryKeysOverride` or `IncludePrimaryKeys` is configured, the message key is not needed — primary key column names come from the config and values are already present in the event payload. This PR adds a `buildPKMap` helper on `TopicConfigFormatter` that skips key parsing in that case and returns an empty `pkMap`.
- `buildPrimaryKeys` is unchanged — it already correctly handles the `PrimaryKeysOverride` early-return path with an empty `pkMap`.

## Changes

- **`processes/consumer/configs.go`**: New `buildPKMap` method that returns an empty map when the key is nil and PK config exists, otherwise delegates to `GetPrimaryKey`.
- **`processes/consumer/process.go`**: Call `buildPKMap` instead of `GetPrimaryKey` directly.
- **`processes/consumer/process_test.go`**: `TestBuildPKMap` (unit tests for the helper) and `TestProcessMessageNilKeyWithPrimaryKeyOverride` (end-to-end test with nil key + override).


Fixes TRANSFER-BA
Supersedes #1735

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes primary-key extraction behavior in the consumer processing path; misclassification could lead to incorrect PK handling for some topics, though the change is narrowly scoped and covered by new tests.
> 
> **Overview**
> Prevents consumer failures when Kafka messages have an empty/nil key but primary keys are supplied via `PrimaryKeysOverride` or `IncludePrimaryKeys`.
> 
> Adds `TopicConfigFormatter.buildPKMap` to return an empty PK map in that configuration (skipping key parsing), updates `process()` to use it instead of calling `GetPrimaryKey` directly, and adds unit + end-to-end tests covering nil-key override/include and the fallback error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f88738f2f10eb188a055f1e8dc9c9190c8defa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->