### PR TITLE
Add ddl.applied webhook event

### DIFF
--- a/clients/shared/append.go
+++ b/clients/shared/append.go
@@ -11,7 +11,7 @@ import (
 	"github.com/artie-labs/transfer/lib/webhooks"
 )
 
-func Append(ctx context.Context, dest destination.SQLDestination, tableData *optimization.TableData, _ *webhooks.Client, opts types.AdditionalSettings) error {
+func Append(ctx context.Context, dest destination.SQLDestination, tableData *optimization.TableData, whClient *webhooks.Client, opts types.AdditionalSettings) error {
 	if tableData.ShouldSkipUpdate() {
 		return nil
 	}
@@ -32,11 +32,11 @@ func Append(ctx context.Context, dest destination.SQLDestination, tableData *opt
 	columnSettings := opts.ColumnSettings
 	columnSettings.SkipPrimaryKeyCreation = tableData.TopicConfig().SkipPrimaryKeyCreation
 	if tableConfig.CreateTable() {
-		if err = CreateTable(ctx, dest, tableData.Mode(), tableConfig, columnSettings, tableID, false, targetKeysMissing); err != nil {
+		if err = CreateTable(ctx, dest, tableData.Mode(), tableConfig, columnSettings, tableID, false, targetKeysMissing, whClient); err != nil {
 			return fmt.Errorf("failed to create table: %w", err)
 		}
 	} else {
-		if err = AlterTableAddColumns(ctx, dest, tableConfig, columnSettings, tableID, targetKeysMissing); err != nil {
+		if err = AlterTableAddColumns(ctx, dest, tableConfig, columnSettings, tableID, targetKeysMissing, whClient); err != nil {
 			return fmt.Errorf("failed to alter table: %w", err)
 		}
 	}

--- a/clients/shared/merge.go
+++ b/clients/shared/merge.go
@@ -25,7 +25,7 @@ const (
 	heartbeatsInterval     = 2 * time.Minute
 )
 
-func Merge(ctx context.Context, dest destination.SQLDestination, tableData *optimization.TableData, opts types.MergeOpts, _ *webhooks.Client) error {
+func Merge(ctx context.Context, dest destination.SQLDestination, tableData *optimization.TableData, opts types.MergeOpts, whClient *webhooks.Client) error {
 	if tableData.ShouldSkipUpdate() {
 		return nil
 	}
@@ -53,16 +53,16 @@ func Merge(ctx context.Context, dest destination.SQLDestination, tableData *opti
 	columnSettings := opts.ColumnSettings
 	columnSettings.SkipPrimaryKeyCreation = tableData.TopicConfig().SkipPrimaryKeyCreation
 	if tableConfig.CreateTable() {
-		if err = CreateTable(ctx, dest, tableData.Mode(), tableConfig, columnSettings, tableID, false, targetKeysMissing); err != nil {
+		if err = CreateTable(ctx, dest, tableData.Mode(), tableConfig, columnSettings, tableID, false, targetKeysMissing, whClient); err != nil {
 			return fmt.Errorf("failed to create table: %w", err)
 		}
 	} else {
-		if err = AlterTableAddColumns(ctx, dest, tableConfig, columnSettings, tableID, targetKeysMissing); err != nil {
+		if err = AlterTableAddColumns(ctx, dest, tableConfig, columnSettings, tableID, targetKeysMissing, whClient); err != nil {
 			return fmt.Errorf("failed to add columns for table %q: %w", tableID.Table(), err)
 		}
 	}
 
-	if err = AlterTableDropColumns(ctx, dest, tableConfig, tableID, srcKeysMissing, tableData.GetLatestTimestamp(), tableData.ContainsOtherOperations()); err != nil {
+	if err = AlterTableDropColumns(ctx, dest, tableConfig, tableID, srcKeysMissing, tableData.GetLatestTimestamp(), tableData.ContainsOtherOperations(), whClient); err != nil {
 		return fmt.Errorf("failed to drop columns for table %q: %w", tableID.Table(), err)
 	}
 

--- a/clients/shared/multi_step_merge.go
+++ b/clients/shared/multi_step_merge.go
@@ -14,7 +14,7 @@ import (
 	"github.com/artie-labs/transfer/lib/webhooks"
 )
 
-func MultiStepMerge(ctx context.Context, dest destination.SQLDestination, tableData *optimization.TableData, opts types.MergeOpts, _ *webhooks.Client) (bool, error) {
+func MultiStepMerge(ctx context.Context, dest destination.SQLDestination, tableData *optimization.TableData, opts types.MergeOpts, whClient *webhooks.Client) (bool, error) {
 	msmSettings := tableData.MultiStepMergeSettings()
 	if !msmSettings.Enabled {
 		return false, fmt.Errorf("multi-step merge is not enabled")
@@ -60,11 +60,11 @@ func MultiStepMerge(ctx context.Context, dest destination.SQLDestination, tableD
 		)
 
 		if msmTableConfig.CreateTable() {
-			if err = CreateTable(ctx, dest, tableData.Mode(), msmTableConfig, columnSettings, msmTableID, true, resp.TargetColumnsMissing); err != nil {
+			if err = CreateTable(ctx, dest, tableData.Mode(), msmTableConfig, columnSettings, msmTableID, true, resp.TargetColumnsMissing, whClient); err != nil {
 				return false, fmt.Errorf("failed to create table: %w", err)
 			}
 		} else {
-			if err = AlterTableAddColumns(ctx, dest, msmTableConfig, columnSettings, msmTableID, resp.TargetColumnsMissing); err != nil {
+			if err = AlterTableAddColumns(ctx, dest, msmTableConfig, columnSettings, msmTableID, resp.TargetColumnsMissing, whClient); err != nil {
 				return false, fmt.Errorf("failed to add columns for table %q: %w", msmTableID.Table(), err)
 			}
 		}
@@ -79,11 +79,11 @@ func MultiStepMerge(ctx context.Context, dest destination.SQLDestination, tableD
 		)
 
 		if targetTableConfig.CreateTable() {
-			if err = CreateTable(ctx, dest, tableData.Mode(), targetTableConfig, columnSettings, targetTableID, false, targetKeysMissing); err != nil {
+			if err = CreateTable(ctx, dest, tableData.Mode(), targetTableConfig, columnSettings, targetTableID, false, targetKeysMissing, whClient); err != nil {
 				return false, fmt.Errorf("failed to create table: %w", err)
 			}
 		} else {
-			if err = AlterTableAddColumns(ctx, dest, targetTableConfig, columnSettings, targetTableID, targetKeysMissing); err != nil {
+			if err = AlterTableAddColumns(ctx, dest, targetTableConfig, columnSettings, targetTableID, targetKeysMissing, whClient); err != nil {
 				return false, fmt.Errorf("failed to add columns for table %q: %w", targetTableID.Table(), err)
 			}
 		}

--- a/clients/shared/multi_step_merge.go
+++ b/clients/shared/multi_step_merge.go
@@ -60,11 +60,11 @@ func MultiStepMerge(ctx context.Context, dest destination.SQLDestination, tableD
 		)
 
 		if msmTableConfig.CreateTable() {
-			if err = CreateTable(ctx, dest, tableData.Mode(), msmTableConfig, columnSettings, msmTableID, true, resp.TargetColumnsMissing, whClient); err != nil {
+			if err = CreateTable(ctx, dest, tableData.Mode(), msmTableConfig, columnSettings, msmTableID, true, resp.TargetColumnsMissing, nil); err != nil {
 				return false, fmt.Errorf("failed to create table: %w", err)
 			}
 		} else {
-			if err = AlterTableAddColumns(ctx, dest, msmTableConfig, columnSettings, msmTableID, resp.TargetColumnsMissing, whClient); err != nil {
+			if err = AlterTableAddColumns(ctx, dest, msmTableConfig, columnSettings, msmTableID, resp.TargetColumnsMissing, nil); err != nil {
 				return false, fmt.Errorf("failed to add columns for table %q: %w", msmTableID.Table(), err)
 			}
 		}

--- a/clients/shared/table.go
+++ b/clients/shared/table.go
@@ -16,7 +16,20 @@ import (
 	"github.com/artie-labs/transfer/lib/optimization"
 	"github.com/artie-labs/transfer/lib/sql"
 	"github.com/artie-labs/transfer/lib/typing/columns"
+	"github.com/artie-labs/transfer/lib/webhooks"
 )
+
+func emitDDLApplied(ctx context.Context, whClient *webhooks.Client, tableID sql.TableIdentifier, query string) {
+	if whClient == nil {
+		return
+	}
+
+	whClient.SendEvent(ctx, webhooks.EventDDLApplied, webhooks.EventProperties{
+		Query:  query,
+		Table:  tableID.Table(),
+		Schema: tableID.Schema(),
+	})
+}
 
 func getValidColumns(cols []columns.Column) []columns.Column {
 	var validCols []columns.Column
@@ -33,10 +46,10 @@ func getValidColumns(cols []columns.Column) []columns.Column {
 
 func CreateTempTable(ctx context.Context, dest destination.SQLDestination, tableData *optimization.TableData, tc *types.DestinationTableConfig, settings config.SharedDestinationColumnSettings, tableID sql.TableIdentifier) error {
 	settings.SkipPrimaryKeyCreation = tableData.TopicConfig().SkipPrimaryKeyCreation
-	return CreateTable(ctx, dest, tableData.Mode(), tc, settings, tableID, true, tableData.ReadOnlyInMemoryCols().GetColumns())
+	return CreateTable(ctx, dest, tableData.Mode(), tc, settings, tableID, true, tableData.ReadOnlyInMemoryCols().GetColumns(), nil)
 }
 
-func CreateTable(ctx context.Context, dest destination.SQLDestination, mode config.Mode, tc *types.DestinationTableConfig, settings config.SharedDestinationColumnSettings, tableID sql.TableIdentifier, tempTable bool, cols []columns.Column) error {
+func CreateTable(ctx context.Context, dest destination.SQLDestination, mode config.Mode, tc *types.DestinationTableConfig, settings config.SharedDestinationColumnSettings, tableID sql.TableIdentifier, tempTable bool, cols []columns.Column, whClient *webhooks.Client) error {
 	cols = getValidColumns(cols)
 	if len(cols) == 0 {
 		return nil
@@ -52,12 +65,16 @@ func CreateTable(ctx context.Context, dest destination.SQLDestination, mode conf
 		return fmt.Errorf("failed to create temp table: %w", err)
 	}
 
+	if !tempTable {
+		emitDDLApplied(ctx, whClient, tableID, query)
+	}
+
 	// Update cache with the new columns that we've added.
 	tc.MutateInMemoryColumns(constants.AddColumn, cols)
 	return nil
 }
 
-func addColumn(ctx context.Context, dest destination.SQLDestination, sqlPart string, attempts int) error {
+func addColumn(ctx context.Context, dest destination.SQLDestination, tableID sql.TableIdentifier, sqlPart string, attempts int, whClient *webhooks.Client) error {
 	if attempts >= 100 {
 		return fmt.Errorf("failed to add column after 100 attempts")
 	}
@@ -79,16 +96,17 @@ func addColumn(ctx context.Context, dest destination.SQLDestination, sqlPart str
 			case <-time.After(sleepDuration):
 			}
 
-			return addColumn(ctx, dest, sqlPart, attempts+1)
+			return addColumn(ctx, dest, tableID, sqlPart, attempts+1, whClient)
 		}
 
 		return fmt.Errorf("failed to alter table: %w", err)
 	}
 
+	emitDDLApplied(ctx, whClient, tableID, sqlPart)
 	return nil
 }
 
-func AlterTableAddColumns(ctx context.Context, dest destination.SQLDestination, tc *types.DestinationTableConfig, settings config.SharedDestinationColumnSettings, tableID sql.TableIdentifier, cols []columns.Column) error {
+func AlterTableAddColumns(ctx context.Context, dest destination.SQLDestination, tc *types.DestinationTableConfig, settings config.SharedDestinationColumnSettings, tableID sql.TableIdentifier, cols []columns.Column, whClient *webhooks.Client) error {
 	cols = getValidColumns(cols)
 	if len(cols) == 0 {
 		return nil
@@ -100,7 +118,7 @@ func AlterTableAddColumns(ctx context.Context, dest destination.SQLDestination, 
 	}
 
 	for _, sqlPart := range sqlParts {
-		if err := addColumn(ctx, dest, sqlPart, 0); err != nil {
+		if err := addColumn(ctx, dest, tableID, sqlPart, 0, whClient); err != nil {
 			return fmt.Errorf("failed to add column: %w", err)
 		}
 	}
@@ -109,7 +127,7 @@ func AlterTableAddColumns(ctx context.Context, dest destination.SQLDestination, 
 	return nil
 }
 
-func AlterTableDropColumns(ctx context.Context, dest destination.SQLDestination, tc *types.DestinationTableConfig, tableID sql.TableIdentifier, cols []columns.Column, cdcTime time.Time, containsOtherOperations bool) error {
+func AlterTableDropColumns(ctx context.Context, dest destination.SQLDestination, tc *types.DestinationTableConfig, tableID sql.TableIdentifier, cols []columns.Column, cdcTime time.Time, containsOtherOperations bool, whClient *webhooks.Client) error {
 	if len(cols) == 0 {
 		return nil
 	}
@@ -135,6 +153,8 @@ func AlterTableDropColumns(ctx context.Context, dest destination.SQLDestination,
 		if _, err = dest.ExecContext(ctx, query); err != nil {
 			return fmt.Errorf("failed to alter table: %w", err)
 		}
+
+		emitDDLApplied(ctx, whClient, tableID, query)
 	}
 
 	tc.MutateInMemoryColumns(constants.DropColumn, colsToDrop)

--- a/lib/destination/ddl/ddl_alter_delete_test.go
+++ b/lib/destination/ddl/ddl_alter_delete_test.go
@@ -59,7 +59,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 
 	// Snowflake
 	for _, column := range cols.GetColumns() {
-		err := shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, snowflakeTc, snowflakeTableID, []columns.Column{column}, ts, true)
+		err := shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, snowflakeTc, snowflakeTableID, []columns.Column{column}, ts, true, nil)
 		assert.NoError(d.T(), err)
 	}
 
@@ -69,7 +69,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 
 	// BigQuery
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, bqTc, bqTableID, []columns.Column{column}, ts, true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, bqTc, bqTableID, []columns.Column{column}, ts, true, nil))
 	}
 
 	// Never actually deleted.
@@ -78,7 +78,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 
 	// Redshift
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.redshiftStore, redshiftTc, redshiftTableID, []columns.Column{column}, ts, true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.redshiftStore, redshiftTc, redshiftTableID, []columns.Column{column}, ts, true, nil))
 	}
 
 	// Never actually deleted.
@@ -101,7 +101,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	assert.Equal(d.T(), 0, len(snowflakeTc.ReadOnlyColumnsToDelete()), snowflakeTc.ReadOnlyColumnsToDelete())
 
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, snowflakeTc, snowflakeTableID, []columns.Column{column}, ts, false))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, snowflakeTc, snowflakeTableID, []columns.Column{column}, ts, false, nil))
 	}
 
 	// Never actually deleted.
@@ -110,7 +110,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 
 	// BigQuery
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, bqTc, bqTableID, []columns.Column{column}, ts, false))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, bqTc, bqTableID, []columns.Column{column}, ts, false, nil))
 	}
 
 	// Never actually deleted.
@@ -119,7 +119,7 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 
 	// Redshift
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.redshiftStore, redshiftTc, redshiftTableID, []columns.Column{column}, ts, false))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.redshiftStore, redshiftTc, redshiftTableID, []columns.Column{column}, ts, false, nil))
 	}
 
 	// Never actually deleted.
@@ -146,18 +146,18 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 	{
 		// Snowflake
 		for _, column := range cols.GetColumns() {
-			assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, snowflakeTc, snowflakeTableID, []columns.Column{column}, ts, true))
+			assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, snowflakeTc, snowflakeTableID, []columns.Column{column}, ts, true, nil))
 		}
 	}
 
 	// BigQuery
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, bqTc, bqTableID, []columns.Column{column}, ts, true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, bqTc, bqTableID, []columns.Column{column}, ts, true, nil))
 	}
 
 	// Redshift
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.redshiftStore, redshiftTc, redshiftTableID, []columns.Column{column}, ts, true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.redshiftStore, redshiftTc, redshiftTableID, []columns.Column{column}, ts, true, nil))
 	}
 
 	// Nothing has been deleted, but it is all added to the permissions table.
