### PR TITLE
[Redshift] Incremental Dedupe with APPROXIMATE PERCENTILE_DISC

### DIFF
--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -116,7 +116,7 @@ func (rd RedshiftDialect) BuildDedupeQueries(tableID, stagingTableID sql.TableId
 	return parts
 }
 
-func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID sql.TableIdentifier, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, numChunks int) []string {
+func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, numChunks int) []string {
 	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
 
 	orderColsToIterate := primaryKeysEscaped

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -186,8 +186,6 @@ func (rd RedshiftDialect) BuildDedupeChunkInsertQuery(tableID, newTableID sql.Ta
 // BuildDedupeNullChunkInsertQuery returns an INSERT ... SELECT that copies rows
 // where the boundary key is NULL. MIN/MAX/percentile boundaries only cover
 // non-NULL values, so these rows would otherwise be silently dropped on swap.
-// Redshift does not enforce PK NOT NULL, so this needs to run whenever the
-// boundary column is nullable.
 func (rd RedshiftDialect) BuildDedupeNullChunkInsertQuery(tableID, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, boundaryKey string) string {
 	partitionBy, orderBy := rd.dedupeWindow(primaryKeys, includeArtieUpdatedAt)
 

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -116,6 +116,44 @@ func (rd RedshiftDialect) BuildDedupeQueries(tableID, stagingTableID sql.TableId
 	return parts
 }
 
+func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID sql.TableIdentifier, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, numChunks int) []string {
+	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
+
+	orderColsToIterate := primaryKeysEscaped
+	if includeArtieUpdatedAt {
+		orderColsToIterate = append(orderColsToIterate, rd.QuoteIdentifier(constants.UpdateColumnMarker))
+	}
+
+	var orderByCols []string
+	for _, orderByCol := range orderColsToIterate {
+		orderByCols = append(orderByCols, fmt.Sprintf("%s ASC", orderByCol))
+	}
+
+	partitionBy := strings.Join(primaryKeysEscaped, ", ")
+	orderBy := strings.Join(orderByCols, ", ")
+
+	var parts []string
+	parts = append(parts, fmt.Sprintf("CREATE TABLE %s (LIKE %s)", newTableID.FullyQualifiedName(), tableID.FullyQualifiedName()))
+
+	for i := 1; i <= numChunks; i++ {
+		parts = append(parts, fmt.Sprintf(
+			"INSERT INTO %s SELECT * FROM %s WHERE true QUALIFY NTILE(%d) OVER (ORDER BY %s) = %d AND ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1",
+			newTableID.FullyQualifiedName(),
+			tableID.FullyQualifiedName(),
+			numChunks,
+			partitionBy,
+			i,
+			partitionBy,
+			orderBy,
+		))
+	}
+
+	parts = append(parts, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName()))
+	parts = append(parts, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTableID.FullyQualifiedName(), tableID.EscapedTable()))
+
+	return parts
+}
+
 func (rd RedshiftDialect) buildMergeInsertQuery(
 	tableID sql.TableIdentifier,
 	subQuery string,

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -149,9 +149,6 @@ func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID, newTableID sql.Tabl
 		))
 	}
 
