### PR TITLE
[Redshift] Incremental Dedupe with NTILE

### DIFF
--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -116,7 +116,7 @@ func (rd RedshiftDialect) BuildDedupeQueries(tableID, stagingTableID sql.TableId
 	return parts
 }
 
-func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID sql.TableIdentifier, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, numChunks int) []string {
+func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, numChunks int) []string {
 	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
 
 	orderColsToIterate := primaryKeysEscaped

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -116,6 +116,44 @@ func (rd RedshiftDialect) BuildDedupeQueries(tableID, stagingTableID sql.TableId
 	return parts
 }
 
+func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID sql.TableIdentifier, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, numChunks int) []string {
+	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
+
+	orderColsToIterate := primaryKeysEscaped
+	if includeArtieUpdatedAt {
+		orderColsToIterate = append(orderColsToIterate, rd.QuoteIdentifier(constants.UpdateColumnMarker))
+	}
+
+	var orderByCols []string
+	for _, orderByCol := range orderColsToIterate {
+		orderByCols = append(orderByCols, fmt.Sprintf("%s ASC", orderByCol))
+	}
+
+	partitionBy := strings.Join(primaryKeysEscaped, ", ")
+	orderBy := strings.Join(orderByCols, ", ")
+
+	var parts []string
+	parts = append(parts, fmt.Sprintf("CREATE TABLE %s (LIKE %s)", newTableID.FullyQualifiedName(), tableID.FullyQualifiedName()))
+
+	for i := 1; i <= numChunks; i++ {
+		parts = append(parts, fmt.Sprintf(
+			"INSERT INTO %s SELECT * FROM %s WHERE true QUALIFY NTILE(%d) OVER (ORDER BY %s) = %d AND ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1",
+			newTableID.FullyQualifiedName(),
+			tableID.FullyQualifiedName(),
+			numChunks,
+			partitionBy,
+			i,
+			partitionBy,
+			orderBy,
+		))
+	}
+
+	parts = append(parts, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName()))
+	parts = append(parts, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTableID.FullyQualifiedName(), tableID.EscapedTable()))
+
+	return parts
+}
+
 func (rd RedshiftDialect) buildMergeInsertQuery(
 	tableID sql.TableIdentifier,
 	subQuery string,

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -149,9 +149,6 @@ func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID, newTableID sql.Tabl
 		))
 	}
 
-	parts = append(parts, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName()))
-	parts = append(parts, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTableID.FullyQualifiedName(), tableID.EscapedTable()))
-
 	return parts
 }
 

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -119,7 +119,8 @@ func (rd RedshiftDialect) BuildDedupeQueries(tableID, stagingTableID sql.TableId
 func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, numChunks int) []string {
 	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
 
-	orderColsToIterate := primaryKeysEscaped
+	orderColsToIterate := make([]string, len(primaryKeysEscaped))
+	copy(orderColsToIterate, primaryKeysEscaped)
 	if includeArtieUpdatedAt {
 		orderColsToIterate = append(orderColsToIterate, rd.QuoteIdentifier(constants.UpdateColumnMarker))
 	}

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -126,7 +126,7 @@ func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID, newTableID sql.Tabl
 
 	var orderByCols []string
 	for _, orderByCol := range orderColsToIterate {
-		orderByCols = append(orderByCols, fmt.Sprintf("%s ASC", orderByCol))
+		orderByCols = append(orderByCols, fmt.Sprintf("%s DESC", orderByCol))
 	}
 
 	partitionBy := strings.Join(primaryKeysEscaped, ", ")

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -133,6 +133,7 @@ func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID sql.TableIdentifier,
 	orderBy := strings.Join(orderByCols, ", ")
 
 	var parts []string
+	parts = append(parts, fmt.Sprintf("DROP TABLE IF EXISTS %s", newTableID.FullyQualifiedName()))
 	parts = append(parts, fmt.Sprintf("CREATE TABLE %s (LIKE %s)", newTableID.FullyQualifiedName(), tableID.FullyQualifiedName()))
 
 	for i := 1; i <= numChunks; i++ {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -2,7 +2,6 @@ package redshift
 
 import (
 	"context"
-	gosql "database/sql"
 	"fmt"
 	"log/slog"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/db"
+	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/environ"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -139,21 +139,9 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	}
 
 	// Swap the tables atomically so there's no window where the target table doesn't exist.
-	tx, err := s.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to start transaction for table swap: %w", err)
-	}
-
-	if err = db.CommitOrRollback(tx, func(tx *gosql.Tx) error {
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName())); err != nil {
-			return fmt.Errorf("failed to drop original table: %w", err)
-		}
-
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTableID.FullyQualifiedName(), tableID.EscapedTable())); err != nil {
-			return fmt.Errorf("failed to rename table: %w", err)
-		}
-
-		return nil
+	if _, err := destination.ExecContextStatements(ctx, s, []string{
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName()),
+		fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTableID.FullyQualifiedName(), tableID.EscapedTable()),
 	}); err != nil {
 		return fmt.Errorf("failed to swap tables: %w", err)
 	}

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 
@@ -21,7 +20,6 @@ import (
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/retry"
 	"github.com/artie-labs/transfer/lib/sql"
-	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/webhooks"
 )
 