@@ -171,11 +171,11 @@ func (d *DDLTestSuite) TestAlterDelete_Complete() {
 
 	for _, column := range cols.GetColumns() {
 		// Snowflake
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, snowflakeTc, snowflakeTableID, []columns.Column{column}, ts.Add(2*constants.DeletionConfidencePadding), true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, snowflakeTc, snowflakeTableID, []columns.Column{column}, ts.Add(2*constants.DeletionConfidencePadding), true, nil))
 		// BigQuery
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, bqTc, bqTableID, []columns.Column{column}, ts.Add(2*constants.DeletionConfidencePadding), true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, bqTc, bqTableID, []columns.Column{column}, ts.Add(2*constants.DeletionConfidencePadding), true, nil))
 		// Redshift
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.redshiftStore, redshiftTc, redshiftTableID, []columns.Column{column}, ts.Add(2*constants.DeletionConfidencePadding), true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.redshiftStore, redshiftTc, redshiftTableID, []columns.Column{column}, ts.Add(2*constants.DeletionConfidencePadding), true, nil))
 	}
 
 	// Everything has been deleted.

--- a/lib/destination/ddl/ddl_bq_test.go
+++ b/lib/destination/ddl/ddl_bq_test.go
@@ -50,7 +50,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 	// Prior to deletion, there should be no colsToDelete
 	assert.Empty(d.T(), d.bigQueryStore.GetConfigMap().GetTableConfig(tableID).ReadOnlyColumnsToDelete())
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, tc, tableID, []columns.Column{column}, ts, true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, tc, tableID, []columns.Column{column}, ts, true, nil))
 	}
 
 	// Have not deleted, but tried to!