-	parts = append(parts, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName()))
-	parts = append(parts, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTableID.FullyQualifiedName(), tableID.EscapedTable()))
-
 	return parts
 }
 

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -119,7 +119,8 @@ func (rd RedshiftDialect) BuildDedupeQueries(tableID, stagingTableID sql.TableId
 func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, numChunks int) []string {
 	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
 
-	orderColsToIterate := primaryKeysEscaped
+	orderColsToIterate := make([]string, len(primaryKeysEscaped))
+	copy(orderColsToIterate, primaryKeysEscaped)
 	if includeArtieUpdatedAt {
 		orderColsToIterate = append(orderColsToIterate, rd.QuoteIdentifier(constants.UpdateColumnMarker))
 	}

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -137,6 +137,25 @@ func (rd RedshiftDialect) BuildDedupeBoundaryQuery(tableID sql.TableIdentifier, 
 	return fmt.Sprintf("SELECT %s FROM %s", strings.Join(selectParts, ", "), tableID.FullyQualifiedName())
 }
 
+// dedupeWindow returns the PARTITION BY and ORDER BY clause fragments shared
+// by the chunk insert queries.
+func (rd RedshiftDialect) dedupeWindow(primaryKeys []string, includeArtieUpdatedAt bool) (partitionBy, orderBy string) {
+	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
+
+	orderCols := make([]string, len(primaryKeysEscaped))
+	copy(orderCols, primaryKeysEscaped)
+	if includeArtieUpdatedAt {
+		orderCols = append(orderCols, rd.QuoteIdentifier(constants.UpdateColumnMarker))
+	}
+
+	orderByCols := make([]string, len(orderCols))
+	for i, col := range orderCols {
+		orderByCols[i] = fmt.Sprintf("%s DESC", col)
+	}
+
+	return strings.Join(primaryKeysEscaped, ", "), strings.Join(orderByCols, ", ")
+}
+
 // BuildDedupeChunkInsertQuery returns an INSERT ... SELECT that copies a range
 // of rows (bounded by placeholders $1 and $2 on boundaryKey) from the source
 // table into the dedupe table, collapsing duplicates with ROW_NUMBER. The upper
@@ -147,21 +166,7 @@ func (rd RedshiftDialect) BuildDedupeBoundaryQuery(tableID sql.TableIdentifier, 
 // boundaryKey is (or correlates with) the sort key, so each chunk only reads a
 // fraction of the underlying data instead of rescanning the whole table.
 func (rd RedshiftDialect) BuildDedupeChunkInsertQuery(tableID, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, boundaryKey string, inclusiveUpper bool) string {
-	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
-
-	orderColsToIterate := make([]string, len(primaryKeysEscaped))
-	copy(orderColsToIterate, primaryKeysEscaped)
-	if includeArtieUpdatedAt {
-		orderColsToIterate = append(orderColsToIterate, rd.QuoteIdentifier(constants.UpdateColumnMarker))
-	}
-
-	orderByCols := make([]string, 0, len(orderColsToIterate))
-	for _, col := range orderColsToIterate {
-		orderByCols = append(orderByCols, fmt.Sprintf("%s DESC", col))
-	}
-
-	partitionBy := strings.Join(primaryKeysEscaped, ", ")
-	orderBy := strings.Join(orderByCols, ", ")
+	partitionBy, orderBy := rd.dedupeWindow(primaryKeys, includeArtieUpdatedAt)
 
 	boundaryCol := rd.QuoteIdentifier(boundaryKey)
 	upperOp := "<"
@@ -174,6 +179,23 @@ func (rd RedshiftDialect) BuildDedupeChunkInsertQuery(tableID, newTableID sql.Ta
 		newTableID.FullyQualifiedName(),
 		tableID.FullyQualifiedName(),
 		boundaryCol, boundaryCol, upperOp,
+		partitionBy, orderBy,
+	)
+}
+
+// BuildDedupeNullChunkInsertQuery returns an INSERT ... SELECT that copies rows
+// where the boundary key is NULL. MIN/MAX/percentile boundaries only cover
+// non-NULL values, so these rows would otherwise be silently dropped on swap.
+// Redshift does not enforce PK NOT NULL, so this needs to run whenever the
+// boundary column is nullable.
+func (rd RedshiftDialect) BuildDedupeNullChunkInsertQuery(tableID, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, boundaryKey string) string {
+	partitionBy, orderBy := rd.dedupeWindow(primaryKeys, includeArtieUpdatedAt)
+
+	return fmt.Sprintf(
+		"INSERT INTO %s SELECT * FROM %s WHERE %s IS NULL QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1",
+		newTableID.FullyQualifiedName(),
+		tableID.FullyQualifiedName(),
+		rd.QuoteIdentifier(boundaryKey),
 		partitionBy, orderBy,
 	)
 }

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -126,7 +126,7 @@ func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID, newTableID sql.Tabl
 
 	var orderByCols []string
 	for _, orderByCol := range orderColsToIterate {
-		orderByCols = append(orderByCols, fmt.Sprintf("%s ASC", orderByCol))
+		orderByCols = append(orderByCols, fmt.Sprintf("%s DESC", orderByCol))
 	}
 
 	partitionBy := strings.Join(primaryKeysEscaped, ", ")

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -116,7 +116,37 @@ func (rd RedshiftDialect) BuildDedupeQueries(tableID, stagingTableID sql.TableId
 	return parts
 }
 
-func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, numChunks int) []string {
+// BuildDedupeBoundaryQuery returns a single-row query whose columns are the
+// chunk boundaries for the leading primary key: MIN, approximate percentiles at
+// 1/numChunks, 2/numChunks, ..., (numChunks-1)/numChunks, and MAX. The resulting
+// numChunks+1 values define numChunks half-open ranges (the last range is
+// inclusive on the upper bound) used by BuildDedupeChunkInsertQuery.
+//
+// APPROXIMATE PERCENTILE_DISC uses sketches, so this runs in a single pass over
+// the table without a global sort.
+func (rd RedshiftDialect) BuildDedupeBoundaryQuery(tableID sql.TableIdentifier, boundaryKey string, numChunks int) string {
+	pk := rd.QuoteIdentifier(boundaryKey)
+
+	selectParts := []string{fmt.Sprintf("MIN(%s)", pk)}
+	for i := 1; i < numChunks; i++ {
+		pct := float64(i) / float64(numChunks)
+		selectParts = append(selectParts, fmt.Sprintf("APPROXIMATE PERCENTILE_DISC(%g) WITHIN GROUP (ORDER BY %s)", pct, pk))
+	}
+	selectParts = append(selectParts, fmt.Sprintf("MAX(%s)", pk))
+
+	return fmt.Sprintf("SELECT %s FROM %s", strings.Join(selectParts, ", "), tableID.FullyQualifiedName())
+}
+
+// BuildDedupeChunkInsertQuery returns an INSERT ... SELECT that copies a range
+// of rows (bounded by placeholders $1 and $2 on boundaryKey) from the source
+// table into the dedupe table, collapsing duplicates with ROW_NUMBER. The upper
+// bound is exclusive unless inclusiveUpper is true (used for the final chunk so
+// the maximum value is included).
+//
+// Bounding on boundaryKey lets Redshift skip blocks via zone maps when
+// boundaryKey is (or correlates with) the sort key, so each chunk only reads a
+// fraction of the underlying data instead of rescanning the whole table.
+func (rd RedshiftDialect) BuildDedupeChunkInsertQuery(tableID, newTableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, boundaryKey string, inclusiveUpper bool) string {
 	primaryKeysEscaped := sql.QuoteIdentifiers(primaryKeys, rd)
 
 	orderColsToIterate := make([]string, len(primaryKeysEscaped))
@@ -125,32 +155,27 @@ func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID, newTableID sql.Tabl
 		orderColsToIterate = append(orderColsToIterate, rd.QuoteIdentifier(constants.UpdateColumnMarker))
 	}
 
-	var orderByCols []string
-	for _, orderByCol := range orderColsToIterate {
-		orderByCols = append(orderByCols, fmt.Sprintf("%s DESC", orderByCol))
+	orderByCols := make([]string, 0, len(orderColsToIterate))
+	for _, col := range orderColsToIterate {
+		orderByCols = append(orderByCols, fmt.Sprintf("%s DESC", col))
 	}
 
 	partitionBy := strings.Join(primaryKeysEscaped, ", ")
 	orderBy := strings.Join(orderByCols, ", ")
 
-	var parts []string
-	parts = append(parts, fmt.Sprintf("DROP TABLE IF EXISTS %s", newTableID.FullyQualifiedName()))
-	parts = append(parts, fmt.Sprintf("CREATE TABLE %s (LIKE %s)", newTableID.FullyQualifiedName(), tableID.FullyQualifiedName()))
-
-	for i := 1; i <= numChunks; i++ {
-		parts = append(parts, fmt.Sprintf(
-			"INSERT INTO %s SELECT * FROM %s WHERE true QUALIFY NTILE(%d) OVER (ORDER BY %s) = %d AND ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1",
-			newTableID.FullyQualifiedName(),
-			tableID.FullyQualifiedName(),
-			numChunks,
-			partitionBy,
-			i,
-			partitionBy,
-			orderBy,
-		))
+	boundaryCol := rd.QuoteIdentifier(boundaryKey)
+	upperOp := "<"
+	if inclusiveUpper {
+		upperOp = "<="
 	}
 
-	return parts
+	return fmt.Sprintf(
+		"INSERT INTO %s SELECT * FROM %s WHERE %s >= $1 AND %s %s $2 QUALIFY ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) = 1",
+		newTableID.FullyQualifiedName(),
+		tableID.FullyQualifiedName(),
+		boundaryCol, boundaryCol, upperOp,
+		partitionBy, orderBy,
+	)
 }
 
 func (rd RedshiftDialect) buildMergeInsertQuery(

--- a/clients/redshift/dialect/dialect.go
+++ b/clients/redshift/dialect/dialect.go
@@ -133,6 +133,7 @@ func (rd RedshiftDialect) BuildDedupeChunkedQueries(tableID sql.TableIdentifier,
 	orderBy := strings.Join(orderByCols, ", ")
 
 	var parts []string
+	parts = append(parts, fmt.Sprintf("DROP TABLE IF EXISTS %s", newTableID.FullyQualifiedName()))
 	parts = append(parts, fmt.Sprintf("CREATE TABLE %s (LIKE %s)", newTableID.FullyQualifiedName(), tableID.FullyQualifiedName()))
 
 	for i := 1; i <= numChunks; i++ {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -179,7 +179,8 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 var numericDataTypes = []string{"smallint", "integer", "bigint", "numeric", "decimal", "real", "double precision"}
 
 func (s *Store) isBoundaryKeyNumeric(ctx context.Context, tableID sql.TableIdentifier, boundaryKey string) (bool, error) {
-	const query = `SELECT data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = $3`
+	// LOWER() to stay consistent with the BuildDescribeTableQuery query.
+	const query = `SELECT data_type FROM information_schema.columns WHERE LOWER(table_schema) = LOWER($1) AND LOWER(table_name) = LOWER($2) AND LOWER(column_name) = LOWER($3)`
 
 	var dataType string
 	if err := s.QueryRowContext(ctx, query, tableID.Schema(), tableID.Table(), boundaryKey).Scan(&dataType); err != nil {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -200,7 +200,7 @@ func (s *Store) dedupeRangeChunked(ctx context.Context, tableID sql.TableIdentif
 	}
 
 	if boundaries == nil {
-		slog.Info("Source table is empty, skipping dedupe chunk inserts",
+		slog.Info("No non-NULL boundary key values, skipping range chunks",
 			slog.String("table", tableID.FullyQualifiedName()))
 	} else {
 		for i := 0; i < numChunks; i++ {
@@ -216,6 +216,15 @@ func (s *Store) dedupeRangeChunked(ctx context.Context, tableID sql.TableIdentif
 				return fmt.Errorf("failed to dedupe chunk %d [%s, %s], err: %w", i, boundaries[i], boundaries[i+1], err)
 			}
 		}
+	}
+
+	// Range chunks only cover non-NULL boundary key values, so run a separate
+	// pass for NULL-keyed rows to avoid silently dropping them on swap. This is
+	// a no-op when the column is NOT NULL.
+	nullQuery := s.dialect().BuildDedupeNullChunkInsertQuery(tableID, newTableID, primaryKeys, includeArtieUpdatedAt, boundaryKey)
+	slog.Info("Executing NULL-key dedupe chunk...", slog.String("query", nullQuery))
+	if _, err := s.ExecContext(ctx, nullQuery); err != nil {
+		return fmt.Errorf("failed to dedupe NULL-key chunk: %w", err)
 	}
 
 	// Swap the tables atomically so there's no window where the target table doesn't exist.

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -2,7 +2,6 @@ package redshift
 
 import (
 	"context"
-	gosql "database/sql"
 	"fmt"
 	"log/slog"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/db"
+	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/environ"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -139,21 +139,9 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	}
 
 	// Swap the tables atomically so there's no window where the target table doesn't exist.
-	tx, err := s.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to start transaction for table swap: %w", err)
-	}
-
-	if err = db.CommitOrRollback(tx, func(tx *gosql.Tx) error {
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName())); err != nil {
-			return fmt.Errorf("failed to drop original table: %w", err)
-		}
-
-		if _, err := tx.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTableID.FullyQualifiedName(), tableID.EscapedTable())); err != nil {
-			return fmt.Errorf("failed to rename table: %w", err)
-		}
-
-		return nil
+	if _, err := destination.ExecContextStatements(ctx, s, []string{
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName()),
+		fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTableID.FullyQualifiedName(), tableID.EscapedTable()),
 	}); err != nil {
 		return fmt.Errorf("failed to swap tables: %w", err)
 	}

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -130,6 +130,16 @@ func (s *Store) SweepTemporaryTables(ctx context.Context) error {
 	return shared.Sweep(ctx, s, s.config.TopicConfigs(), s.dialect().BuildSweepQuery)
 }
 
+// Dedupe rewrites tableID in-place with duplicates on primaryKeys collapsed.
+//
+// The numeric-PK fast path is NOT snapshot-isolated: it captures MIN/MAX and
+// approximate percentiles of the first PK, copies each range into a sibling
+// table in separate statements, then atomically swaps the tables. Rows written
+// to tableID after boundary capture but before the swap can be silently lost
+// (new PK > observed MAX, new PK < observed MIN, or new PK inside the observed
+// range but past the chunk that covered it). Callers must ensure no concurrent
+// writers to tableID between invocation and return - today this is only called
+// during snapshot/backfill, where CDC is not running yet.
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair kafkalib.DatabaseAndSchemaPair, primaryKeys []string, includeArtieUpdatedAt bool) error {
 	if len(primaryKeys) == 0 {
 		return fmt.Errorf("cannot dedupe %s without primary keys", tableID.FullyQualifiedName())
@@ -265,11 +275,9 @@ func (s *Store) computeDedupeBoundaries(ctx context.Context, tableID sql.TableId
 	for i := range scanned {
 		scanArgs[i] = &scanned[i]
 	}
-	if err := rows.Scan(scanArgs...); err != nil {
-		return nil, fmt.Errorf("failed to scan boundary row: %w", err)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, fmt.Errorf("failed to close boundary rows: %w", err)
+
+	if err := s.QueryRowContext(ctx, query).Scan(scanArgs...); err != nil {
+		return nil, fmt.Errorf("boundary query failed: %w", err)
 	}
 
 	// If MIN is NULL the table is empty (percentiles and MAX will be NULL too).

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strings"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 
@@ -21,7 +20,6 @@ import (
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/retry"
 	"github.com/artie-labs/transfer/lib/sql"
-	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/webhooks"
 )
 
@@ -129,7 +127,7 @@ func (s *Store) SweepTemporaryTables(ctx context.Context) error {
 }
 
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair kafkalib.DatabaseAndSchemaPair, primaryKeys []string, includeArtieUpdatedAt bool) error {
-	newTableID := dialect.NewTableIdentifier(tableID.Schema(), fmt.Sprintf("%s_%s_%s", tableID.Table(), constants.ArtiePrefix, strings.ToLower(stringutil.Random(5))))
+	newTableID := dialect.NewTableIdentifier(tableID.Schema(), fmt.Sprintf("%s_%s_dedupe", tableID.Table(), constants.ArtiePrefix))
 	dedupeQueries := s.dialect().BuildDedupeChunkedQueries(tableID, newTableID, primaryKeys, includeArtieUpdatedAt, 10)
 
 	for _, query := range dedupeQueries {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/retry"
 	"github.com/artie-labs/transfer/lib/sql"
+	"github.com/artie-labs/transfer/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/webhooks"
 )
 
@@ -127,8 +129,8 @@ func (s *Store) SweepTemporaryTables(ctx context.Context) error {
 }
 
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair kafkalib.DatabaseAndSchemaPair, primaryKeys []string, includeArtieUpdatedAt bool) error {
-	stagingTableID := shared.BuildStagingTableID(s, pair, tableID)
-	dedupeQueries := s.Dialect().BuildDedupeQueries(tableID, stagingTableID, primaryKeys, includeArtieUpdatedAt)
+	newTableID := dialect.NewTableIdentifier(tableID.Schema(), fmt.Sprintf("%s_%s_%s", tableID.Table(), constants.ArtiePrefix, strings.ToLower(stringutil.Random(5))))
+	dedupeQueries := s.dialect().BuildDedupeChunkedQueries(tableID, newTableID, primaryKeys, includeArtieUpdatedAt, 10)
 
 	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
 		return fmt.Errorf("failed to dedupe: %w", err)

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -3,6 +3,7 @@ package redshift
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/artie-labs/transfer/lib/config"
 	"github.com/artie-labs/transfer/lib/config/constants"
 	"github.com/artie-labs/transfer/lib/db"
-	"github.com/artie-labs/transfer/lib/destination"
 	"github.com/artie-labs/transfer/lib/destination/types"
 	"github.com/artie-labs/transfer/lib/environ"
 	"github.com/artie-labs/transfer/lib/kafkalib"
@@ -132,8 +132,11 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	newTableID := dialect.NewTableIdentifier(tableID.Schema(), fmt.Sprintf("%s_%s_%s", tableID.Table(), constants.ArtiePrefix, strings.ToLower(stringutil.Random(5))))
 	dedupeQueries := s.dialect().BuildDedupeChunkedQueries(tableID, newTableID, primaryKeys, includeArtieUpdatedAt, 10)
 
-	if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
-		return fmt.Errorf("failed to dedupe: %w", err)
+	for _, query := range dedupeQueries {
+		slog.Info("Executing dedupe step...", slog.String("query", query))
+		if _, err := s.ExecContext(ctx, query); err != nil {
+			return fmt.Errorf("failed to dedupe — query: %s, err: %w", query, err)
+		}
 	}
 
 	return nil

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -134,7 +134,7 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	for _, query := range dedupeQueries {
 		slog.Info("Executing dedupe step...", slog.String("query", query))
 		if _, err := s.ExecContext(ctx, query); err != nil {
-			return fmt.Errorf("failed to dedupe — query: %s, err: %w", query, err)
+			return fmt.Errorf("failed to dedupe, query: %s, err: %w", query, err)
 		}
 	}
 

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -258,19 +258,6 @@ func (s *Store) computeDedupeBoundaries(ctx context.Context, tableID sql.TableId
 	query := s.dialect().BuildDedupeBoundaryQuery(tableID, boundaryKey, numChunks)
 	slog.Info("Computing dedupe chunk boundaries...", slog.String("query", query))
 
-	rows, err := s.QueryContext(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("boundary query failed: %w", err)
-	}
-	defer rows.Close()
-
-	if !rows.Next() {
-		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("boundary query iteration failed: %w", err)
-		}
-		return nil, fmt.Errorf("boundary query returned no rows")
-	}
-
 	scanned := make([]gosql.NullString, numChunks+1)
 	scanArgs := make([]any, numChunks+1)
 	for i := range scanned {

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -2,6 +2,7 @@ package redshift
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"log/slog"
 	"os"
@@ -135,6 +136,26 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 		if _, err := s.ExecContext(ctx, query); err != nil {
 			return fmt.Errorf("failed to dedupe — query: %s, err: %w", query, err)
 		}
+	}
+
+	// Swap the tables atomically so there's no window where the target table doesn't exist.
+	tx, err := s.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start transaction for table swap: %w", err)
+	}
+
+	if err = db.CommitOrRollback(tx, func(tx *gosql.Tx) error {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableID.FullyQualifiedName())); err != nil {
+			return fmt.Errorf("failed to drop original table: %w", err)
+		}
+
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", newTableID.FullyQualifiedName(), tableID.EscapedTable())); err != nil {
+			return fmt.Errorf("failed to rename table: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to swap tables: %w", err)
 	}
 
 	return nil

--- a/clients/redshift/redshift.go
+++ b/clients/redshift/redshift.go
@@ -2,9 +2,12 @@ package redshift
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
+	"strings"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 
@@ -128,13 +131,90 @@ func (s *Store) SweepTemporaryTables(ctx context.Context) error {
 }
 
 func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair kafkalib.DatabaseAndSchemaPair, primaryKeys []string, includeArtieUpdatedAt bool) error {
-	newTableID := dialect.NewTableIdentifier(tableID.Schema(), fmt.Sprintf("%s_%s_dedupe", tableID.Table(), constants.ArtiePrefix))
-	dedupeQueries := s.dialect().BuildDedupeChunkedQueries(tableID, newTableID, primaryKeys, includeArtieUpdatedAt, 10)
+	if len(primaryKeys) == 0 {
+		return fmt.Errorf("cannot dedupe %s without primary keys", tableID.FullyQualifiedName())
+	}
 
-	for _, query := range dedupeQueries {
-		slog.Info("Executing dedupe step...", slog.String("query", query))
-		if _, err := s.ExecContext(ctx, query); err != nil {
-			return fmt.Errorf("failed to dedupe, query: %s, err: %w", query, err)
+	// Boundary key is the first primary key; chunks are defined as ranges on it.
+	// The ROW_NUMBER() inside each chunk still partitions by the full PK, so
+	// composite PKs are deduped correctly.
+	boundaryKey := primaryKeys[0]
+
+	// Range chunking via APPROXIMATE PERCENTILE_DISC only makes sense for
+	// numeric PKs - percentiles on strings aren't meaningful and MIN/MAX would
+	// happily return varchar values. For anything else, fall back.
+	numeric, err := s.isBoundaryKeyNumeric(ctx, tableID, boundaryKey)
+	if err != nil {
+		return fmt.Errorf("failed to look up boundary key type for %s: %w", tableID.FullyQualifiedName(), err)
+	}
+	if !numeric {
+		slog.Info("Boundary key is not numeric, falling back to standard dedupe",
+			slog.String("table", tableID.FullyQualifiedName()),
+			slog.String("boundary_key", boundaryKey),
+		)
+		stagingTableID := shared.BuildStagingTableID(s, pair, tableID)
+		dedupeQueries := s.dialect().BuildDedupeQueries(tableID, stagingTableID, primaryKeys, includeArtieUpdatedAt)
+		if _, err := destination.ExecContextStatements(ctx, s, dedupeQueries); err != nil {
+			return fmt.Errorf("failed to dedupe: %w", err)
+		}
+		return nil
+	}
+
+	return s.dedupeRangeChunked(ctx, tableID, primaryKeys, includeArtieUpdatedAt, boundaryKey)
+}
+
+// numericDataTypes are the lower-cased information_schema.data_type values
+// for Redshift's numeric column types.
+// https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
+var numericDataTypes = []string{"smallint", "integer", "bigint", "numeric", "decimal", "real", "double precision"}
+
+func (s *Store) isBoundaryKeyNumeric(ctx context.Context, tableID sql.TableIdentifier, boundaryKey string) (bool, error) {
+	const query = `SELECT data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = $3`
+
+	var dataType string
+	if err := s.QueryRowContext(ctx, query, tableID.Schema(), tableID.Table(), boundaryKey).Scan(&dataType); err != nil {
+		return false, fmt.Errorf("failed to read data_type for %s.%s: %w", tableID.FullyQualifiedName(), boundaryKey, err)
+	}
+
+	return slices.Contains(numericDataTypes, strings.ToLower(dataType)), nil
+}
+
+func (s *Store) dedupeRangeChunked(ctx context.Context, tableID sql.TableIdentifier, primaryKeys []string, includeArtieUpdatedAt bool, boundaryKey string) error {
+	const numChunks = 10
+
+	newTableID := dialect.NewTableIdentifier(tableID.Schema(), fmt.Sprintf("%s_%s_dedupe", tableID.Table(), constants.ArtiePrefix))
+
+	for _, q := range []string{
+		fmt.Sprintf("DROP TABLE IF EXISTS %s", newTableID.FullyQualifiedName()),
+		fmt.Sprintf("CREATE TABLE %s (LIKE %s)", newTableID.FullyQualifiedName(), tableID.FullyQualifiedName()),
+	} {
+		slog.Info("Executing dedupe step...", slog.String("query", q))
+		if _, err := s.ExecContext(ctx, q); err != nil {
+			return fmt.Errorf("failed to prepare dedupe table, query: %s, err: %w", q, err)
+		}
+	}
+
+	boundaries, err := s.computeDedupeBoundaries(ctx, tableID, boundaryKey, numChunks)
+	if err != nil {
+		return fmt.Errorf("failed to compute dedupe boundaries for %s: %w", tableID.FullyQualifiedName(), err)
+	}
+
+	if boundaries == nil {
+		slog.Info("Source table is empty, skipping dedupe chunk inserts",
+			slog.String("table", tableID.FullyQualifiedName()))
+	} else {
+		for i := 0; i < numChunks; i++ {
+			inclusiveUpper := i == numChunks-1
+			query := s.dialect().BuildDedupeChunkInsertQuery(tableID, newTableID, primaryKeys, includeArtieUpdatedAt, boundaryKey, inclusiveUpper)
+			slog.Info("Executing dedupe chunk...",
+				slog.Int("chunk", i),
+				slog.String("lo", boundaries[i]),
+				slog.String("hi", boundaries[i+1]),
+				slog.String("query", query),
+			)
+			if _, err := s.ExecContext(ctx, query, boundaries[i], boundaries[i+1]); err != nil {
+				return fmt.Errorf("failed to dedupe chunk %d [%s, %s], err: %w", i, boundaries[i], boundaries[i+1], err)
+			}
 		}
 	}
 
@@ -147,6 +227,55 @@ func (s *Store) Dedupe(ctx context.Context, tableID sql.TableIdentifier, pair ka
 	}
 
 	return nil
+}
+
+// computeDedupeBoundaries returns numChunks+1 boundary values for the given
+// boundary key. Returns (nil, nil) if the source table is empty (MIN is NULL).
+// Values are scanned as strings so that any numeric PK type (int, bigint,
+// decimal, etc.) can be passed back to Redshift as a parameter without float
+// precision loss.
+func (s *Store) computeDedupeBoundaries(ctx context.Context, tableID sql.TableIdentifier, boundaryKey string, numChunks int) ([]string, error) {
+	query := s.dialect().BuildDedupeBoundaryQuery(tableID, boundaryKey, numChunks)
+	slog.Info("Computing dedupe chunk boundaries...", slog.String("query", query))
+
+	rows, err := s.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("boundary query failed: %w", err)
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("boundary query iteration failed: %w", err)
+		}
+		return nil, fmt.Errorf("boundary query returned no rows")
+	}
+
+	scanned := make([]gosql.NullString, numChunks+1)
+	scanArgs := make([]any, numChunks+1)
+	for i := range scanned {
+		scanArgs[i] = &scanned[i]
+	}
+	if err := rows.Scan(scanArgs...); err != nil {
+		return nil, fmt.Errorf("failed to scan boundary row: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close boundary rows: %w", err)
+	}
+
+	// If MIN is NULL the table is empty (percentiles and MAX will be NULL too).
+	if !scanned[0].Valid {
+		return nil, nil
+	}
+
+	boundaries := make([]string, numChunks+1)
+	for i, v := range scanned {
+		if !v.Valid {
+			return nil, fmt.Errorf("boundary %d came back NULL; cannot chunk dedupe", i)
+		}
+		boundaries[i] = v.String
+	}
+	return boundaries, nil
 }
 
 func LoadStore(ctx context.Context, cfg config.Config, _store *db.Store) (*Store, error) {

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -6,68 +6,103 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/clients/redshift/dialect"
-	"github.com/artie-labs/transfer/clients/shared"
 )
 
 func (r *RedshiftTestSuite) Test_GenerateDedupeQueries() {
 	{
 		// Dedupe with one primary key + no `__artie_updated_at` flag.
 		tableID := dialect.NewTableIdentifier("public", "customers")
-		stagingTableID := shared.TempTableID(r.store, tableID)
+		stagingTableID := dialect.NewTableIdentifier("public", "customers__artie_stg")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeQueries(tableID, stagingTableID, []string{"id"}, false)
 		assert.Len(r.T(), parts, 3)
 		assert.Equal(
 			r.T(),
-			fmt.Sprintf(`CREATE TEMPORARY TABLE "%s" AS (SELECT * FROM public."customers" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 2)`, stagingTableID.Table()),
+			`CREATE TEMPORARY TABLE "customers__artie_stg" AS (SELECT * FROM public."customers" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 2)`,
 			parts[0],
 		)
-		assert.Equal(r.T(), fmt.Sprintf(`DELETE FROM public."customers" USING "%s" t2 WHERE "customers"."id" = t2."id"`, stagingTableID.Table()), parts[1])
-		assert.Equal(r.T(), fmt.Sprintf(`INSERT INTO public."customers" SELECT * FROM "%s"`, stagingTableID.Table()), parts[2])
+		assert.Equal(r.T(), `DELETE FROM public."customers" USING "customers__artie_stg" t2 WHERE "customers"."id" = t2."id"`, parts[1])
+		assert.Equal(r.T(), `INSERT INTO public."customers" SELECT * FROM "customers__artie_stg"`, parts[2])
 	}
 	{
 		// Dedupe with one primary key + `__artie_updated_at` flag.
 		tableID := dialect.NewTableIdentifier("public", "customers")
-		stagingTableID := shared.TempTableID(r.store, tableID)
+		stagingTableID := dialect.NewTableIdentifier("public", "customers__artie_stg")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeQueries(tableID, stagingTableID, []string{"id"}, true)
 		assert.Len(r.T(), parts, 3)
 		assert.Equal(
 			r.T(),
-			fmt.Sprintf(`CREATE TEMPORARY TABLE "%s" AS (SELECT * FROM public."customers" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 2)`, stagingTableID.Table()),
+			`CREATE TEMPORARY TABLE "customers__artie_stg" AS (SELECT * FROM public."customers" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 2)`,
 			parts[0],
 		)
-		assert.Equal(r.T(), fmt.Sprintf(`DELETE FROM public."customers" USING "%s" t2 WHERE "customers"."id" = t2."id"`, stagingTableID.Table()), parts[1])
-		assert.Equal(r.T(), fmt.Sprintf(`INSERT INTO public."customers" SELECT * FROM "%s"`, stagingTableID.Table()), parts[2])
+		assert.Equal(r.T(), `DELETE FROM public."customers" USING "customers__artie_stg" t2 WHERE "customers"."id" = t2."id"`, parts[1])
+		assert.Equal(r.T(), `INSERT INTO public."customers" SELECT * FROM "customers__artie_stg"`, parts[2])
+	}
+}
+
+func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
+	{
+		// Chunked dedupe with one primary key + no `__artie_updated_at` flag.
+		tableID := dialect.NewTableIdentifier("public", "customers")
+		newTableID := dialect.NewTableIdentifier("public", "customers__artie_new")
+
+		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, false, 3)
+		assert.Len(r.T(), parts, 6) // 1 create + 3 inserts + 1 drop + 1 rename
+		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_new" (LIKE public."customers")`, parts[0])
+		for i := 1; i <= 3; i++ {
+			assert.Equal(
+				r.T(),
+				fmt.Sprintf(
+					`INSERT INTO public."customers__artie_new" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 1`,
+					i,
+				),
+				parts[i],
+			)
+		}
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[4])
+		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_new" RENAME TO "customers"`, parts[5])
 	}
 	{
-		// Dedupe with composite keys + no `__artie_updated_at` flag.
-		tableID := dialect.NewTableIdentifier("public", "user_settings")
-		stagingTableID := shared.TempTableID(r.store, tableID)
+		// Chunked dedupe with one primary key + `__artie_updated_at` flag.
+		tableID := dialect.NewTableIdentifier("public", "customers")
+		newTableID := dialect.NewTableIdentifier("public", "customers__artie_new")
 
-		parts := dialect.RedshiftDialect{}.BuildDedupeQueries(tableID, stagingTableID, []string{"user_id", "settings"}, false)
-		assert.Len(r.T(), parts, 3)
-		assert.Equal(
-			r.T(),
-			fmt.Sprintf(`CREATE TEMPORARY TABLE "%s" AS (SELECT * FROM public."user_settings" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 2)`, stagingTableID.Table()),
-			parts[0],
-		)
-		assert.Equal(r.T(), fmt.Sprintf(`DELETE FROM public."user_settings" USING "%s" t2 WHERE "user_settings"."user_id" = t2."user_id" AND "user_settings"."settings" = t2."settings"`, stagingTableID.Table()), parts[1])
-		assert.Equal(r.T(), fmt.Sprintf(`INSERT INTO public."user_settings" SELECT * FROM "%s"`, stagingTableID.Table()), parts[2])
+		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, true, 2)
+		assert.Len(r.T(), parts, 5) // 1 create + 2 inserts + 1 drop + 1 rename
+		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_new" (LIKE public."customers")`, parts[0])
+		for i := 1; i <= 2; i++ {
+			assert.Equal(
+				r.T(),
+				fmt.Sprintf(
+					`INSERT INTO public."customers__artie_new" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 1`,
+					i,
+				),
+				parts[i],
+			)
+		}
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[3])
+		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_new" RENAME TO "customers"`, parts[4])
 	}
 	{
-		// Dedupe with composite keys + `__artie_updated_at` flag.
+		// Chunked dedupe with composite keys.
 		tableID := dialect.NewTableIdentifier("public", "user_settings")
-		stagingTableID := shared.TempTableID(r.store, tableID)
+		newTableID := dialect.NewTableIdentifier("public", "user_settings__artie_new")
 
-		parts := dialect.RedshiftDialect{}.BuildDedupeQueries(tableID, stagingTableID, []string{"user_id", "settings"}, true)
-		assert.Len(r.T(), parts, 3)
-		assert.Equal(
-			r.T(),
-			fmt.Sprintf(`CREATE TEMPORARY TABLE "%s" AS (SELECT * FROM public."user_settings" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC, "__artie_updated_at" ASC) = 2)`, stagingTableID.Table()),
-			parts[0],
-		)
-		assert.Equal(r.T(), fmt.Sprintf(`DELETE FROM public."user_settings" USING "%s" t2 WHERE "user_settings"."user_id" = t2."user_id" AND "user_settings"."settings" = t2."settings"`, stagingTableID.Table()), parts[1])
-		assert.Equal(r.T(), fmt.Sprintf(`INSERT INTO public."user_settings" SELECT * FROM "%s"`, stagingTableID.Table()), parts[2])
+		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"user_id", "settings"}, false, 2)
+		assert.Len(r.T(), parts, 5)
+		assert.Equal(r.T(), `CREATE TABLE public."user_settings__artie_new" (LIKE public."user_settings")`, parts[0])
+		for i := 1; i <= 2; i++ {
+			assert.Equal(
+				r.T(),
+				fmt.Sprintf(
+					`INSERT INTO public."user_settings__artie_new" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 1`,
+					i,
+				),
+				parts[i],
+			)
+		}
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings"`, parts[3])
+		assert.Equal(r.T(), `ALTER TABLE public."user_settings__artie_new" RENAME TO "user_settings"`, parts[4])
 	}
 }

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -37,6 +37,36 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeQueries() {
 		assert.Equal(r.T(), `DELETE FROM public."customers" USING "customers__artie_stg" t2 WHERE "customers"."id" = t2."id"`, parts[1])
 		assert.Equal(r.T(), `INSERT INTO public."customers" SELECT * FROM "customers__artie_stg"`, parts[2])
 	}