@@ -129,7 +127,7 @@ func (s *Store) SweepTemporaryTables(ctx context.Context) error {
 }
 
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair kafkalib.DatabaseAndSchemaPair, primaryKeys []string, includeArtieUpdatedAt bool) error {
-	newTableID := dialect.NewTableIdentifier(tableID.Schema(), fmt.Sprintf("%s_%s_%s", tableID.Table(), constants.ArtiePrefix, strings.ToLower(stringutil.Random(5))))
+	newTableID := dialect.NewTableIdentifier(tableID.Schema(), fmt.Sprintf("%s_%s_dedupe", tableID.Table(), constants.ArtiePrefix))
 	dedupeQueries := s.dialect().BuildDedupeChunkedQueries(tableID, newTableID, primaryKeys, includeArtieUpdatedAt, 10)
 
 	for _, query := range dedupeQueries {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/retry"
 	"github.com/artie-labs/transfer/lib/sql"
+	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/webhooks"
 )
 
@@ -127,8 +129,8 @@ func (s *Store) SweepTemporaryTables(ctx context.Context) error {
 }
 
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair kafkalib.DatabaseAndSchemaPair, primaryKeys []string, includeArtieUpdatedAt bool) error {
-	stagingTableID := shared.BuildStagingTableID(s, pair, tableID)
-	dedupeQueries := s.Dialect().BuildDedupeQueries(tableID, stagingTableID, primaryKeys, includeArtieUpdatedAt)
+	newTableID := dialect.NewTableIdentifier(tableID.Schema(), fmt.Sprintf("%s_%s_%s", tableID.Table(), constants.ArtiePrefix, strings.ToLower(stringutil.Random(5))))
+	dedupeQueries := s.dialect().BuildDedupeChunkedQueries(tableID, newTableID, primaryKeys, includeArtieUpdatedAt, 10)
 
 	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
 		return fmt.Errorf("failed to dedupe: %w", err)

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -3,6 +3,7 @@ package redshift
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/db"
-	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/environ"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -132,8 +132,11 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	newTableID := dialect.NewTableIdentifier(tableID.Schema(), fmt.Sprintf("%s_%s_%s", tableID.Table(), constants.ArtiePrefix, strings.ToLower(stringutil.Random(5))))
 	dedupeQueries := s.dialect().BuildDedupeChunkedQueries(tableID, newTableID, primaryKeys, includeArtieUpdatedAt, 10)
 
-	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
-		return fmt.Errorf("failed to dedupe: %w", err)
+	for _, query := range dedupeQueries {
+		slog.Info("Executing dedupe step...", slog.String("query", query))
+		if _, err := s.ExecContext(ctx, query); err != nil {
+			return fmt.Errorf("failed to dedupe — query: %s, err: %w", query, err)
+		}
 	}
 
 	return nil

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -134,7 +134,7 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	for _, query := range dedupeQueries {
 		slog.Info("Executing dedupe step...", slog.String("query", query))
 		if _, err := s.ExecContext(ctx, query); err != nil {
-			return fmt.Errorf("failed to dedupe — query: %s, err: %w", query, err)
+			return fmt.Errorf("failed to dedupe, query: %s, err: %w", query, err)
 		}
 	}
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -2,6 +2,7 @@ package redshift
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"log/slog"
 	"os"
@@ -135,6 +136,26 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 		if _, err := s.ExecContext(ctx, query); err != nil {
 			return fmt.Errorf("failed to dedupe — query: %s, err: %w", query, err)
 		}
+	}
+
+	// Swap the tables atomically so there's no window where the target table doesn't exist.
+	tx, err := s.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start transaction for table swap: %w", err)
+	}
+
+	if err = db.CommitOrRollback(tx, func(tx *gosql.Tx) error {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName())); err != nil {
+			return fmt.Errorf("failed to drop original table: %w", err)
+		}
+
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTableID.FullyQualifiedName(), tableID.EscapedTable())); err != nil {
+			return fmt.Errorf("failed to rename table: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to swap tables: %w", err)
 	}
 
 	return nil

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -6,68 +6,103 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/clients/redshift/dialect"
-	"github.com/artie-labs/transfer/clients/shared"
 )
 
 func (r *RedshiftTestSuite) Test_GenerateDedupeQueries() {
 	{
 		// Dedupe with one primary key + no `__artie_updated_at` flag.
 		tableID := dialect.NewTableIdentifier("public", "customers")
-		stagingTableID := shared.TempTableID(r.store, tableID)
+		stagingTableID := dialect.NewTableIdentifier("public", "customers__artie_stg")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeQueries(tableID, stagingTableID, []string{"id"}, false)
 		assert.Len(r.T(), parts, 3)
 		assert.Equal(
 			r.T(),
-			fmt.Sprintf(`CREATE TEMPORARY TABLE "%s" AS (SELECT * FROM public."customers" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 2)`, stagingTableID.Table()),
+			`CREATE TEMPORARY TABLE "customers__artie_stg" AS (SELECT * FROM public."customers" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 2)`,
 			parts[0],
 		)
-		assert.Equal(r.T(), fmt.Sprintf(`DELETE FROM public."customers" USING "%s" t2 WHERE "customers"."id" = t2."id"`, stagingTableID.Table()), parts[1])
-		assert.Equal(r.T(), fmt.Sprintf(`INSERT INTO public."customers" SELECT * FROM "%s"`, stagingTableID.Table()), parts[2])
+		assert.Equal(r.T(), `DELETE FROM public."customers" USING "customers__artie_stg" t2 WHERE "customers"."id" = t2."id"`, parts[1])
+		assert.Equal(r.T(), `INSERT INTO public."customers" SELECT * FROM "customers__artie_stg"`, parts[2])
 	}
 	{
 		// Dedupe with one primary key + `__artie_updated_at` flag.
 		tableID := dialect.NewTableIdentifier("public", "customers")
-		stagingTableID := shared.TempTableID(r.store, tableID)
+		stagingTableID := dialect.NewTableIdentifier("public", "customers__artie_stg")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeQueries(tableID, stagingTableID, []string{"id"}, true)
 		assert.Len(r.T(), parts, 3)
 		assert.Equal(
 			r.T(),
-			fmt.Sprintf(`CREATE TEMPORARY TABLE "%s" AS (SELECT * FROM public."customers" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 2)`, stagingTableID.Table()),
+			`CREATE TEMPORARY TABLE "customers__artie_stg" AS (SELECT * FROM public."customers" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 2)`,
 			parts[0],
 		)
-		assert.Equal(r.T(), fmt.Sprintf(`DELETE FROM public."customers" USING "%s" t2 WHERE "customers"."id" = t2."id"`, stagingTableID.Table()), parts[1])
-		assert.Equal(r.T(), fmt.Sprintf(`INSERT INTO public."customers" SELECT * FROM "%s"`, stagingTableID.Table()), parts[2])
+		assert.Equal(r.T(), `DELETE FROM public."customers" USING "customers__artie_stg" t2 WHERE "customers"."id" = t2."id"`, parts[1])
+		assert.Equal(r.T(), `INSERT INTO public."customers" SELECT * FROM "customers__artie_stg"`, parts[2])
+	}
+}
+
+func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
+	{
+		// Chunked dedupe with one primary key + no `__artie_updated_at` flag.
+		tableID := dialect.NewTableIdentifier("public", "customers")
+		newTableID := dialect.NewTableIdentifier("public", "customers__artie_new")
+
+		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, false, 3)
+		assert.Len(r.T(), parts, 6) // 1 create + 3 inserts + 1 drop + 1 rename
+		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_new" (LIKE public."customers")`, parts[0])
+		for i := 1; i <= 3; i++ {
+			assert.Equal(
+				r.T(),
+				fmt.Sprintf(
+					`INSERT INTO public."customers__artie_new" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 1`,
+					i,
+				),
+				parts[i],
+			)
+		}
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[4])
+		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_new" RENAME TO "customers"`, parts[5])
 	}
 	{
-		// Dedupe with composite keys + no `__artie_updated_at` flag.
-		tableID := dialect.NewTableIdentifier("public", "user_settings")
-		stagingTableID := shared.TempTableID(r.store, tableID)
+		// Chunked dedupe with one primary key + `__artie_updated_at` flag.
+		tableID := dialect.NewTableIdentifier("public", "customers")
+		newTableID := dialect.NewTableIdentifier("public", "customers__artie_new")
 
-		parts := dialect.RedshiftDialect{}.BuildDedupeQueries(tableID, stagingTableID, []string{"user_id", "settings"}, false)
-		assert.Len(r.T(), parts, 3)
-		assert.Equal(
-			r.T(),
-			fmt.Sprintf(`CREATE TEMPORARY TABLE "%s" AS (SELECT * FROM public."user_settings" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 2)`, stagingTableID.Table()),
-			parts[0],
-		)
-		assert.Equal(r.T(), fmt.Sprintf(`DELETE FROM public."user_settings" USING "%s" t2 WHERE "user_settings"."user_id" = t2."user_id" AND "user_settings"."settings" = t2."settings"`, stagingTableID.Table()), parts[1])
-		assert.Equal(r.T(), fmt.Sprintf(`INSERT INTO public."user_settings" SELECT * FROM "%s"`, stagingTableID.Table()), parts[2])
+		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, true, 2)
+		assert.Len(r.T(), parts, 5) // 1 create + 2 inserts + 1 drop + 1 rename
+		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_new" (LIKE public."customers")`, parts[0])
+		for i := 1; i <= 2; i++ {
+			assert.Equal(
+				r.T(),
+				fmt.Sprintf(
+					`INSERT INTO public."customers__artie_new" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 1`,
+					i,
+				),
+				parts[i],
+			)
+		}
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[3])
+		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_new" RENAME TO "customers"`, parts[4])
 	}
 	{
-		// Dedupe with composite keys + `__artie_updated_at` flag.
+		// Chunked dedupe with composite keys.
 		tableID := dialect.NewTableIdentifier("public", "user_settings")
-		stagingTableID := shared.TempTableID(r.store, tableID)
+		newTableID := dialect.NewTableIdentifier("public", "user_settings__artie_new")
 
-		parts := dialect.RedshiftDialect{}.BuildDedupeQueries(tableID, stagingTableID, []string{"user_id", "settings"}, true)
-		assert.Len(r.T(), parts, 3)
-		assert.Equal(
-			r.T(),
-			fmt.Sprintf(`CREATE TEMPORARY TABLE "%s" AS (SELECT * FROM public."user_settings" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC, "__artie_updated_at" ASC) = 2)`, stagingTableID.Table()),
-			parts[0],
-		)
-		assert.Equal(r.T(), fmt.Sprintf(`DELETE FROM public."user_settings" USING "%s" t2 WHERE "user_settings"."user_id" = t2."user_id" AND "user_settings"."settings" = t2."settings"`, stagingTableID.Table()), parts[1])
-		assert.Equal(r.T(), fmt.Sprintf(`INSERT INTO public."user_settings" SELECT * FROM "%s"`, stagingTableID.Table()), parts[2])
+		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"user_id", "settings"}, false, 2)
+		assert.Len(r.T(), parts, 5)
+		assert.Equal(r.T(), `CREATE TABLE public."user_settings__artie_new" (LIKE public."user_settings")`, parts[0])
+		for i := 1; i <= 2; i++ {
+			assert.Equal(
+				r.T(),
+				fmt.Sprintf(
+					`INSERT INTO public."user_settings__artie_new" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 1`,
+					i,
+				),
+				parts[i],
+			)
+		}
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings"`, parts[3])
+		assert.Equal(r.T(), `ALTER TABLE public."user_settings__artie_new" RENAME TO "user_settings"`, parts[4])
 	}
 }

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -55,7 +55,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 1`,
+					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" DESC) = 1`,
 					i,
 				),
 				parts[i+1],