@@ -61,7 +61,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuery() {
 	// Now try to delete again and with an increased TS. It should now be all deleted.
 	var callIdx int
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, tc, tableID, []columns.Column{column}, ts.Add(2*constants.DeletionConfidencePadding), true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, tc, tableID, []columns.Column{column}, ts.Add(2*constants.DeletionConfidencePadding), true, nil))
 		_, query, _ := d.fakeBigQueryStore.ExecContextArgsForCall(callIdx)
 		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s", fqName, d.bigQueryStore.Dialect().QuoteIdentifier(column.Name())), query)
 		callIdx += 1
@@ -106,7 +106,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumns() {
 	tc := d.bigQueryStore.GetConfigMap().GetTableConfig(tableID)
 	for name, kind := range newCols {
 		col := columns.NewColumn(name, kind)
-		assert.NoError(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.bigQueryStore, tc, config.SharedDestinationColumnSettings{}, tableID, []columns.Column{col}))
+		assert.NoError(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.bigQueryStore, tc, config.SharedDestinationColumnSettings{}, tableID, []columns.Column{col}, nil))
 
 		dataType, err := d.bigQueryStore.Dialect().DataTypeForKind(kind, false, config.SharedDestinationColumnSettings{})
 		assert.NoError(d.T(), err)
@@ -161,7 +161,7 @@ func (d *DDLTestSuite) TestAlterTableAddColumnsSomeAlreadyExist() {
 		dataType, err := d.bigQueryStore.Dialect().DataTypeForKind(column.KindDetails, false, config.SharedDestinationColumnSettings{})
 		assert.NoError(d.T(), err)
 
-		assert.NoError(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.bigQueryStore, tc, config.SharedDestinationColumnSettings{}, tableID, []columns.Column{column}))
+		assert.NoError(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.bigQueryStore, tc, config.SharedDestinationColumnSettings{}, tableID, []columns.Column{column}, nil))
 		_, query, _ := d.fakeBigQueryStore.ExecContextArgsForCall(callIdx)
 		assert.Equal(d.T(), fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", fqName, d.bigQueryStore.Dialect().QuoteIdentifier(column.Name()), dataType), query)
 		callIdx += 1
@@ -202,7 +202,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 	// Prior to deletion, there should be no colsToDelete
 	assert.Equal(d.T(), 0, len(d.bigQueryStore.GetConfigMap().GetTableConfig(tableID).ReadOnlyColumnsToDelete()), d.bigQueryStore.GetConfigMap().GetTableConfig(tableID).ReadOnlyColumnsToDelete())
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, tc, tableID, []columns.Column{column}, ts, false))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, tc, tableID, []columns.Column{column}, ts, false, nil))
 	}
 
 	// Because containsOtherOperations is false, it should have never tried to delete.