+	{
+		// Dedupe with composite keys + no `__artie_updated_at` flag.
+		tableID := dialect.NewTableIdentifier("public", "user_settings")
+		stagingTableID := dialect.NewTableIdentifier("public", "user_settings__artie_stg")
+
+		parts := dialect.RedshiftDialect{}.BuildDedupeQueries(tableID, stagingTableID, []string{"user_id", "settings"}, false)
+		assert.Len(r.T(), parts, 3)
+		assert.Equal(
+			r.T(),
+			`CREATE TEMPORARY TABLE "user_settings__artie_stg" AS (SELECT * FROM public."user_settings" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 2)`,
+			parts[0],
+		)
+		assert.Equal(r.T(), `DELETE FROM public."user_settings" USING "user_settings__artie_stg" t2 WHERE "user_settings"."user_id" = t2."user_id" AND "user_settings"."settings" = t2."settings"`, parts[1])
+		assert.Equal(r.T(), `INSERT INTO public."user_settings" SELECT * FROM "user_settings__artie_stg"`, parts[2])
+	}
+	{
+		// Dedupe with composite keys + `__artie_updated_at` flag.
+		tableID := dialect.NewTableIdentifier("public", "user_settings")
+		stagingTableID := dialect.NewTableIdentifier("public", "user_settings__artie_stg")
+
+		parts := dialect.RedshiftDialect{}.BuildDedupeQueries(tableID, stagingTableID, []string{"user_id", "settings"}, true)
+		assert.Len(r.T(), parts, 3)
+		assert.Equal(
+			r.T(),
+			`CREATE TEMPORARY TABLE "user_settings__artie_stg" AS (SELECT * FROM public."user_settings" WHERE true QUALIFY ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC, "__artie_updated_at" ASC) = 2)`,
+			parts[0],
+		)
+		assert.Equal(r.T(), `DELETE FROM public."user_settings" USING "user_settings__artie_stg" t2 WHERE "user_settings"."user_id" = t2."user_id" AND "user_settings"."settings" = t2."settings"`, parts[1])
+		assert.Equal(r.T(), `INSERT INTO public."user_settings" SELECT * FROM "user_settings__artie_stg"`, parts[2])
+	}
 }
 
 func (r *RedshiftTestSuite) Test_BuildDedupeBoundaryQuery() {

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -1,8 +1,6 @@
 package redshift
 
 import (
-	"fmt"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/transfer/clients/redshift/dialect"
@@ -41,65 +39,58 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeQueries() {
 	}
 }
 
-func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
+func (r *RedshiftTestSuite) Test_BuildDedupeBoundaryQuery() {
+	tableID := dialect.NewTableIdentifier("public", "customers")
 	{
-		// Chunked dedupe with one primary key + no `__artie_updated_at` flag.
-		tableID := dialect.NewTableIdentifier("public", "customers")
-		newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
-
-		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, false, 3)
-		assert.Len(r.T(), parts, 5) // 1 drop + 1 create + 3 inserts
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers__artie_dedupe"`, parts[0])
-		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_dedupe" (LIKE public."customers")`, parts[1])
-		for i := 1; i <= 3; i++ {
-			assert.Equal(
-				r.T(),
-				fmt.Sprintf(
-					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" DESC) = 1`,
-					i,
-				),
-				parts[i+1],
-			)
-		}
+		// 2 chunks -> MIN + 1 percentile (0.5) + MAX.
+		query := dialect.RedshiftDialect{}.BuildDedupeBoundaryQuery(tableID, "id", 2)
+		assert.Equal(
+			r.T(),
+			`SELECT MIN("id"), APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY "id"), MAX("id") FROM public."customers"`,
+			query,
+		)
 	}
 	{
-		// Chunked dedupe with one primary key + `__artie_updated_at` flag.
-		tableID := dialect.NewTableIdentifier("public", "customers")
-		newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
+		// 4 chunks -> MIN + 3 percentiles (0.25, 0.5, 0.75) + MAX.
+		query := dialect.RedshiftDialect{}.BuildDedupeBoundaryQuery(tableID, "id", 4)
+		assert.Equal(
+			r.T(),
+			`SELECT MIN("id"), APPROXIMATE PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY "id"), APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY "id"), APPROXIMATE PERCENTILE_DISC(0.75) WITHIN GROUP (ORDER BY "id"), MAX("id") FROM public."customers"`,
+			query,
+		)
+	}
+}
 
