### PR TITLE
Adding Transfer shutdown

### DIFF
--- a/lib/system/shutdown.go
+++ b/lib/system/shutdown.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 )
 
-func ShutdownHook(logger *slog.Logger, cleanUpHandlers func(), cancel context.CancelFunc) {
+func ShutdownHook(cleanUpHandlers func(), cancel context.CancelFunc) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	go func() {

--- a/lib/system/shutdown.go
+++ b/lib/system/shutdown.go
@@ -14,6 +14,7 @@ func ShutdownHook(logger *slog.Logger, cleanUpHandlers func(), cancel context.Ca
 	go func() {
 		sig := <-sigCh
 		slog.Info("Received shutdown signal, initiating graceful shutdown...", slog.String("signal", sig.String()))
+
 		cleanUpHandlers()
 		cancel()
 	}()

--- a/lib/system/shutdown.go
+++ b/lib/system/shutdown.go
@@ -1,0 +1,20 @@
+package system
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func ShutdownHook(logger *slog.Logger, cleanUpHandlers func(), cancel context.CancelFunc) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		sig := <-sigCh
+		slog.Info("Received shutdown signal, initiating graceful shutdown...", slog.String("signal", sig.String()))
+		cleanUpHandlers()
+		cancel()
+	}()
+}

--- a/lib/system/shutdown.go
+++ b/lib/system/shutdown.go
@@ -13,6 +13,7 @@ func ShutdownHook(cleanUpHandlers func(), cancel context.CancelFunc) {
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		sig := <-sigCh
+		signal.Stop(sigCh) // allow a second signal to terminate if cleanup blocks
 		slog.Info("Received shutdown signal, initiating graceful shutdown...", slog.String("signal", sig.String()))
 
 		cleanUpHandlers()

--- a/lib/system/shutdown_test.go
+++ b/lib/system/shutdown_test.go
@@ -1,0 +1,1 @@
+package system

--- a/lib/system/shutdown_test.go
+++ b/lib/system/shutdown_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package system
 
 import (
@@ -10,21 +12,23 @@ import (
 	"time"
 )
 
-func TestShutdownOnSignal_runsCleanupAndCancelsContext(t *testing.T) {
-	t.Parallel()
-
+func TestShutdownHook_runsCleanupAndCancelsContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	var cleaned atomic.Bool
 	cleanup := func() { cleaned.Store(true) }
 
-	sigCh := make(chan os.Signal, 1)
 	logger := slog.New(slog.DiscardHandler)
 
-	shutdownOnSignal(sigCh, logger, cleanup, cancel)
+	ShutdownHook(logger, cleanup, cancel)
 
-	sigCh <- syscall.SIGINT
+	// Let the goroutine register with signal.Notify before we signal.
+	time.Sleep(50 * time.Millisecond)
+
+	if err := syscall.Kill(os.Getpid(), syscall.SIGINT); err != nil {
+		t.Fatalf("send SIGINT: %v", err)
+	}
 
 	select {
 	case <-ctx.Done():

--- a/lib/system/shutdown_test.go
+++ b/lib/system/shutdown_test.go
@@ -1,1 +1,38 @@
 package system
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestShutdownOnSignal_runsCleanupAndCancelsContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var cleaned atomic.Bool
+	cleanup := func() { cleaned.Store(true) }
+
+	sigCh := make(chan os.Signal, 1)
+	logger := slog.New(slog.DiscardHandler)
+
+	shutdownOnSignal(sigCh, logger, cleanup, cancel)
+
+	sigCh <- syscall.SIGINT
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected context cancelled after signal")
+	}
+
+	if !cleaned.Load() {
+		t.Fatal("expected cleanup to run")
+	}
+}

--- a/lib/system/shutdown_test.go
+++ b/lib/system/shutdown_test.go
@@ -4,7 +4,6 @@ package system
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"sync/atomic"
 	"syscall"
@@ -19,9 +18,7 @@ func TestShutdownHook_runsCleanupAndCancelsContext(t *testing.T) {
 	var cleaned atomic.Bool
 	cleanup := func() { cleaned.Store(true) }
 
-	logger := slog.New(slog.DiscardHandler)
-
-	ShutdownHook(logger, cleanup, cancel)
+	ShutdownHook(cleanup, cancel)
 
 	// Let the goroutine register with signal.Notify before we signal.
 	time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, additive signal-handling utility plus test; main risk is only around correctness of shutdown sequencing on Unix platforms.
> 
> **Overview**
> Adds `system.ShutdownHook` to listen for `SIGINT`/`SIGTERM` and asynchronously trigger **graceful shutdown** by logging the signal, running provided cleanup handlers, and cancelling a supplied context.
> 
> Adds a unix-only test that sends `SIGINT` to the current process and asserts cleanup execution and context cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb458df458edd3fdd05b7325319db947693729f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->