@@ -210,7 +210,7 @@ func (d *DDLTestSuite) TestAlterTableDropColumnsBigQuerySafety() {
 
 	// Timestamp got increased, but containsOtherOperations is false, so it should not have tried to delete.
 	for _, column := range cols.GetColumns() {
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, tc, tableID, []columns.Column{column}, ts.Add(2*constants.DeletionConfidencePadding), false))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.bigQueryStore, tc, tableID, []columns.Column{column}, ts.Add(2*constants.DeletionConfidencePadding), false, nil))
 	}
 
 	assert.Equal(d.T(), 0, d.fakeBigQueryStore.ExecContextCallCount())

--- a/lib/destination/ddl/ddl_sflk_test.go
+++ b/lib/destination/ddl/ddl_sflk_test.go
@@ -28,7 +28,7 @@ func (d *DDLTestSuite) TestAlterComplexObjects() {
 	tableID := dialect.NewTableIdentifier("shop", "public", "complex_columns")
 	d.snowflakeStagesStore.GetConfigMap().AddTable(tableID, types.NewDestinationTableConfig(nil, true))
 	tc := d.snowflakeStagesStore.GetConfigMap().GetTableConfig(tableID)
-	assert.NoError(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.snowflakeStagesStore, tc, config.SharedDestinationColumnSettings{}, tableID, cols))
+	assert.NoError(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.snowflakeStagesStore, tc, config.SharedDestinationColumnSettings{}, tableID, cols, nil))
 	for i := 0; i < len(cols); i++ {
 		dataType, err := d.snowflakeStagesStore.Dialect().DataTypeForKind(cols[i].KindDetails, false, config.SharedDestinationColumnSettings{})
 		assert.NoError(d.T(), err)
@@ -53,7 +53,7 @@ func (d *DDLTestSuite) TestAlterIdempotency() {
 	tc := d.snowflakeStagesStore.GetConfigMap().GetTableConfig(tableID)
 
 	d.fakeSnowflakeStagesStore.ExecContextReturns(nil, errors.New("table does not exist"))
-	assert.ErrorContains(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.snowflakeStagesStore, tc, config.SharedDestinationColumnSettings{}, tableID, cols), `failed to alter table: table does not exist`)
+	assert.ErrorContains(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.snowflakeStagesStore, tc, config.SharedDestinationColumnSettings{}, tableID, cols, nil), `failed to alter table: table does not exist`)
 }
 
 func (d *DDLTestSuite) TestAlterTableAdd() {
@@ -69,7 +69,7 @@ func (d *DDLTestSuite) TestAlterTableAdd() {
 	d.snowflakeStagesStore.GetConfigMap().AddTable(tableID, types.NewDestinationTableConfig(nil, true))
 	tc := d.snowflakeStagesStore.GetConfigMap().GetTableConfig(tableID)
 
-	assert.NoError(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.snowflakeStagesStore, tc, config.SharedDestinationColumnSettings{}, tableID, cols))
+	assert.NoError(d.T(), shared.AlterTableAddColumns(d.T().Context(), d.snowflakeStagesStore, tc, config.SharedDestinationColumnSettings{}, tableID, cols, nil))
 	assert.Equal(d.T(), len(cols), d.fakeSnowflakeStagesStore.ExecContextCallCount(), "called SFLK the same amt to create cols")
 
 	// Check the table config
@@ -100,7 +100,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 	d.snowflakeStagesStore.GetConfigMap().AddTable(tableID, types.NewDestinationTableConfig(nil, true))
 	tc := d.snowflakeStagesStore.GetConfigMap().GetTableConfig(tableID)
 
-	assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, tc, tableID, cols, time.Now().UTC(), true))
+	assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, tc, tableID, cols, time.Now().UTC(), true, nil))
 	assert.Equal(d.T(), 0, d.fakeSnowflakeStagesStore.ExecContextCallCount(), "tried to delete, but not yet.")
 
 	// Check the table config