-		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, true, 2)
-		assert.Len(r.T(), parts, 4) // 1 drop + 1 create + 2 inserts
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers__artie_dedupe"`, parts[0])
-		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_dedupe" (LIKE public."customers")`, parts[1])
-		for i := 1; i <= 2; i++ {
-			assert.Equal(
-				r.T(),
-				fmt.Sprintf(
-					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" DESC, "__artie_updated_at" DESC) = 1`,
-					i,
-				),
-				parts[i+1],
-			)
-		}
+func (r *RedshiftTestSuite) Test_BuildDedupeChunkInsertQuery() {
+	tableID := dialect.NewTableIdentifier("public", "customers")
+	newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
+	{
+		// Single PK, exclusive upper.
+		query := dialect.RedshiftDialect{}.BuildDedupeChunkInsertQuery(tableID, newTableID, []string{"id"}, false, "id", false)
+		assert.Equal(
+			r.T(),
+			`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE "id" >= $1 AND "id" < $2 QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" DESC) = 1`,
+			query,
+		)
 	}
 	{
-		// Chunked dedupe with composite keys.
-		tableID := dialect.NewTableIdentifier("public", "user_settings")
-		newTableID := dialect.NewTableIdentifier("public", "user_settings__artie_dedupe")
-
-		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"user_id", "settings"}, false, 2)
-		assert.Len(r.T(), parts, 4) // 1 drop + 1 create + 2 inserts
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings__artie_dedupe"`, parts[0])
-		assert.Equal(r.T(), `CREATE TABLE public."user_settings__artie_dedupe" (LIKE public."user_settings")`, parts[1])
-		for i := 1; i <= 2; i++ {
-			assert.Equal(
-				r.T(),
-				fmt.Sprintf(
-					`INSERT INTO public."user_settings__artie_dedupe" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" DESC, "settings" DESC) = 1`,
-					i,
-				),
-				parts[i+1],
-			)
-		}
+		// Single PK with __artie_updated_at, inclusive upper (last chunk).
+		query := dialect.RedshiftDialect{}.BuildDedupeChunkInsertQuery(tableID, newTableID, []string{"id"}, true, "id", true)
+		assert.Equal(
+			r.T(),
+			`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE "id" >= $1 AND "id" <= $2 QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" DESC, "__artie_updated_at" DESC) = 1`,
+			query,
+		)
+	}
+	{
+		// Composite PK; boundary key is the first PK, PARTITION BY covers the full PK.
+		settingsTableID := dialect.NewTableIdentifier("public", "user_settings")
+		newSettingsTableID := dialect.NewTableIdentifier("public", "user_settings__artie_dedupe")
+		query := dialect.RedshiftDialect{}.BuildDedupeChunkInsertQuery(settingsTableID, newSettingsTableID, []string{"user_id", "settings"}, false, "user_id", false)
+		assert.Equal(
+			r.T(),
+			`INSERT INTO public."user_settings__artie_dedupe" SELECT * FROM public."user_settings" WHERE "user_id" >= $1 AND "user_id" < $2 QUALIFY ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" DESC, "settings" DESC) = 1`,
+			query,
+		)
 	}
 }

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -55,7 +55,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 1`,
+					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" DESC) = 1`,
 					i,
 				),
 				parts[i+1],