@@ -75,7 +75,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 1`,
+					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" DESC, "__artie_updated_at" DESC) = 1`,
 					i,
 				),
 				parts[i+1],
@@ -95,7 +95,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."user_settings__artie_dedupe" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 1`,
+					`INSERT INTO public."user_settings__artie_dedupe" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" DESC, "settings" DESC) = 1`,
 					i,
 				),
 				parts[i+1],

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -48,7 +48,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 		newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, false, 3)
-		assert.Len(r.T(), parts, 7) // 1 drop + 1 create + 3 inserts + 1 drop + 1 rename
+		assert.Len(r.T(), parts, 5) // 1 drop + 1 create + 3 inserts
 		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers__artie_dedupe"`, parts[0])
 		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_dedupe" (LIKE public."customers")`, parts[1])
 		for i := 1; i <= 3; i++ {
@@ -61,8 +61,6 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[5])
-		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_dedupe" RENAME TO "customers"`, parts[6])
 	}
 	{
 		// Chunked dedupe with one primary key + `__artie_updated_at` flag.
@@ -70,7 +68,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 		newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, true, 2)
-		assert.Len(r.T(), parts, 6) // 1 drop + 1 create + 2 inserts + 1 drop + 1 rename
+		assert.Len(r.T(), parts, 4) // 1 drop + 1 create + 2 inserts
 		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers__artie_dedupe"`, parts[0])
 		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_dedupe" (LIKE public."customers")`, parts[1])
 		for i := 1; i <= 2; i++ {
@@ -83,8 +81,6 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[4])
-		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_dedupe" RENAME TO "customers"`, parts[5])
 	}
 	{
 		// Chunked dedupe with composite keys.
@@ -92,7 +88,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 		newTableID := dialect.NewTableIdentifier("public", "user_settings__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"user_id", "settings"}, false, 2)
-		assert.Len(r.T(), parts, 6)
+		assert.Len(r.T(), parts, 4) // 1 drop + 1 create + 2 inserts
 		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings__artie_dedupe"`, parts[0])
 		assert.Equal(r.T(), `CREATE TABLE public."user_settings__artie_dedupe" (LIKE public."user_settings")`, parts[1])
 		for i := 1; i <= 2; i++ {
@@ -105,7 +101,5 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings"`, parts[4])
-		assert.Equal(r.T(), `ALTER TABLE public."user_settings__artie_dedupe" RENAME TO "user_settings"`, parts[5])
 	}
 }

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -45,64 +45,67 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 	{
 		// Chunked dedupe with one primary key + no `__artie_updated_at` flag.
 		tableID := dialect.NewTableIdentifier("public", "customers")
-		newTableID := dialect.NewTableIdentifier("public", "customers__artie_new")
+		newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, false, 3)
-		assert.Len(r.T(), parts, 6) // 1 create + 3 inserts + 1 drop + 1 rename
-		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_new" (LIKE public."customers")`, parts[0])
+		assert.Len(r.T(), parts, 7) // 1 drop + 1 create + 3 inserts + 1 drop + 1 rename
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers__artie_dedupe"`, parts[0])
+		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_dedupe" (LIKE public."customers")`, parts[1])
 		for i := 1; i <= 3; i++ {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."customers__artie_new" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 1`,
+					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 1`,
 					i,
 				),
-				parts[i],
+				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[4])
-		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_new" RENAME TO "customers"`, parts[5])
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[5])
+		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_dedupe" RENAME TO "customers"`, parts[6])
 	}
 	{
 		// Chunked dedupe with one primary key + `__artie_updated_at` flag.
 		tableID := dialect.NewTableIdentifier("public", "customers")
-		newTableID := dialect.NewTableIdentifier("public", "customers__artie_new")
+		newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, true, 2)
-		assert.Len(r.T(), parts, 5) // 1 create + 2 inserts + 1 drop + 1 rename
-		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_new" (LIKE public."customers")`, parts[0])
+		assert.Len(r.T(), parts, 6) // 1 drop + 1 create + 2 inserts + 1 drop + 1 rename
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers__artie_dedupe"`, parts[0])
+		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_dedupe" (LIKE public."customers")`, parts[1])
 		for i := 1; i <= 2; i++ {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."customers__artie_new" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 1`,
+					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 1`,
 					i,
 				),