@@ -125,7 +125,7 @@ func (d *DDLTestSuite) TestAlterTableDeleteDryRun() {
 		// Now let's actually try to dial the time back, and it should actually try to delete.
 		tableConfig.AddColumnsToDelete(colToActuallyDelete, time.Now().Add(-1*time.Hour))
 
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, tc, tableID, cols, time.Now().UTC(), true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, tc, tableID, cols, time.Now().UTC(), true, nil))
 		assert.Equal(d.T(), i+1, d.fakeSnowflakeStagesStore.ExecContextCallCount(), "tried to delete one column")
 
 		_, execArg, _ := d.fakeSnowflakeStagesStore.ExecContextArgsForCall(i)
@@ -155,14 +155,14 @@ func (d *DDLTestSuite) TestAlterTableDelete() {
 	tc := d.snowflakeStagesStore.GetConfigMap().GetTableConfig(tableID)
 	{
 		// containsOtherOperations = false
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, tc, tableID, cols, time.Now(), false))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, tc, tableID, cols, time.Now(), false, nil))
 		// Nothing got deleted
 		assert.Equal(d.T(), 0, d.fakeSnowflakeStagesStore.ExecContextCallCount())
 		assert.Equal(d.T(), colsToDeleteMap, tc.ReadOnlyColumnsToDelete())
 	}
 	{
 		// containsOtherOperations = true
-		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, tc, tableID, cols, time.Now(), true))
+		assert.NoError(d.T(), shared.AlterTableDropColumns(d.T().Context(), d.snowflakeStagesStore, tc, tableID, cols, time.Now(), true, nil))
 		assert.Equal(d.T(), 3, d.fakeSnowflakeStagesStore.ExecContextCallCount())
 
 		// Check the table config