@@ -75,7 +75,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 1`,
+					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" DESC, "__artie_updated_at" DESC) = 1`,
 					i,
 				),
 				parts[i+1],
@@ -95,7 +95,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."user_settings__artie_dedupe" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 1`,
+					`INSERT INTO public."user_settings__artie_dedupe" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" DESC, "settings" DESC) = 1`,
 					i,
 				),
 				parts[i+1],

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -48,7 +48,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 		newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, false, 3)
-		assert.Len(r.T(), parts, 7) // 1 drop + 1 create + 3 inserts + 1 drop + 1 rename
+		assert.Len(r.T(), parts, 5) // 1 drop + 1 create + 3 inserts
 		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers__artie_dedupe"`, parts[0])
 		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_dedupe" (LIKE public."customers")`, parts[1])
 		for i := 1; i <= 3; i++ {
@@ -61,8 +61,6 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[5])
-		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_dedupe" RENAME TO "customers"`, parts[6])
 	}
 	{
 		// Chunked dedupe with one primary key + `__artie_updated_at` flag.
@@ -70,7 +68,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 		newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, true, 2)
-		assert.Len(r.T(), parts, 6) // 1 drop + 1 create + 2 inserts + 1 drop + 1 rename
+		assert.Len(r.T(), parts, 4) // 1 drop + 1 create + 2 inserts
 		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers__artie_dedupe"`, parts[0])
 		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_dedupe" (LIKE public."customers")`, parts[1])
 		for i := 1; i <= 2; i++ {
@@ -83,8 +81,6 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[4])
-		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_dedupe" RENAME TO "customers"`, parts[5])
 	}
 	{
 		// Chunked dedupe with composite keys.
@@ -92,7 +88,7 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 		newTableID := dialect.NewTableIdentifier("public", "user_settings__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"user_id", "settings"}, false, 2)
-		assert.Len(r.T(), parts, 6)
+		assert.Len(r.T(), parts, 4) // 1 drop + 1 create + 2 inserts
 		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings__artie_dedupe"`, parts[0])
 		assert.Equal(r.T(), `CREATE TABLE public."user_settings__artie_dedupe" (LIKE public."user_settings")`, parts[1])
 		for i := 1; i <= 2; i++ {
@@ -105,7 +101,5 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings"`, parts[4])
-		assert.Equal(r.T(), `ALTER TABLE public."user_settings__artie_dedupe" RENAME TO "user_settings"`, parts[5])
 	}
 }

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -94,3 +94,28 @@ func (r *RedshiftTestSuite) Test_BuildDedupeChunkInsertQuery() {
 		)
 	}
 }