-				parts[i],
+				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[3])
-		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_new" RENAME TO "customers"`, parts[4])
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[4])
+		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_dedupe" RENAME TO "customers"`, parts[5])
 	}
 	{
 		// Chunked dedupe with composite keys.
 		tableID := dialect.NewTableIdentifier("public", "user_settings")
-		newTableID := dialect.NewTableIdentifier("public", "user_settings__artie_new")
+		newTableID := dialect.NewTableIdentifier("public", "user_settings__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"user_id", "settings"}, false, 2)
-		assert.Len(r.T(), parts, 5)
-		assert.Equal(r.T(), `CREATE TABLE public."user_settings__artie_new" (LIKE public."user_settings")`, parts[0])
+		assert.Len(r.T(), parts, 6)
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings__artie_dedupe"`, parts[0])
+		assert.Equal(r.T(), `CREATE TABLE public."user_settings__artie_dedupe" (LIKE public."user_settings")`, parts[1])
 		for i := 1; i <= 2; i++ {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."user_settings__artie_new" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 1`,
+					`INSERT INTO public."user_settings__artie_dedupe" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 1`,
 					i,
 				),
-				parts[i],
+				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings"`, parts[3])
-		assert.Equal(r.T(), `ALTER TABLE public."user_settings__artie_new" RENAME TO "user_settings"`, parts[4])
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings"`, parts[4])
+		assert.Equal(r.T(), `ALTER TABLE public."user_settings__artie_dedupe" RENAME TO "user_settings"`, parts[5])
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Redshift data-maintenance logic by rebuilding and swapping tables; incorrect partition/order or swap behavior could cause data loss/incorrect dedupe results, though scope is limited to the dedupe path.
> 
> **Overview**
> Switches Redshift deduplication from a staging-table delete/reinsert to a *chunked rebuild* strategy: create a new `*_dedupe` table, populate it in `N` `INSERT ... QUALIFY` passes using `NTILE()` + `ROW_NUMBER()` to keep the latest row per primary key (optionally including `__artie_updated_at`), then atomically swap tables via drop+rename.
> 
> Adds per-step logging for dedupe execution and expands unit tests to cover the new chunked query generation (including composite keys) while updating existing tests to use explicit staging table identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a77b01a20204c248c3ed6f3b0242a80a839f5407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->