--- a/lib/webhooks/types.go
+++ b/lib/webhooks/types.go
@@ -22,6 +22,7 @@ const (
 	EventReplicationError   EventType = "replication.error"
 	EventRowSkipped         EventType = "row.skipped"
 	EventDDLSeen            EventType = "ddl.seen"
+	EventDDLApplied         EventType = "ddl.applied"
 
 	// Dashboard specific events
 	EventDEKGenerated EventType = "dek.generated"
@@ -45,6 +46,7 @@ var AllEventTypes = []EventType{
 	EventReplicationError,
 	EventRowSkipped,
 	EventDDLSeen,
+	EventDDLApplied,
 	EventDEKGenerated,
 
 	EventReplicationFailed,
@@ -88,6 +90,7 @@ var eventMetadataMap = map[EventType]EventMetadata{
 	EventReplicationError:   {SeverityError, "replication", "Replication error"},
 	EventRowSkipped:         {SeverityWarning, "replication", "Row skipped"},
 	EventDDLSeen:            {SeverityInfo, "replication", "DDL seen"},
+	EventDDLApplied:         {SeverityInfo, "replication", "DDL applied"},
 	// Dashboard specific events
 	EventDEKGenerated: {SeverityInfo, "dashboard", "Data Encryption Key (DEK) generated"},
 

--- a/lib/webhooks/types_test.go
+++ b/lib/webhooks/types_test.go
@@ -13,6 +13,8 @@ func TestGetEventSeverity(t *testing.T) {
 		EventBackfillFailed:     SeverityError,
 		EventReplicationStarted: SeverityInfo,
 		EventReplicationError:   SeverityError,
+		EventDDLSeen:            SeverityInfo,
+		EventDDLApplied:         SeverityInfo,
 		EventType("unknown"):    SeverityInfo,
 	}
 
@@ -28,6 +30,8 @@ func TestGetEventMessage(t *testing.T) {
 		EventBackfillFailed:     "Backfill failed",
 		EventReplicationStarted: "Replication started",
 		EventReplicationError:   "Replication error",
+		EventDDLSeen:            "DDL seen",
+		EventDDLApplied:         "DDL applied",
 		EventType("unknown"):    "Unknown event type",
 	}
 


### PR DESCRIPTION
## Summary

Adds a new `ddl.applied` webhook event emitted by transfer after destination-side schema DDL is successfully executed against SQL warehouses. Downstream consumers can now observe when target-table `CREATE TABLE`, `ALTER TABLE ADD COLUMN`, and `ALTER TABLE DROP COLUMN` statements have actually run.

- Registers `EventDDLApplied = "ddl.applied"` in `lib/webhooks/types.go` (severity `info`, category `replication`).
- Threads `*webhooks.Client` through `CreateTable` / `addColumn` / `AlterTableAddColumns` / `AlterTableDropColumns` in `clients/shared/table.go` and emits `ddl.applied` with `Query`, `Table`, and `Schema` after each successful `ExecContext`.
- Named the previously-ignored `*webhooks.Client` parameter in `shared.Merge`, `shared.Append`, and `shared.MultiStepMerge` and forwards it to the DDL helpers.
- `CreateTempTable` and `CreateTable` with `tempTable=true` do not emit (internal staging DDL on every flush would be prohibitively noisy). `DropTemporaryTable` is unchanged.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new webhook emission path in the critical replication DDL flow (create/alter/drop), which could increase outbound event volume and leak full DDL query text to webhook consumers if misconfigured.
> 
> **Overview**
> Adds a new webhook event type, `ddl.applied`, and registers it in `lib/webhooks/types.go` (including metadata and tests).
> 
> Threads `*webhooks.Client` through shared table DDL helpers (`CreateTable`, `AlterTableAddColumns`, `AlterTableDropColumns`) and the main write paths (`Append`, `Merge`, `MultiStepMerge`) to emit `ddl.applied` *after* successful `ExecContext` of target-table `CREATE TABLE`/`ALTER TABLE` statements (explicitly skipping temp/staging-table DDL to avoid noise).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 431e8b81a599b361229b1961a52f611a08b5a844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->