+
+func (r *RedshiftTestSuite) Test_BuildDedupeNullChunkInsertQuery() {
+	tableID := dialect.NewTableIdentifier("public", "customers")
+	newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
+	{
+		// Single PK, no __artie_updated_at.
+		query := dialect.RedshiftDialect{}.BuildDedupeNullChunkInsertQuery(tableID, newTableID, []string{"id"}, false, "id")
+		assert.Equal(
+			r.T(),
+			`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE "id" IS NULL QUALIFY ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" DESC) = 1`,
+			query,
+		)
+	}
+	{
+		// Composite PK with __artie_updated_at.
+		settingsTableID := dialect.NewTableIdentifier("public", "user_settings")
+		newSettingsTableID := dialect.NewTableIdentifier("public", "user_settings__artie_dedupe")
+		query := dialect.RedshiftDialect{}.BuildDedupeNullChunkInsertQuery(settingsTableID, newSettingsTableID, []string{"user_id", "settings"}, true, "user_id")
+		assert.Equal(
+			r.T(),
+			`INSERT INTO public."user_settings__artie_dedupe" SELECT * FROM public."user_settings" WHERE "user_id" IS NULL QUALIFY ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" DESC, "settings" DESC, "__artie_updated_at" DESC) = 1`,
+			query,
+		)
+	}
+}

