### PR TITLE
Add topic referenceID and uniqueness validation

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -300,6 +300,10 @@ func (c Config) Validate() error {
 		return fmt.Errorf("no topic configs found")
 	}
 
+	if err := kafkalib.ValidateReferenceIDs(tcs); err != nil {
+		return err
+	}
+
 	var hasColumnsToEncrypt bool
 	for _, topicConfig := range tcs {
 		if err := topicConfig.Validate(); err != nil {

--- a/lib/kafkalib/topic.go
+++ b/lib/kafkalib/topic.go
@@ -51,6 +51,25 @@ func GetAllUniqueSchemas(tcs []*TopicConfig) []string {
 	return slices.Collect(maps.Keys(seenMap))
 }
 
+// ValidateReferenceIDs returns an error if any non-empty referenceID appears more than once across topic configs.
+func ValidateReferenceIDs(tcs []*TopicConfig) error {
+	firstTopicByRef := make(map[string]string)
+	for _, tc := range tcs {
+		if tc == nil {
+			continue
+		}
+		ref := tc.ReferenceID
+		if ref == "" {
+			continue
+		}
+		if firstTopic, dup := firstTopicByRef[ref]; dup {
+			return fmt.Errorf("duplicate referenceID %q (topics %q and %q)", ref, firstTopic, tc.Topic)
+		}
+		firstTopicByRef[ref] = tc.Topic
+	}
+	return nil
+}
+
 type MultiStepMergeSettings struct {
 	Enabled bool `yaml:"enabled"`
 	// FlushCount is the number of times we will flush to the multi-step merge table before merging into the destination table.
@@ -149,8 +168,10 @@ func (sp SoftPartitioning) Validate() error {
 }
 
 type TopicConfig struct {
-	Database string `yaml:"db"`
-	Schema   string `yaml:"schema"`
+	// [ReferenceID] - This is a unique identifier for the topic config. This is used for services that are built on top of Transfer to reference this specific topic config.
+	ReferenceID string `yaml:"referenceID,omitempty"`
+	Database    string `yaml:"db"`
+	Schema      string `yaml:"schema"`
 	// [StagingSchema] - Optional schema to use for staging tables. If not specified, Schema will be used.
 	StagingSchema string `yaml:"stagingSchema,omitempty"`
 	// [TableName] - if left empty, the table name will be deduced from each event.

--- a/lib/kafkalib/topic_test.go
+++ b/lib/kafkalib/topic_test.go
@@ -8,6 +8,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidateReferenceIDs(t *testing.T) {
+	{
+		assert.NoError(t, ValidateReferenceIDs(nil))
+	}
+	{
+		assert.NoError(t, ValidateReferenceIDs([]*TopicConfig{}))
+	}
+	{
+		tcs := []*TopicConfig{
+			{ReferenceID: "a", Topic: "t1", Schema: "s", CDCFormat: "f", CDCKeyFormat: JSONKeyFmt},
+			{ReferenceID: "b", Topic: "t2", Schema: "s", CDCFormat: "f", CDCKeyFormat: JSONKeyFmt},
+		}
+		assert.NoError(t, ValidateReferenceIDs(tcs))
+	}
+	{
+		// Empty referenceID is ignored for uniqueness
+		tcs := []*TopicConfig{
+			{Topic: "t1", Schema: "s", CDCFormat: "f", CDCKeyFormat: JSONKeyFmt},
+			{Topic: "t2", Schema: "s", CDCFormat: "f", CDCKeyFormat: JSONKeyFmt},
+		}
+		assert.NoError(t, ValidateReferenceIDs(tcs))
+	}
+	{
+		tcs := []*TopicConfig{
+			{ReferenceID: "dup", Topic: "first", Schema: "s", CDCFormat: "f", CDCKeyFormat: JSONKeyFmt},
+			{ReferenceID: "dup", Topic: "second", Schema: "s", CDCFormat: "f", CDCKeyFormat: JSONKeyFmt},
+		}
+		err := ValidateReferenceIDs(tcs)
+		assert.ErrorContains(t, err, `duplicate referenceID "dup"`)
+		assert.ErrorContains(t, err, "first")
+		assert.ErrorContains(t, err, "second")
+	}
+}
+
 func TestGetUniqueStagingDatabaseAndSchemaPairs(t *testing.T) {
 	{
 		// No topic configs


### PR DESCRIPTION
## Summary

Adds an optional `referenceID` field on `TopicConfig` for services built on top of Transfer to identify a specific topic configuration.

When `referenceID` is set, it must be unique across all topic configs. Validation runs in `Config.Validate` via `kafkalib.ValidateReferenceIDs`.

## Testing

- `go test ./lib/kafkalib/... ./lib/config/...`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `referenceID` field and a new config validation that only fails when duplicate non-empty IDs are provided.
> 
> **Overview**
> Adds an optional `referenceID` to `kafkalib.TopicConfig` so external services can refer to a specific topic configuration.
> 
> Updates `Config.Validate` to reject configs where the same non-empty `referenceID` appears in multiple topic configs, implemented via new `kafkalib.ValidateReferenceIDs` and covered by unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a76cc1e283372bd67fb897bcf72c5cad4caeaf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->