--- a/clients/redshift/redshift_dedupe_test.go
+++ b/clients/redshift/redshift_dedupe_test.go
@@ -45,64 +45,67 @@ func (r *RedshiftTestSuite) Test_GenerateDedupeChunkedQueries() {
 	{
 		// Chunked dedupe with one primary key + no `__artie_updated_at` flag.
 		tableID := dialect.NewTableIdentifier("public", "customers")
-		newTableID := dialect.NewTableIdentifier("public", "customers__artie_new")
+		newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, false, 3)
-		assert.Len(r.T(), parts, 6) // 1 create + 3 inserts + 1 drop + 1 rename
-		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_new" (LIKE public."customers")`, parts[0])
+		assert.Len(r.T(), parts, 7) // 1 drop + 1 create + 3 inserts + 1 drop + 1 rename
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers__artie_dedupe"`, parts[0])
+		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_dedupe" (LIKE public."customers")`, parts[1])
 		for i := 1; i <= 3; i++ {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."customers__artie_new" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 1`,
+					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(3) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC) = 1`,
 					i,
 				),
-				parts[i],
+				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[4])
-		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_new" RENAME TO "customers"`, parts[5])
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[5])
+		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_dedupe" RENAME TO "customers"`, parts[6])
 	}
 	{
 		// Chunked dedupe with one primary key + `__artie_updated_at` flag.
 		tableID := dialect.NewTableIdentifier("public", "customers")
-		newTableID := dialect.NewTableIdentifier("public", "customers__artie_new")
+		newTableID := dialect.NewTableIdentifier("public", "customers__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"id"}, true, 2)
-		assert.Len(r.T(), parts, 5) // 1 create + 2 inserts + 1 drop + 1 rename
-		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_new" (LIKE public."customers")`, parts[0])
+		assert.Len(r.T(), parts, 6) // 1 drop + 1 create + 2 inserts + 1 drop + 1 rename
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers__artie_dedupe"`, parts[0])
+		assert.Equal(r.T(), `CREATE TABLE public."customers__artie_dedupe" (LIKE public."customers")`, parts[1])
 		for i := 1; i <= 2; i++ {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."customers__artie_new" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 1`,
+					`INSERT INTO public."customers__artie_dedupe" SELECT * FROM public."customers" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "id") = %d AND ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" ASC, "__artie_updated_at" ASC) = 1`,
 					i,
 				),
-				parts[i],
+				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[3])
-		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_new" RENAME TO "customers"`, parts[4])
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."customers"`, parts[4])
+		assert.Equal(r.T(), `ALTER TABLE public."customers__artie_dedupe" RENAME TO "customers"`, parts[5])
 	}
 	{
 		// Chunked dedupe with composite keys.
 		tableID := dialect.NewTableIdentifier("public", "user_settings")
-		newTableID := dialect.NewTableIdentifier("public", "user_settings__artie_new")
+		newTableID := dialect.NewTableIdentifier("public", "user_settings__artie_dedupe")
 
 		parts := dialect.RedshiftDialect{}.BuildDedupeChunkedQueries(tableID, newTableID, []string{"user_id", "settings"}, false, 2)
-		assert.Len(r.T(), parts, 5)
-		assert.Equal(r.T(), `CREATE TABLE public."user_settings__artie_new" (LIKE public."user_settings")`, parts[0])
+		assert.Len(r.T(), parts, 6)
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings__artie_dedupe"`, parts[0])
+		assert.Equal(r.T(), `CREATE TABLE public."user_settings__artie_dedupe" (LIKE public."user_settings")`, parts[1])
 		for i := 1; i <= 2; i++ {
 			assert.Equal(
 				r.T(),
 				fmt.Sprintf(
-					`INSERT INTO public."user_settings__artie_new" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 1`,
+					`INSERT INTO public."user_settings__artie_dedupe" SELECT * FROM public."user_settings" WHERE true QUALIFY NTILE(2) OVER (ORDER BY "user_id", "settings") = %d AND ROW_NUMBER() OVER (PARTITION BY "user_id", "settings" ORDER BY "user_id" ASC, "settings" ASC) = 1`,
 					i,
 				),
-				parts[i],
+				parts[i+1],
 			)
 		}
-		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings"`, parts[3])
-		assert.Equal(r.T(), `ALTER TABLE public."user_settings__artie_new" RENAME TO "user_settings"`, parts[4])
+		assert.Equal(r.T(), `DROP TABLE IF EXISTS public."user_settings"`, parts[4])
+		assert.Equal(r.T(), `ALTER TABLE public."user_settings__artie_dedupe" RENAME TO "user_settings"`, parts[5])
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Redshift dedupe to optionally rewrite tables via chunked `INSERT ... SELECT` into a new table followed by an atomic swap, which affects large-scale data movement and can drop rows if there are concurrent writers. Fallback keeps prior behavior for non-numeric PKs, but boundary computation/NULL handling introduces new edge cases to validate.
> 
> **Overview**
> Adds a new **range-chunked dedupe path for Redshift tables with numeric primary keys**, using `APPROXIMATE PERCENTILE_DISC` to compute chunk boundaries on the leading PK and then inserting each PK range into a new deduped table with `ROW_NUMBER()` before atomically swapping tables.
> 
> `Store.Dedupe` now detects whether the leading PK is numeric via `information_schema.columns` and **falls back to the existing staging-table dedupe** when it isn’t; the new path also runs an extra pass to include rows where the boundary key is `NULL`.
> 
> Extends the Redshift dialect with boundary/chunk query builders and updates/tests new SQL generation for both the legacy and chunked dedupe modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1f5ae29990b7fecce53237a2b993dc9ee78b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->